### PR TITLE
Allow comments in queries to contain characters after #

### DIFF
--- a/classes/ETL/DbEntity/Column.php
+++ b/classes/ETL/DbEntity/Column.php
@@ -70,7 +70,7 @@ implements iTableItem
         }
 
         foreach ( $config as $property => $value ) {
-            if ( '#' == $property ) {
+            if ( $this->isComment($property) ) {
                 continue;
             }
 

--- a/classes/ETL/DbEntity/Join.php
+++ b/classes/ETL/DbEntity/Join.php
@@ -63,7 +63,7 @@ implements iTableItem
         }
 
         foreach ( $config as $property => $value ) {
-            if ( '#' == $property ) {
+            if ( $this->isComment($property) ) {
                 continue;
             }
 

--- a/classes/ETL/DbEntity/Query.php
+++ b/classes/ETL/DbEntity/Query.php
@@ -745,7 +745,7 @@ class Query extends aNamedEntity
         $columnList = array();
         $thisObj = $this;
         foreach ( $this->records as $columnName => $formula ) {
-            if ( "#" == $columnName ) {
+            if ( $this->isComment($columnName) ) {
                 continue;
             }
 

--- a/classes/ETL/DbEntity/Trigger.php
+++ b/classes/ETL/DbEntity/Trigger.php
@@ -43,7 +43,7 @@ implements iTableItem
     public function __construct($config, $systemQuoteChar = null, Log $logger = null)
     {
         parent::__construct($systemQuoteChar, $logger);
-    
+
         if ( ! is_object($config) ) {
             $msg = __CLASS__ . ": Argument is not an object";
             $this->logAndThrowException($msg);
@@ -68,7 +68,7 @@ implements iTableItem
         }
 
         foreach ( $config as $property => $value ) {
-            if ( '#' == $property ) {
+            if ( $this->isComment($property) ) {
                 continue;
             }
 
@@ -78,13 +78,13 @@ implements iTableItem
             }
 
             $this->$property = $value;
-      
+
         }  // foreach ( $config as $property => $value )
 
         $this->initialized = true;
 
     }  // initialize()
- 
+
     /* ------------------------------------------------------------------------------------------
      * @return The time that the trigger will fire, null if not specified
      * ------------------------------------------------------------------------------------------
@@ -94,7 +94,7 @@ implements iTableItem
     {
         return $this->time;
     }  // getTime()
-  
+
     /* ------------------------------------------------------------------------------------------
      * @return The trigger event, null if not specified
      * ------------------------------------------------------------------------------------------
@@ -104,7 +104,7 @@ implements iTableItem
     {
         return $this->event;
     }  // getEvent()
-  
+
     /* ------------------------------------------------------------------------------------------
      * @return The table that the trigger is associated with, null if not specified
      * ------------------------------------------------------------------------------------------
@@ -114,7 +114,7 @@ implements iTableItem
     {
         return $this->table;
     }  // getTable()
-  
+
     /* ------------------------------------------------------------------------------------------
      * @return The trigger body, null if not specified
      * ------------------------------------------------------------------------------------------
@@ -124,7 +124,7 @@ implements iTableItem
     {
         return $this->body;
     }  // getBody()
-  
+
     /* ------------------------------------------------------------------------------------------
      * @return The trigger definer, null if not specified
      * ------------------------------------------------------------------------------------------
@@ -134,7 +134,7 @@ implements iTableItem
     {
         return $this->definer;
     }  // getDefiner()
-  
+
     /* ------------------------------------------------------------------------------------------
      * @see iTableItem::compare()
      * ------------------------------------------------------------------------------------------

--- a/classes/ETL/DbEntity/aNamedEntity.php
+++ b/classes/ETL/DbEntity/aNamedEntity.php
@@ -27,6 +27,9 @@ abstract class aNamedEntity extends aEtlObject
 
     protected $systemQuoteChar = '`';
 
+    // Keys starting with this character are considered comments
+    const COMMENT_KEY = "#";
+
     /* ------------------------------------------------------------------------------------------
      * Construct a database entity object from a JSON definition file or a definition object.
      *
@@ -158,5 +161,19 @@ abstract class aNamedEntity extends aEtlObject
     {
         return $this->systemQuoteChar . $identifier . $this->systemQuoteChar;
     }  // quote()
+
+    /* ------------------------------------------------------------------------------------------
+     * Identify commented out keys in JSON definition/specification files.
+     *
+     * @param $key The string to examine
+     *
+     * @return TRUE if the key is considered a comment, FALSE otherwise.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function isComment($key)
+    {
+        return ( 0 === strpos($key, self::COMMENT_KEY) );
+    }  // isComment()
 
 }  // abstract class aNamedEntity


### PR DESCRIPTION
Allow comments in queries to contain characters after #

## Description
Comments in JSON files are defined as any key starting with "#". This enables the same behavior in ETL query definitions (previously only a "#" was allowed and not "# name" for example).

## Motivation and Context
Improve ETL inline documentation and testing workflow.

## Tests performed
Tested with "#" and "# name" as comments, verified results are correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
