### PR TITLE
Create per-pipeline ETL locks

### DIFF
--- a/classes/ETL/EtlOverseerOptions.php
+++ b/classes/ETL/EtlOverseerOptions.php
@@ -57,6 +57,12 @@ class EtlOverseerOptions extends Loggable implements \Iterator
     // $includeOnlyResourceCodes
     private $excludeResourceCodes = array();
 
+    // Directory where lock files are stored
+    private $lockDir = null;
+
+    // Optional prefix for lock files
+    private $lockFilePrefix = null;
+
     // A mapping of resource codes to resource ids.
     private $resourceCodeToIdMap = array();
 
@@ -157,6 +163,12 @@ class EtlOverseerOptions extends Loggable implements \Iterator
                     break;
                 case 'start-date':
                     $this->setStartDate($value);
+                    break;
+                case 'lock-dir':
+                    $this->setLockDir($value);
+                    break;
+                case 'lock-file-prefix':
+                    $this->setLockFilePrefix($value);
                     break;
                 default:
                     break;
@@ -353,7 +365,7 @@ class EtlOverseerOptions extends Loggable implements \Iterator
 
     public function setNumberOfDays($numberOfDays)
     {
-        if ( ! is_numeric($numberOfDays) ) {
+        if ( null !== $numberOfDays && ! is_numeric($numberOfDays) ) {
             $msg = "Invalid number for number of days: '$numberOfDays'";
             $this->logAndThrowException($msg);
         }
@@ -483,6 +495,56 @@ class EtlOverseerOptions extends Loggable implements \Iterator
         $this->etlIntervalChunkSize = $days;
         return $this;
     }  // setChunkSize()
+
+    /* ------------------------------------------------------------------------------------------
+     * @return The directory where lock files are stored.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getLockDir()
+    {
+        return $this->lockDir;
+    }  // getLockDir()
+
+    /* ------------------------------------------------------------------------------------------
+     * Set the directory where lock files are stored.
+     *
+     * @param $dir The lock directory.
+     *
+     * @return This object to support method chaining.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function setLockDir($dir)
+    {
+        $this->lockDir = $dir;
+        return $this;
+    }  // setLockDir()
+
+    /* ------------------------------------------------------------------------------------------
+     * @return The optional prefix to use when creating lock files.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getLockFilePrefix()
+    {
+        return $this->lockFilePrefix;
+    }  // getLockFilePrefix()
+
+    /* ------------------------------------------------------------------------------------------
+     * Set the directory where lock files are stored.
+     *
+     * @param $dir The lock directory.
+     *
+     * @return This object to support method chaining.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function setLockFilePrefix($prefix)
+    {
+        $this->lockFilePrefix = $prefix;
+        return $this;
+    }  // setLockFilePrefix()
 
     /* ------------------------------------------------------------------------------------------
      * @return The value of the force flag

--- a/classes/ETL/LockFile.php
+++ b/classes/ETL/LockFile.php
@@ -1,0 +1,258 @@
+<?php
+
+/* ==========================================================================================
+ * Handling of ETL lock files. In order to allow multiple ETL processes to be run concurrently, the
+ * lock files are not solely pid-based, but also take into account the actions that are being
+ * executed. This allows multiple etl pipelines to be executed concurrently as long as the actions
+ * being performed do not overlap.
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ * @date 2016-12-19
+ * ==========================================================================================
+ */
+
+namespace ETL;
+
+use \Exception;
+use Log;
+
+class LockFile extends Loggable
+{
+    // Process ID of the current process
+    protected $pid = null;
+
+    // Directory where lock files are stored, read from the configuration file
+    protected $lockDir = null;
+
+    // Optional prefix for lock files, read from the configuration file
+    protected $lockFilePrefix = null;
+
+    /* ------------------------------------------------------------------------------------------
+     * Set the provided logger or instantiate a null logger if one was not provided.  The null handler
+     * consumes log events and does nothing with them.
+     *
+     * @param $logger A PEAR Log object or null to use the null logger.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function __construct($lockDir, $lockPrefix = null, Log $logger = null)
+    {
+        parent::__construct($logger);
+
+        if ( null === $lockDir || "" === $lockDir ) {
+            $lockDir = getcwd();
+            $msg = "Empty lock directory specified, using current directory '$lockDir'";
+            $this->logger->info($msg);
+        }
+
+        $this->lockDir = $lockDir;
+        $this->pid = getmypid();
+        $this->lockFilePrefix = $lockPrefix;
+
+        if ( ! is_dir($this->lockDir) ) {
+            $this->logger->info("Creating lock directory '" . $this->lockDir . "'");
+            if ( false === @mkdir($this->lockDir) ) {
+                $error = error_get_last();
+                $msg = "Error creating lock directory '" . $this->lockDir . "': " . $error['message'];
+                $this->logAndThrowException($msg);
+            }
+        }  // if ( ! is_dir($this->lockDir) )
+
+    }  // __construct()
+
+    /* ------------------------------------------------------------------------------------------
+     * Generate a lock file name.
+     *
+     * @param $pid An optional PID to use rather than the current PID
+     *
+     * @return A fully qualified path to the lock file.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function generateLockfileName($pid = null)
+    {
+        return sprintf(
+            '%s/%s%d',
+            $this->lockDir,
+            ( null !== $this->lockFilePrefix ? $this->lockFilePrefix : "" ),
+            ( null !== $pid ? $pid : $this->pid )
+        );
+    }  // generateLockfileName()
+
+    /* ------------------------------------------------------------------------------------------
+     * Check if the specified process is running.
+     *
+     * @param $pid PID to check
+     *
+     * @return TRUE if a process with the specified PID is is running, FALSE otherwise.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function isProcessRunning($pid = null)
+    {
+        $pid = ( null === $pid ? $this->pid : $pid );
+        $pidList = explode(PHP_EOL, shell_exec("ps -A | awk '{print $1}'"));
+
+        if ( in_array($pid, $pidList) ) {
+            return true;
+        }
+
+        return false;
+
+    }  // isProcessRunning()
+
+    /* ------------------------------------------------------------------------------------------
+     * Generate a lock file for the current process and action list. If any of the actions are
+     * present in any other lock files, we cannot generate the lock.
+     *
+     * @param $actionList An array of action names to be executed by this ETL process.
+     *
+     * @return TRUE if the lock was generated, FALSE otherwise.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function lock(array $actionList)
+    {
+        $lockFile = $this->generateLockfileName();
+
+        // Examine all existing lock files and make sure that no actions overlap existing processes.
+
+        if ( false === ($dh = opendir($this->lockDir)) ) {
+            $error = error_get_last();
+            $msg = "Error opening lock directory '" . $this->lockDir . "': " . $error['message'];
+            $this->logger->warning($msg);
+            return false;
+        }
+
+        while ( ($file = readdir($dh) ) !== false ) {
+            if ( '.' == $file || '..' == $file ) {
+                continue;
+            }
+
+            $file = $this->lockDir . '/' . $file;
+
+            // If the proecess is not running, remove this lock file and continue to the next.
+
+            if ( $this->_cleanup($file) ) {
+                continue;
+            }
+
+            $lockFileActionList = explode(PHP_EOL, file_get_contents($file));
+            $pid = array_shift($lockFileActionList);
+            $actionIntersection = array_intersect($lockFileActionList, $actionList);
+            if ( 0 != count($actionIntersection) ) {
+                $msg = "Cannot obtain lock. Process '$pid' already running and executing overlapping actions (" . implode(", ", $actionIntersection) . ")";
+                $this->logAndThrowException($msg);
+            }
+        }  // while ( ($file = readdir($dh) ) !== false )
+
+        closedir($dh);
+
+        $this->logger->info("Obtaining lock file '$lockFile'");
+
+        $contents = implode(PHP_EOL, array_merge(array($this->pid), $actionList));
+
+        if ( false === @file_put_contents($lockFile, $contents) ) {
+            $error = error_get_last();
+            $msg = "Error creating lock file '$lockFile': " . $error['message'];
+            $this->logger->warning($msg);
+            return false;
+        }
+
+        return true;
+
+    }  // lock()
+
+    /* ------------------------------------------------------------------------------------------
+     * Release the lock for the specified PID.
+     *
+     * @param $pid PID to check, NULL to use the PID of the current process.
+     *
+     * @return TRUE if the lock was released, FALSE otherwise.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function unlock($pid = null)
+    {
+        $lockFile = $this->generateLockfileName($pid);
+        $isRunning = $this->isProcessRunning($pid);
+
+        $pid = ( null === $pid ? $this->pid : $pid );
+
+        if ( file_exists($lockFile) ) {
+
+            if ( ! $isRunning ) {
+                $msg = "Process '$pid' is not running";
+                $this->logger->warning($msg);
+            }
+
+            $this->logger->info("Releasing lock '$lockFile'");
+
+            if ( false === @unlink($lockFile) ) {
+                $error = error_get_last();
+                $msg = "Error removing lock file '$lockFile': " . $error['message'];
+                $this->logger->warning($msg);
+                return false;
+            }
+
+        }  // if ( file_exists($lockFile) )
+
+        return true;
+
+    }  // unlock()
+
+    /* ------------------------------------------------------------------------------------------
+     * Clean up any lock files that do not have corresponding running processes.
+     *
+     * @return TRUE on success, FALSE if there was an error.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function cleanup()
+    {
+
+        if ( false === ($dh = opendir($this->lockDir)) ) {
+            $error = error_get_last();
+            $msg = "Error opening lock directory '" . $this->lockDir . "': " . $error['message'];
+            $this->logger->warning($msg);
+            return false;
+        }
+
+        while ( ($file = readdir($dh) ) !== false ) {
+            if ( '.' == $file || '..' == $file ) {
+                continue;
+            }
+            $file = $this->lockDir . '/' . $file;
+            $this->_cleanup($file);
+        } // while ( ($file = readdir($dh) ) !== false )
+
+        closedir($dh);
+
+        return true;
+
+    }  // cleanup()
+
+    /* ------------------------------------------------------------------------------------------
+     * Check that the process associated with the lock file is running, if not then clean up the
+     * lock file.
+     *
+     * @param $file Lock file to check
+     *
+     * @return TRUE if the lock was released, FALSE otherwise.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private function _cleanup($file)
+    {
+        $contents = explode(PHP_EOL, file_get_contents($file));
+        $pid = array_shift($contents);
+
+        if ( ! $this->isProcessRunning($pid) ) {
+            return $this->unlock($pid);
+        }
+
+        return false;
+
+    }  // _cleanup()
+
+}  // class Lockfile

--- a/classes/ETL/Maintenance.php
+++ b/classes/ETL/Maintenance.php
@@ -64,7 +64,7 @@ class Maintenance
         if ( class_exists($className) ) {
             $action = new $className($options, $etlConfig, $logger);
         } else {
-            $msg = __CLASS__ . ": Error creating ingestor '{$options->name}', class '$className' not found";
+            $msg = __CLASS__ . ": Error creating action '{$options->name}', class '$className' not found";
             if ( null !== $logger ) {
                 $logger->err($msg);
             }

--- a/classes/ETL/Maintenance/ExecuteSql.php
+++ b/classes/ETL/Maintenance/ExecuteSql.php
@@ -185,7 +185,8 @@ implements iAction
             'SOURCE_SCHEMA' => $sourceEndpoint->getSchema(),
             'DESTINATION_SCHEMA' => $destinationEndpoint->getSchema(),
             'START_DATE' =>  $destinationEndpoint->quote($etlOverseerOptions->getStartDate()),
-            'END_DATE' => $destinationEndpoint->quote($etlOverseerOptions->getEndDate())
+            'END_DATE' => $destinationEndpoint->quote($etlOverseerOptions->getEndDate()),
+            'LAST_MODIFIED' => $destinationEndpoint->quote($etlOverseerOptions->getLastModifiedStartDate())
             );
         $this->variableMap = array_merge($this->variableMap, $localVariableMap);
 
@@ -243,10 +244,10 @@ implements iAction
 
                 $this->logger->debug("Executing SQL: $sql");
                 $sqlStartTime = microtime(true);
-
+                $numRowsAffected = 0;
                 try {
                     if ( ! $this->etlOverseerOptions->isDryrun() ) {
-                        $destinationEndpoint->getHandle()->execute($sql);
+                        $numRowsAffected = $destinationEndpoint->getHandle()->execute($sql);
                     }
                 } catch ( PDOException $e ) {
                     $msg = "Error executing sql: " . $e->getMessage();
@@ -254,7 +255,7 @@ implements iAction
                 }
 
                 $time = microtime(true) - $sqlStartTime;
-                $this->logger->debug("Elapsed time: " . round($time, 5));
+                $this->logger->debug("Affected $numRowsAffected rows. Elapsed time: " . round($time, 5));
 
                 $numStatementsProcessed++;
 

--- a/classes/ETL/Maintenance/TestAction.php
+++ b/classes/ETL/Maintenance/TestAction.php
@@ -34,14 +34,6 @@ implements iAction
 
     public function execute(EtlOverseerOptions $etlOptions)
     {
-        // This should be made into a generic testing action that can
-        // 1. Sleep
-        // 2. Throw an exception
-        // 3. Echo a string
-        if ( ! isset($this->options->type) ) {
-            return true;
-        }
-
         if ( $etlOptions->isDryrun() ) {
             return;
         }

--- a/classes/ETL/Maintenance/TestAction.php
+++ b/classes/ETL/Maintenance/TestAction.php
@@ -1,0 +1,108 @@
+<?php
+/* ==========================================================================================
+ * Multi-use testing action that supports the following options:
+ *  - Sleep for a number of seconds
+ *  - Throw an exception
+ *  - Echo a string
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ * @date 2016-12-20
+ *
+ * @see iAction
+ * ==========================================================================================
+ */
+
+namespace ETL\Maintenance;
+
+use ETL\aOptions;
+use ETL\iAction;
+use ETL\aAction;
+use ETL\EtlConfiguration;
+use ETL\EtlOverseerOptions;
+use Log;
+
+class TestAction extends aAction
+implements iAction
+{
+    protected $options;
+    public function __construct(aOptions $options, EtlConfiguration $etlConfig, Log $logger = null)
+    {
+        $requiredKeys = array("type");
+        $this->verifyRequiredConfigKeys($requiredKeys, $options);
+        parent::__construct($options, $etlConfig, $logger);
+    }
+
+    public function execute(EtlOverseerOptions $etlOptions)
+    {
+        // This should be made into a generic testing action that can
+        // 1. Sleep
+        // 2. Throw an exception
+        // 3. Echo a string
+        if ( ! isset($this->options->type) ) {
+            return true;
+        }
+
+        if ( $etlOptions->isDryrun() ) {
+            return;
+        }
+
+        switch ($this->options->type) {
+
+            case 'sleep':
+                $sleepSeconds = ( isset($this->options->sleep_seconds) ? $this->options->sleep_seconds : 60 );
+                $this->logger->debug("Sleeping $sleepSeconds seconds");
+                sleep($sleepSeconds);
+                break;
+
+            case 'exception':
+                $msg = ( isset($this->options->exception_message) ? $this->options->exception_message : "" );
+                $this->logger->debug("Throwing exception");
+                $this->logAndThrowException($msg);
+                break;
+
+            case 'echo':
+                $msg = ( isset($this->options->echo_message) ? $this->options->echo_message : "" );
+                $this->logger->debug("Printing message '$msg'");
+                print "$msg\n";
+                break;
+
+            default:
+                $msg = "Unsupported type '" . $this->options->type . "'";
+                $this->logAndThrowException($msg);
+                break;
+        }
+
+        return true;
+    }
+
+    public function initialize()
+    {
+        return true;
+    }
+
+    public function verify(EtlOverseerOptions $etlConfig = null)
+    {
+        return true;
+    }
+
+    public function getName()
+    {
+        return $this->options->name;
+    }
+
+    public function getClass()
+    {
+        return $this->options->class;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function isVerified()
+    {
+        return true;
+    }
+
+}  // class TestAction

--- a/configuration/etl/etl.d/test_suite.json
+++ b/configuration/etl/etl.d/test_suite.json
@@ -1,0 +1,48 @@
+{
+    "defaults": {
+
+        "test-suite": {
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions"
+        }
+       
+    },
+
+    "test-suite": [
+        {
+            "name": "Sleep",
+            "class": "TestAction",
+            "type": "sleep",
+            "enabled": true
+        },
+        {
+            "name": "Sleep120",
+            "class": "TestAction",
+            "type": "sleep",
+            "sleep_seconds": 120,
+            "enabled": true
+        },
+        {
+            "name": "Exception",
+            "class": "TestAction",
+            "type": "exception",
+            "exception_message": "I'm throwing an exception!",
+            "enabled": true
+        },
+        {
+            "name": "ExceptionNoStop",
+            "class": "TestAction",
+            "type": "exception",
+            "exception_message": "I'm throwing an exception but not stopping ETL!",
+            "enabled": true,
+            "stop_on_exception": false
+        },
+        {
+            "name": "Echo",
+            "class": "TestAction",
+            "type": "echo",
+            "echo_message": "Test message",
+            "enabled": true
+        }
+    ]
+}

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -26,6 +26,8 @@ use ETL\Utilities;
 // ==========================================================================================
 // Script options with defaults
 
+// Allow initialization of some options from the configuration file
+
 $scriptOptions = array(
     // List of individual actions to execute
     'actions'           => array(),
@@ -59,6 +61,10 @@ $scriptOptions = array(
     'list-ingestors'    => false,
     // List available resources
     'list-resources'    => false,
+    // Directory for storing ETL lock files
+    'lock-dir'          => null,
+    // Optional ETL lock file prefix
+    'lock-file-prefix'  => null,
     // Previous number of days to ingest
     'number-of-days'    => null,
     // List of options to add to or override individual action options
@@ -73,6 +79,28 @@ $scriptOptions = array(
     'start-date'        => null,
     'verbosity'         => Log::NOTICE
     );
+
+// Override defaults with values from the configuration file, if there are any
+
+try {
+    $etlConfigOptions = \xd_utilities\getConfigurationSection("etl");
+
+    foreach ( $etlConfigOptions as $configKey => $configValue ) {
+
+        // Allow options to be separated with underscores or dashes
+        $dashKey = str_replace('_', '-', $configKey);
+
+        if ( array_key_exists($configKey, $scriptOptions) ) {
+            $scriptOptions[$configKey] = $configValue;
+        } else if ( array_key_exists($dashKey, $scriptOptions) ) {
+            $scriptOptions[$dashKey] = $configValue;
+        }
+    }  // foreach ( $etlConfigOptions as $configkey => $configValue )
+
+} catch ( Exception $e ) {
+    // Simply ignore the exception if there is no [etl] section in the config file
+    continue;
+}
 
 $showList = false;
 
@@ -98,7 +126,9 @@ $options = array(
     't'   => 'dryrun',
     'v:'  => 'verbosity:',
     'x:'  => 'exclude-resource-codes:',
-    'y:'  => 'last-modified-end-date:'
+    'y:'  => 'last-modified-end-date:',
+    ''    => 'lock-dir',
+    ''    => 'lock-file-prefix'
     );
 
 $args = getopt(implode('', array_keys($options)), $options);
@@ -264,6 +294,14 @@ foreach ($args as $arg => $value) {
         $scriptOptions['last-modified-end-date'] = $value;
         break;
 
+    case 'lock-dir':
+        $scriptOptions['lock-dir'] = $value;
+        break;
+
+    case 'lock-preifx':
+        $scriptOptions['lock-prefix'] = $value;
+        break;
+
     case 'h':
     case 'help':
         usage_and_exit();
@@ -295,9 +333,11 @@ foreach ( $argv as $index => $arg ) {
     }
 }
 
-if ( null === $scriptOptions['start-date'] &&
-     null === $scriptOptions['end-date'] &&
-     null === $scriptOptions['number-of-days'] ) {
+if ( ! $showList &&
+     ( null === $scriptOptions['start-date'] &&
+       null === $scriptOptions['end-date'] &&
+       null === $scriptOptions['number-of-days']) )
+{
     usage_and_exit("Must provide start/end date or number of days");
 }
 
@@ -545,13 +585,12 @@ if ( count($scriptOptions['process-sections']) == 0 &&
 // ------------------------------------------------------------------------------------------
 // Create the overseer and perform the requested operations for each date interval
 
-$overseer = new EtlOverseer($overseerOptions);
+$overseer = new EtlOverseer($overseerOptions, $logger);
 if ( ! ($overseer instanceof iEtlOverseer ) )
 {
     $msg = "EtlOverseer is not an instance of iEtlOverseer";
     exit($msg);
 }
-$overseer->setLogger($logger);
 
 try {
     $logger->notice(array('message'         => 'ETL time period',


### PR DESCRIPTION
ETLv2 allows multiple ETL processes to be run concurrently but concurrent executions should not include the same action. To support this, lock files are not solely pid-based but also take into account the names of the actions that are being executed. This allows multiple ETL pipelines to be executed concurrently as long as the actions being performed do not overlap.

## Description

A new `ETL\LockFile` class supports a lock file that contains a PID as well as a unique list of actions to be executed by that process. Prior to obtaining a lock, all ETLv2 lock files are checked to make sure that no running process is executing an action that overlaps the new process. Orphaned files are also cleaned up at this point. Note that a prefix (default of `etlv2_`) is required to identify ETLv2 lock files since multiple processes can run concurrently.

The ETL overseer script now supports `--lock-dir` and `--lock-file-prefix` options. In addition, a new `etl` section in the portal_settings.ini allows any option available as a command-line argument to be set (command-line options override portal_settings.ini values). For example:
```
[etl]
lock_dir = '/var/lock/xdmod'
lock_file_prefix = 'etlv2_'
```

Also implemented `ETL\Maintenance\TestAction` to facilitate testing. This action allows one of the following operations to be specified: **sleep** a number of seconds, throw an **exception** (helps test exception handling including the configurable behavior of continuing or stopping on an exception), **echo** a string. Additional test actions can be added as needed.

## Motivation and Context

Allow parallel ETLv2 pipelines but facilitate identification of possible conflicts, especially when automated.

## Tests performed

Tested various configurations:
1. Single pipeline
2. Multiple pipelines with no intersecting actions (both pipelines run)
3. Multiple pipelines with intersection actions (2nd pipeline aborts)
4. Orphaned lock files left by old processes (lock files are cleaned up)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
