### PR TITLE
Save the pi/group as the account and allocation charge number

### DIFF
--- a/classes/OpenXdmod/Ingestor/Hpcdb/Accounts.php
+++ b/classes/OpenXdmod/Ingestor/Hpcdb/Accounts.php
@@ -15,7 +15,7 @@ class Accounts extends PDODBMultiIngestor
             "
                 SELECT
                     account_id   AS id,
-                    ''           AS charge_number,
+                    account_name AS charge_number,
                     -1           AS granttype_id,
                     account_name AS short_name,
                     account_name AS long_name

--- a/classes/OpenXdmod/Ingestor/Hpcdb/Allocations.php
+++ b/classes/OpenXdmod/Ingestor/Hpcdb/Allocations.php
@@ -19,7 +19,8 @@ class Allocations extends PDODBMultiIngestor
                     al.account_id,
                     req.request_id,
                     pi.person_id AS principalinvestigator_person_id,
-                    req.primary_fos_id AS fos_id
+                    req.primary_fos_id AS fos_id,
+                    acc.account_name AS charge_number
                 FROM hpcdb_allocations al
                 JOIN hpcdb_accounts acc
                     ON al.account_id = acc.account_id


### PR DESCRIPTION
In Open XDMoD, save the PI group or accounting group of a job as the charge number in the account and allocation tables.

## Description

To help support allocations in Open XDMoD, save the job's PI or accounting group as the charge number in the  allocations and accounts tables. Initially, sites can then run a post-ingest ETL action to update the allocation values. In the case of SDSC this will allow them to send the same data that is sent to the XDCDB into their Open XDMoD instance. **Display of allocations data in Open XDMoD is not currently supported, but planned for the future.**

## Motivation and Context

Provide support for allocations at SDSC. If the allocations are included in the modw.allocations table then a post-ingest process can update the initial and remaining allocation values.

## Tests performed

The following steps were performed:
1. Build an Open XDMoD RPM based on the new code branch
2. Install and configure this RPM on a cloud instance (xdmod-setup)
3. Ingest 2 months of debug partition data (sacct, xdmod-shredder, xdmod-ingestor)
4. Verify that `modw.accounts` and `modw.allocations` contain the PI group and that the number of distinct group names/charge numbers is the same in these 2 tables and the `modw.jobfact` table (with the addition of the "Unknown" account).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
