### PR TITLE
Handle proper escaping of backslashes to preserve source data

### DIFF
--- a/classes/ETL/DbEntity/Query.php
+++ b/classes/ETL/DbEntity/Query.php
@@ -412,7 +412,7 @@ class Query extends aNamedEntity
     public function addOrderBy($orderBy)
     {
         if ( empty($orderBy) || ! is_string($orderBy) ) {
-            $msg = "Cannot add an empty group by";
+            $msg = "Cannot add an empty order by";
             $this->logAndThrowException($msg);
         }
 

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -811,6 +811,9 @@ class pdoIngestor extends aIngestor
                     $value = '\N';
                 } elseif ( empty($value) ) {
                     $value = $stringEnc . '' . $stringEnc;
+                } else {
+                    // Handle proper escaping of backslashes to preserve source data containing them.
+                    $value = str_replace('\\', '\\\\', $value);
                 }
             }
 


### PR DESCRIPTION
Handle proper escaping of backslashes to preserve source data

## Description

Source data containing backslashes must be properly escaped to preserve the backslashes.

## Motivation and Context

See #52 

## Tests performed

Tested using SimpleDatabaseIngestor with the following source data and verified that backslashes were not preserved prior to but were after the patch.
```
'\', '\\', '\\n\\'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
