### PR TITLE
Improve ETLv2 query debug

### DIFF
--- a/classes/ETL/Aggregator/JobsAggregator.php
+++ b/classes/ETL/Aggregator/JobsAggregator.php
@@ -52,8 +52,10 @@ implements iAction
                 return false;
             }
         } catch (PDOException $e ) {
-            $msg = "Error querying {$sourceSchema}.{$tableName}";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error querying {$sourceSchema}.{$tableName}",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->utilityEndpoint)
+            );
         }
 
         return parent::performPreAggregationUnitTasks($aggregationUnit);
@@ -106,8 +108,10 @@ implements iAction
                 $this->logger->info("Updated $numRows rows");
             }
         } catch (PDOException $e ) {
-            $msg = "Error updating {$sourceSchema}.{$tableName}";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error updating {$sourceSchema}.{$tableName}",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->destinationEndpoint)
+            );
         }
 
         return parent::performPostAggregationUnitTasks($aggregationUnit, $numAggregationPeriodsProcessed);
@@ -188,8 +192,10 @@ implements iAction
             }
 
         } catch (PDOException $e ) {
-            $msg = "Error cleaning {$sourceSchema}.{$tableName}";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error cleaning {$sourceSchema}.{$tableName}",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->destinationEndpoint)
+            );
         }
 
         return parent::performPostExecuteTasks($numRecordsProcessed);
@@ -337,7 +343,10 @@ implements iAction
                 $result = $this->utilityHandle->query($sql);
             }
         } catch (PDOException $e) {
-            $this->logAndThrowSqlException($sql, $e, "Error querying dirty date ids");
+            $this->logAndThrowException(
+                "Error querying aggregation dirty date ids",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->utilityEndpoint)
+            );
         }
 
         return $result;
@@ -381,7 +390,7 @@ implements iAction
             ":endDate" => $endDate
             );
 
-        $this->logger->debug("Verify resource specs exist:\n$sql");
+        $this->logger->debug("Verify resource specs exist " . $this->sourceEndpoint . ":\n$sql");
         $result = $this->sourceHandle->query($sql, $params);
         if ( count($result) > 0 ) {
             $resources = array();

--- a/classes/ETL/Aggregator/JobsAggregator.php
+++ b/classes/ETL/Aggregator/JobsAggregator.php
@@ -17,8 +17,7 @@ namespace ETL\Aggregator;
 use ETL\iAction;
 use \PDOException;
 
-class JobsAggregator extends pdoAggregator
-implements iAction
+class JobsAggregator extends pdoAggregator implements iAction
 {
     // Name of the status table that we will be updating
     const STATUS_TABLE = "jobfactstatus";
@@ -183,7 +182,7 @@ implements iAction
 
             // If we always run the full set of aggregation periods, this can be done once at the end...
 
-            $sql = "DELETE FROM {$sourceSchema}.{$tableName} WHERE " . implode(" AND " , $whereClauses);
+            $sql = "DELETE FROM {$sourceSchema}.{$tableName} WHERE " . implode(" AND ", $whereClauses);
             $this->logger->debug($sql);
 
             if ( ! $this->etlOverseerOptions->isDryrun() ) {
@@ -245,9 +244,9 @@ implements iAction
             if ( null !== $startDate && null !== $endDate ) {
                 $dateRangeSql = "d.${aggregationUnit}_end_ts >= UNIX_TIMESTAMP($startDate) " .
                     "AND d.${aggregationUnit}_start_ts <= UNIX_TIMESTAMP($endDate)";
-            } else if ( null !== $startDate ) {
+            } elseif ( null !== $startDate ) {
                 $dateRangeSql = "d.${aggregationUnit}_end_ts >= UNIX_TIMESTAMP($startDate)";
-            } else if ( null !== $endDate ) {
+            } elseif ( null !== $endDate ) {
                 $dateRangeSql = "d.${aggregationUnit}_start_ts <= UNIX_TIMESTAMP($endDate)";
             }
 
@@ -412,5 +411,4 @@ implements iAction
         $this->verifiedResourceSpecs = true;
 
     }  // checkResourceSpecs()
-
 }  // class JobsAggregator

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -159,7 +159,7 @@ class pdoAggregator extends aAggregator
         if ( null === $this->etlSourceQuery ) {
             $msg = "ETL source query is not set";
             $this->logAndThrowException($msg);
-        } else if ( ! $this->etlSourceQuery instanceof Query ) {
+        } elseif ( ! $this->etlSourceQuery instanceof Query ) {
             $msg = "ETL source query is not an instance of Query";
             $this->logAndThrowException($msg);
         }
@@ -235,9 +235,11 @@ class pdoAggregator extends aAggregator
         }
 
         $this->logger->debug("Create ETL destination aggregation table object");
-        $this->etlDestinationTable = new AggregationTable($this->parsedDefinitionFile->table_definition,
-                                                          $this->destinationEndpoint->getSystemQuoteChar(),
-                                                          $this->logger);
+        $this->etlDestinationTable = new AggregationTable(
+            $this->parsedDefinitionFile->table_definition,
+            $this->destinationEndpoint->getSystemQuoteChar(),
+            $this->logger
+        );
         $this->etlDestinationTable->setSchema($this->destinationEndpoint->getSchema());
 
         if ( isset($this->options->table_prefix) &&
@@ -266,8 +268,10 @@ class pdoAggregator extends aAggregator
             }
 
             $this->logger->debug("Create ETL source query object");
-            $this->etlSourceQuery = new Query($this->parsedDefinitionFile->source_query,
-                                              $this->sourceEndpoint->getSystemQuoteChar());
+            $this->etlSourceQuery = new Query(
+                $this->parsedDefinitionFile->source_query,
+                $this->sourceEndpoint->getSystemQuoteChar()
+            );
         }  // ( null === $this->etlSourceQuery )
 
         // --------------------------------------------------------------------------------
@@ -297,7 +301,7 @@ class pdoAggregator extends aAggregator
             ':PERIOD_START_DAY_ID' => ":period_start_day_id",
             // The day_id of the end of this period
             ':PERIOD_END_DAY_ID' => ":period_end_day_id"
-            );
+        );
 
         $this->variableMap = array_merge($this->variableMap, $parameters);
 
@@ -570,41 +574,41 @@ class pdoAggregator extends aAggregator
         $endDayIdToUnitId = null;
 
         switch ( $aggregationUnit ) {
-        case 'day':
-            // No conversion needed
-            $unitIdToStartDayId = "d.id";
-            $unitIdToEndDayId = "d.id";
-            $startDayIdToUnitId = $startDayIdField;
-            $endDayIdToUnitId = $endDayIdField;
-            break;
-        case 'month':
-            $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-', d.`month`, '-01'))";
-            $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-', d.`month`, '-01'), interval 1 month), interval 1 day))";
-            $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
-                . "MONTH(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
-            $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
-                . "MONTH(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
-            break;
-        case 'quarter':
-            $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(date_add(concat(d.`year`, '-01-01'), interval (d.`quarter` - 1) quarter))";
-            $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval d.`quarter` quarter), interval 1 day))";
-            $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
-                . "QUARTER(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
-            $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
-                . "QUARTER(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
-            break;
-        case 'year':
-            $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-01-01'))";
-            $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval 1 year), interval 1 day))";
-            $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000";
-            $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000";
-            break;
-        default:
-            // We should never get here because we are verifying the existance of the aggregation
-            // unit tables in performPreAggregationUnitTasks.
-            $msg = "Unsupported aggregation unit '$aggregationUnit'";
-            $this->logAndThrowException($msg);
-            break;
+            case 'day':
+                // No conversion needed
+                $unitIdToStartDayId = "d.id";
+                $unitIdToEndDayId = "d.id";
+                $startDayIdToUnitId = $startDayIdField;
+                $endDayIdToUnitId = $endDayIdField;
+                break;
+            case 'month':
+                $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-', d.`month`, '-01'))";
+                $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-', d.`month`, '-01'), interval 1 month), interval 1 day))";
+                $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
+                    . "MONTH(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
+                $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
+                    . "MONTH(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
+                break;
+            case 'quarter':
+                $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(date_add(concat(d.`year`, '-01-01'), interval (d.`quarter` - 1) quarter))";
+                $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval d.`quarter` quarter), interval 1 day))";
+                $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000 + "
+                    . "QUARTER(date_add(concat(truncate($startDayIdField/100000, 0), '-01-01'), interval (mod($startDayIdField, 1000) - 1) day))";
+                $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000 + "
+                    . "QUARTER(date_add(concat(truncate($endDayIdField/100000, 0), '-01-01'), interval (mod($endDayIdField, 1000) - 1) day))";
+                break;
+            case 'year':
+                $unitIdToStartDayId = "d.`year`*100000 + DAYOFYEAR(concat(d.`year`, '-01-01'))";
+                $unitIdToEndDayId = "d.`year`*100000 + DAYOFYEAR(date_sub(date_add(concat(d.`year`, '-01-01'), interval 1 year), interval 1 day))";
+                $startDayIdToUnitId = "truncate($startDayIdField/100000, 0)*100000";
+                $endDayIdToUnitId = "truncate($endDayIdField/100000, 0)*100000";
+                break;
+            default:
+                // We should never get here because we are verifying the existance of the aggregation
+                // unit tables in performPreAggregationUnitTasks.
+                $msg = "Unsupported aggregation unit '$aggregationUnit'";
+                $this->logAndThrowException($msg);
+                break;
         }  // switch ( $aggregationUnit )
 
         if ( $this->etlOverseerOptions->isForce() ) {
@@ -656,7 +660,7 @@ class pdoAggregator extends aAggregator
                 $query->overseer_restrictions = $aggregationPeriodQueryOptions->overseer_restrictions;
             } else {
                 $msg = "No restrictions on selection of periods to aggregate. "
-                     . "Re-aggregating all records in " . $sourceSchema . "." . $tableName;
+                    . "Re-aggregating all records in " . $sourceSchema . "." . $tableName;
                 $this->logger->notice($msg);
             }
 
@@ -784,7 +788,7 @@ class pdoAggregator extends aAggregator
             }
             $this->etlSourceQueryModified = true;
 
-        } else if ( ! $enableBatchAggregation && $this->etlSourceQueryModified ) {
+        } elseif ( ! $enableBatchAggregation && $this->etlSourceQueryModified ) {
 
             $this->logger->info("[EXPERIMENTAL] Restore original first table");
 
@@ -876,7 +880,8 @@ class pdoAggregator extends aAggregator
                 $selectStmt,
                 $insertStmt,
                 $discoveredBindParams,
-                $numAggregationPeriods);
+                $numAggregationPeriods
+            );
 
         } else {
 
@@ -970,7 +975,7 @@ class pdoAggregator extends aAggregator
 
                     $availableParamValues = array_map(
                         function ($k, $first, $last) {
-                            if ( FALSE !== strpos($k, '_end') || FALSE !== strpos($k, 'end_') ) {
+                            if ( false !== strpos($k, '_end') || false !== strpos($k, 'end_') ) {
                                 return $first;
                             } else {
                                 return $last;
@@ -978,7 +983,8 @@ class pdoAggregator extends aAggregator
                         },
                         array_keys($firstSlice),
                         $firstSlice,
-                        $lastSlice);
+                        $lastSlice
+                    );
 
                     $availableParams = array_combine($availableParamKeys, $availableParamValues);
 
@@ -1006,7 +1012,8 @@ class pdoAggregator extends aAggregator
                     $insertStmt,
                     $discoveredBindParams,
                     $numAggregationPeriods,
-                    $aggregationPeriodListOffset);
+                    $aggregationPeriodListOffset
+                );
 
                 $this->logger->info(
                     "[EXPERIMENTAL] Total time for batch (day_id $minDayId - $maxDayId): "
@@ -1038,7 +1045,7 @@ class pdoAggregator extends aAggregator
                                     "start_time"   => $time_start,
                                     "end_time"     => $time_end,
                                     "elapsed_time" => round($time, 5)
-                                  ));
+        ));
 
         return $numAggregationPeriods;
 
@@ -1074,8 +1081,8 @@ class pdoAggregator extends aAggregator
         PDOStatement $insertStmt,
         array $discoveredBindParams,
         $totalNumAggregationPeriods,
-        $aggregationPeriodOffset = 0)
-    {
+        $aggregationPeriodOffset = 0
+    ) {
         if ( $this->etlOverseerOptions->isDryrun() ) {
             return 0;
         }
@@ -1280,12 +1287,15 @@ class pdoAggregator extends aAggregator
             "(" .
             implode(",\n", array_keys($this->etlSourceQuery->getRecords()))
             . ")\nVALUES\n(" .
-            implode(",\n",
-                    array_map(function ($s) {
-                            return ":$s";
-                        },
-                        array_keys($this->etlSourceQuery->getRecords()))
-                ) .
+            implode(
+                ",\n",
+                array_map(
+                    function ($s) {
+                        return ":$s";
+                    },
+                    array_keys($this->etlSourceQuery->getRecords())
+                )
+            ) .
             ")";
 
         $this->optimizedInsertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
@@ -1309,5 +1319,4 @@ class pdoAggregator extends aAggregator
         return true;
 
     }  // buildSqlStatements()
-
 }  // class pdoAggregator

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -952,12 +952,7 @@ class pdoAggregator extends aAggregator
                     // information will need to come from the last and first slice,
                     // respecitively (see note below).
 
-                    $availableParamKeys = array_map(
-                        function ($k) {
-                            return ":$k";
-                        },
-                        array_keys($firstSlice)
-                    );
+                    $availableParamKeys = Utilities::createPdoBindVarsFromArrayKeys($firstSlice);
 
                     // NOTE 1
                     //
@@ -1097,13 +1092,7 @@ class pdoAggregator extends aAggregator
             // Make all of the data for each aggregation period available to the
             // query. Change the array keys into bind parameters.
 
-            $availableParamKeys = array_map(
-                function ($k) {
-                    return ":$k";
-                },
-                array_keys($aggregationPeriodInfo)
-            );
-
+            $availableParamKeys = Utilities::createPdoBindVarsFromArrayKeys($aggregationPeriodInfo);
             $availableParams = array_combine($availableParamKeys, $aggregationPeriodInfo);
             $periodId = $aggregationPeriodInfo['period_id'];
 
@@ -1284,19 +1273,11 @@ class pdoAggregator extends aAggregator
         $this->selectSql = $this->etlSourceQuery->getSelectSql($includeSchema);
 
         $this->insertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
-            "(" .
-            implode(",\n", array_keys($this->etlSourceQuery->getRecords()))
-            . ")\nVALUES\n(" .
-            implode(
-                ",\n",
-                array_map(
-                    function ($s) {
-                        return ":$s";
-                    },
-                    array_keys($this->etlSourceQuery->getRecords())
-                )
-            ) .
-            ")";
+            "("
+            . implode(",\n", array_keys($this->etlSourceQuery->getRecords()))
+            . ")\nVALUES\n("
+            . implode(",\n", Utilities::createPdoBindVarsFromArrayKeys($this->etlSourceQuery->getRecords()))
+            . ")";
 
         $this->optimizedInsertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
             "(" .

--- a/classes/ETL/DataEndpoint/Mysql.php
+++ b/classes/ETL/DataEndpoint/Mysql.php
@@ -111,8 +111,10 @@ WHERE schema_name = :schema";
             $dbh = $this->getHandle();
             $result = $dbh->execute($sql);
         } catch (\PdoException $e) {
-            $msg = "Error creating schema '$schemaName'";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error creating schema '$schemaName'",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
+            );
         }
 
         return true;

--- a/classes/ETL/DataEndpoint/Oracle.php
+++ b/classes/ETL/DataEndpoint/Oracle.php
@@ -110,8 +110,10 @@ AND table_name = UPPER(:tablename)";
                 return false;
             }
         } catch (PDOException $e) {
-            $msg = "Error querying for table '$schema'.'$tableName':";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error querying for table '$schema'.'$tableName':",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
+            );
         }
 
         return true;
@@ -152,8 +154,10 @@ ORDER BY column_id ASC";
                 $this->logAndThrowException($msg);
             }
         } catch (PDOException $e) {
-            $msg = "Error retrieving column names from '" . $this->getSchema() . ".'$tableName' ";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error retrieving column names from '" . $this->getSchema() . ".'$tableName' ",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
+            );
         }
 
         $columnNames = array();

--- a/classes/ETL/DataEndpoint/Postgres.php
+++ b/classes/ETL/DataEndpoint/Postgres.php
@@ -79,8 +79,10 @@ WHERE nspname = :schema";
             $dbh = $this->getHandle();
             $result = $dbh->query($sql, $params);
         } catch (\PdoException $e) {
-            $msg = "Error creating schema '$schemaName'";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error creating schema '$schemaName'",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
+            );
         }
 
         return true;

--- a/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
+++ b/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
@@ -215,8 +215,10 @@ AND table_name = :tablename";
                 return false;
             }
         } catch (PDOException $e) {
-            $msg = "Error querying for table '$schema'.'$tableName':";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error querying for table '$schema'.'$tableName':",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
+            );
         }
 
         return true;
@@ -257,8 +259,10 @@ ORDER BY ordinal_position ASC";
                 $this->logAndThrowException($msg);
             }
         } catch (PDOException $e) {
-            $msg = "Error retrieving column names from '$schemaName'$tableName' ";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error retrieving column names from '$schemaName'.'$tableName' ",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
+            );
         }
 
         $columnNames = array();
@@ -305,8 +309,10 @@ ORDER BY ordinal_position ASC";
                 return false;
             }
         } catch (\PdoException $e) {
-            $msg = "Error querying for schema '$schemaName'";
-            $this->logAndThrowSqlException($sql, $e, $msg);
+            $this->logAndThrowException(
+                "Error querying for schema '$schemaName'",
+                array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
+            );
         }
 
         return true;
@@ -319,7 +325,7 @@ ORDER BY ordinal_position ASC";
 
     public function __toString()
     {
-        return "{$this->name} (" . get_class($this) . ", config={$this->config}, schema={$this->schema}" .
+        return "('" . $this->name . "', class=" . get_class($this) . ", config={$this->config}, schema={$this->schema}" .
             (null !== $this->hostname ? ", host={$this->hostname}" : "" ) .
             (null !== $this->port ? ":{$this->port}" : "" ) .
             (null !== $this->username ? ", user={$this->username}" : "" ) .

--- a/classes/ETL/DbEntity/Table.php
+++ b/classes/ETL/DbEntity/Table.php
@@ -71,7 +71,7 @@ class Table extends aNamedEntity
 
         if ( ! is_object($config) && is_string($config) ) {
             $config = $this->parseJsonFile($config, "Table Definition");
-        } else if ( ! $config instanceof stdClass) {
+        } elseif ( ! $config instanceof stdClass) {
             $msg = __CLASS__ . ": Argument is not a filename or object";
             $this->logAndThrowException($msg);
         }
@@ -205,8 +205,8 @@ class Table extends aNamedEntity
         $tableName,
         iRdbmsEndpoint $endpoint,
         $systemQuoteChar = null,
-        Log $logger = null)
-    {
+        Log $logger = null
+    ) {
         $schemaName = null;
         $qualifiedTableName = null;
 
@@ -774,7 +774,7 @@ ORDER BY trigger_name ASC";
         foreach ( $changeColNames as $name ) {
             $destColumn = $destTable->getColumn($name);
             // Not all properties are required so a simple object comparison isn't possible
-            if ( 0 == $destColumn->compare( $this->getColumn($name) ) ) {
+            if ( 0 == $destColumn->compare($this->getColumn($name)) ) {
                 continue;
             }
             $alterList[] = "CHANGE COLUMN " . $destColumn->getName(true) . " " . $destColumn->getAlterSql($includeSchema);
@@ -784,7 +784,7 @@ ORDER BY trigger_name ASC";
             $destColumn = $destTable->getColumn($toColumnName);
             $currentColumn = $this->getColumn($fromColumnName);
             // Not all properties are required so a simple object comparison isn't possible
-            if ( 0 == $destColumn->compare( $currentColumn ) ) {
+            if ( 0 == $destColumn->compare($currentColumn) ) {
                 continue;
             }
             $alterList[] = "CHANGE COLUMN " . $currentColumn->getName(true) . " " . $destColumn->getAlterSql($includeSchema);
@@ -843,7 +843,7 @@ ORDER BY trigger_name ASC";
 
         foreach ( $changeTriggerNames as $name ) {
             $destTrigger = $destTable->getTrigger($name);
-            if ( 0 == $destTrigger->compare( $this->getTrigger($name)) ) {
+            if ( 0 == $destTrigger->compare($this->getTrigger($name))) {
                 continue;
             }
 
@@ -941,5 +941,4 @@ ORDER BY trigger_name ASC";
     {
         return json_encode($this->toJsonObj($succinct, $includeSchema));
     }  // toJson()
-
 }  // class Table

--- a/classes/ETL/DbEntity/Table.php
+++ b/classes/ETL/DbEntity/Table.php
@@ -419,8 +419,10 @@ ORDER BY trigger_name ASC";
         $name = $item->getName();
 
         if ( array_key_exists($name, $this->columns) && ! $overwriteDuplicates ) {
-            $msg = "Cannot add duplicate column '$name'";
-            $this->logAndThrowException($msg, PEAR_LOG_WARNING);
+            $this->logAndThrowException(
+                "Cannot add duplicate column '$name'",
+                array('log_level' => PEAR_LOG_WARNING)
+            );
         }
 
         $this->columns[ $name ] = $item;

--- a/classes/ETL/Ingestor/RestIngestor.php
+++ b/classes/ETL/Ingestor/RestIngestor.php
@@ -74,8 +74,7 @@ class RestIngestor extends aIngestor implements iAction
 
         if ( ! $this->sourceEndpoint instanceof Rest ) {
             $this->sourceEndpoint = null;
-            $msg = "Source endpoint is not an instance of ETL\\DataEndpoint\\Rest";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Source endpoint is not an instance of ETL\\DataEndpoint\\Rest");
         }
         $this->logger->debug("Source endpoint: " . $this->sourceEndpoint);
         $this->sourceEndpoint->connect();
@@ -86,8 +85,7 @@ class RestIngestor extends aIngestor implements iAction
 
         if ( ! $this->utilityEndpoint instanceof aRdbmsEndpoint ) {
             $this->utilityEndpoint = null;
-            $msg = "Source endpoint is not an instance of ETL\\DataEndpoint\\aRdbmsEndpoint";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Source endpoint is not an instance of ETL\\DataEndpoint\\aRdbmsEndpoint");
         }
         $this->utilityHandle = $this->utilityEndpoint->getHandle();
 
@@ -115,8 +113,7 @@ class RestIngestor extends aIngestor implements iAction
         $this->etlDestinationTable = current($this->etlDestinationTableList);
         $etlTableKey = key($this->etlDestinationTableList);
         if ( count($this->etlDestinationTableList) > 1 ) {
-            $msg = $this . " does not support multiple ETL destination tables, using first table with key: '$etlTableKey'";
-            $logger->warning($msg);
+            $logger->warning($this . " does not support multiple ETL destination tables, using first table with key: '$etlTableKey'");
         }
 
         // If the source query is specified in the definition file use it to obtain parameters for the
@@ -163,15 +160,13 @@ class RestIngestor extends aIngestor implements iAction
                 (array) $this->parsedDefinitionFile->rest_response
             );
         } elseif ( ! isset($this->parsedDefinitionFile->rest_response) ) {
-            $msg = "rest_response key not found in definition file";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("rest_response key not found in definition file");
         }
 
         if ( null === $this->restRequestConfig && isset($this->parsedDefinitionFile->rest_request) ) {
             $this->restRequestConfig = $this->parsedDefinitionFile->rest_request;
         } elseif ( ! isset($this->parsedDefinitionFile->rest_response) ) {
-            $msg = "rest_request key not found in definition file";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("rest_request key not found in definition file");
         }
 
         // --------------------------------------------------------------------------------
@@ -192,8 +187,7 @@ class RestIngestor extends aIngestor implements iAction
                     continue;
                 }
                 if ( ! isset($value->value) ) {
-                    $msg = "{$this} Parameter '$parameter' object does not specify a 'value' key, skipping";
-                    $this->logger->warning($msg);
+                    $this->logger->warning("{$this} Parameter '$parameter' object does not specify a 'value' key, skipping");
                     continue;
                 }
                 $this->parameterDirectives[$parameter] = $value;
@@ -209,8 +203,7 @@ class RestIngestor extends aIngestor implements iAction
                     continue;
                 }
                 if ( ! isset($value->name) ) {
-                    $msg = "{$this} Response field map '$key' object does not specify a 'name' key, skipping";
-                    $this->logger->warning($msg);
+                    $this->logger->warning("{$this} Response field map '$key' object does not specify a 'name' key, skipping");
                     continue;
                 }
                 // Use the response field name as the key so we can make easy lookups in the response object
@@ -247,11 +240,9 @@ class RestIngestor extends aIngestor implements iAction
         parent::verify();
 
         if ( null !== $this->restRequestConfig && ! is_object($this->restRequestConfig) ) {
-            $msg = "REST request config must be an object";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("REST request config must be an object");
         } elseif ( null !== $this->restResponseConfig && ! is_object($this->restResponseConfig) ) {
-            $msg = "REST response config must be an object";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("REST response config must be an object");
         }
 
         // Verify that any type formatting directives in the request and response are valid
@@ -288,8 +279,7 @@ class RestIngestor extends aIngestor implements iAction
             $this->manageTable($this->etlDestinationTable, $this->destinationEndpoint);
 
         } catch ( Exception $e ) {
-            $msg = "Error managing ETL table for " . $this->getName() . ": " . $e->getMessage();
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Error managing ETL table for " . $this->getName() . ": " . $e->getMessage());
         }
 
         $this->destinationTableColumnNames = $this->etlDestinationTable->getColumnNames();
@@ -302,8 +292,7 @@ class RestIngestor extends aIngestor implements iAction
                 $this->destinationTableColumnNames
             );
             if ( 0 != count($diff) ) {
-                $msg = "Field map includes columns not in destination table: " . implode(",", $diff);
-                $this->logAndThrowException($msg);
+                $this->logAndThrowException("Field map includes columns not in destination table: " . implode(",", $diff));
             }
         }  // if ( isset($this->restResponseConfig->field_map) )
 
@@ -320,8 +309,7 @@ class RestIngestor extends aIngestor implements iAction
             $this->etlSourceQueryResult = $this->utilityHandle->query($sql, array(), true);
 
             if ( 0 == $this->etlSourceQueryResult->rowCount() ) {
-                $msg = "Source query return 0 rows, exiting";
-                $this->logger->warning($msg);
+                $this->logger->warning("{$this} Source query return 0 rows, exiting");
                 return false;
             }
         }  // if ( null !== $this->etlSourceQuery ) {
@@ -424,16 +412,14 @@ class RestIngestor extends aIngestor implements iAction
         while ( false !== ( $retval = curl_exec($this->sourceHandle) ) ) {
 
             if ( 0 !== curl_errno($this->sourceHandle) ) {
-                $msg = "Error during REST call: " . curl_error($this->sourceHandle);
-                $this->logger->err($msg);
+                $this->logger->err("${this} Error during REST call: " . curl_error($this->sourceHandle));
                 break;
             }
 
             $response = json_decode($retval);
 
             if ( null === $response || ! is_object($response) ) {
-                $msg = "Response is not an object: $retval";
-                $this->logger->err($msg);
+                $this->logger->err("{$this} Response is not an object: $retval");
                 break;
             }
 
@@ -453,9 +439,10 @@ class RestIngestor extends aIngestor implements iAction
                         }
                         continue;
                     } else {
-                        $msg = "Configured top-level response key '$responseKey' not found in response. " .
-                            "Response keys are '" . implode(",", array_keys((array) $response)) . "'";
-                        $this->logAndThrowException($msg);
+                        $this->logAndThrowException(
+                            "Configured top-level response key '$responseKey' not found in response. "
+                            . "Response keys are '" . implode(",", array_keys((array) $response)) . "'"
+                        );
                     }
                 } else {
                     $response = $response->$responseKey;
@@ -474,9 +461,10 @@ class RestIngestor extends aIngestor implements iAction
                         }
                         continue;
                     } else {
-                        $msg = "Configured results key '$resultsKey' not found in response. " .
-                            "Response keys are '" . implode(",", array_keys((array) $response)) . "'\n" . print_r($response, true);
-                        $this->logAndThrowException($msg);
+                        $this->logAndThrowException(
+                            "Configured results key '$resultsKey' not found in response. "
+                            . "Response keys are '" . implode(",", array_keys((array) $response)) . "'\n" . print_r($response, true)
+                        );
                     }
                 } else {
                     $results = $response->$resultsKey;
@@ -490,11 +478,9 @@ class RestIngestor extends aIngestor implements iAction
             // We assume that the response is an array of results, even if it is a single result.
 
             if ( ! is_array($results) ) {
-                $msg = "Request results is expected to be an array. Type returned was " . gettype($results);
-                $this->logAndThrowException($msg);
+                $this->logAndThrowException("Request results is expected to be an array. Type returned was " . gettype($results));
             } elseif ( 0 == count($results) ) {
-                $msg = "Request returned an empty result set, skipping. url = {$this->currentUrl}";
-                $this->logger->notice($msg);
+                $this->logger->notice("Request returned an empty result set, skipping. url = {$this->currentUrl}");
 
                 if ( false === $this->setNextUrl($response, $nextKey) ) {
                     break;
@@ -519,24 +505,9 @@ class RestIngestor extends aIngestor implements iAction
                 if ( null === $fieldMap ) {
                     $diff = array_diff($resultKeyNames, $this->destinationTableColumnNames);
                     if ( 0 != count($diff) ) {
-                        $msg = "Result missing keys found in destination table: " .
-                            implode(",", $diff);
-                        $this->logAndThrowException($msg);
+                        $this->logAndThrowException("Result missing keys found in destination table: " . implode(",", $diff));
                     }
                 }
-
-                /*
-                  $diff = ( null === $fieldMap
-                  ? array_diff($resultKeyNames, $this->destinationTableColumnNames)
-                  : array_diff(array_values($fieldMap), $resultKeyNames) );
-
-                  if ( 0 != count($diff) ) {
-                  $msg = "Result missing keys found in " .
-                  ( null === $fieldMap ? "destination table" : "field map") . ": " .
-                  implode(",", $diff);
-                  $this->logAndThrowException($msg);
-                  }
-                */
 
                 // Create a mapping of result fields to database columns using the field map if provided or
                 // the result keys otherwise. A field map is recommended.
@@ -592,9 +563,10 @@ class RestIngestor extends aIngestor implements iAction
                 }
 
                 if ( $numColumns != count($recordParameters) ) {
-                    $msg = "Record counts do not match (expected $numColumns but receieved " . count($recordParameters) .
-                        "). url = {$this->currentUrl}";
-                    $this->logger->warning($msg);
+                    $this->logger->warning(
+                        "{$this} Record counts do not match (expected $numColumns but receieved "
+                        . count($recordParameters) . "). url = {$this->currentUrl}"
+                    );
                 }
 
                 $valueList[] = "(" . implode(", ", array_keys($recordParameters)) . ")";
@@ -692,8 +664,7 @@ class RestIngestor extends aIngestor implements iAction
     protected function setParameter($parameter, $value)
     {
         if ( null === $parameter || empty($parameter) ) {
-            $msg = "REST parameter name not provided";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("REST parameter name not provided");
         }
 
         $this->restParameters[$parameter] = $value;
@@ -728,8 +699,10 @@ class RestIngestor extends aIngestor implements iAction
                 try {
                     $this->restParameters[$parameter] = $this->applyDirectives($this->restParameters[$parameter], $directives);
                 } catch ( Exception $e ) {
-                    $msg = "Parameter '$parameter' (" . $this->restParameters[$parameter] . ") failed processing directives, skipping.";
-                    $this->logger->err($msg);
+                    $this->logger->err(
+                        "{$this} Parameter '$parameter' (" . $this->restParameters[$parameter]
+                        . ") failed processing directives, skipping."
+                    );
                     return false;
                 }
             }
@@ -859,8 +832,7 @@ class RestIngestor extends aIngestor implements iAction
                 $transformList = ( is_array($directives->transform) ? $directives->transform : array($directives->transform) );
                 foreach ( $transformList as $directive ) {
                     if ( ! is_object($directive) ) {
-                        $msg = "Transformation directives for '$parameter' must be an object";
-                        $this->logAndThrowException($msg);
+                        $this->logAndThrowException("Transformation directives for '$parameter' must be an object");
                     }
                     $this->verifyTransformDirective($parameter, $directive);
                 }
@@ -870,8 +842,7 @@ class RestIngestor extends aIngestor implements iAction
                 $verifyList = ( is_array($directives->verify) ? $directives->verify : array($directives->verify) );
                 foreach ( $verifyList as $directive ) {
                     if ( ! is_object($directive) ) {
-                        $msg = "Verification directives for '$parameter' must be an object";
-                        $this->logAndThrowException($msg);
+                        $this->logAndThrowException("Verification directives for '$parameter' must be an object");
                     }
                     $this->verifyVerifyDirective($parameter, $directive);
                 }
@@ -885,8 +856,7 @@ class RestIngestor extends aIngestor implements iAction
                 $transformList = ( is_array($directives->transform) ? $directives->transform : array($directives->transform) );
                 foreach ( $transformList as $directive ) {
                     if ( ! is_object($directive) ) {
-                        $msg = "Transformation directives for '$key' must be an object";
-                        $this->logAndThrowException($msg);
+                        $this->logAndThrowException("Transformation directives for '$key' must be an object");
                     }
                     $this->verifyTransformDirective($key, $directive);
                 }
@@ -896,8 +866,7 @@ class RestIngestor extends aIngestor implements iAction
                 $verifyList = ( is_array($directives->verify) ? $directives->verify : array($directives->verify) );
                 foreach ( $verifyList as $directive ) {
                     if ( ! is_object($directive) ) {
-                        $msg = "Verification directives for '$key' must be an object";
-                        $this->logAndThrowException($msg);
+                        $this->logAndThrowException("Verification directives for '$key' must be an object");
                     }
                     $this->verifyVerifyDirective($key, $directive);
                 }
@@ -925,8 +894,7 @@ class RestIngestor extends aIngestor implements iAction
     private function verifyTransformDirective($key, \stdClass $directive)
     {
         if ( ! isset($directive->type) || ! isset($directive->format) ) {
-            $msg = "Transform directive for '$key' must specify a type and format.";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Transform directive for '$key' must specify a type and format.");
         }
 
         switch ( $directive->type ) {
@@ -936,13 +904,11 @@ class RestIngestor extends aIngestor implements iAction
                 break;
             case 'regex':
                 if ( false === preg_match($directive->format, "test") ) {
-                    $msg = "Invalid regex format '{$directive->format}' for key '$key'";
-                    $this->logAndThrowException($msg);
+                    $this->logAndThrowException("Invalid regex format '{$directive->format}' for key '$key'");
                 }
                 break;
             default:
-                $msg = "Unsupported transform type '{$directive->type}' for key '$key'";
-                $this->logAndThrowException($msg);
+                $this->logAndThrowException("Unsupported transform type '{$directive->type}' for key '$key'");
                 break;
         }
 
@@ -965,20 +931,17 @@ class RestIngestor extends aIngestor implements iAction
     private function verifyVerifyDirective($key, \stdClass $directive)
     {
         if ( ! isset($directive->type) || ! isset($directive->format) ) {
-            $msg = "Transform directive for '$key' must specify a type and format.";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Transform directive for '$key' must specify a type and format.");
         }
 
         switch ( $directive->type ) {
             case 'regex':
                 if ( false === preg_match($directive->format, "test") ) {
-                    $msg = "Invalid regex format '{$directive->format}' for key '$key'";
-                    $this->logAndThrowException($msg);
+                    $this->logAndThrowException("Invalid regex format '{$directive->format}' for key '$key'");
                 }
                 break;
             default:
-                $msg = "Unsupported transform type '{$directive->type}' for key '$key'";
-                $this->logAndThrowException($msg);
+                $this->logAndThrowException("Unsupported transform type '{$directive->type}' for key '$key'");
                 break;
         }
 
@@ -1040,8 +1003,7 @@ class RestIngestor extends aIngestor implements iAction
                 $matches = null;
                 $matched = preg_match($directive->format, $value, $matches);
                 if ( false === $matched ) {
-                    $msg = "Error transforming regex '{$directive->format}'";
-                    $this->logAndThrowException($msg);
+                    $this->logAndThrowException("Error transforming regex '{$directive->format}'");
                 } elseif ( 1 == $matched ) {
                     $value = $matches[0];
                 }
@@ -1075,8 +1037,7 @@ class RestIngestor extends aIngestor implements iAction
             case 'regex':
                 $matched = preg_match($directive->format, $value);
                 if ( 0 === $matched ) {
-                    $msg = "Failed {$directive->type} ({$directive->format}) verification for '$value'";
-                    $this->logAndThrowException($msg);
+                    $this->logAndThrowException("Failed {$directive->type} ({$directive->format}) verification for '$value'");
                 }
                 break;
             default:

--- a/classes/ETL/Ingestor/RestIngestor.php
+++ b/classes/ETL/Ingestor/RestIngestor.php
@@ -24,8 +24,7 @@ use ETL\Utilities;
 use \Log;
 use \PDO;
 
-class RestIngestor extends aIngestor
-implements iAction
+class RestIngestor extends aIngestor implements iAction
 {
     // Parsed configuration options for REST request handling
     protected $restRequestConfig = null;
@@ -126,8 +125,10 @@ implements iAction
 
         if ( null === $this->etlSourceQuery && isset($this->parsedDefinitionFile->source_query) ) {
             $this->logger->info("Create ETL source query object");
-            $this->etlSourceQuery = new Query($this->parsedDefinitionFile->source_query,
-                                              $this->utilityEndpoint->getSystemQuoteChar());
+            $this->etlSourceQuery = new Query(
+                $this->parsedDefinitionFile->source_query,
+                $this->utilityEndpoint->getSystemQuoteChar()
+            );
 
             // If supported by the source query, set the date ranges here
 
@@ -157,16 +158,18 @@ implements iAction
             );
 
         if ( null === $this->restResponseConfig && isset($this->parsedDefinitionFile->rest_response) ) {
-            $this->restResponseConfig = (object) array_merge((array) $defaultRestResponseConfig,
-                                                             (array) $this->parsedDefinitionFile->rest_response);
-        } else if ( ! isset($this->parsedDefinitionFile->rest_response) ) {
+            $this->restResponseConfig = (object) array_merge(
+                (array) $defaultRestResponseConfig,
+                (array) $this->parsedDefinitionFile->rest_response
+            );
+        } elseif ( ! isset($this->parsedDefinitionFile->rest_response) ) {
             $msg = "rest_response key not found in definition file";
             $this->logAndThrowException($msg);
         }
 
         if ( null === $this->restRequestConfig && isset($this->parsedDefinitionFile->rest_request) ) {
             $this->restRequestConfig = $this->parsedDefinitionFile->rest_request;
-        } else if ( ! isset($this->parsedDefinitionFile->rest_response) ) {
+        } elseif ( ! isset($this->parsedDefinitionFile->rest_response) ) {
             $msg = "rest_request key not found in definition file";
             $this->logAndThrowException($msg);
         }
@@ -246,7 +249,7 @@ implements iAction
         if ( null !== $this->restRequestConfig && ! is_object($this->restRequestConfig) ) {
             $msg = "REST request config must be an object";
             $this->logAndThrowException($msg);
-        } else if ( null !== $this->restResponseConfig && ! is_object($this->restResponseConfig) ) {
+        } elseif ( null !== $this->restResponseConfig && ! is_object($this->restResponseConfig) ) {
             $msg = "REST response config must be an object";
             $this->logAndThrowException($msg);
         }
@@ -294,8 +297,10 @@ implements iAction
         // If the field map is set, ensure that all destination colums exist in the table
 
         if ( isset($this->restResponseConfig->field_map) ) {
-            $diff = array_diff(array_keys((array) $this->restResponseConfig->field_map),
-                               $this->destinationTableColumnNames);
+            $diff = array_diff(
+                array_keys((array) $this->restResponseConfig->field_map),
+                $this->destinationTableColumnNames
+            );
             if ( 0 != count($diff) ) {
                 $msg = "Field map includes columns not in destination table: " . implode(",", $diff);
                 $this->logAndThrowException($msg);
@@ -376,10 +381,12 @@ implements iAction
         $prevKey = ( isset($this->restResponseConfig->prev) ? $this->restResponseConfig->prev : null );
         $fieldMap = ( isset($this->restResponseConfig->field_map) ? (array) $this->restResponseConfig->field_map : null );
 
-        $reservedKeys = array_filter(array($countKey, $resultsKey, $nextKey, $prevKey),
-                                     function ($value) {
-                                         return ( null !== $value );
-                                     } );
+        $reservedKeys = array_filter(
+            array($countKey, $resultsKey, $nextKey, $prevKey),
+            function ($value) {
+                return ( null !== $value );
+            }
+        );
 
         // --------------------------------------------------------------------------------
         // Perform a-priori verifications
@@ -485,7 +492,7 @@ implements iAction
             if ( ! is_array($results) ) {
                 $msg = "Request results is expected to be an array. Type returned was " . gettype($results);
                 $this->logAndThrowException($msg);
-            } else if ( 0 == count($results) ) {
+            } elseif ( 0 == count($results) ) {
                 $msg = "Request returned an empty result set, skipping. url = {$this->currentUrl}";
                 $this->logger->notice($msg);
 
@@ -713,7 +720,7 @@ implements iAction
 
         // Apply any parameter transform/verify directives prior to setting the url.
 
-        if ( 0 != count( $this->parameterDirectives) ) {
+        if ( 0 != count($this->parameterDirectives) ) {
             foreach ( $this->parameterDirectives as $parameter => $directives ) {
                 if ( ! array_key_exists($parameter, $this->restParameters) ) {
                     continue;
@@ -726,37 +733,44 @@ implements iAction
                     return false;
                 }
             }
-        }  // if ( 0 != count( $this->responseDirectives) )
+        }  // if ( 0 != count($this->responseDirectives) )
 
         if ( null !== $this->restRequestConfig && isset($this->restRequestConfig->format) ) {
 
             // A format was specified. Substitute any existing parameters in the format string.
 
             $substitutions = array();
-            $queryString = Utilities::substituteVariables($this->restRequestConfig->format,
-                                                          $this->restParameters,
-                                                          $substitutions);
+            $queryString = Utilities::substituteVariables(
+                $this->restRequestConfig->format,
+                $this->restParameters,
+                $substitutions
+            );
 
             if ( false !== strpos($queryString, '${^REMAINING}') ) {
                 $used = array_combine($substitutions, $substitutions);
                 $remaining = array_diff_key($this->restParameters, $used);
-                $parameters = implode("&", array_map(function ($v, $k) {
+                $parameters = implode(
+                    "&",
+                    array_map(
+                        function ($v, $k) {
                             return $k . "=" . urlencode($v);
                         },
                         $remaining,
-                        array_keys($remaining))
-                    );
+                        array_keys($remaining)
+                    )
+                );
                 $queryString = Utilities::substituteVariables($queryString, array('^REMAINING' => $parameters));
             }
         } else {
             // Use standard query string format
 
-            $parameters = array_map(function ($v, $k) {
+            $parameters = array_map(
+                function ($v, $k) {
                     return $k . "=" . urlencode($v);
                 },
                 $this->restParameters,
                 array_keys($this->restParameters)
-                );
+            );
             $queryString = "?" . implode("&", $parameters);
         }
 
@@ -804,7 +818,7 @@ implements iAction
                 return false;
             }
 
-        } else if ( null !== $nextKey ) {
+        } elseif ( null !== $nextKey ) {
             if ( ! isset($response->$nextKey) || null === $response->$nextKey ) {
                 $this->logger->warning("Next property '$nextKey' not present or has null value in response, finished.");
                 return false;
@@ -916,19 +930,20 @@ implements iAction
         }
 
         switch ( $directive->type ) {
-        case 'datetime':
-            break;
-        case 'sprintf':
-            break;
-        case 'regex':
-            if ( false === preg_match($directive->format, "test") ) {
-                $msg = "Invalid regex format '{$directive->format}' for key '$key'";
+            case 'datetime':
+                break;
+            case 'sprintf':
+                break;
+            case 'regex':
+                if ( false === preg_match($directive->format, "test") ) {
+                    $msg = "Invalid regex format '{$directive->format}' for key '$key'";
+                    $this->logAndThrowException($msg);
+                }
+                break;
+            default:
+                $msg = "Unsupported transform type '{$directive->type}' for key '$key'";
                 $this->logAndThrowException($msg);
-            }
-        default:
-            $msg = "Unsupported transform type '{$directive->type}' for key '$key'";
-            $this->logAndThrowException($msg);
-            break;
+                break;
         }
 
         return true;
@@ -955,16 +970,16 @@ implements iAction
         }
 
         switch ( $directive->type ) {
-        case 'regex':
-            if ( false === preg_match($directive->format, "test") ) {
-                $msg = "Invalid regex format '{$directive->format}' for key '$key'";
+            case 'regex':
+                if ( false === preg_match($directive->format, "test") ) {
+                    $msg = "Invalid regex format '{$directive->format}' for key '$key'";
+                    $this->logAndThrowException($msg);
+                }
+                break;
+            default:
+                $msg = "Unsupported transform type '{$directive->type}' for key '$key'";
                 $this->logAndThrowException($msg);
-            }
-            break;
-        default:
-            $msg = "Unsupported transform type '{$directive->type}' for key '$key'";
-            $this->logAndThrowException($msg);
-            break;
+                break;
         }
 
         return true;
@@ -1018,24 +1033,24 @@ implements iAction
     private function applyTransformDirective($value, \stdClass $directive)
     {
         switch ( $directive->type ) {
-        case 'datetime':
-            $value = date($directive->format, strtotime($value));
-            break;
-        case 'regex':
-            $matches = null;
-            $matched = preg_match($directive->format, $value, $matches);
-            if ( false === $matched ) {
-                $msg = "Error transforming regex '{$directive->format}'";
-                $this->logAndThrowException($msg);
-            } else if ( 1 == $matched ) {
-                $value = $matches[0];
-            }
-            break;
-        case 'sprintf':
-            $value = sprintf($directive->format, $value);
-            break;
-        default:
-            break;
+            case 'datetime':
+                $value = date($directive->format, strtotime($value));
+                break;
+            case 'regex':
+                $matches = null;
+                $matched = preg_match($directive->format, $value, $matches);
+                if ( false === $matched ) {
+                    $msg = "Error transforming regex '{$directive->format}'";
+                    $this->logAndThrowException($msg);
+                } elseif ( 1 == $matched ) {
+                    $value = $matches[0];
+                }
+                break;
+            case 'sprintf':
+                $value = sprintf($directive->format, $value);
+                break;
+            default:
+                break;
         }  // switch ( $directive->type )
 
         return $value;
@@ -1057,19 +1072,18 @@ implements iAction
     private function applyVerifyDirective($value, \stdClass $directive)
     {
         switch ( $directive->type ) {
-        case 'regex':
-            $matched = preg_match($directive->format, $value);
-            if ( 0 === $matched ) {
-                $msg = "Failed {$directive->type} ({$directive->format}) verification for '$value'";
-                $this->logAndThrowException($msg);
-            }
-            break;
-        default:
-            break;
+            case 'regex':
+                $matched = preg_match($directive->format, $value);
+                if ( 0 === $matched ) {
+                    $msg = "Failed {$directive->type} ({$directive->format}) verification for '$value'";
+                    $this->logAndThrowException($msg);
+                }
+                break;
+            default:
+                break;
         }  // switch ( $directive->type )
 
         return true;
 
     }  // verifyTransformDirective()
-
 }  // class RestIngestor

--- a/classes/ETL/Ingestor/RestIngestor.php
+++ b/classes/ETL/Ingestor/RestIngestor.php
@@ -334,7 +334,7 @@ implements iAction
             // Disable keys for faster inserts
             $qualifiedDestTableName = $this->etlDestinationTable->getFullName();
             $sqlList = array("ALTER TABLE $qualifiedDestTableName DISABLE KEYS");
-            $this->executeSqlList($sqlList, $this->destinationHandle) ;
+            $this->executeSqlList($sqlList, $this->destinationEndpoint);
         }
 
         return true;
@@ -351,7 +351,7 @@ implements iAction
         if ( "myisam" == strtolower($this->etlDestinationTable->getEngine()) ) {
             $qualifiedDestTableName = $this->etlDestinationTable->getFullName();
             $sqlList = array("ALTER TABLE $qualifiedDestTableName ENABLE KEYS");
-            $this->executeSqlList($sqlList, $this->destinationHandle);
+            $this->executeSqlList($sqlList, $this->destinationEndpoint);
         }
 
         return true;

--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -168,7 +168,7 @@ class StructuredFileIngestor extends aIngestor implements iAction
             }, $destColumns))
         ;
 
-        $this->logger->debug("Insert query\n$sql");
+        $this->logger->debug("Insert query " . $this->destinationEndpoint . ":\n$sql");
 
         if ( ! $this->etlOverseerOptions->isDryrun() ) {
             try {
@@ -182,7 +182,10 @@ class StructuredFileIngestor extends aIngestor implements iAction
                     ));
                 }
             } catch (PDOException $e) {
-                $this->logAndThrowSqlException($sql, $e, "Error inserting file data");
+                $this->logAndThrowException(
+                    "Error inserting file data",
+                    array('exception' => $e, 'endpoint' => $this)
+                );
             }
         }
 

--- a/classes/ETL/Ingestor/UpdateIngestor.php
+++ b/classes/ETL/Ingestor/UpdateIngestor.php
@@ -141,7 +141,7 @@ implements iAction
             $msg = "'fields' key missing or not an array in 'source_data' block: " . $this->definitionFile;
             $this->logAndThrowException($msg);
         }
-        
+
         // 2. Create data & verify source. Data source is iteratable. Instantiate object based on columns and data.
         // 3. In execute()
         //    a. Construct prepared update statement
@@ -169,7 +169,7 @@ implements iAction
         }
 
         // If the data is a string assume it is a filename, otherwise assume it is parsed JSON.
-        
+
         if ( is_string($this->parsedDefinitionFile->source_data->data) ) {
             $filename = $this->parsedDefinitionFile->source_data->data;
             if ( 0 !== strpos($filename, "/") ) {
@@ -198,7 +198,7 @@ implements iAction
      * @see iAction::execute()
      * ------------------------------------------------------------------------------------------
      */
-  
+
     public function execute(EtlOverseerOptions $etlOptions)
     {
         $this->etlOverseerOptions = $etlOptions;
@@ -215,9 +215,9 @@ implements iAction
             implode(", ", array_map(function($s) { return "$s = ?"; }, $this->parsedDefinitionFile->update->set)) .
             " WHERE " .
             implode(" AND ", array_map(function($w) { return "$w = ?"; }, $this->parsedDefinitionFile->update->where));
-        
-        $this->logger->debug("Update query\n$sql"); 
-       
+
+        $this->logger->debug("Update query\n$sql");
+
         // The order and number of the fields must match the update statement
         $dataFields = array_merge($this->parsedDefinitionFile->update->set, $this->parsedDefinitionFile->update->where);
 
@@ -227,11 +227,11 @@ implements iAction
             function($field) use($fieldsToIndexes) { return $fieldsToIndexes[$field]; },
             $dataFields
             );
-        
+
         if ( ! $etlOptions->isDryrun() ) {
             try {
                 $updateStatement = $this->destinationHandle->prepare($sql);
-                
+
                 foreach ( $this->data as $record ) {
                     $row = array_map(
                         function($index) use ($record) { return $record[$index]; },
@@ -243,7 +243,10 @@ implements iAction
                 }
 
             } catch (PDOException $e) {
-                $this->logAndThrowSqlException($sql, $e, "Error updating " . $this->etlDestinationTable->getFullName());
+                $this->logAndThrowException(
+                    "Error updating " . $this->etlDestinationTable->getFullName(),
+                    array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->destinationEndpoint)
+                );
             }
         }
 

--- a/classes/ETL/Maintenance/ExecuteSql.php
+++ b/classes/ETL/Maintenance/ExecuteSql.php
@@ -27,8 +27,7 @@ use PHPSQLParser\exceptions\UnsupportedFeatureException;
 // exceptions we must do the same and reference the global \Exception when we throw one.
 use Exception;
 
-class ExecuteSql extends aAction
-implements iAction
+class ExecuteSql extends aAction implements iAction
 {
     // Delimiter for SQL scripts that contain multiple statements
     const DEFAULT_MULTI_STATEMENT_DELIMITER = '//';
@@ -103,7 +102,7 @@ implements iAction
             if ( ! file_exists($filename) ) {
                 $msg = "SQL file does not exist '$filename'";
                 $this->logAndThrowException($msg);
-            } else if ( ! is_readable($filename) ) {
+            } elseif ( ! is_readable($filename) ) {
                 $msg = "SQL file is not readable '$filename'";
                 $this->logAndThrowException($msg);
             }
@@ -275,5 +274,4 @@ implements iAction
                                     'elapsed_time' => round($time, 5)
                                   ));
     }  // execute()
-
 }  // class ExecuteSql

--- a/classes/ETL/Maintenance/ExecuteSql.php
+++ b/classes/ETL/Maintenance/ExecuteSql.php
@@ -242,7 +242,7 @@ implements iAction
                     continue;
                 }
 
-                $this->logger->debug("Executing SQL: $sql");
+                $this->logger->debug("Executing SQL " . $destinationEndpoint . ":\n$sql");
                 $sqlStartTime = microtime(true);
                 $numRowsAffected = 0;
                 try {
@@ -250,8 +250,10 @@ implements iAction
                         $numRowsAffected = $destinationEndpoint->getHandle()->execute($sql);
                     }
                 } catch ( PDOException $e ) {
-                    $msg = "Error executing sql: " . $e->getMessage();
-                    $this->logAndThrowSqlException($sql, $e);
+                    $this->logAndThrowException(
+                        "Error executing SQL",
+                        array('exception' => $e, 'sql' => $this->sqlQueryString, 'endpoint' => $this->sourceEndpoint)
+                    );
                 }
 
                 $time = microtime(true) - $sqlStartTime;

--- a/classes/ETL/Maintenance/VerifyDatabase.php
+++ b/classes/ETL/Maintenance/VerifyDatabase.php
@@ -27,8 +27,7 @@ use PHPSQLParser\PHPSQLParser;
 // exceptions we must do the same and reference the global \Exception when we throw one.
 use Exception;
 
-class VerifyDatabase extends aAction
-implements iAction
+class VerifyDatabase extends aAction implements iAction
 {
     // Column names extracted from the query, used to verify macro expansions used in the line
     // messages are valid.
@@ -93,19 +92,19 @@ implements iAction
 
         // Verify that the response block and destination email are set
 
-        if (  ! isset($this->parsedDefinitionFile->verify_database) ) {
+        if ( ! isset($this->parsedDefinitionFile->verify_database) ) {
             $msg = "Required key verify_database not found in definition file";
             $this->logAndThrowException($msg);
         }
 
         $verifyConfig = $this->parsedDefinitionFile->verify_database;
 
-        if (  ! isset($verifyConfig->response) ) {
+        if ( ! isset($verifyConfig->response) ) {
             $msg = "Required key verify_database.response not found in definition file";
             $this->logAndThrowException($msg);
         }
 
-        if (  ! isset($verifyConfig->response->line) ) {
+        if ( ! isset($verifyConfig->response->line) ) {
             $msg = "Required key verify_database.response.line not found in definition file";
             $this->logAndThrowException($msg);
         }
@@ -117,7 +116,7 @@ implements iAction
             $missing = array_diff($matches[0], $this->queryColumnNames);
             if ( 0 != count($missing) ) {
                 $msg = "The following column names were referenced in the line template but are "
-                    . "not present in the query: " . implode(", " , $missing);
+                    . "not present in the query: " . implode(", ", $missing);
                 $this->logAndThrowException($msg);
             }
         }
@@ -177,7 +176,7 @@ implements iAction
         if ( ! isset($this->parsedDefinitionFile->source_query) ) {
             $msg = "Required source_query key not found";
             $this->logAndThrowException($msg);
-        } else if ( isset($this->parsedDefinitionFile->source_query->sql_file) ) {
+        } elseif ( isset($this->parsedDefinitionFile->source_query->sql_file) ) {
 
             $sqlFile = $this->parsedDefinitionFile->source_query->sql_file;
             $sqlFile = $this->options->applyBasePath("paths->sql_dir", $sqlFile);
@@ -219,9 +218,11 @@ implements iAction
 
         } else {
             $this->logger->debug("Create ETL source query object");
-            $sourceQuery = new Query($this->parsedDefinitionFile->source_query,
-                                     $this->sourceEndpoint->getSystemQuoteChar(),
-                                     $this->logger);
+            $sourceQuery = new Query(
+                $this->parsedDefinitionFile->source_query,
+                $this->sourceEndpoint->getSystemQuoteChar(),
+                $this->logger
+            );
             $this->queryColumnNames = array_keys($sourceQuery->getRecords());
             $this->setOverseerRestrictionOverrides();
             $this->etlOverseerOptions->applyOverseerRestrictions($sourceQuery, $this->sourceEndpoint, $this->overseerRestrictionOverrides);
@@ -254,7 +255,8 @@ implements iAction
                 $verifyConfig->response->$option,
                 $this->variableMap,
                 $substitutedVars,
-                $unsubstitutedVars);
+                $unsubstitutedVars
+            );
 
             if ( 0 != count($unsubstitutedVars) ) {
                 $msg = $this . " Unsubstituted variables found in response $option: " . implode(",", $unsubstitutedVars);
@@ -324,5 +326,4 @@ implements iAction
                                     'elapsed_time' => round($time, 5)
                                   ));
     }  // execute()
-
 }  // class ExecuteSql

--- a/classes/ETL/Maintenance/VerifyDatabase.php
+++ b/classes/ETL/Maintenance/VerifyDatabase.php
@@ -281,7 +281,7 @@ implements iAction
 
         $time_start = microtime(true);
 
-        $this->logger->debug("Executing SQL: " . $this->sqlQueryString);
+        $this->logger->debug("Executing SQL " . $this->sourceEndpoint . ": " . $this->sqlQueryString);
         $verifyConfig = $this->parsedDefinitionFile->verify_database;
         $lineTemplate = $verifyConfig->response->line;
         $lines = array();
@@ -300,8 +300,10 @@ implements iAction
                 }
             }
         } catch ( PDOException $e ) {
-            $msg = "Error executing sql: " . $e->getMessage();
-            $this->logAndThrowSqlException($this->sqlQueryString, $e);
+            $this->logAndThrowException(
+                "Error executing SQL",
+                array('exception' => $e, 'sql' => $this->sqlQueryString, 'endpoint' => $this->sourceEndpoint)
+            );
         }
 
         // How do we substitute variables in the header and footer?

--- a/classes/ETL/Utilities.php
+++ b/classes/ETL/Utilities.php
@@ -51,8 +51,8 @@ class Utilities
         $string,
         array $map,
         array &$substitutedVariables = null,
-        array &$unsubstitutedVariables = null )
-    {
+        array &$unsubstitutedVariables = null
+    ) {
 
         // If we are not tracking the variables that have or have not been substituted, simply
         // perform a string replacement.
@@ -68,13 +68,17 @@ class Utilities
 
             // Track variables that have been substituted
 
-            array_map(function ($v, $k) use (&$string, &$localSubstituted) {
+            array_map(
+                function ($v, $k) use (&$string, &$localSubstituted) {
                     $search = '${' . $k . '}';
                     if ( false !== strpos($string, $search) ) {
                         $substituted[] = $k;
                     }
                     $string = str_replace($search, $v, $string);
-                }, $map, array_keys($map));
+                },
+                $map,
+                array_keys($map)
+            );
 
             // If there are any variables left in the string, track them as unsubstituted.
 
@@ -145,7 +149,7 @@ class Utilities
         if ( ! isset($paths->macro_dir) ) {
             $msg = __CLASS__ . ": ETL configuration paths.macro_dir is not set";
             throw new Exception($msg);
-        } else if ( ! is_dir($paths->macro_dir) ) {
+        } elseif ( ! is_dir($paths->macro_dir) ) {
             $msg = __CLASS__ . ": ETL configuration paths.macro_dir '{$paths->macro_dir}' is not a directory";
             throw new Exception($msg);
         }
@@ -172,7 +176,7 @@ class Utilities
         if ( ! is_file($filename) ) {
             $msg = __CLASS__ . ": Cannot load macro file '$filename'";
             throw new Exception($msg);
-        } else if ( 0 == filesize($filename) ) {
+        } elseif ( 0 == filesize($filename) ) {
             // No use processing an empty macro
             return;
         }
@@ -187,7 +191,7 @@ class Utilities
         $stripped = array();
 
         foreach ( explode("\n", $macro) as $line ) {
-            if ( 0 === strpos($line, "--") || 0 === strpos($line,  "#") ) {
+            if ( 0 === strpos($line, "--") || 0 === strpos($line, "#") ) {
                 continue;
             }
             $stripped[] = $line;
@@ -226,4 +230,23 @@ class Utilities
         return ( false === $value ? false : filter_var($value, $filter, $options) );
     }  // filterBooleanVar()
 
+    /* ------------------------------------------------------------------------------------------
+     * Generate an array of strings that can be used as PDO bind parameters (e.g., :var)
+     * using the keys from the source array.
+     *
+     * @param $source An associative array whose keys will be used to generate bind parameters
+     *
+     * @return An array containing the keys of $source pre-pended with ":"
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function createPdoBindVarsFromArrayKeys(array $source)
+    {
+        return array_map(
+            function ($key) {
+                return ":$key";
+            },
+            array_keys($source)
+        );
+    }  // createPdoBindVarsFromArrayKeys()
 }  // class Utilities

--- a/classes/ETL/aRdbmsDestinationAction.php
+++ b/classes/ETL/aRdbmsDestinationAction.php
@@ -151,7 +151,7 @@ abstract class aRdbmsDestinationAction extends aAction
             if ( is_object($parsedTableDefinition) ) {
                 // Standard single destination table
                 $tableDefinitionList[$parsedTableDefinition->name] = $parsedTableDefinition;
-            } else if ( is_array($parsedTableDefinition) ) {
+            } elseif ( is_array($parsedTableDefinition) ) {
                 // Temporary format for multiple destination tables
                 foreach ( $parsedTableDefinition as $singleTableDefinition ) {
                     $tableDefinitionList[$singleTableDefinition->name] = $singleTableDefinition;
@@ -161,9 +161,11 @@ abstract class aRdbmsDestinationAction extends aAction
             foreach ( $tableDefinitionList as $etlTableKey => $tableDefinition ) {
 
                 $this->logger->debug("Create ETL destination table object for table definition key '$etlTableKey'");
-                $etlTable = new Table($tableDefinition,
-                                      $this->destinationEndpoint->getSystemQuoteChar(),
-                                      $this->logger);
+                $etlTable = new Table(
+                    $tableDefinition,
+                    $this->destinationEndpoint->getSystemQuoteChar(),
+                    $this->logger
+                );
                 $etlTable->setSchema($this->destinationEndpoint->getSchema());
                 $tableName = $etlTable->getFullName();
 
@@ -424,10 +426,12 @@ abstract class aRdbmsDestinationAction extends aAction
 
         // Check for an existing table with the same name
 
-        $existingTable = Table::discover($table->getName(),
-                                         $endpoint,
-                                         $endpoint->getSystemQuoteChar(),
-                                         $this->logger);
+        $existingTable = Table::discover(
+            $table->getName(),
+            $endpoint,
+            $endpoint->getSystemQuoteChar(),
+            $this->logger
+        );
 
         // If no table with that name exists, create it. Otherwise check for differences and apply them.
 
@@ -464,5 +468,4 @@ abstract class aRdbmsDestinationAction extends aAction
         return $table;
 
     }  // manageTable()
-
 }  // abstract class aRdbmsDestinationAction


### PR DESCRIPTION
Improve ETLv2 query debuging

## Description

Augment Loggable::logAndThrowException() to accept a list of options and customize messages based on these options. This allowed us to merge Loggable::logAndThrowSqlException() into Loggable::logAndThrowException() and improve the display of SQL in debug mode.

Also display the DataEndpoint associated with every query now and fix phpcs style issues.

**Note that commits 216aa24, 8bfbcac, 729b1da were from a local merge and have already been merged in #45.**

## Motivation and Context

ETL is getting more complex pulling data from multiple databases, schemas, and files. It is important when debugging to know the queries being generated and the databases and schemas (DataEndpoints) that they are being run against.

## Tests performed

Ran the following ETLv2 pipelines: xdcdb-jobs (with and without aggregation binning), test-suite, resource-allocations. These test the following actions:
- Database Ingestor
- Update ingestor
- Jobs Aggregator
- Simple Aggregator
- Execute SQL
- MySQL, Postgres, JSON data endpoints

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
