### PR TITLE
Escape backslashes in PDODBMultiIngestor for MySQL LOAD DATA INFILE

### DIFF
--- a/classes/DB/PDODBMultiIngestor.php
+++ b/classes/DB/PDODBMultiIngestor.php
@@ -208,7 +208,7 @@ class PDODBMultiIngestor implements Ingestor
                         : (
                             empty($srcRow[$insert_field])
                             ? $string_enc . '' . $string_enc
-                            : $srcRow[$insert_field]
+                            : str_replace('\\', '\\\\', $srcRow[$insert_field])
                         )
                     );
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Escape backslashes in data fields.

## Motivation and Context

Backslashes must be escaped in data fields (see https://dev.mysql.com/doc/refman/5.5/en/load-data.html).  Depending on what character directly follows the backslash a variety of issues arise.  If a field contains only a backslash it escapes the enclosing character corrupting all data that follows.

## Tests performed

Shredded and ingested data containing a backslash.  Confirmed that the correct data was ingested.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
