### PR TITLE
Improve aggregation bind params

### DIFF
--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -159,7 +159,7 @@ class pdoAggregator extends aAggregator
         if ( null === $this->etlSourceQuery ) {
             $msg = "ETL source query is not set";
             $this->logAndThrowException($msg);
-        } else if ( ! $this->etlSourceQuery instanceof Query ) {
+        } elseif ( ! $this->etlSourceQuery instanceof Query ) {
             $msg = "ETL source query is not an instance of Query";
             $this->logAndThrowException($msg);
         }
@@ -235,9 +235,11 @@ class pdoAggregator extends aAggregator
         }
 
         $this->logger->debug("Create ETL destination aggregation table object");
-        $this->etlDestinationTable = new AggregationTable($this->parsedDefinitionFile->table_definition,
-                                                          $this->destinationEndpoint->getSystemQuoteChar(),
-                                                          $this->logger);
+        $this->etlDestinationTable = new AggregationTable(
+            $this->parsedDefinitionFile->table_definition,
+            $this->destinationEndpoint->getSystemQuoteChar(),
+            $this->logger
+        );
         $this->etlDestinationTable->setSchema($this->destinationEndpoint->getSchema());
 
         if ( isset($this->options->table_prefix) &&
@@ -266,8 +268,10 @@ class pdoAggregator extends aAggregator
             }
 
             $this->logger->debug("Create ETL source query object");
-            $this->etlSourceQuery = new Query($this->parsedDefinitionFile->source_query,
-                                              $this->sourceEndpoint->getSystemQuoteChar());
+            $this->etlSourceQuery = new Query(
+                $this->parsedDefinitionFile->source_query,
+                $this->sourceEndpoint->getSystemQuoteChar()
+            );
         }  // ( null === $this->etlSourceQuery )
 
         // --------------------------------------------------------------------------------
@@ -297,7 +301,7 @@ class pdoAggregator extends aAggregator
             ':PERIOD_START_DAY_ID' => ":period_start_day_id",
             // The day_id of the end of this period
             ':PERIOD_END_DAY_ID' => ":period_end_day_id"
-            );
+        );
 
         $this->variableMap = array_merge($this->variableMap, $parameters);
 
@@ -570,41 +574,41 @@ class pdoAggregator extends aAggregator
         $endDayIdToUnitId = null;
 
         switch ( $aggregationUnit ) {
-        case 'day':
-            // No conversion needed
-            $unitIdToStartDayId = "d.id";
-            $unitIdToEndDayId = "d.id";
-            $startDayIdToUnitId = $startDayIdField;
-            $endDayIdToUnitId = $endDayIdField;
-            break;
-        case 'month':
-            $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-', d.`month`, '-01'))";
-            $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-', d.`month`, '-01'), interval 1 month), interval 1 day))";
-            $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
-                . "MONTH(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
-            $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
-                . "MONTH(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
-            break;
-        case 'quarter':
-            $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(date_add(concat(d.`year`, '-01-01'), interval (d.`quarter` - 1) quarter))";
-            $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval d.`quarter` quarter), interval 1 day))";
-            $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
-                . "QUARTER(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
-            $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
-                . "QUARTER(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
-            break;
-        case 'year':
-            $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-01-01'))";
-            $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval 1 year), interval 1 day))";
-            $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000";
-            $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000";
-            break;
-        default:
-            // We should never get here because we are verifying the existance of the aggregation
-            // unit tables in performPreAggregationUnitTasks.
-            $msg = "Unsupported aggregation unit '$aggregationUnit'";
-            $this->logAndThrowException($msg);
-            break;
+            case 'day':
+                // No conversion needed
+                $unitIdToStartDayId = "d.id";
+                $unitIdToEndDayId = "d.id";
+                $startDayIdToUnitId = $startDayIdField;
+                $endDayIdToUnitId = $endDayIdField;
+                break;
+            case 'month':
+                $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-', d.`month`, '-01'))";
+                $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-', d.`month`, '-01'), interval 1 month), interval 1 day))";
+                $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
+                    . "MONTH(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
+                $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
+                    . "MONTH(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
+                break;
+            case 'quarter':
+                $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(date_add(concat(d.`year`, '-01-01'), interval (d.`quarter` - 1) quarter))";
+                $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval d.`quarter` quarter), interval 1 day))";
+                $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
+                    . "QUARTER(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
+                $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
+                    . "QUARTER(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
+                break;
+            case 'year':
+                $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-01-01'))";
+                $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval 1 year), interval 1 day))";
+                $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000";
+                $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000";
+                break;
+            default:
+                // We should never get here because we are verifying the existance of the aggregation
+                // unit tables in performPreAggregationUnitTasks.
+                $msg = "Unsupported aggregation unit '$aggregationUnit'";
+                $this->logAndThrowException($msg);
+                break;
         }  // switch ( $aggregationUnit )
 
         if ( $this->etlOverseerOptions->isForce() ) {
@@ -656,7 +660,7 @@ class pdoAggregator extends aAggregator
                 $query->overseer_restrictions = $aggregationPeriodQueryOptions->overseer_restrictions;
             } else {
                 $msg = "No restrictions on selection of periods to aggregate. "
-                     . "Re-aggregating all records in " . $sourceSchema . "." . $tableName;
+                    . "Re-aggregating all records in " . $sourceSchema . "." . $tableName;
                 $this->logger->notice($msg);
             }
 
@@ -784,7 +788,7 @@ class pdoAggregator extends aAggregator
             }
             $this->etlSourceQueryModified = true;
 
-        } else if ( ! $enableBatchAggregation && $this->etlSourceQueryModified ) {
+        } elseif ( ! $enableBatchAggregation && $this->etlSourceQueryModified ) {
 
             $this->logger->info("[EXPERIMENTAL] Restore original first table");
 
@@ -876,7 +880,8 @@ class pdoAggregator extends aAggregator
                 $selectStmt,
                 $insertStmt,
                 $discoveredBindParams,
-                $numAggregationPeriods);
+                $numAggregationPeriods
+            );
 
         } else {
 
@@ -970,7 +975,7 @@ class pdoAggregator extends aAggregator
 
                     $availableParamValues = array_map(
                         function ($k, $first, $last) {
-                            if ( FALSE !== strpos($k, '_end') || FALSE !== strpos($k, 'end_') ) {
+                            if ( false !== strpos($k, '_end') || false !== strpos($k, 'end_') ) {
                                 return $first;
                             } else {
                                 return $last;
@@ -978,7 +983,8 @@ class pdoAggregator extends aAggregator
                         },
                         array_keys($firstSlice),
                         $firstSlice,
-                        $lastSlice);
+                        $lastSlice
+                    );
 
                     $availableParams = array_combine($availableParamKeys, $availableParamValues);
 
@@ -1006,7 +1012,8 @@ class pdoAggregator extends aAggregator
                     $insertStmt,
                     $discoveredBindParams,
                     $numAggregationPeriods,
-                    $aggregationPeriodListOffset);
+                    $aggregationPeriodListOffset
+                );
 
                 $this->logger->info(
                     "[EXPERIMENTAL] Total time for batch (day_id $minDayId - $maxDayId): "
@@ -1038,7 +1045,7 @@ class pdoAggregator extends aAggregator
                                     "start_time"   => $time_start,
                                     "end_time"     => $time_end,
                                     "elapsed_time" => round($time, 5)
-                                  ));
+        ));
 
         return $numAggregationPeriods;
 
@@ -1074,8 +1081,8 @@ class pdoAggregator extends aAggregator
         PDOStatement $insertStmt,
         array $discoveredBindParams,
         $totalNumAggregationPeriods,
-        $aggregationPeriodOffset = 0)
-    {
+        $aggregationPeriodOffset = 0
+    ) {
         if ( $this->etlOverseerOptions->isDryrun() ) {
             return 0;
         }
@@ -1280,12 +1287,15 @@ class pdoAggregator extends aAggregator
             "(" .
             implode(",\n", array_keys($this->etlSourceQuery->getRecords()))
             . ")\nVALUES\n(" .
-            implode(",\n",
-                    array_map(function ($s) {
-                            return ":$s";
-                        },
-                        array_keys($this->etlSourceQuery->getRecords()))
-                ) .
+            implode(
+                ",\n",
+                array_map(
+                    function ($s) {
+                        return ":$s";
+                    },
+                    array_keys($this->etlSourceQuery->getRecords())
+                )
+            ) .
             ")";
 
         $this->optimizedInsertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
@@ -1309,5 +1319,4 @@ class pdoAggregator extends aAggregator
         return true;
 
     }  // buildSqlStatements()
-
 }  // class pdoAggregator

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -952,12 +952,7 @@ class pdoAggregator extends aAggregator
                     // information will need to come from the last and first slice,
                     // respecitively (see note below).
 
-                    $availableParamKeys = array_map(
-                        function ($k) {
-                            return ":$k";
-                        },
-                        array_keys($firstSlice)
-                    );
+                    $availableParamKeys = Utilities::createPdoBindVarsFromArrayKeys($firstSlice);
 
                     // NOTE 1
                     //
@@ -1097,13 +1092,7 @@ class pdoAggregator extends aAggregator
             // Make all of the data for each aggregation period available to the
             // query. Change the array keys into bind parameters.
 
-            $availableParamKeys = array_map(
-                function ($k) {
-                    return ":$k";
-                },
-                array_keys($aggregationPeriodInfo)
-            );
-
+            $availableParamKeys = Utilities::createPdoBindVarsFromArrayKeys($aggregationPeriodInfo);
             $availableParams = array_combine($availableParamKeys, $aggregationPeriodInfo);
             $periodId = $aggregationPeriodInfo['period_id'];
 
@@ -1284,19 +1273,11 @@ class pdoAggregator extends aAggregator
         $this->selectSql = $this->etlSourceQuery->getSelectSql($includeSchema);
 
         $this->insertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
-            "(" .
-            implode(",\n", array_keys($this->etlSourceQuery->getRecords()))
-            . ")\nVALUES\n(" .
-            implode(
-                ",\n",
-                array_map(
-                    function ($s) {
-                        return ":$s";
-                    },
-                    array_keys($this->etlSourceQuery->getRecords())
-                )
-            ) .
-            ")";
+            "("
+            . implode(",\n", array_keys($this->etlSourceQuery->getRecords()))
+            . ")\nVALUES\n("
+            . implode(",\n", Utilities::createPdoBindVarsFromArrayKeys($this->etlSourceQuery->getRecords()))
+            . ")";
 
         $this->optimizedInsertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
             "(" .

--- a/classes/ETL/Utilities.php
+++ b/classes/ETL/Utilities.php
@@ -51,8 +51,8 @@ class Utilities
         $string,
         array $map,
         array &$substitutedVariables = null,
-        array &$unsubstitutedVariables = null )
-    {
+        array &$unsubstitutedVariables = null
+    ) {
 
         // If we are not tracking the variables that have or have not been substituted, simply
         // perform a string replacement.
@@ -68,13 +68,17 @@ class Utilities
 
             // Track variables that have been substituted
 
-            array_map(function ($v, $k) use (&$string, &$localSubstituted) {
+            array_map(
+                function ($v, $k) use (&$string, &$localSubstituted) {
                     $search = '${' . $k . '}';
                     if ( false !== strpos($string, $search) ) {
                         $substituted[] = $k;
                     }
                     $string = str_replace($search, $v, $string);
-                }, $map, array_keys($map));
+                },
+                $map,
+                array_keys($map)
+            );
 
             // If there are any variables left in the string, track them as unsubstituted.
 
@@ -145,7 +149,7 @@ class Utilities
         if ( ! isset($paths->macro_dir) ) {
             $msg = __CLASS__ . ": ETL configuration paths.macro_dir is not set";
             throw new Exception($msg);
-        } else if ( ! is_dir($paths->macro_dir) ) {
+        } elseif ( ! is_dir($paths->macro_dir) ) {
             $msg = __CLASS__ . ": ETL configuration paths.macro_dir '{$paths->macro_dir}' is not a directory";
             throw new Exception($msg);
         }
@@ -172,7 +176,7 @@ class Utilities
         if ( ! is_file($filename) ) {
             $msg = __CLASS__ . ": Cannot load macro file '$filename'";
             throw new Exception($msg);
-        } else if ( 0 == filesize($filename) ) {
+        } elseif ( 0 == filesize($filename) ) {
             // No use processing an empty macro
             return;
         }
@@ -187,7 +191,7 @@ class Utilities
         $stripped = array();
 
         foreach ( explode("\n", $macro) as $line ) {
-            if ( 0 === strpos($line, "--") || 0 === strpos($line,  "#") ) {
+            if ( 0 === strpos($line, "--") || 0 === strpos($line, "#") ) {
                 continue;
             }
             $stripped[] = $line;
@@ -226,4 +230,23 @@ class Utilities
         return ( false === $value ? false : filter_var($value, $filter, $options) );
     }  // filterBooleanVar()
 
+    /* ------------------------------------------------------------------------------------------
+     * Generate an array of strings that can be used as PDO bind parameters (e.g., :var)
+     * using the keys from the source array.
+     *
+     * @param $source An associative array whose keys will be used to generate bind parameters
+     *
+     * @return An array containing the keys of $source pre-pended with ":"
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function createPdoBindVarsFromArrayKeys(array $source)
+    {
+        return array_map(
+            function ($key) {
+                return ":$key";
+            },
+            array_keys($source)
+        );
+    }  // createPdoBindVarsFromArrayKeys()
 }  // class Utilities


### PR DESCRIPTION
## Description
Not all information returned for an aggregation period was available as a bind parameter for aggregators. Now, any columns returned by `getDirtyAggregationPeriods()` will automatically be made available as a bind parameter for use in aggregation queries.

## Motivation and Context
Laying the groundwork for using `start_date` and `end_date` in the new Accounts realm rather than `start_date_ts` and `end_date_ts`, which are not available.

## Tests performed
Ran ingestion and aggregation of the past 100 days worth of jobs including experimental batch aggregation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
