### PR TITLE
Improve ETL JSON data endpoint filter logging

### DIFF
--- a/classes/ETL/DataEndpoint/JsonFile.php
+++ b/classes/ETL/DataEndpoint/JsonFile.php
@@ -78,12 +78,17 @@ implements iDataEndpoint
                 $this->logAndThrowException("No valid filter options specified for '{$this->path}'.");
             }
 
-            // Run the filter process.
-            $filterProc = ProcessBuilder::create($filterProcArgs)->getProcess();
+            try {
+                // Run the filter process.
+                $filterProc = ProcessBuilder::create($filterProcArgs)->getProcess();
 
-            $filterProc->run();
-            if (! $filterProc->isSuccessful()) {
-                $this->logAndThrowException('Filter Error: ' . $filterProc->getErrorOutput());
+                $filterProc->run();
+                if (! $filterProc->isSuccessful()) {
+                    $this->logAndThrowException('Filter Error: ' . $filterProc->getErrorOutput());
+                }
+            } catch (Exception $e) {
+                $msg = "Filter Error (" . implode(", ", $filterProcArgs) . "): " . $e->getMessage();
+                $this->logAndThrowException($msg);
             }
 
             // Parse the filter process's output.

--- a/classes/ETL/DataEndpoint/JsonFile.php
+++ b/classes/ETL/DataEndpoint/JsonFile.php
@@ -15,8 +15,7 @@ use \Log;
 use JsonSchema\Validator;
 use Symfony\Component\Process\ProcessBuilder;
 
-class JsonFile extends StructuredFile
-implements iDataEndpoint
+class JsonFile extends StructuredFile implements iDataEndpoint
 {
     /**
      * A JSON Schema describing each element in an array-based JSON file.
@@ -193,36 +192,36 @@ implements iDataEndpoint
         $message = "";
 
         switch ( $errorCode ) {
-        case JSON_ERROR_NONE:
-            $message = "No error has occurred";
-            break;
-        case JSON_ERROR_DEPTH:
-            $message = "The maximum stack depth has been exceeded";
-            break;
-        case JSON_ERROR_STATE_MISMATCH:
-            $message = "Invalid or malformed JSON";
-            break;
-        case JSON_ERROR_CTRL_CHAR:
-            $message = "  Control character error, possibly incorrectly encoded";
-            break;
-        case JSON_ERROR_SYNTAX:
-            $message = "Syntax error";
-            break;
-        case JSON_ERROR_UTF8:
-            $message = "Malformed UTF-8 characters, possibly incorrectly encoded";
-            break;
-        case JSON_ERROR_RECURSION:
-            $message = "One or more recursive references in the value to be encoded";
-            break;
-        case JSON_ERROR_INF_OR_NAN:
-            $message = "One or more NAN or INF values in the value to be encoded";
-            break;
-        case JSON_ERROR_UNSUPPORTED_TYPE:
-            $message = "A value of a type that cannot be encoded was given";
-            break;
-        default:
-            $message = "Unknown error";
-            break;
+            case JSON_ERROR_NONE:
+                $message = "No error has occurred";
+                break;
+            case JSON_ERROR_DEPTH:
+                $message = "The maximum stack depth has been exceeded";
+                break;
+            case JSON_ERROR_STATE_MISMATCH:
+                $message = "Invalid or malformed JSON";
+                break;
+            case JSON_ERROR_CTRL_CHAR:
+                $message = "  Control character error, possibly incorrectly encoded";
+                break;
+            case JSON_ERROR_SYNTAX:
+                $message = "Syntax error";
+                break;
+            case JSON_ERROR_UTF8:
+                $message = "Malformed UTF-8 characters, possibly incorrectly encoded";
+                break;
+            case JSON_ERROR_RECURSION:
+                $message = "One or more recursive references in the value to be encoded";
+                break;
+            case JSON_ERROR_INF_OR_NAN:
+                $message = "One or more NAN or INF values in the value to be encoded";
+                break;
+            case JSON_ERROR_UNSUPPORTED_TYPE:
+                $message = "A value of a type that cannot be encoded was given";
+                break;
+            default:
+                $message = "Unknown error";
+                break;
         }
 
         return $message;


### PR DESCRIPTION
Wrap JSON ETL DataEndpoint filter execution in try/catch block for improved error logging.

## Description
Wrap JSON ETL DataEndpoint filter execution in try/catch block for improved error logging. Also fix phpcs warnings.

## Motivation and Context
Improved logging

## Tests performed
Provided the patch to IU for testing on their system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
