### PR TITLE
Remove rounding from processor count statistic classes

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageProcessorCountStatistic.php
@@ -13,7 +13,7 @@ class AverageProcessorCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
 	public function __construct($query_instance = NULL)
 	{
 		$job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-		parent::__construct('coalesce(ceil(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.')),0)', 'avg_processors', 'Job Size: Per Job', 'Core Count',1);
+		parent::__construct('coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.'),0)', 'avg_processors', 'Job Size: Per Job', 'Core Count',1);
 	}
 
 	public function getInfo()

--- a/classes/DataWarehouse/Query/Jobs/Statistics/MaxProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/MaxProcessorCountStatistic.php
@@ -12,7 +12,7 @@ class MaxProcessorCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
 	public function __construct($query_instance = NULL)
 	{
-		parent::__construct('coalesce(ceil(max(jf.processors)),0)', 'max_processors', 'Job Size: Max', 'Core Count',0);
+		parent::__construct('coalesce(max(jf.processors),0)', 'max_processors', 'Job Size: Max', 'Core Count',0);
 	}
 
 	public function getInfo()

--- a/classes/DataWarehouse/Query/Jobs/Statistics/MinProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/MinProcessorCountStatistic.php
@@ -12,7 +12,7 @@ class MinProcessorCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
 	public function __construct($query_instance = NULL)
 	{
-		parent::__construct('coalesce(ceil(min(case when jf.processors = 0 then null else jf.processors end)),0)', 'min_processors', 'Job Size: Min', 'Core Count',0);
+		parent::__construct('coalesce(min(case when jf.processors = 0 then null else jf.processors end),0)', 'min_processors', 'Job Size: Min', 'Core Count',0);
 		$this->setOrderByStat(SORT_DESC);
 	}
 	public function getInfo()

--- a/classes/DataWarehouse/Query/Jobs/Statistics/NormalizedAverageProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/NormalizedAverageProcessorCountStatistic.php
@@ -13,7 +13,7 @@ class NormalizedAverageProcessorCountStatistic extends \DataWarehouse\Query\Jobs
 	public function __construct($query_instance = NULL)
 	{
 		$job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-		parent::__construct('100.0*coalesce(ceil(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.'))/(select sum(rrf.processors) from modw.resourcespecs rrf where find_in_set(rrf.resource_id,group_concat(distinct jf.resource_id)) <> 0 and '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts >= rrf.start_date_ts and (rrf.end_date_ts is null or '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts <= rrf.end_date_ts)),0)', 'normalized_avg_processors', 'Job Size: Normalized', '% of Total Cores',1);
+		parent::__construct('100.0*coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.')/(select sum(rrf.processors) from modw.resourcespecs rrf where find_in_set(rrf.resource_id,group_concat(distinct jf.resource_id)) <> 0 and '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts >= rrf.start_date_ts and (rrf.end_date_ts is null or '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts <= rrf.end_date_ts)),0)', 'normalized_avg_processors', 'Job Size: Normalized', '% of Total Cores',1);
 	}
 
 	public function getInfo()


### PR DESCRIPTION
## Description

Removes use of the `CEIL` function in SQL for processor count statistics.

## Motivation and Context

The average processor count values are displayed as decimals in the chart tooltips (as well as value labels, etc.).  This would imply that the precision of these numbers is higher than what is being returned from the data warehouse.  While the maximum and minimum processor counts are expected to be integers, it is reasonable to have non-integer (average) job size (core counts).

## Tests performed

Viewed usage tab charts for the altered statistics and observed the now non-integer values.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
