### PR TITLE
Travis: Manually update Composer when automatic update fails

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -7,6 +7,16 @@ if "$using_php_533"; then
     echo "Using newer version of PHP for installing dependencies"
     phpenv global 5.3
     php --version
+
+    # Update Composer since the attempt made by the Travis setup script
+    # using PHP 5.3.3 would have failed.
+    #
+    # First, we update to the latest developer version since the version
+    # of Composer pre-installed on Travis systems (1.0.0) doesn't support
+    # selecting an update channel. Then, we use this version to rollback to
+    # the latest stable version.
+    composer self-update
+    composer self-update --stable
 fi
 
 # Install Composer dependencies.


### PR DESCRIPTION
## Description
This pull request fixes a case where Travis CI was not updating Composer to the latest stable version, causing builds with newer Composer config files to fail.

## Motivation and Context
When Travis attempts to automatically update Composer to the latest version while using PHP 5.3.3, it fails because of SSL issues with Travis systems using PHP 5.3.3. This meant that tests were done using the pre-installed version of Composer, 1.0.0. This now presents a problem, as newer versions of Composer have introduced backwards-incompatible changes to the lock file format.

## Tests performed
I ran the updated Travis scripts with pushes on my fork. The results may be found [here](https://travis-ci.org/tyearke/xdmod/builds/193842715).

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
