### PR TITLE
Remove unused database table column (`moddb`.`Users`.`parent_user_id`)

### DIFF
--- a/bin/xdmod-upgrade
+++ b/bin/xdmod-upgrade
@@ -25,7 +25,7 @@ ini_set('memory_limit', -1);
  * @var array
  */
 $supportedUpgrades = array(
-    '6.0.0' => '6.5.0',
+    '6.5.0' => '6.6.0',
 );
 
 /**

--- a/classes/OpenXdmod/Migration/Version650To660/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version650To660/ConfigFilesMigration.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Jeffrey T. Palmer <jtpalmer@buffalo.edu>
+ */
+
+namespace OpenXdmod\Migration\Version650To660;
+
+use OpenXdmod\Migration\ConfigFilesMigration as AbstractConfigFilesMigration;
+
+/**
+ * Update config files from version 6.5.0 to 6.6.0.
+ */
+class ConfigFilesMigration extends AbstractConfigFilesMigration
+{
+    /**
+     * Execute the migration.
+     */
+    public function execute()
+    {
+        // Make sure all the config files that will be changed are writable.
+        $this->assertPortalSettingsIsWritable();
+
+        // Set new options in portal_settings.ini.
+        $this->writePortalSettingsFile();
+    }
+}

--- a/classes/OpenXdmod/Migration/Version650To660/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version650To660/DatabasesMigration.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @author Jeffrey T. Palmer <jtpalmer@buffalo.edu>
+ */
+
+namespace OpenXdmod\Migration\Version650To660;
+
+/**
+ * Migrate databases from version 6.5.0 to 6.6.0.
+ */
+class DatabasesMigration extends \OpenXdmod\Migration\DatabasesMigration
+{
+}

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -6,7 +6,7 @@ contact_page_recipient = ""
 tech_support_recipient = ""
 
 ; The version number is updated during the upgrade process.
-version = "6.5.0"
+version = "6.6.0"
 
 debug_mode = "off"
 debug_recipient = ""

--- a/db/data/moddb.sql
+++ b/db/data/moddb.sql
@@ -37,4 +37,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
-INSERT INTO `schema_version_history` VALUES ('moddb', '6.0.0', NOW(), 'created', 'N/A');
+INSERT INTO `schema_version_history` VALUES ('moddb', '6.6.0', NOW(), 'created', 'N/A');

--- a/db/migrations/6.5.0-6.6.0/moddb.sql
+++ b/db/migrations/6.5.0-6.6.0/moddb.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `Users` DROP COLUMN `parent_user_id`;
+
+INSERT INTO `schema_version_history` VALUES ('moddb', '6.6.0', NOW(), 'upgraded', 'N/A');

--- a/db/schema/moddb.sql
+++ b/db/schema/moddb.sql
@@ -272,7 +272,6 @@ CREATE TABLE `Users` (
   `field_of_science` int(11) DEFAULT NULL,
   `token` varchar(32) DEFAULT NULL,
   `token_expiration` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `parent_user_id` int(11) NOT NULL,
   `user_type` int(11) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `person_id_idx` (`person_id`)

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -81,7 +81,6 @@ $config = array(
         'personId' => 'person_id',
         'orgId' => 'organization_id',
         'fieldOfScience' => 'field_of_science',
-        'parentId' => 'parent_user_id',
         'itname' => 'username'
       )
     )

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod",
-    "version": "6.5.0",
+    "version": "6.6.0",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod",
-    "version": "6.5.0",
+    "version": "6.6.0",
     "description": "An open framework for collecting and analyzing HPC metrics.",
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds migration to remove the `parent_user_id` column from the `Users` table in the `moddb` database.

Also bumps version numbers and adds migration boilerplate.  This could be moved to a separate PR, but is needed for testing purposes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This column is not used and causes problems with [MySQL's strict `sql_mode`s](https://dev.mysql.com/doc/refman/5.5/en/sql-mode.html) since it is `NOT NULL` and does not have a default value and no value was being set.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested migration:

- Installed Open XDMoD 6.5.0
- Upgraded to a build of this branch
- Ran `xdmod-upgrade`
- Observed that the column was removed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
