### PR TITLE
Prevent errors when previewing a report

### DIFF
--- a/html/gui/js/report_builder/ReportCreator.js
+++ b/html/gui/js/report_builder/ReportCreator.js
@@ -585,6 +585,22 @@ XDMoD.ReportCreator = Ext.extend(Ext.form.FormPanel, {
         };
 
         var previewReport = function () {
+            if (self.getReportID().length == 0) {
+                CCR.xdmod.ui.reportGeneratorMessage(
+                    'Report Editor',
+                    'You must save this report before you can preview it.'
+                );
+                return;
+            }
+
+            if (self.isDirty()) {
+                CCR.xdmod.ui.reportGeneratorMessage(
+                    'Report Editor',
+                    'You have made changes to this report which you must save before previewing.'
+                );
+                return;
+            }
+
             if (self.reportCharts.reportStore.data.length == 0) {
                 CCR.xdmod.ui.reportGeneratorMessage(
                     'Report Editor',


### PR DESCRIPTION
## Description

Adds additional checks when an attempt is made to preview a report.

## Motivation and Context

Currently, when a user attempts to preview a report that has not been saved they will be presented with what appears to be a report filled with errors.  This change prevents that behavior and instead presents a friendlier message that is consistent with those displayed when an attempt is made to either download or email an unsaved report.

## Tests performed

Created a report and attempted to preview it without first saving it.  Observed new error message.  Saved and then successfully previewed the report.  Altered the report and again attempted to preview before saving.  Observed new error message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
