### PR TITLE
Ensure use of PHPUnit installed by composer

### DIFF
--- a/classes/UnitTesting/RunTests.sh
+++ b/classes/UnitTesting/RunTests.sh
@@ -14,4 +14,11 @@ then
 fi
 
 cd $(dirname $0)
-phpunit ${PHPUNITARGS} .
+phpunit="$(readlink -f ../../vendor/bin/phpunit)"
+
+if [ ! -x "$phpunit" ]; then
+    echo phpunit not found, run \"composer install\" 1>&2
+    exit 127
+fi
+
+$phpunit ${PHPUNITARGS} .

--- a/open_xdmod/modules/xdmod/tests/runtests.sh
+++ b/open_xdmod/modules/xdmod/tests/runtests.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-if { ! which phpunit >/dev/null 2>&1; } then
-    echo phpunit not found 1>&2
+cd $(dirname $0)
+phpunit="$(readlink -f ../../../../vendor/bin/phpunit)"
+
+if [ ! -x "$phpunit" ]; then
+    echo phpunit not found, run \"composer install\" 1>&2
     exit 127
 fi
 
-cd $(dirname $0)
-phpunit .
+$phpunit .
 exit $?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes tests scripts so that they explicitly use the `phpunit` command installed by composer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The travis scripts set the `PATH` to include the composer vendor directory, but there is no guarantee that a developer running the tests scripts will do the same or that they will not have a different version of PHPUnit installed elsewhere in their `PATH`.  These changes ensure that the `phpunit` that is installed in the vendor directory will be used.

There may be a better way to do this, or we may not want to do it at all, so I'm open to discussion.  I do think we should do something to make sure that it's easy for developers running these scripts on the command line to know the correct version of PHPUnit is being used.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran updated tests scripts on the command line.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
