### PR TITLE
Fixed GitHub-related folders being included in external module builds

### DIFF
--- a/classes/OpenXdmod/Build/Packager.php
+++ b/classes/OpenXdmod/Build/Packager.php
@@ -491,7 +491,10 @@ class Packager
         $dirs = array_diff(scandir($srcDir), array(
             '.',
             '..',
+            '.git',
+            '.github',
             'assets',
+            'docs',
             'tests',
         ));
 


### PR DESCRIPTION
## Description
This pull request prevents `.git`, `.github`, and `docs` subdirectories located in module root directories from being included in builds.

## Motivation and Context
This prevents many unnecessary files from being included in builds.

## Tests performed
I ran the build process on a fresh VM and verified that the subdirectories were no longer being included in source tarballs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~All new and existing tests passed.~~
