### PR TITLE
Remove experimental shredder feature

### DIFF
--- a/classes/OpenXdmod/Shredder.php
+++ b/classes/OpenXdmod/Shredder.php
@@ -293,30 +293,6 @@ class Shredder
     }
 
     /**
-     * Return the resource node name for a node name.
-     *
-     * @param string $node
-     * @param string $date
-     * @param string $fallback
-     *
-     * @return string
-     */
-    public function getResourceForNode($node, $date, $fallback = null)
-    {
-        $this->logger->debug("Getting resource name for node '$node'");
-
-        if ($this->hasResource()) {
-            return $this->getResource();
-        }
-
-        if ($fallback === null) {
-            throw new Exception("Failed to find resource for node '$node'");
-        }
-
-        return $fallback;
-    }
-
-    /**
      * Set the column used to determine the PI.
      *
      * @param string $columnName

--- a/classes/OpenXdmod/Shredder/Pbs.php
+++ b/classes/OpenXdmod/Shredder/Pbs.php
@@ -253,11 +253,7 @@ class Pbs extends Shredder
             return;
         }
 
-        $job['host'] = $this->getResourceForNode(
-            $node,
-            $date,
-            $jobIdData['host']
-        );
+        $job['host'] = $this->getResource();
 
         foreach (array_keys($job) as $key) {
             if (!in_array($key, self::$columnNames)) {

--- a/classes/OpenXdmod/Shredder/Sge.php
+++ b/classes/OpenXdmod/Shredder/Sge.php
@@ -353,12 +353,7 @@ class Sge extends Shredder
 
         $this->checkJobData($line, $job);
 
-        $date = DateTime::createFromFormat('U', $job['end_time']);
-
-        $job['clustername'] = $this->getResourceForNode(
-            $job['hostname'],
-            $date->format('Y-m-d')
-        );
+        $job['clustername'] = $this->getResource();
 
         $this->insertRow($job);
     }

--- a/classes/OpenXdmod/Shredder/Slurm.php
+++ b/classes/OpenXdmod/Shredder/Slurm.php
@@ -226,8 +226,6 @@ class Slurm extends Shredder
             return;
         }
 
-        $date = substr($job['end_time'], 0, 10);
-
         // Convert datetime strings into unix timestamps.
         $dateKeys = array(
             'submit_time',
@@ -250,11 +248,7 @@ class Slurm extends Shredder
             $job[$key] = $this->parseTimeField($job[$key]);
         }
 
-        $job['cluster_name'] = $this->getResourceForNode(
-            $node,
-            $date,
-            $job['cluster_name']
-        );
+        $job['cluster_name'] = $this->getResource();
 
         $this->checkJobData($line, $job);
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,13 +289,6 @@ principal investigator (`pi`), center staff (`cs`) and manager (`mgr`).
         }
     }
 
-### node_attributes.json
-
-Used to define data needed for sub-resources.
-
-**NOTE**: This configuration file is deprecated and may be removed in
-a future release.
-
 ### organization.json
 
 Defines the organization name and abbreviation.

--- a/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/LsfShredderTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/LsfShredderTest.php
@@ -34,7 +34,7 @@ class LsfShredderTest extends \PHPUnit_Framework_TestCase
         $shredder = $this
             ->getMockBuilder('\OpenXdmod\Shredder\Lsf')
             ->disableOriginalConstructor()
-            ->setMethods(array('insertRow'))
+            ->setMethods(array('insertRow', 'getResourceConfig'))
             ->getMock();
 
         $shredder
@@ -42,7 +42,13 @@ class LsfShredderTest extends \PHPUnit_Framework_TestCase
             ->method('insertRow')
             ->with($row);
 
+        $shredder
+            ->method('getResourceConfig')
+            ->willReturn(array());
+
         $shredder->setLogger(\Log::singleton('null'));
+
+        $shredder->setResource('testresource');
 
         $shredder->shredLine($line);
     }
@@ -202,7 +208,7 @@ class LsfShredderTest extends \PHPUnit_Framework_TestCase
                     'unknown61' => '1',
                     'unknown62' => '',
                     'walltime' => 5794523.29,
-                    'resource_name' => null,
+                    'resource_name' => 'testresource',
                     'node_list' => 'host1201-ib,host1234-ib,host1235-ib,host1236-ib,host1257-ib,host1270-ib,host1301-ib,host1303-ib',
                 )
             ),

--- a/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/PbsShredderTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/PbsShredderTest.php
@@ -35,7 +35,7 @@ class PbsShredderTest extends \PHPUnit_Framework_TestCase
         $shredder = $this
             ->getMockBuilder('\OpenXdmod\Shredder\Pbs')
             ->disableOriginalConstructor()
-            ->setMethods(array('insertRow'))
+            ->setMethods(array('insertRow', 'getResourceConfig'))
             ->getMock();
 
         $shredder
@@ -43,7 +43,13 @@ class PbsShredderTest extends \PHPUnit_Framework_TestCase
             ->method('insertRow')
             ->with($row);
 
+        $shredder
+            ->method('getResourceConfig')
+            ->willReturn(array());
+
         $shredder->setLogger(\Log::singleton('null'));
+
+        $shredder->setResource('testresource');
 
         $shredder->shredLine($line);
     }
@@ -57,7 +63,7 @@ class PbsShredderTest extends \PHPUnit_Framework_TestCase
                 '12/21/2009 15:27:00;E;6.edge.ccr.buffalo.edu;user=jonesm group=ccrstaff jobname=impi-hybrid queue=ccr ctime=1261424924 qtime=1261424924 etime=1261424924 start=1261425023 owner=jonesm@edge.ccr.buffalo.edu exec_host=i02n33/7+i02n33/6+i02n33/5+i02n33/4+i02n33/3+i02n33/2+i02n33/1+i02n33/0+i02n32/7+i02n32/6+i02n32/5+i02n32/4+i02n32/3+i02n32/2+i02n32/1+i02n32/0+i02n31/7+i02n31/6+i02n31/5+i02n31/4+i02n31/3+i02n31/2+i02n31/1+i02n31/0+i02n30/7+i02n30/6+i02n30/5+i02n30/4+i02n30/3+i02n30/2+i02n30/1+i02n30/0 Resource_List.neednodes=4:ppn=8 Resource_List.nodect=4 Resource_List.nodes=4:ppn=8 Resource_List.pcput=144:00:00 Resource_List.walltime=04:00:00 session=5510 end=1261427220 Exit_status=0 resources_used.cput=00:00:00 resources_used.mem=15240kb resources_used.vmem=350936kb resources_used.walltime=00:36:37',
                 array(
                     'job_id'                  => '6',
-                    'host'                    => 'edge.ccr.buffalo.edu',
+                    'host'                    => 'testresource',
                     'queue'                   => 'ccr',
                     'user'                    => 'jonesm',
                     'groupname'               => 'ccrstaff',
@@ -90,7 +96,7 @@ class PbsShredderTest extends \PHPUnit_Framework_TestCase
                 '11/09/2014 23:59:51;E;6464684.anonhost;user=anonuser group=anongroup jobname=anonjob queue=default ctime=1415579756 qtime=1415579756 etime=1415579756 start=1415589841 owner=anon@n180 exec_host=n404/2+n404/3+n404/4+n404/5 Resource_List.mem=1993mb Resource_List.ncpus=1 Resource_List.neednodes=1:ppn=4:avx Resource_List.nodect=1 Resource_List.nodes=1:ppn=4:avx Resource_List.walltime=24:00:00 session=100966 end=1415599191 Exit_status=1 resources_used.cput=10:16:36 resources_used.mem=167864kb resources_used.vmem=622552kb resources_used.walltime=02:35:49 account=anonaccount',
                 array(
                     'job_id'                  => '6464684',
-                    'host'                    => 'anonhost',
+                    'host'                    => 'testresource',
                     'queue'                   => 'default',
                     'user'                    => 'anonuser',
                     'groupname'               => 'anongroup',
@@ -125,7 +131,7 @@ class PbsShredderTest extends \PHPUnit_Framework_TestCase
                 '01/26/2016 00:00:37;E;2994.pbs;user=anonuser group=anongroup project=_pbs_project_default jobname=anonjob queue=workq ctime=1453756297 qtime=1453756297 etime=1453756297 start=1453766281 exec_host=c1/0*13+c2/0*13+c3/0*13+c4/0*13+c5/0*13 exec_vnode=(c1:ncpus=13)+(c2:ncpus=13)+(c3:ncpus=13)+(c4:ncpus=13)+(c5:ncpus=13) Resource_List.ncpus=65 Resource_List.nodect=5 Resource_List.place=scatter:excl Resource_List.select=5:ncpus=13 Resource_List.walltime=00:02:43 session=17927 end=1453766437 Exit_status=0 resources_used.cpupercent=0 resources_used.cput=00:00:00 resources_used.mem=664kb resources_used.ncpus=65 resources_used.vmem=10704kb resources_used.walltime=00:00:00 run_count=1',
                 array(
                     'job_id'                  => '2994',
-                    'host'                    => 'pbs',
+                    'host'                    => 'testresource',
                     'queue'                   => 'workq',
                     'user'                    => 'anonuser',
                     'groupname'               => 'anongroup',
@@ -154,7 +160,7 @@ class PbsShredderTest extends \PHPUnit_Framework_TestCase
                 '01/26/2016 00:00:37;E;2995.pbs;user=anonuser group=anongroup project=_pbs_project_default jobname=anonjob queue=anonq ctime=1453756297 qtime=1453756297 etime=1453756297 start=1453766281 exec_host=c1/0-3+c2/0-7 Resource_List.ncpus=12 Resource_List.nodect=2 Resource_List.walltime=00:02:43 session=17927 end=1453766437 Exit_status=0 resources_used.cput=00:00:00 resources_used.mem=664kb resources_used.ncpus=12 resources_used.vmem=10704kb resources_used.walltime=00:00:00 run_count=1',
                 array(
                     'job_id'                  => '2995',
-                    'host'                    => 'pbs',
+                    'host'                    => 'testresource',
                     'queue'                   => 'anonq',
                     'user'                    => 'anonuser',
                     'groupname'               => 'anongroup',

--- a/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/SgeShredderTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/SgeShredderTest.php
@@ -35,19 +35,21 @@ class SgeShredderTest extends \PHPUnit_Framework_TestCase
         $shredder = $this
             ->getMockBuilder('\OpenXdmod\Shredder\Sge')
             ->disableOriginalConstructor()
-            ->setMethods(array('insertRow', 'hasResource'))
+            ->setMethods(array('insertRow', 'getResourceConfig'))
             ->getMock();
-
-        $shredder
-            ->method('hasResource')
-            ->willReturn(true);
 
         $shredder
             ->expects($this->once())
             ->method('insertRow')
             ->with($row);
 
+        $shredder
+            ->method('getResourceConfig')
+            ->willReturn(array());
+
         $shredder->setLogger(\Log::singleton('null'));
+
+        $shredder->setResource('testresource');
 
         $shredder->shredLine($line);
     }
@@ -114,7 +116,7 @@ class SgeShredderTest extends \PHPUnit_Framework_TestCase
                     'resource_list_s_cpu' => '36000',
                     'resource_list_s_rt' => '36000',
                     'resource_list_slots' => '1',
-                    'clustername' => null,
+                    'clustername' => 'testresource',
                 ),
             ),
         );

--- a/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/SlurmShredderTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/SlurmShredderTest.php
@@ -34,7 +34,7 @@ class SlurmShredderTest extends \PHPUnit_Framework_TestCase
         $shredder = $this
             ->getMockBuilder('\OpenXdmod\Shredder\Slurm')
             ->setConstructorArgs(array($this->db))
-            ->setMethods(array('insertRow'))
+            ->setMethods(array('insertRow', 'getResourceConfig'))
             ->getMock();
 
         $shredder
@@ -42,7 +42,13 @@ class SlurmShredderTest extends \PHPUnit_Framework_TestCase
             ->method('insertRow')
             ->with($row);
 
+        $shredder
+            ->method('getResourceConfig')
+            ->willReturn(array());
+
         $shredder->setLogger(\Log::singleton('null'));
+
+        $shredder->setResource('testresource');
 
         $shredder->shredLine($line);
     }
@@ -91,7 +97,7 @@ class SlurmShredderTest extends \PHPUnit_Framework_TestCase
                     'job_id' => '4103947',
                     'job_id_raw' => '4103947',
                     'job_array_index' => -1,
-                    'cluster_name' => 'ub-hpc',
+                    'cluster_name' => 'testresource',
                     'partition_name' => 'general-compute',
                     'account_name' => 'anon',
                     'group_name' => 'anon',
@@ -122,7 +128,7 @@ class SlurmShredderTest extends \PHPUnit_Framework_TestCase
                     'job_id' => '4107166',
                     'job_id_raw' => '4107166',
                     'job_array_index' => -1,
-                    'cluster_name' => 'ub-hpc',
+                    'cluster_name' => 'testresource',
                     'partition_name' => 'general-compute',
                     'account_name' => 'dspumpkins',
                     'group_name' => 'dspumpkins',
@@ -153,7 +159,7 @@ class SlurmShredderTest extends \PHPUnit_Framework_TestCase
                     'job_id' => '4107219',
                     'job_id_raw' => '4107219',
                     'job_array_index' => -1,
-                    'cluster_name' => 'ub-hpc',
+                    'cluster_name' => 'testresource',
                     'partition_name' => 'general-compute',
                     'account_name' => 'anonacct',
                     'group_name' => 'anongroup',
@@ -184,7 +190,7 @@ class SlurmShredderTest extends \PHPUnit_Framework_TestCase
                     'job_id' => '5692623',
                     'job_id_raw' => '5692623',
                     'job_array_index' => -1,
-                    'cluster_name' => 'ub-hpc',
+                    'cluster_name' => 'testresource',
                     'partition_name' => '',
                     'account_name' => 'ccr',
                     'group_name' => 'na',

--- a/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/UgeShredderTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Shredder/UgeShredderTest.php
@@ -35,19 +35,21 @@ class UgeShredderTest extends \PHPUnit_Framework_TestCase
         $shredder = $this
             ->getMockBuilder('\OpenXdmod\Shredder\Uge')
             ->disableOriginalConstructor()
-            ->setMethods(array('insertRow', 'hasResource'))
+            ->setMethods(array('insertRow', 'getResourceConfig'))
             ->getMock();
-
-        $shredder
-            ->method('hasResource')
-            ->willReturn(true);
 
         $shredder
             ->expects($this->once())
             ->method('insertRow')
             ->with($row);
 
+        $shredder
+            ->method('getResourceConfig')
+            ->willReturn(array());
+
         $shredder->setLogger(\Log::singleton('null'));
+
+        $shredder->setResource('testresource');
 
         $shredder->shredLine($line);
     }
@@ -115,7 +117,7 @@ class UgeShredderTest extends \PHPUnit_Framework_TestCase
                     'resource_list_s_cpu' => '36000',
                     'resource_list_s_rt' => '36000',
                     'resource_list_slots' => '1',
-                    'clustername' => null,
+                    'clustername' => 'testresource',
                 ),
             ),
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Removes the `getResourceForNode` method from the shredder base class.  This method was originally intended to provide a feature where the resource name could be determined from name of a node used by a job on a given day.  This would allow for defining sub-resources within a given resource.  It was never fully implemented and the removed method effectively returned the resource name that was set for a shredder instance (since the resource name is always required by the `xdmod-shredder` command).

The tests have also been improved to ensure that the resource name corresponds to the one which is set and not the resource name that may be contained in the accounting data (which is what is expected elsewhere in the ingestion process).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since this feature was never fully implemented it provides no benefits and makes the code more complicated.  Removing it simplifies the code and makes it easier to understand.  It also fixes an issue where parsing the end time in SGE logs files fails.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
