### PR TITLE
Added default ETLv2 main config file

### DIFF
--- a/configuration/etl/etl.json
+++ b/configuration/etl/etl.json
@@ -1,0 +1,43 @@
+{
+    "#": "Paths for the various configuraiton and data subdirectories. This is added to the global",
+    "#": "defaults and actions.",
+
+    "paths": {
+        "definition_file_dir": "etl_tables.d",
+        "specs_dir": "etl_specs.d",
+        "macro_dir": "etl_macros.d",
+        "sql_dir": "etl_sql.d",
+        "data_dir": "etl_data.d",
+        "local_config_dir": "etl.d"
+    },
+
+    "defaults": {
+
+        "#": "Global options are lowest priority and applied to all actions",
+
+        "global" : {
+            "#": "The utility endpoint is used by the etl_overseer script to query resource codes.",
+            "endpoints": {
+                "utility": {
+                    "type": "mysql",
+                    "name": "Utility DB",
+                    "config": "datawarehouse",
+                    "schema": "modw"
+                }
+            }
+        },
+
+        "#": "Options specific to the 'ingestors' pipeline",
+
+        "ingestors": {
+            "namespace": "ETL\\Ingestor",
+            "options_class": "IngestorOptions"
+        }
+       
+    },
+    
+    "#": "Empty default pipeline",
+
+    "ingestors": []
+
+}


### PR DESCRIPTION
## Description
This was originally located in the XSEDE module when ETLv2 was XSEDE-specific, but it now needs to be in Open XDMoD for ETLv2 to be usable by other modules.

## Motivation and Context
This eases deployment of upcoming modules that make use of ETLv2 within Open XDMoD.

## Tests performed
I ran the ETL process for the module and verified that it now worked correctly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~All new and existing tests passed.~~
