### PR TITLE
fix notices in xdsamlauth

### DIFF
--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -113,10 +113,10 @@ class XDSamlAuthentication
             $orgDisplay = "";
             $icon = "";
             foreach ($idpAuth as $idp) {
-                if ($idp['OrganizationDisplayName']) {
+                if (array_key_exists('OrganizationDisplayName', $idp) && !empty($idp['OrganizationDisplayName'])) {
                     $orgDisplay = $idp['OrganizationDisplayName'];
                 }
-                if ($idp['icon']) {
+                if (array_key_exists('icon', $idp) && !empty($idp['icon'])) {
                     $icon = $idp['icon'];
                 }
             }

--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -113,10 +113,10 @@ class XDSamlAuthentication
             $orgDisplay = "";
             $icon = "";
             foreach ($idpAuth as $idp) {
-                if (array_key_exists('OrganizationDisplayName', $idp) && !empty($idp['OrganizationDisplayName'])) {
+                if (!empty($idp['OrganizationDisplayName'])) {
                     $orgDisplay = $idp['OrganizationDisplayName'];
                 }
-                if (array_key_exists('icon', $idp) && !empty($idp['icon'])) {
+                if (!empty($idp['icon'])) {
                     $icon = $idp['icon'];
                 }
             }


### PR DESCRIPTION
## Description
notices are thrown if the idp does not have the right indexes

## Motivation and Context
Dont want to throw notices if they are not needed

## Tests performed
Verified that the notices were no longer shown when display_errors = On in php.ini

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
