### PR TITLE
make 'private' public....

### DIFF
--- a/classes/DB/Aggregator.php
+++ b/classes/DB/Aggregator.php
@@ -10,7 +10,7 @@
 
 class Aggregator extends Loggable
 {
-    private static $__initialized;
+    public static $__initialized;
 
     /**
      * (Optional) The name of the realm associated with this aggregator.


### PR DESCRIPTION
Somone didnt follow convention and used a _ when the variable was actually public...