### PR TITLE
Set default on parent GroupBy class to hide error bars. Removed overr…

### DIFF
--- a/classes/DataWarehouse/Query/GroupBy.php
+++ b/classes/DataWarehouse/Query/GroupBy.php
@@ -345,7 +345,7 @@ abstract class GroupBy extends \Common\Identity
 	}
 	public function getDefaultShowErrorBars()
 	{
-		return 'y';
+		return 'n';
 	}
 	public function getDefaultShowGuideLines()
 	{

--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByNSFDirectorate.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByNSFDirectorate.php
@@ -62,11 +62,6 @@ class GroupByNSFDirectorate extends \DataWarehouse\Query\Jobs\GroupBy
    {
       return 'y';
    }
-
-   public function getDefaultShowErrorBars()
-   {
-       return 'n';
-   }
    public function getDefaultShowGuideLines()
    {
        return 'n';


### PR DESCRIPTION
Error bar datasets will no longer be plotted by default in Usage tab. Parent GroupBy class now turns off error bar display; child classes do not override this setting.

Refer to pull request ubccr/xdmod-supremm/#5 which takes care of a single SUPREMM module case.

## Description
This change affects only the Jobs realm "Per Job" (Average) plots, which are the only places where standard deviation datasets are generated and available to plot as error bars.

## Motivation and Context
Feature request and further discussion:
https://app.asana.com/0/14787510600562/217118195806574

## Tests performed
Jobs realm "Per Job" Usage plots have been verified to be free of error bars by default. Error bars confirmed available to plot as the user wishes.

## Types of changes
This may depend on your definition of "breaking". All Jobs realm plots that report averages are now plotted in Usage tab without error bars due to this change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
