### PR TITLE
Update rules to exclude restrictions on control structure indentation.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,6 +18,7 @@
       <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
       <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
       <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpenBrace" />
+      <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
   </rule>
   <rule ref="Generic.Files.LineLength">
       <properties>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,28 @@
 <?xml version="1.0"?>
 <ruleset name="XDMoD Standard">
   <description>XDMoD PHP coding standard</description>
-  <rule ref="PSR1"/>
-  <rule ref="PSR2"/>
+  <rule ref="PSR1">?
+      <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+  </rule>
+  <rule ref="PSR2">
+      <exclude name="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket" />
+      <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
+      <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace" />
+      <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
+      <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine" />
+      <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
+      <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis" />
+      <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword" />
+      <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceAfterOpen" />
+      <exclude name="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose" />
+      <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose" />
+      <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen" />
+      <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpenBrace" />
+  </rule>
+  <rule ref="Generic.Files.LineLength">
+      <properties>
+          <property name="lineLimit" value="512"/>
+          <property name="absoluteLineLimit" value="0"/>
+      </properties>
+  </rule>
 </ruleset>


### PR DESCRIPTION
Relax the phpcs rules so that it does not disallow perfectly reasonably indented code.

## Motivation and Context
Forcing a clurly brace on one line vs the next does not result in a big improvement to the code quality, but it does result in a onerous burden on the developers. This change relaxes these types of rules.

## Tests performed
Ran phpcs on the code with the new ruleset.
