### PR TITLE
Fix Slurm job array index parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Open XDMoD Change Log
         - Fixed documentation files from modules overwriting core files when
           installing using tarballs.
         - Fixed UGE shredder.
+        - Fixed Slurm job array index parsing.
 - Refactors and Miscellaneous
     - Added documentation for using LDAP for federated authentication.
     - Spun the App Kernels, SUPReMM, and XSEDE modules out into separate

--- a/html/about/release_notes/xdmod.html
+++ b/html/about/release_notes/xdmod.html
@@ -46,6 +46,7 @@ listed.</p>
         <li>Fixed automatic aggregation unit selection for charts not working
         correctly for some installations of Open XDMoD.</li>
         <li>Fixed UGE shredder</li>
+        <li>Fixed Slurm job array index parsing.</li>
       </ul>
     </li>
     <li>SUPReMM

--- a/open_xdmod/modules/xdmod/xdmod.spec.in
+++ b/open_xdmod/modules/xdmod/xdmod.spec.in
@@ -103,6 +103,7 @@ rm -rf $RPM_BUILD_ROOT
         - Fixed documentation files from modules overwriting core files when
           installing using tarballs.
         - Fixed UGE shredder.
+        - Fixed Slurm job array index parsing.
 - Refactors and Miscellaneous
     - Added documentation for using LDAP for federated authentication.
     - Spun the App Kernels, SUPReMM, and XSEDE modules out into separate


### PR DESCRIPTION
## Description

Fixes the slurm job array index parsing.

## Motivation and Context

The slurm job array index parsing was broken.  It was only handling two of the possible cases and not more general possibilities.

## Tests performed

Added new unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
