### PR TITLE
Correct merging of labels from multiple aggregate datasets, with Show Remainder checked.

### DIFF
--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -938,11 +938,17 @@ class HighChart2
 								// only compute average (2nd parameter) if not drawing pie chart
 								$yAxisDataObject->truncate($this->limit, $data_description->display_type!=='pie');
 
-								// now set the x labels from what we've done:
-								$this->_xAxisDataObject->setValues($yAxisDataObject->getXValues());
+								// now merge the x labels, if needed, from multiple datasets:
+								$mergedlabels = $yAxisDataObject->getXValues();
+								foreach( $mergedlabels as $idx => $label) {
+									if ($label === null) {
+										$tmp = $this->_xAxisDataObject->getValues();
+										$mergedlabels[$idx] = $tmp[$idx];
+									}
+								}
+								$this->_xAxisDataObject->setValues($mergedlabels);
 								$this->_xAxisDataObject->getCount(true);
 								$this->setXAxis( $x_axis, $font_size);
-
 								$dataSeriesSummarized = true;
 						}
 				} // summarizeDataseries


### PR DESCRIPTION
Aggregate dataset value labels are merged now, instead of being taken from last dataset added.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When dataseries is being truncated (Show Remainder is checked), new x axis labels are the result of merged values from all datasets plotted.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
This is a fix to the following behavior:
When multiple aggregate datasets are plotted, labels were derived from the last dataset added to the plot. If that dataset lacks any values, they are labeled improperly when Show Remainder is checked.

Bug was reported here:
https://app.asana.com/0/14787510600562/207594235757737

## Tests performed
Behavior was tested on multi-dataset plots that lacked data for one dataset, such as:
- SUPREMM avg cpu pct idle, by job size, filtered on: shared/exclusive and plotted as two datasets
- SUPREMM number of jobs finished, by Application, filtered on: shared/exclusive and plotted as two datasets.

Verified that:
- Toggling Show Remainder preserves all x axis labels, even when values are not represented in all datasets. 
- The change fixes behavior in all chart types (bar, line, spline, etc.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
