### PR TITLE
Removed all overrides to trend line display in plots; open_xdmod

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByNSFStatus.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByNSFStatus.php
@@ -48,11 +48,6 @@ class GroupByNSFStatus extends \DataWarehouse\Query\Jobs\GroupBy
 		return 'stack';
 	}
 	
-	public function getDefaultShowTrendLine()
-	{
-		return 'n';
-	}
-
 	public function applyTo(\DataWarehouse\Query\Query &$query, \DataWarehouse\Query\Model\Table $data_table, $multi_group = false)
 	{
 		$query->addTable($this->nsfstatuscode_table);

--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByNone.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByNone.php
@@ -44,11 +44,6 @@ class GroupByNone extends \DataWarehouse\Query\Jobs\GroupBy
 		return 'stack';
 	}
 
-	public function getDefaultShowTrendLine()
-	{
-		return 'y';
-	}
-
     // JMS Oct 15
     // Use the GroupBy subclass to add a Where clause and needed Join 
 	public function addWhereJoin(\DataWarehouse\Query\Query &$query, 


### PR DESCRIPTION
Trend line display default is now 'off' for all GroupBy classes, thus for all Usage plots, for open xdmod. See also pull requests ubccr/xdmod-supremm#2 and ubccr/xdmod-xsede#1 which address this change for supremm module and xdmod xsede module.


## Description
Overrides to getDefaultShowTrendLine() removed in all GroupBy classes; retained in parent GroupBy class.

## Motivation and Context
Assigned as follows:
https://app.asana.com/0/14787510600562/217118195806574

## Tests performed
Changes affect only Usage plots. Verified that Usage line plot types that previously overrode trend line behavior now display no trend lines by default, namely:
Jobs GroupByNSFStatus, and
GroupByNone for:
 - Jobs
 - Supremm
 - Accounts
 - Allocations
 - Requests
 - ResourceAllocations
 - Grants
 - Performance
 - Proposal
(note that the latter three plot types do not exist, in fact)

Verified that function definition for getDefaultShowTrendLine() is found only in parent GroupBy class, Query/GroupBy.php

Tests were done against clean merged code with xdmod6.5.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

…shown by default.