### PR TITLE
Fix ETLv2 Query group-by generation

### DIFF
--- a/classes/ETL/DbEntity/Query.php
+++ b/classes/ETL/DbEntity/Query.php
@@ -794,7 +794,7 @@ class Query extends aNamedEntity
             implode(",\n", $columnList) . "\n" .
             implode("\n", $joinList) . "\n" .
             ( count($whereConditions) > 0 ? "WHERE " . implode("\nAND ", $whereConditions) . "\n" : "" ) .
-            ( count($this->orderBys) > 0 ? "ORDER BY " . implode(", ", $this->orderBys) : "" );
+            ( count($this->orderBys) > 0 ? "ORDER BY " . implode(", ", $this->orderBys) : "" ) .
             ( count($this->groupBys) > 0 ? "GROUP BY " . implode(", ", $this->groupBys) : "" );
 
         // If any macros have been defined, process those macros now. Since macros can contain variables

--- a/classes/ETL/DbEntity/Query.php
+++ b/classes/ETL/DbEntity/Query.php
@@ -794,8 +794,8 @@ class Query extends aNamedEntity
             implode(",\n", $columnList) . "\n" .
             implode("\n", $joinList) . "\n" .
             ( count($whereConditions) > 0 ? "WHERE " . implode("\nAND ", $whereConditions) . "\n" : "" ) .
-            ( count($this->orderBys) > 0 ? "ORDER BY " . implode(", ", $this->orderBys) : "" ) .
-            ( count($this->groupBys) > 0 ? "GROUP BY " . implode(", ", $this->groupBys) : "" );
+            ( count($this->groupBys) > 0 ? "GROUP BY " . implode(", ", $this->groupBys) : "" ) .
+            ( count($this->orderBys) > 0 ? "ORDER BY " . implode(", ", $this->orderBys) : "" );
 
         // If any macros have been defined, process those macros now. Since macros can contain variables
         // themselves, we will process the variables later.


### PR DESCRIPTION
Fix ETLv2 Query group-by generation

## Description

Add concatenation operator to include group-by in generated queries.

## Motivation and Context

bugfix

## Tests performed

Re-tested query generation and verified group by is incorrect before fix and in place after fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
