### PR TITLE
fix case error in documentation link

### DIFF
--- a/docs/simpleSAMLphp-ldap.md
+++ b/docs/simpleSAMLphp-ldap.md
@@ -6,7 +6,7 @@ For XDMoD to authenticate against LDAP XDMoD has to be set up as an IDP.
 
 *Note: For this example we are going to use the [ForumSystems Online LDAP Test Server][forumsys-ldap] You will need to change settings to your ldap as appropriate*
 
-Make sure you have read and setup [OpenXDMoD for SimpleSAML](simplesamlphp.html).
+Make sure you have read and setup [OpenXDMoD for SimpleSAML](simpleSAMLphp.html).
 More information on [SimpleSAMLphp LDAP][ssp-ldap].
 
 


### PR DESCRIPTION
## Description
Fix an error in the link for documentation

## Motivation and Context
Make documentation links work

## Tests performed
used `bundler` and `jekyll serve` to run local server to verify documentation output

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
