### PR TITLE
update composer and php-codesniffer dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ clone it or create a symbolic link to it at `open_xdmod/modules/supremm`.
 This process has been tested on CentOS 6, CentOS 7, and Ubuntu 16.04. Known
 issues are documented in the [Building FAQ](#building-faq) below. If you run
 into any issues not listed below on these or any other platforms, please
-let us know.
+let us know. The tested version of composer is 1.3.2 (TravisCI builds use --stable)
 
   1. Change directory to the root of the Open XDMoD repository.
   1. Install Composer dependencies for Open XDMoD.
@@ -262,7 +262,7 @@ The resulting RPM will be located in `~/rpmbuild/RPMS/noarch`.
 
 Certain combinations of PHP and Composer do not handle redirects over HTTPS
 correctly. This is known to affect the version of PHP that CentOS 6 supplies
-combined with current stable versions of Composer (as of this writing, 1.2.4).
+combined with current stable versions of Composer (as of this writing, 1.3.2).
 To get things working, try one or more steps below.
 
   1. Update Composer to a newer version.
@@ -274,19 +274,9 @@ To get things working, try one or more steps below.
 
 #### Why is Composer failing to unzip Ext JS?
 
-The ZIP file for the version of Ext JS being used contains multiple files
-with the same path, and some ZIP programs and libraries do not handle this case
-quietly. If Composer uses the system's `unzip` utility to unpack the ZIP file
-and that version of `unzip` asks for input, Composer will error out. This is
-known to affect the ZIP utilities that Ubuntu 16.04 supplies and the current
-stable versions of Composer (as of this writing, 1.2.4).
+Older versions of Composer (< 1.3.2) had issues with the Ext JS zip file.
 
-Fortunately, PHP's ZIP library will work for this case. Unfortunately,
-getting Composer to use the PHP library currently requires either modifying
-Composer's code or hiding your system's `unzip` utility. You can do the latter
-quickly by temporarily renaming `unzip` to something like `unzip-hidden`, then
-changing the name back once Composer has completed installation. These solutions
-aren't ones we're fans of, so if you have a better solution, please share!
+Upgrading to at least version 1.3.2 resolves this issue.
 
 #### Why is `rpmbuild` warning about files not being found?
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.8.0"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "56d4332d0a9b08011dbc37e7a409449d",
+    "content-hash": "ceeef77ecbe7a0be2763939f54b3ba06",
     "packages": [
         {
             "name": "apache/commons-beanutils",
@@ -2449,16 +2449,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b"
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1bcdf03b068a530ac1962ce671dead356eeba43b",
-                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/86dd55a522238211f9f3631e3361703578941d9a",
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a",
                 "shasum": ""
             },
             "require": {
@@ -2523,7 +2523,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-04-03T22:58:34+00:00"
+            "time": "2017-02-02T03:30:00+00:00"
         },
         {
             "name": "symfony/polyfill-php54",


### PR DESCRIPTION
## Description
Update lock file with php-codesniffer dependency stuck to a specific version, bring all repositories in line with same version

## Motivation and Context
Make sure all composer.lock files match composer 1.3.x version

## Tests performed
ran composer install without errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)