### PR TITLE
Organize realms under categories

### DIFF
--- a/classes/DataWarehouse.php
+++ b/classes/DataWarehouse.php
@@ -15,6 +15,7 @@
  */
 
 use CCR\DB;
+use Xdmod\Config;
 
 /*
  *	@Class DataWarehouse
@@ -448,4 +449,52 @@ class DataWarehouse
         );
         return $results;
     } // getAllocationsByChargeNumber()
+
+    /**
+     * Get a mapping of categories to realms.
+     *
+     * If a realm does not explicitly declare a category, its name is used
+     * as the category.
+     *
+     * @return array An associative array mapping categories to the realms
+     *               they contain.
+     */
+    public static function getCategories()
+    {
+        $config = Config::factory();
+        $dwConfig = $config['datawarehouse'];
+
+        $categories = array();
+        foreach ($dwConfig['realms'] as $realmName => $realm) {
+            $category = (
+                isset($realm['category'])
+                ? $realm['category']
+                : $realmName
+            );
+            $categories[$category][] = $realmName;
+        }
+        return $categories;
+    }
+
+    /**
+     * Get the category for a given realm.
+     *
+     * If a realm does not explicitly declare a category, its name is used
+     * as the category.
+     *
+     * @param  string $realmName The name of the realm to get
+     *                           the category for.
+     * @return string            The category the realm belongs to.
+     */
+    public static function getCategoryForRealm($realmName)
+    {
+        $config = Config::factory();
+        $dwConfig = $config['datawarehouse'];
+
+        if (isset($dwConfig['realms'][$realmName]['category'])) {
+            return $dwConfig['realms'][$realmName]['category'];
+        }
+
+        return $realmName;
+    }
 } // class DataWarehouse

--- a/classes/DataWarehouse.php
+++ b/classes/DataWarehouse.php
@@ -23,43 +23,44 @@ use CCR\DB;
 class DataWarehouse
 {
 
-	private static $db = null;
+    private static $db = null;
 
-	/*
+    /*
 	 * @function connect()
 	 * @access public
 	 */
-	public static function connect()
-	{
-		if(!self::$db)
-		{
-			self::$db = DB::factory('datawarehouse');
-		}
-		return self::$db;
+    public static function connect()
+    {
+        if(!self::$db)
+        {
+            self::$db = DB::factory('datawarehouse');
+        }
+        return self::$db;
 
-	}
-	/*
+    }
+
+    /*
 	 * @function destroy()
 	 * @access public
 	 */
-	public function destroy()
-	{
-		if(self::$db !== null)
-		{
-			self::$db = null;
-		}
-	}
+    public function destroy()
+    {
+        if(self::$db !== null)
+        {
+            self::$db = null;
+        }
+    }
 
-	/*
+    /*
 	 * @function __destruct()
 	 * @access public
 	 */
-	function __destruct()
-	{
-		destroy();
-	}
+    public function __destruct()
+    {
+        destroy();
+    }
 
-	/************************************************************
+    /************************************************************
 	 * @function getPersonIdByUsername
 	 * @access public
 	 *
@@ -67,23 +68,25 @@ class DataWarehouse
 	 *
 	 * @return person_id or -2
 	 ************************************************************/
-	 public function getPersonIdByUsername($username = NULL){
-		 if(!empty($username)){
-			$dbh = self::connect();
-			$personId = $dbh->query(" SELECT person_id
+    public function getPersonIdByUsername($username = null){
+        if(!empty($username)){
+            $dbh = self::connect();
+            $personId = $dbh->query(
+                " SELECT person_id
 				FROM modw.systemaccount
 				WHERE username = :username
 				LIMIT 1",
-			 array(
-				':username' => $username,
-			));
-			if(count($personId) > 0){
-				return $personId[0]['person_id'];
-			}
-		}
-		 return -2;
-	 }
-	/************************************************************
+                array(
+                ':username' => $username,
+                )
+            );
+            if(count($personId) > 0){
+                return $personId[0]['person_id'];
+            }
+        }
+        return -2;
+    }
+    /************************************************************
 	 * @function getAllocations()
 	 * @access public
 	 *
@@ -98,21 +101,21 @@ class DataWarehouse
 	 * Used by: Allocations tab controller, html/controllers/ui_data/allocations.php
 	 *
 	 ************************************************************/
-	public static function getAllocations($config = array())
-	{
+    public static function getAllocations($config = array())
+    {
 
-		$person_id = $config['person_id'];
-		$showActive = isset($config['show_active']) ? $config['show_active'] : true;
-		$allocation_id = isset($config['allocation_id']) ? $config['allocation_id'] : -1;
+        $person_id = $config['person_id'];
+        $showActive = isset($config['show_active']) ? $config['show_active'] : true;
+        $allocation_id = isset($config['allocation_id']) ? $config['allocation_id'] : -1;
 
-		$pi = "";
+        $pi = "";
 
-		if (isset($config['is_pi_of_allocation'])) {
-			 $pi = "and als.principalinvestigator_person_id ".($config['is_pi_of_allocation'] ? "" : "!")."= $person_id";
-		}
+        if (isset($config['is_pi_of_allocation'])) {
+             $pi = "and als.principalinvestigator_person_id ".($config['is_pi_of_allocation'] ? "" : "!")."= $person_id";
+        }
 
 
-		$query = "SELECT DISTINCT
+        $query = "SELECT DISTINCT
 				als.allocation_id,
 				als.principalinvestigator_person_id,
 				als.person_id,
@@ -146,205 +149,205 @@ class DataWarehouse
 				end
 			DESC";
 
-		self::connect();
-		$results = self::$db->query($query);
+        self::connect();
+        $results = self::$db->query($query);
 
-		$results_b = array();
+        $results_b = array();
 
-		$charge_allocation_map = array();
+        $charge_allocation_map = array();
 
-		// =================================================================================================
+        // =================================================================================================
 
-		$rct = 0;
+        $rct = 0;
 
-		// Consolidation Phase (eliminating redundant records based on a common charge number)
-		// The redundancies are also due to the same charge number across multiple resources (each of which has a unique allocation id)
-		// Constructing a 1:M (M >= 1) map of charge number to allocation id(s) and/or resource(s)
+        // Consolidation Phase (eliminating redundant records based on a common charge number)
+        // The redundancies are also due to the same charge number across multiple resources (each of which has a unique allocation id)
+        // Constructing a 1:M (M >= 1) map of charge number to allocation id(s) and/or resource(s)
 
-		foreach ($results as $r) {
+        foreach ($results as $r) {
 
-			$cn = $r['charge_number'];
+            $cn = $r['charge_number'];
 
-			if (!isset($charge_allocation_map[$cn])) {
-				$charge_allocation_map[$cn] = array(
-					'pi' => 0,
-					'allocation_ids' => array(),
-					'resources' => array(),
-					'base' => 0,
-					'remaining' => 0,
-					'total_base_formatted' => 0,
-					'total_remaining_formatted' => 0
-				);
-			}
+            if (!isset($charge_allocation_map[$cn])) {
+                $charge_allocation_map[$cn] = array(
+                    'pi' => 0,
+                    'allocation_ids' => array(),
+                    'resources' => array(),
+                    'base' => 0,
+                    'remaining' => 0,
+                    'total_base_formatted' => 0,
+                    'total_remaining_formatted' => 0
+                );
+            }
 
-			$charge_allocation_map[$cn]['pi'] = $r['principalinvestigator_person_id'];
-			$charge_allocation_map[$cn]['allocation_ids'][$r['allocation_id']] = array(
-				'name' => $r['resource_name'],
-				'timeframe' => $r['start'].' to '.$r['end'],
-				'type' => $r['request_type']
-			);
+            $charge_allocation_map[$cn]['pi'] = $r['principalinvestigator_person_id'];
+            $charge_allocation_map[$cn]['allocation_ids'][$r['allocation_id']] = array(
+                'name' => $r['resource_name'],
+                'timeframe' => $r['start'].' to '.$r['end'],
+                'type' => $r['request_type']
+            );
 
-			$charge_allocation_map[$cn]['resources'][] = array(
-				'allocation_id' => $r['allocation_id'],
-				'resource_name' => $r['resource_name'],
-				'timeframe' => $r['start'].' to '.$r['end'],
-				'type' => $r['request_type'],
-				'base' => $r['base'],
-				'remaining' => $r['remaining'],
-				'base_formatted' => number_format($r['base'],2),
-				'remaining_formatted' => number_format($r['remaining'],2)
-			);
+            $charge_allocation_map[$cn]['resources'][] = array(
+                'allocation_id' => $r['allocation_id'],
+                'resource_name' => $r['resource_name'],
+                'timeframe' => $r['start'].' to '.$r['end'],
+                'type' => $r['request_type'],
+                'base' => $r['base'],
+                'remaining' => $r['remaining'],
+                'base_formatted' => number_format($r['base'], 2),
+                'remaining_formatted' => number_format($r['remaining'], 2)
+            );
 
-			// General project details =======================================
+            // General project details =======================================
 
-			$charge_allocation_map[$cn]['project_title'] = $r['project_title'];
-			$charge_allocation_map[$cn]['charge_number'] = $r['charge_number'];
-			$charge_allocation_map[$cn]['status'] = $r['status'];
-			$charge_allocation_map[$cn]['start'] = $r['start'];
-			$charge_allocation_map[$cn]['end'] = $r['end'];
+            $charge_allocation_map[$cn]['project_title'] = $r['project_title'];
+            $charge_allocation_map[$cn]['charge_number'] = $r['charge_number'];
+            $charge_allocation_map[$cn]['status'] = $r['status'];
+            $charge_allocation_map[$cn]['start'] = $r['start'];
+            $charge_allocation_map[$cn]['end'] = $r['end'];
 
-			// Base & Remaining SU details ===================================
+            // Base & Remaining SU details ===================================
 
-			$charge_allocation_map[$cn]['base'] += $r['base'];
-			$charge_allocation_map[$cn]['remaining'] += $r['remaining'];
+            $charge_allocation_map[$cn]['base'] += $r['base'];
+            $charge_allocation_map[$cn]['remaining'] += $r['remaining'];
 
-			$charge_allocation_map[$cn]['base_formatted'] = number_format($charge_allocation_map[$cn]['base'],2);
-			$charge_allocation_map[$cn]['remaining_formatted'] = number_format($charge_allocation_map[$cn]['remaining'],2);
+            $charge_allocation_map[$cn]['base_formatted'] = number_format($charge_allocation_map[$cn]['base'], 2);
+            $charge_allocation_map[$cn]['remaining_formatted'] = number_format($charge_allocation_map[$cn]['remaining'], 2);
 
-		}//foreach ($results as $r)
+        }//foreach ($results as $r)
 
-		// =================================================================================================
+        // =================================================================================================
 
-		foreach ($charge_allocation_map as &$c) {
+        foreach ($charge_allocation_map as &$c) {
 
-			$allocation_ids = implode(',', array_keys($c['allocation_ids']));
+            $allocation_ids = implode(',', array_keys($c['allocation_ids']));
 
-			$query = "SELECT ab.allocation_id, ab.person_id, p.last_name, p.first_name, ab.used_allocation
+            $query = "SELECT ab.allocation_id, ab.person_id, p.last_name, p.first_name, ab.used_allocation
 				FROM modw.allocationbreakdown AS ab, modw.person AS p
 				WHERE ab.person_id = p.id
 				AND ab.allocation_id
 				AND FIND_IN_SET(ab.allocation_id, :allocation_ids)
 				ORDER BY ab.person_id";
 
-			$results = self::$db->query($query, array(':allocation_ids' => $allocation_ids));
+            $results = self::$db->query($query, array(':allocation_ids' => $allocation_ids));
 
-			$user_pool = array();
+            $user_pool = array();
 
-			// Construct an inverse map (allocation_id to user listing)
-			$inverseMap = array();
+            // Construct an inverse map (allocation_id to user listing)
+            $inverseMap = array();
 
-			foreach ($results as $r) {
+            foreach ($results as $r) {
 
-				$pid = $r['person_id'];
+                $pid = $r['person_id'];
 
-				// Force the (upcoming) sort procedure to place the PI at the top
-				//$prefix = ($c['pi'] == $pid) ? "0" : "";
+                // Force the (upcoming) sort procedure to place the PI at the top
+                //$prefix = ($c['pi'] == $pid) ? "0" : "";
 
-				if (!isset($user_pool[$pid])) {
+                if (!isset($user_pool[$pid])) {
 
-					$user_pool[$pid] = array(
-						'name' => $r['last_name'].", ".$r['first_name'],
-						'is_pi' => ($c['pi'] === $pid),
-						'total' => 0,
-						'resources' => array()
-					);
+                    $user_pool[$pid] = array(
+                        'name' => $r['last_name'].", ".$r['first_name'],
+                        'is_pi' => ($c['pi'] === $pid),
+                        'total' => 0,
+                        'resources' => array()
+                    );
 
-				}
+                }
 
-				if (!isset($inverseMap[$r['allocation_id']])) {
-					$inverseMap[$r['allocation_id']] = array();
-				}
+                if (!isset($inverseMap[$r['allocation_id']])) {
+                    $inverseMap[$r['allocation_id']] = array();
+                }
 
-				if (number_format($r['used_allocation']) != 0) {
+                if (number_format($r['used_allocation']) != 0) {
 
-					// Append any utilized resources to the current user, each differentiated by allocation id
+                    // Append any utilized resources to the current user, each differentiated by allocation id
 
-					$user_pool[$pid]['resources'][$r['allocation_id']] = array(
-						//'allocation_id' => $r['allocation_id'],
-						'name' => $c['allocation_ids'][$r['allocation_id']]['name'],
-						'timeframe' => $c['allocation_ids'][$r['allocation_id']]['timeframe'],
-						'type' => $c['allocation_ids'][$r['allocation_id']]['type'],
-						'used' => number_format($r['used_allocation'],2)
-					);
+                    $user_pool[$pid]['resources'][$r['allocation_id']] = array(
+                        //'allocation_id' => $r['allocation_id'],
+                        'name' => $c['allocation_ids'][$r['allocation_id']]['name'],
+                        'timeframe' => $c['allocation_ids'][$r['allocation_id']]['timeframe'],
+                        'type' => $c['allocation_ids'][$r['allocation_id']]['type'],
+                        'used' => number_format($r['used_allocation'], 2)
+                    );
 
-					$inverseMap[$r['allocation_id']][] = array(
-						'name' => $user_pool[$pid]['name'],
-						'is_pi' => ($c['pi'] === $pid),
-						'consumption' => $r['used_allocation'],
-						'used' => number_format($r['used_allocation'],2)
-					);
+                    $inverseMap[$r['allocation_id']][] = array(
+                        'name' => $user_pool[$pid]['name'],
+                        'is_pi' => ($c['pi'] === $pid),
+                        'consumption' => $r['used_allocation'],
+                        'used' => number_format($r['used_allocation'], 2)
+                    );
 
-				}
+                }
 
-				$user_pool[$pid]['total'] += $r['used_allocation'];
-				$user_pool[$pid]['total_formatted'] = number_format($user_pool[$pid]['total'],2);
+                $user_pool[$pid]['total'] += $r['used_allocation'];
+                $user_pool[$pid]['total_formatted'] = number_format($user_pool[$pid]['total'], 2);
 
-			}//foreach ($results as $r)
+            }//foreach ($results as $r)
 
-			// ----------------------------------------------------
+            // ----------------------------------------------------
 
-			foreach ($c['resources'] as &$cr) {
+            foreach ($c['resources'] as &$cr) {
 
-				$cr['users'] = $inverseMap[$cr['allocation_id']];
+                $cr['users'] = $inverseMap[$cr['allocation_id']];
 
-				// Sort users on each resource (by decreasing usage)
-				usort($cr['users'], function($a, $b){
-					return $b['consumption'] - $a['consumption'];
-					//return strcmp($a['name'], $b['name']);	<-- former sort method was alphabetical, ascending
+                // Sort users on each resource (by decreasing usage)
+                usort($cr['users'], function ($a, $b) {
+                    return $b['consumption'] - $a['consumption'];
+                    //return strcmp($a['name'], $b['name']);	<-- former sort method was alphabetical, ascending
 
-				});
+                });
 
-				unset($cr['allocation_id']);
+                unset($cr['allocation_id']);
 
-			}//foreach
+            }//foreach
 
-			unset($c['allocation_ids']);
+            unset($c['allocation_ids']);
 
-			// Sort the resources (associated with a user) by (ascending) resource name
-			foreach ($user_pool as $p => &$v) {
+            // Sort the resources (associated with a user) by (ascending) resource name
+            foreach ($user_pool as $p => &$v) {
 
-				$v['resources'] = array_values($v['resources']);
+                $v['resources'] = array_values($v['resources']);
 
-				usort($v['resources'], function($a, $b){
-					return strcmp($a['name'], $b['name']);
-				});
+                usort($v['resources'], function ($a, $b) {
+                    return strcmp($a['name'], $b['name']);
+                });
 
-			}//foreach
+            }//foreach
 
-			// Cache the PI user entry and remove it from $user_pool (prior to being sorted)
-			$pi_slot = $user_pool[$c['pi']];
-			unset($user_pool[$c['pi']]);
-			unset($c['pi']);
+            // Cache the PI user entry and remove it from $user_pool (prior to being sorted)
+            $pi_slot = $user_pool[$c['pi']];
+            unset($user_pool[$c['pi']]);
+            unset($c['pi']);
 
-			$c['users'] = array_values($user_pool);
+            $c['users'] = array_values($user_pool);
 
-			// Sort users by total usage (descending)
-			usort($c['users'], function($a, $b){
+            // Sort users by total usage (descending)
+            usort($c['users'], function ($a, $b) {
 
-				return $b['total'] - $a['total'];
-				// return strcmp($a['name'], $b['name']);	<-- former sort method was alphabetical, ascending
+                return $b['total'] - $a['total'];
+                // return strcmp($a['name'], $b['name']);	<-- former sort method was alphabetical, ascending
 
-			});
+            });
 
-			// PI will be @ top, regardless of sort outcome
-			array_unshift($c['users'], $pi_slot);
+            // PI will be @ top, regardless of sort outcome
+            array_unshift($c['users'], $pi_slot);
 
-			// Sort the resources alphabetically
+            // Sort the resources alphabetically
 
-			usort($c['resources'], function($a, $b){
-				return strcmp($a['resource_name'], $b['resource_name']);
-			});
+            usort($c['resources'], function ($a, $b) {
+                return strcmp($a['resource_name'], $b['resource_name']);
+            });
 
-		}//foreach ($charge_allocation_map as &$c)
+        }//foreach ($charge_allocation_map as &$c)
 
-		// =================================================================================================
+        // =================================================================================================
 
-		return array_values($charge_allocation_map);
+        return array_values($charge_allocation_map);
 
-	}	//getAllocations()
+    }   //getAllocations()
 
 
-	/************************************************************
+    /************************************************************
 	 * @function getAllocationsByChargeNumber()
 	 * @access public
 	 *
@@ -360,9 +363,9 @@ class DataWarehouse
 	 * Used by: /html/oauth/user_check.php
 	 ************************************************************/
 
-	 public static function getAllocationsByChargeNumber($person_id, $start_date, $end_date, $is_pi = false)
-	 {
-		$query = "SELECT
+    public static function getAllocationsByChargeNumber($person_id, $start_date, $end_date, $is_pi = false)
+    {
+        $query = "SELECT
 			als.charge_number,
 			als.allocation_id,
 			GROUP_CONCAT(
@@ -436,14 +439,13 @@ class DataWarehouse
 			end
 		DESC";
 
-		self::connect();
-		$results = self::$db->query($query,
-			array('person_id' => $person_id,
-			'start_date' => $start_date,
-			'end_date' => $end_date)
-		);
-		return $results;
-	} // getAllocationsByChargeNumber()
-
+        self::connect();
+        $results = self::$db->query(
+            $query,
+            array('person_id' => $person_id,
+            'start_date' => $start_date,
+            'end_date' => $end_date)
+        );
+        return $results;
+    } // getAllocationsByChargeNumber()
 } // class DataWarehouse
-?>

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -2,6 +2,9 @@
 
 namespace DataWarehouse\Access;
 
+use Exception;
+
+use DataWarehouse;
 use DataWarehouse\Access\MetricExplorer;
 use XDChartPool;
 use XDUser;
@@ -43,752 +46,764 @@ class Usage extends Common
      *                             headers: Headers to set on the response.
      */
     public function getCharts(XDUser $user, $chartsKey = 'data') {
-        // Get the request's realm and the realm's query class.
-        $usageRealm = \xd_utilities\array_get($this->request, 'realm');
-        $usageRealmAggregateClass = "\\DataWarehouse\\Query\\$usageRealm\\Aggregate";
-
-        // If present, move the dimension value into statistic.
-        if (array_key_exists('dimension', $this->request)) {
-            $this->request['group_by'] = $this->request['dimension'];
-            unset($this->request['dimension']);
+        // Determine which realms are being requested.
+        if (empty($this->request['realm'])) {
+            throw new Exception('One or more realms must be specified.');
         }
+        $requestedRealms = array_map('trim', explode(',', $this->request['realm']));
 
-        // Get the request's group by.
-        $usageGroupBy = \xd_utilities\array_get($this->request, 'group_by', 'none');
-        $usageGroupByObject = $usageRealmAggregateClass::getGroupBy($usageGroupBy);
+        // For each realm requested, get the requested charts.
+        $usageCharts = array();
+        foreach ($requestedRealms as $usageRealm) {
+            // Set the realm on the request object for functions that look
+            // at the request directly.
+            $this->request['realm'] = $usageRealm;
 
-        // Get whether or not the request is for a timeseries chart.
-        $usageIsTimeseries = \xd_utilities\array_get($this->request, 'dataset_type') === 'timeseries';
+            // Get the realm's query class.
+            $usageRealmAggregateClass = "\\DataWarehouse\\Query\\$usageRealm\\Aggregate";
 
-        // Get the format to return the results in.
-        $usageFormat = \xd_utilities\array_get($this->request, 'format', 'hc_jsonstore');
-        $isJsonStoreExport = $usageFormat === 'jsonstore';
-        $isCsvExport = $usageFormat === 'csv';
-        $isXmlExport = $usageFormat === 'xml';
-        $isTextExport =
-            $isCsvExport
-            || $isXmlExport
-            || $usageFormat === 'json'
-            || $isJsonStoreExport
-        ;
+            // If present, move the dimension value into statistic.
+            if (array_key_exists('dimension', $this->request)) {
+                $this->request['group_by'] = $this->request['dimension'];
+                unset($this->request['dimension']);
+            }
 
-        // If present, move the fact value into statistic.
-        if (array_key_exists('fact', $this->request)) {
-            $this->request['statistic'] = $this->request['fact'];
-            unset($this->request['fact']);
-        }
+            // Get the request's group by.
+            $usageGroupBy = \xd_utilities\array_get($this->request, 'group_by', 'none');
+            $usageGroupByObject = $usageRealmAggregateClass::getGroupBy($usageGroupBy);
 
-        // Get whether or not the request is for multiple metrics.
-        $isSingleMetricQuery = array_key_exists('statistic', $this->request);
+            // Get whether or not the request is for a timeseries chart.
+            $usageIsTimeseries = \xd_utilities\array_get($this->request, 'dataset_type') === 'timeseries';
 
-        // If this request is asking for timeseries data for multiple metrics
-        // for a datasheet, return an error response.
-        if (
-            $usageIsTimeseries
-            && !$isSingleMetricQuery
-            && $isJsonStoreExport
-        ) {
-            return array(
-                'headers' => \DataWarehouse\ExportBuilder::getHeader($usageFormat),
-                'results' => json_encode(array(
-                    "metaData" => array(
-                        "totalProperty" => "total",
-                        "root" => "records",
-                        "id" => "id",
-                        "fields" => array(
-                            array(
-                                "name" => 'Message',
-                                "type" => 'string',
+            // Get the format to return the results in.
+            $usageFormat = \xd_utilities\array_get($this->request, 'format', 'hc_jsonstore');
+            $isJsonStoreExport = $usageFormat === 'jsonstore';
+            $isCsvExport = $usageFormat === 'csv';
+            $isXmlExport = $usageFormat === 'xml';
+            $isTextExport =
+                $isCsvExport
+                || $isXmlExport
+                || $usageFormat === 'json'
+                || $isJsonStoreExport
+            ;
+
+            // If present, move the fact value into statistic.
+            if (array_key_exists('fact', $this->request)) {
+                $this->request['statistic'] = $this->request['fact'];
+                unset($this->request['fact']);
+            }
+
+            // Get whether or not the request is for multiple metrics.
+            $isSingleMetricQuery = array_key_exists('statistic', $this->request);
+
+            // If this request is asking for timeseries data for multiple metrics
+            // for a datasheet, return an error response.
+            if (
+                $usageIsTimeseries
+                && !$isSingleMetricQuery
+                && $isJsonStoreExport
+            ) {
+                return array(
+                    'headers' => \DataWarehouse\ExportBuilder::getHeader($usageFormat),
+                    'results' => json_encode(array(
+                        "metaData" => array(
+                            "totalProperty" => "total",
+                            "root" => "records",
+                            "id" => "id",
+                            "fields" => array(
+                                array(
+                                    "name" => 'Message',
+                                    "type" => 'string',
+                                ),
                             ),
                         ),
-                    ),
-                    "success" => true,
-                    "message" => 'Datasheet view is not available for timeseries. Turn off timeseries or use the Export button to get the data.',
-                    "total" => 1,
-                    "records" => array(
-                        array(
-                            'Message' => 'Datasheet view is not available for timeseries. Turn off timeseries or use the Export button to get the data.',
+                        "success" => true,
+                        "message" => 'Datasheet view is not available for timeseries. Turn off timeseries or use the Export button to get the data.',
+                        "total" => 1,
+                        "records" => array(
+                            array(
+                                'Message' => 'Datasheet view is not available for timeseries. Turn off timeseries or use the Export button to get the data.',
+                            ),
                         ),
-                    ),
-                    "columns" => array(
-                        array(
-                            "header" => 'Error Message',
-                            "width" => 600,
-                            "dataIndex" => 'Message',
-                            "sortable" => true,
-                            'editable' => false,
-                            'align' => 'left',
-                            'renderer' => "CCR.xdmod.ui.stringRenderer",
+                        "columns" => array(
+                            array(
+                                "header" => 'Error Message',
+                                "width" => 600,
+                                "dataIndex" => 'Message',
+                                "sortable" => true,
+                                'editable' => false,
+                                'align' => 'left',
+                                'renderer' => "CCR.xdmod.ui.stringRenderer",
+                            ),
                         ),
-                    ),
-                )),
-            );
-        }
-
-        // Convert the request options to a set of Metric Explorer requests.
-        //
-        // If one statistic was requested, convert it into a single ME request.
-        // Otherwise, create one ME request for each available statistic.
-        $meRequests = array();
-        if ($isSingleMetricQuery) {
-            $meRequests[] = $this->convertChartRequest($this->request, $isTextExport);
-        } else {
-            $userStatistics = $user->getMostPrivilegedRole()->getQueryDescripters(
-                'tg_usage',
-                $this->request['realm'],
-                $usageGroupBy
-            )->getPermittedStatistics();
-            foreach ($userStatistics as $userStatistic) {
-                $userStatisticObject = $usageRealmAggregateClass::getStatistic($userStatistic);
-                if (!$userStatisticObject->isVisible()) {
-                    continue;
-                }
-
-                $statisticRequest = $this->request;
-                $statisticRequest['statistic'] = $userStatistic;
-                $meRequests[] = $this->convertChartRequest($statisticRequest, $isTextExport);
+                    )),
+                );
             }
-        }
 
-        // If this is a special format, condense the list of requests to a
-        // single request.
-        if ($isTextExport && !empty($meRequests)) {
-            $firstMeRequest = null;
-            foreach ($meRequests as &$meRequest) {
-                if ($firstMeRequest === null) {
-                    $firstMeRequest = $meRequest;
-                    continue;
-                }
-
-                $firstMeRequest['data_series_unencoded'][] = $meRequest['data_series_unencoded'][0];
-            }
-            $firstMeRequest['data_series'] = urlencode(json_encode($firstMeRequest['data_series_unencoded']));
-
-            // Generate the title now, as we can't use the Metric Explorer
-            // response's properties to easily generate the title.
+            // Convert the request options to a set of Metric Explorer requests.
+            //
+            // If one statistic was requested, convert it into a single ME request.
+            // Otherwise, create one ME request for each available statistic.
+            $meRequests = array();
             if ($isSingleMetricQuery) {
-                $specialFormatChartTitle = $usageRealmAggregateClass::getStatistic($this->request['statistic'])->getLabel();
+                $meRequests[] = $this->convertChartRequest($this->request, $isTextExport);
             } else {
-                $specialFormatChartTitle = $usageRealm;
-            }
-            if ($usageGroupBy !== 'none') {
-                $specialFormatChartTitle .= ': by ' . $usageGroupByObject->getLabel();
-            }
-            $firstMeRequest['title'] = $specialFormatChartTitle;
-
-            // Generate the filename based on how Usage previously did it.
-            $firstMeRequest['filename'] = $this->generateFilename(
-                $specialFormatChartTitle,
-                $this->request['start_date'],
-                $this->request['end_date'],
-                $usageIsTimeseries
-            );
-
-            $meRequests = array($firstMeRequest);
-        }
-
-        // Run the Metric Explorer chart generator on each request.
-        $meResponses = array();
-        foreach ($meRequests as $meRequest) {
-            $meGenerator = new MetricExplorer($meRequest);
-            $meResponses[] = $meGenerator->get_data($user);
-        }
-
-        // If no charts were generated, return a failure response.
-        if (empty($meResponses)) {
-            return array(
-                'results' => \xd_charting\encodeJSON(array(
-                    'success' => false,
-                    'message' => 'No charts could be generated using the given parameters.',
-                    'totalCount' => 0,
-                    $chartsKey => array(),
-                )),
-                'headers' => array(),
-            );
-        }
-
-        // If this is a text export, perform special handling of the response.
-        if ($isTextExport) {
-
-            $meResponse = $meResponses[0];
-
-            // If this is a JSON store export...
-            if ($isJsonStoreExport) {
-
-                // Combine multiple results into a single object to return.
-                $meRequest = $meRequests[0];
-                $emptyResultFound = false;
-                $combinedResult = null;
-                $combinedResultColumns = null;
-                $combinedResultFields = null;
-                $combinedResultRecords = array();
-                $combinedResultFirstColumn = null;
-                $combinedResultRestricted = false;
-                foreach ($meResponse['results'] as $meJsonResult) {
-                    $meResult = json_decode($meJsonResult, true);
-                    if ($combinedResultFirstColumn === null) {
-                        $combinedResultFirstColumn = $meResult['metaData']['fields'][0]['name'];
-                    }
-
-                    if ($meResult['records'] == array(array('Message' => 'Dataset is empty'))) {
-                        $emptyResultFound = true;
+                $userStatistics = $user->getMostPrivilegedRole()->getQueryDescripters(
+                    'tg_usage',
+                    $usageRealm,
+                    $usageGroupBy
+                )->getPermittedStatistics();
+                foreach ($userStatistics as $userStatistic) {
+                    $userStatisticObject = $usageRealmAggregateClass::getStatistic($userStatistic);
+                    if (!$userStatisticObject->isVisible()) {
                         continue;
                     }
 
-                    if ($usageIsTimeseries) {
-                        $combinedResultRecords = $meResult['records'];
-                    } else {
-                        foreach ($meResult['records'] as $meResultRecord) {
-                            $meResultRecordFirstValue = $meResultRecord[$combinedResultFirstColumn];
-                            if (array_key_exists($meResultRecordFirstValue, $combinedResultRecords)) {
-                                $combinedResultRecords[$meResultRecordFirstValue] = array_merge(
-                                    $combinedResultRecords[$meResultRecordFirstValue],
-                                    $meResultRecord
-                                );
-                            } else {
-                                $combinedResultRecords[$meResultRecordFirstValue] = $meResultRecord;
+                    $statisticRequest = $this->request;
+                    $statisticRequest['statistic'] = $userStatistic;
+                    $meRequests[] = $this->convertChartRequest($statisticRequest, $isTextExport);
+                }
+            }
+
+            // If this is a special format, condense the list of requests to a
+            // single request.
+            if ($isTextExport && !empty($meRequests)) {
+                $firstMeRequest = null;
+                foreach ($meRequests as &$meRequest) {
+                    if ($firstMeRequest === null) {
+                        $firstMeRequest = $meRequest;
+                        continue;
+                    }
+
+                    $firstMeRequest['data_series_unencoded'][] = $meRequest['data_series_unencoded'][0];
+                }
+                $firstMeRequest['data_series'] = urlencode(json_encode($firstMeRequest['data_series_unencoded']));
+
+                // Generate the title now, as we can't use the Metric Explorer
+                // response's properties to easily generate the title.
+                if ($isSingleMetricQuery) {
+                    $specialFormatChartTitle = $usageRealmAggregateClass::getStatistic($this->request['statistic'])->getLabel();
+                } else {
+                    $specialFormatChartTitle = $usageRealm;
+                }
+                if ($usageGroupBy !== 'none') {
+                    $specialFormatChartTitle .= ': by ' . $usageGroupByObject->getLabel();
+                }
+                $firstMeRequest['title'] = $specialFormatChartTitle;
+
+                // Generate the filename based on how Usage previously did it.
+                $firstMeRequest['filename'] = $this->generateFilename(
+                    $specialFormatChartTitle,
+                    $this->request['start_date'],
+                    $this->request['end_date'],
+                    $usageIsTimeseries
+                );
+
+                $meRequests = array($firstMeRequest);
+            }
+
+            // Run the Metric Explorer chart generator on each request.
+            $meResponses = array();
+            foreach ($meRequests as $meRequest) {
+                $meGenerator = new MetricExplorer($meRequest);
+                $meResponses[] = $meGenerator->get_data($user);
+            }
+
+            // If no charts were generated, return a failure response.
+            if (empty($meResponses)) {
+                return array(
+                    'results' => \xd_charting\encodeJSON(array(
+                        'success' => false,
+                        'message' => 'No charts could be generated using the given parameters.',
+                        'totalCount' => 0,
+                        $chartsKey => array(),
+                    )),
+                    'headers' => array(),
+                );
+            }
+
+            // If this is a text export, perform special handling of the response.
+            if ($isTextExport) {
+
+                $meResponse = $meResponses[0];
+
+                // If this is a JSON store export...
+                if ($isJsonStoreExport) {
+
+                    // Combine multiple results into a single object to return.
+                    $meRequest = $meRequests[0];
+                    $emptyResultFound = false;
+                    $combinedResult = null;
+                    $combinedResultColumns = null;
+                    $combinedResultFields = null;
+                    $combinedResultRecords = array();
+                    $combinedResultFirstColumn = null;
+                    $combinedResultRestricted = false;
+                    foreach ($meResponse['results'] as $meJsonResult) {
+                        $meResult = json_decode($meJsonResult, true);
+                        if ($combinedResultFirstColumn === null) {
+                            $combinedResultFirstColumn = $meResult['metaData']['fields'][0]['name'];
+                        }
+
+                        if ($meResult['records'] == array(array('Message' => 'Dataset is empty'))) {
+                            $emptyResultFound = true;
+                            continue;
+                        }
+
+                        if ($usageIsTimeseries) {
+                            $combinedResultRecords = $meResult['records'];
+                        } else {
+                            foreach ($meResult['records'] as $meResultRecord) {
+                                $meResultRecordFirstValue = $meResultRecord[$combinedResultFirstColumn];
+                                if (array_key_exists($meResultRecordFirstValue, $combinedResultRecords)) {
+                                    $combinedResultRecords[$meResultRecordFirstValue] = array_merge(
+                                        $combinedResultRecords[$meResultRecordFirstValue],
+                                        $meResultRecord
+                                    );
+                                } else {
+                                    $combinedResultRecords[$meResultRecordFirstValue] = $meResultRecord;
+                                }
                             }
                         }
+
+                        if (\xd_utilities\array_get($meResult, 'restrictedByRoles', false)) {
+                            $combinedResultRestricted = true;
+                        }
+
+                        if ($combinedResult === null) {
+                            $combinedResult = $meResult;
+                            $combinedResultFields = $meResult['metaData']['fields'];
+                            $combinedResultColumns = $meResult['columns'];
+                            continue;
+                        }
+
+                        $combinedResultFields[] = $meResult['metaData']['fields'][1];
+                        $combinedResultColumns[] = $meResult['columns'][1];
                     }
 
-                    if (\xd_utilities\array_get($meResult, 'restrictedByRoles', false)) {
-                        $combinedResultRestricted = true;
-                    }
-
+                    // If no results were returned, return a failure response.
+                    // Otherwise, finish combining the results.
                     if ($combinedResult === null) {
-                        $combinedResult = $meResult;
-                        $combinedResultFields = $meResult['metaData']['fields'];
-                        $combinedResultColumns = $meResult['columns'];
-                        continue;
-                    }
-
-                    $combinedResultFields[] = $meResult['metaData']['fields'][1];
-                    $combinedResultColumns[] = $meResult['columns'][1];
-                }
-
-                // If no results were returned, return a failure response.
-                // Otherwise, finish combining the results.
-                if ($combinedResult === null) {
-                    if ($emptyResultFound) {
-                        $failureResults = reset($meResponse['results']);
-                    } else {
-                        $failureResults = json_encode(array(
-                            'success' => false,
-                        ));
-                    }
-
-                    return array(
-                        'headers' => $meResponse['headers'],
-                        'results' => $failureResults,
-                    );
-                }
-
-                if ($usageIsTimeseries) {
-                    $timeseriesTemplateField = $combinedResultFields[2];
-                    $timeseriesTemplateColumn = $combinedResultColumns[2];
-
-                    $timeseriesGroupByColumnName = $combinedResultColumns[1]['dataIndex'];
-                    $valueColumnName = $timeseriesTemplateColumn['dataIndex'];
-
-                    $combinedResultFields = array_slice($combinedResultFields, 0, 1);
-                    $combinedResultColumns = array_slice($combinedResultColumns, 0, 1);
-
-                    $timeseriesFields = array();
-                    $nextFieldNameIndex = 0;
-                    $timeseriesColumns = array();
-                    $timeseriesRecords = array();
-                    foreach ($combinedResultRecords as $resultRecord) {
-                        $resultRecordDimension = $resultRecord[$timeseriesGroupByColumnName];
-
-                        if (!array_key_exists($resultRecordDimension, $timeseriesColumns)) {
-                            $timeseriesDimensionColumnName = "dimension_column_$nextFieldNameIndex";
-                            $nextFieldNameIndex++;
-
-                            $timeseriesColumn = $timeseriesTemplateColumn;
-                            $timeseriesColumn['header'] = "[${resultRecordDimension}] " . $timeseriesColumn['header'];
-                            $timeseriesColumn['dataIndex'] = $timeseriesDimensionColumnName;
-                            $timeseriesColumns[$resultRecordDimension] = $timeseriesColumn;
-
-                            $timeseriesField = $timeseriesTemplateField;
-                            $timeseriesField['name'] = $timeseriesDimensionColumnName;
-                            $timeseriesFields[$resultRecordDimension] = $timeseriesField;
+                        if ($emptyResultFound) {
+                            $failureResults = reset($meResponse['results']);
                         } else {
-                            $timeseriesDimensionColumnName = $timeseriesColumns[$resultRecordDimension]['dataIndex'];
+                            $failureResults = json_encode(array(
+                                'success' => false,
+                            ));
                         }
 
-                        $timeseriesRecordTime = $resultRecord[$combinedResultFirstColumn];
-                        $timeseriesRecord = array(
-                            $combinedResultFirstColumn => $timeseriesRecordTime,
-                            $timeseriesDimensionColumnName => $resultRecord[$valueColumnName],
+                        return array(
+                            'headers' => $meResponse['headers'],
+                            'results' => $failureResults,
                         );
-
-                        if (array_key_exists($timeseriesRecordTime, $timeseriesRecords)) {
-                            $timeseriesRecords[$timeseriesRecordTime] = array_merge(
-                                $timeseriesRecords[$timeseriesRecordTime],
-                                $timeseriesRecord
-                            );
-                        } else {
-                            $timeseriesRecords[$timeseriesRecordTime] = $timeseriesRecord;
-                        }
                     }
-
-                    $combinedResultFields = array_merge(
-                        $combinedResultFields,
-                        array_values($timeseriesFields)
-                    );
-                    $combinedResultColumns = array_merge(
-                        $combinedResultColumns,
-                        array_values($timeseriesColumns)
-                    );
-                    $combinedResultRecords = $timeseriesRecords;
-                }
-
-                // Sort the value columns by title.
-                $combinedResultKeyColumns = array_slice($combinedResultColumns, 0, 1);
-                $combinedResultValueColumns = array_slice($combinedResultColumns, 1);
-                usort($combinedResultValueColumns, function ($a, $b) {
-                    return strcmp($a['header'], $b['header']);
-                });
-                $combinedResultColumns = array_merge(
-                    $combinedResultKeyColumns,
-                    $combinedResultValueColumns
-                );
-
-                // Store the combined results in the object to be returned.
-                $combinedResult['metaData']['fields'] = $combinedResultFields;
-                $combinedResult['columns'] = $combinedResultColumns;
-                $combinedResult['records'] = array_values($combinedResultRecords);
-                $combinedResult['restrictedByRoles'] = $combinedResultRestricted;
-
-                // Get the dimension and metric descriptions.
-                $jsonStoreMessage = '<ul>';
-                $jsonStoreMessage .= '<li>' . $usageGroupByObject->getDescription() . '</li>';
-
-                $jsonStoreMessageMetricDescriptions = array();
-                foreach ($meRequest['data_series_unencoded'] as $meRequestDataSeries) {
-                    $jsonStoreMessageMetricDescriptions[] = '<li>' . $usageRealmAggregateClass::getStatistic($meRequestDataSeries['metric'])->getDescription($usageGroupByObject) . '</li>';
-                }
-                sort($jsonStoreMessageMetricDescriptions);
-                $jsonStoreMessage .= implode('', $jsonStoreMessageMetricDescriptions);
-
-                $jsonStoreMessage .= '</ul>';
-                $combinedResult['message'] = $jsonStoreMessage;
-
-                // Sort the datasheet appropriately.
-                if ($usageIsTimeseries || !$isSingleMetricQuery) {
-                    $sortField = $combinedResultFirstColumn;
-                    $sortDirection = 'asc';
-                } else {
-                    $meRequestSortType = $meRequest['data_series_unencoded'][0]['sort_type'];
-
-                    if (\xd_utilities\string_begins_with($meRequestSortType, 'value')) {
-                        $sortField = $combinedResult['metaData']['fields'][1]['name'];
-                    } else {
-                        $sortField = $combinedResultFirstColumn;
-                    }
-
-                    if (\xd_utilities\string_ends_with($meRequestSortType, 'desc')) {
-                        $sortDirection = 'desc';
-                    } else {
-                        $sortDirection = 'asc';
-                    }
-                }
-
-                $combinedResult['metaData']['sortInfo'] = array(
-                    'field' => $sortField,
-                    'direction' => $sortDirection,
-                );
-
-                // Set the results to the combined result.
-                $meResponse['results'] = json_encode($combinedResult);
-            }
-
-            return $meResponse;
-        }
-
-        // Get attributes common to all charts that will be returned.
-        $usageTitle = \xd_utilities\array_get($this->request, 'title');
-        $usageSubtitle = \xd_utilities\array_get($this->request, 'subtitle');
-        $usageOffset = intval(\xd_utilities\array_get($this->request, 'offset', 0));
-        $usageWidth = intval(\xd_utilities\array_get($this->request, 'width', self::DEFAULT_WIDTH));
-        $usageHeight = intval(\xd_utilities\array_get($this->request, 'height', self::DEFAULT_HEIGHT));
-        $usageFontSize = intval(\xd_utilities\array_get($this->request, 'font_size', 3));
-        $usageShowGradient = \xd_utilities\array_get($this->request, 'show_gradient', 'y');
-        $usageShowGradient = $usageShowGradient === 'true' || $usageShowGradient === 'y';
-        $thumbnailRequested = \xd_utilities\array_get($this->request, 'thumbnail', 'n') === 'y';
-
-        // Generate the chart settings that will be returned with each chart.
-        $usageChartSettings = array(
-            'dataset_type' =>           \xd_utilities\array_get($this->request, 'dataset_type', $usageGroupByObject->getDefaultDatasetType()),
-            'display_type' =>           \xd_utilities\array_get($this->request, 'display_type', $usageGroupByObject->getDefaultDisplayType($usageGroupByObject->getDefaultDatasetType())),
-            'combine_type' =>           \xd_utilities\array_get($this->request, 'combine_type', $usageGroupByObject->getDefaultCombineMethod()),
-            'show_legend' =>            \xd_utilities\array_get($this->request, 'show_legend', $usageGroupByObject->getDefaultShowLegend()),
-            'show_guide_lines' =>       \xd_utilities\array_get($this->request, 'show_guide_lines', $usageGroupByObject->getDefaultShowGuideLines()),
-            'log_scale' =>              \xd_utilities\array_get($this->request, 'log_scale', $usageGroupByObject->getDefaultLogScale()),
-            'limit' =>                  \xd_utilities\array_get($this->request, 'limit', $usageGroupByObject->getDefaultLimit()),
-            'offset' =>                 \xd_utilities\array_get($this->request, 'offset', $usageGroupByObject->getDefaultOffset()),
-            'show_trend_line' =>        \xd_utilities\array_get($this->request, 'show_trend_line', $usageGroupByObject->getDefaultShowTrendLine()),
-            'show_error_bars' =>        \xd_utilities\array_get($this->request, 'show_error_bars', $usageGroupByObject->getDefaultShowErrorBars()),
-            'show_aggregate_labels' =>  \xd_utilities\array_get($this->request, 'show_aggregate_labels', $usageGroupByObject->getDefaultShowAggregateLabels()),
-            'show_error_labels' =>      \xd_utilities\array_get($this->request, 'show_error_labels', $usageGroupByObject->getDefaultShowErrorLabels()),
-            'hide_tooltip' =>           \xd_utilities\array_get($this->request, 'hide_tooltip', false),
-            'enable_errors' =>          \xd_utilities\array_get($this->request, 'enable_errors', $usageGroupByObject->getDefaultEnableErrors()),
-            'enable_trend_line' =>      \xd_utilities\array_get($this->request, 'enable_trend_line', $usageGroupByObject->getDefaultEnableTrendLine()),
-        );
-        $usageChartSettingsJson = json_encode($usageChartSettings);
-
-        $usageSubnotes = array();
-        if ($usageGroupBy === 'resource' || array_key_exists('resource', $this->request)) {
-            $usageSubnotes[] = '* Resources marked with asterisk do not provide processor'
-                . ' counts per job when submitting to the '
-                . ORGANIZATION_NAME . ' Central Database. This affects the'
-                . ' accuracy of the following (and related) statistics: Job'
-                . ' Size and CPU Consumption';
-        }
-
-        // Generate the title style that will be used for all charts.
-        $usageTitleFontSizeInPixels = 16 + $usageFontSize;
-        $usageTitleStyle = array(
-            'color' => '#000000',
-            'fontSize' => "${usageTitleFontSizeInPixels}px",
-        );
-
-        // Get the user's report generator chart pool.
-        $chartPool = new XDChartPool($user);
-
-        // Convert each Metric Explorer response into a Usage chart.
-        $usageCharts = array();
-        foreach ($meResponses as $meResponseIndex => $meResponse) {
-            // If the response indicates failure, skip this response.
-            $meResponseContent = $meResponse['results'];
-            if (!$meResponseContent['success']) {
-                continue;
-            }
-
-            // Get the request for this chart.
-            $meRequest = $meRequests[$meResponseIndex];
-
-            // Get the statistic object used by this chart request.
-            $meRequestMetric = $usageRealmAggregateClass::getStatistic($meRequest['data_series_unencoded'][0]['metric']);
-
-            // Get the chart object from the response.
-            $meChart = &$meResponseContent['data'][0];
-
-            // Extract the report generator options.
-            $meReportGeneratorMeta = \xd_utilities\array_extract($meChart, 'reportGeneratorMeta', array());
-
-            // Replace the in-chart descriptions with empty arrays.
-            $meChart['dimensions'] = array();
-            $meChart['metrics'] = array();
-
-            // Grab the dimension and metric and generate a formatted group
-            // and metric description.
-            $usageChartDimensionDescription = $usageGroupByObject->getDescription();
-            $usageChartMetricDescription = $meRequestMetric->getDescription($usageGroupByObject);
-
-            // If specified, use the given subtitle. Otherwise, get the
-            // subtitle from the title of the resulting chart.
-            //
-            // Because the function doesn't receive a custom title, if any,
-            // from this adapter, the chart's subtitle is placed in the title.
-            $usageChartSubtitle = $usageSubtitle !== null ? $usageSubtitle : $meChart['title']['text'];
-
-            // Only include the subtitle on the chart if the chart is not a
-            // thumbnail.
-            $meChart['subtitle']['text'] = $thumbnailRequested ? '' : $usageChartSubtitle;
-
-            // Generate the title and short title of this chart.
-            $usageChartShortTitle = $meRequestMetric->getLabel();
-            if ($usageTitle !== null) {
-                $usageChartTitle = $usageTitle;
-            } else {
-                $usageChartTitle = $usageChartShortTitle;
-                if ($usageGroupBy !== 'none') {
-                    $usageChartTitle .= ': by ' . $usageGroupByObject->getLabel();
-                }
-            }
-
-            // If a thumbnail was requested, do not use an in-chart title.
-            // Otherwise, use one.
-            if ($thumbnailRequested) {
-                $meChart['title']['text'] = '';
-            } else {
-                // If a title was provided, display that. Otherwise, use the
-                // generated title.
-                $meChart['title']['text'] = $usageChartTitle;
-            }
-
-            // Set the title style.
-            $meChart['title']['style'] = $usageTitleStyle;
-
-            // Generate the expected IDs for the chart.
-            $usageMetric = $meRequest['data_series_unencoded'][0]['metric'];
-            $usageChartId = "statistic_${usageRealm}_${usageGroupBy}_${usageMetric}";
-            $usageChartMenuId = "group_by_${usageRealm}_${usageGroupBy}";
-
-            // Remove extraneous x-axis properties.
-            if ($usageIsTimeseries) {
-                unset($meChart['xAxis']['title']);
-            } else {
-                unset($meChart['xAxis']['title']['text']);
-                unset($meChart['xAxis']['labels']['staggerLines']);
-            }
-            unset($meChart['xAxis']['otitle']);
-            unset($meChart['xAxis']['dtitle']);
-
-            // set x-axis title, if any, bold:
-            if (isset($meChart['xAxis']['title']['style'])) {
-                $meChart['xAxis']['title']['style']['fontWeight'] = 'bold';
-            }
-
-            // If there is a y-axis...
-            if (isset($meChart['yAxis'][0])) {
-                // Remove extraneous y-axis properties.
-                unset($meChart['yAxis'][0]['otitle']);
-                unset($meChart['yAxis'][0]['dtitle']);
-                unset($meChart['yAxis'][0]['opposite']);
-                unset($meChart['yAxis'][0]['max']);
-                unset($meChart['yAxis'][0]['startOnTick']);
-
-                // If a thumbnail was requested, remove the y-axis label.
-                if ($thumbnailRequested) {
-                    $meChart['yAxis'][0]['title']['text'] = '';
-                }
-
-                // set y-axis title, if any, bold:
-                if (isset($meChart['yAxis'][0]['title']['style'])) {
-                    $meChart['yAxis'][0]['title']['style']['fontWeight'] = 'bold';
-                }
-
-                // Fix the x-axis labels to be the same size as the y-axis labels.
-                $meChart['xAxis']['labels']['style']['fontSize'] =
-                    $meChart['yAxis'][0]['labels']['style']['fontSize'];
-
-                // Restore the last y-axis label.
-                $meChart['yAxis'][0]['showLastLabel'] = true;
-
-                // Set the y-axis grid line dash style and color.
-                if ($usageIsTimeseries) {
-                    $meChart['yAxis'][0]['gridLineDashStyle'] = 'Solid';
-                    $meChart['yAxis'][0]['gridLineColor'] = '#C0C0C0';
-                } else {
-                    unset($meChart['yAxis'][0]['gridLineDashStyle']);
-                    unset($meChart['yAxis'][0]['gridLineColor']);
-                }
-            }
-
-            // If there are x-axis categories, they are sorted by value,
-            // and this is a grouped chart, enumerate them with rank.
-            $chartSortedByValue = \xd_utilities\string_begins_with(
-                $meRequest['data_series_unencoded'][0]['sort_type'],
-                'value'
-            );
-            if (
-                isset($meChart['xAxis']['categories'])
-                && $chartSortedByValue
-                && $usageGroupBy !== 'none'
-            ) {
-                $meChartCategories = $meChart['xAxis']['categories'];
-                $usageChartCategories = array();
-                $currentCategoryRank = $usageOffset + 1;
-                foreach ($meChartCategories as $meChartCategory) {
-                    $usageChartCategories[] = "${currentCategoryRank}. ${meChartCategory}";
-                    $currentCategoryRank++;
-                }
-                $meChart['xAxis']['categories'] = $usageChartCategories;
-            }
-
-            // Generate the chart arguments string for the report generator.
-            //
-            // If the controller module was specified in the request, ensure
-            // it is at the front of the arguments string. The rest of the
-            // parameters should be sorted by key.
-            $usageChartArgs = $this->request;
-            unset($usageChartArgs['height']);
-            unset($usageChartArgs['scale']);
-            unset($usageChartArgs['show_title']);
-            unset($usageChartArgs['width']);
-            ksort($usageChartArgs);
-            if (array_key_exists('controller_module', $usageChartArgs)) {
-                $usageChartArgs = array(
-                    'controller_module' => $usageChartArgs['controller_module'],
-                ) + $usageChartArgs;
-            }
-            $usageChartArgsStr = urldecode(http_build_query($usageChartArgs));
-
-            // Check if the user's chart pool contains this chart.
-            $usageChartInPool = $chartPool->chartExistsInQueue($usageChartArgsStr);
-
-            // For each data series...
-            $primaryDataSeriesRank = $usageOffset;
-            array_walk($meChart['series'], function (
-                &$meDataSeries,
-                $meDataSeriesIndex
-            ) use (
-                $usageRealm,
-                $usageGroupBy,
-                $usageIsTimeseries,
-                $thumbnailRequested,
-                $meRequest,
-                $meRequestMetric,
-                $usageGroupByObject,
-                $user,
-                &$primaryDataSeriesRank,
-                $chartSortedByValue
-            ) {
-                // Determine the type of this data series.
-                $isTrendLineSeries = \xd_utilities\string_begins_with($meDataSeries['name'], 'Trend Line: ');
-                $isStdErrSeries = \xd_utilities\array_get($meDataSeries, 'type') === 'errorbar';
-                $isPrimaryDataSeries = !($isTrendLineSeries || $isStdErrSeries);
-
-                // If this is a primary data series, increment the rank of the
-                // current primary data series. Further, if this chart is
-                // a timeseries chart, it is sorted by value, and it is a
-                // grouped chart, add the rank to the series label.
-                if ($isPrimaryDataSeries) {
-                    $primaryDataSeriesRank++;
-                    if (
-                        $usageIsTimeseries
-                        && $chartSortedByValue
-                        && $usageGroupBy !== 'none'
-                    ) {
-                        $meDataSeries['name'] = "${primaryDataSeriesRank}. " . $meDataSeries['name'];
-                    }
-                }
-
-                // If this is the primary data series, modify the data labels
-                // and don't specify the line style. Otherwise, just remove
-                // the data labels.
-                if ($isPrimaryDataSeries) {
-                    $meDataSeries['dataLabels']['y'] = -90;
-                    unset($meDataSeries['dashStyle']);
-                } else {
-                    unset($meDataSeries['dataLabels']);
-                }
-
-                // If this is the primary data series and the chart is not a
-                // thumbnail, use line markers if and only if the number of
-                // points is less than or equal to 30.
-                if ($isPrimaryDataSeries && !$thumbnailRequested) {
-                    $meDataSeries['marker']['enabled'] = count($meDataSeries['data']) <= 30;
-                }
-
-                // If this is a trend line data series...
-                if ($isTrendLineSeries) {
-                    // Change the line style to a dotted line.
-                    $meDataSeries['dashStyle'] = 'ShortDot';
-                }
-
-                // If this is not a trend line series and not a thumbnail,
-                // fill in the drilldown function.
-                if (!$isTrendLineSeries && !$thumbnailRequested) {
-                    $drillDowns = implode(',', $user->getMostPrivilegedRole()->getQueryDescripters(
-                        'tg_usage',
-                        $usageRealm,
-                        $usageGroupBy,
-                        $meRequestMetric->getAlias()->getName()
-                    )->getDrillTargets($meRequestMetric->getAlias()));
-                    $usageGroupByUnit = $usageGroupByObject->getUnit();
 
                     if ($usageIsTimeseries) {
-                        $drilldownDetails = $meDataSeries['drilldown'];
-                        $drilldownId = $drilldownDetails['id'];
-                        $drilldownLabel = json_encode($drilldownDetails['label']);
-                        $drilldownFunction = "function(event) {
-                            this.ts = this.x;
-                            XDMoD.Module.Usage.drillChart(
-                                this,
-                                '$drillDowns',
-                                '${usageGroupBy}-${usageGroupByUnit}',
-                                '$drilldownId',
-                                $drilldownLabel,
-                                'none',
-                                'tg_usage',
-                                '$usageRealm'
+                        $timeseriesTemplateField = $combinedResultFields[2];
+                        $timeseriesTemplateColumn = $combinedResultColumns[2];
+
+                        $timeseriesGroupByColumnName = $combinedResultColumns[1]['dataIndex'];
+                        $valueColumnName = $timeseriesTemplateColumn['dataIndex'];
+
+                        $combinedResultFields = array_slice($combinedResultFields, 0, 1);
+                        $combinedResultColumns = array_slice($combinedResultColumns, 0, 1);
+
+                        $timeseriesFields = array();
+                        $nextFieldNameIndex = 0;
+                        $timeseriesColumns = array();
+                        $timeseriesRecords = array();
+                        foreach ($combinedResultRecords as $resultRecord) {
+                            $resultRecordDimension = $resultRecord[$timeseriesGroupByColumnName];
+
+                            if (!array_key_exists($resultRecordDimension, $timeseriesColumns)) {
+                                $timeseriesDimensionColumnName = "dimension_column_$nextFieldNameIndex";
+                                $nextFieldNameIndex++;
+
+                                $timeseriesColumn = $timeseriesTemplateColumn;
+                                $timeseriesColumn['header'] = "[${resultRecordDimension}] " . $timeseriesColumn['header'];
+                                $timeseriesColumn['dataIndex'] = $timeseriesDimensionColumnName;
+                                $timeseriesColumns[$resultRecordDimension] = $timeseriesColumn;
+
+                                $timeseriesField = $timeseriesTemplateField;
+                                $timeseriesField['name'] = $timeseriesDimensionColumnName;
+                                $timeseriesFields[$resultRecordDimension] = $timeseriesField;
+                            } else {
+                                $timeseriesDimensionColumnName = $timeseriesColumns[$resultRecordDimension]['dataIndex'];
+                            }
+
+                            $timeseriesRecordTime = $resultRecord[$combinedResultFirstColumn];
+                            $timeseriesRecord = array(
+                                $combinedResultFirstColumn => $timeseriesRecordTime,
+                                $timeseriesDimensionColumnName => $resultRecord[$valueColumnName],
                             );
-                        }";
-                    } else {
-                        $drilldownFunction = "function(event) {
-                            var id = this.drilldown.id;
-                            var label = this.drilldown.label;
-                            XDMoD.Module.Usage.drillChart(
-                                this,
-                                '$drillDowns',
-                                '${usageGroupBy}-${usageGroupByUnit}',
-                                id,
-                                label,
-                                'none',
-                                'tg_usage',
-                                '$usageRealm'
-                            );
-                        }";
+
+                            if (array_key_exists($timeseriesRecordTime, $timeseriesRecords)) {
+                                $timeseriesRecords[$timeseriesRecordTime] = array_merge(
+                                    $timeseriesRecords[$timeseriesRecordTime],
+                                    $timeseriesRecord
+                                );
+                            } else {
+                                $timeseriesRecords[$timeseriesRecordTime] = $timeseriesRecord;
+                            }
+                        }
+
+                        $combinedResultFields = array_merge(
+                            $combinedResultFields,
+                            array_values($timeseriesFields)
+                        );
+                        $combinedResultColumns = array_merge(
+                            $combinedResultColumns,
+                            array_values($timeseriesColumns)
+                        );
+                        $combinedResultRecords = $timeseriesRecords;
                     }
 
-                    $meDataSeries['point']['events']['click'] = $drilldownFunction;
+                    // Sort the value columns by title.
+                    $combinedResultKeyColumns = array_slice($combinedResultColumns, 0, 1);
+                    $combinedResultValueColumns = array_slice($combinedResultColumns, 1);
+                    usort($combinedResultValueColumns, function ($a, $b) {
+                        return strcmp($a['header'], $b['header']);
+                    });
+                    $combinedResultColumns = array_merge(
+                        $combinedResultKeyColumns,
+                        $combinedResultValueColumns
+                    );
+
+                    // Store the combined results in the object to be returned.
+                    $combinedResult['metaData']['fields'] = $combinedResultFields;
+                    $combinedResult['columns'] = $combinedResultColumns;
+                    $combinedResult['records'] = array_values($combinedResultRecords);
+                    $combinedResult['restrictedByRoles'] = $combinedResultRestricted;
+
+                    // Get the dimension and metric descriptions.
+                    $jsonStoreMessage = '<ul>';
+                    $jsonStoreMessage .= '<li>' . $usageGroupByObject->getDescription() . '</li>';
+
+                    $jsonStoreMessageMetricDescriptions = array();
+                    foreach ($meRequest['data_series_unencoded'] as $meRequestDataSeries) {
+                        $jsonStoreMessageMetricDescriptions[] = '<li>' . $usageRealmAggregateClass::getStatistic($meRequestDataSeries['metric'])->getDescription($usageGroupByObject) . '</li>';
+                    }
+                    sort($jsonStoreMessageMetricDescriptions);
+                    $jsonStoreMessage .= implode('', $jsonStoreMessageMetricDescriptions);
+
+                    $jsonStoreMessage .= '</ul>';
+                    $combinedResult['message'] = $jsonStoreMessage;
+
+                    // Sort the datasheet appropriately.
+                    if ($usageIsTimeseries || !$isSingleMetricQuery) {
+                        $sortField = $combinedResultFirstColumn;
+                        $sortDirection = 'asc';
+                    } else {
+                        $meRequestSortType = $meRequest['data_series_unencoded'][0]['sort_type'];
+
+                        if (\xd_utilities\string_begins_with($meRequestSortType, 'value')) {
+                            $sortField = $combinedResult['metaData']['fields'][1]['name'];
+                        } else {
+                            $sortField = $combinedResultFirstColumn;
+                        }
+
+                        if (\xd_utilities\string_ends_with($meRequestSortType, 'desc')) {
+                            $sortDirection = 'desc';
+                        } else {
+                            $sortDirection = 'asc';
+                        }
+                    }
+
+                    $combinedResult['metaData']['sortInfo'] = array(
+                        'field' => $sortField,
+                        'direction' => $sortDirection,
+                    );
+
+                    // Set the results to the combined result.
+                    $meResponse['results'] = json_encode($combinedResult);
                 }
 
-                // Set properties that are different.
-                $meDataSeries['zIndex'] = $meDataSeriesIndex + 2;
+                return $meResponse;
+            }
 
-                // Remove extraneous properties.
-                unset($meDataSeries['otitle']);
-                unset($meDataSeries['datasetId']);
-                unset($meDataSeries['visible']);
-                unset($meDataSeries['events']);
+            // Get attributes common to all charts that will be returned.
+            $usageTitle = \xd_utilities\array_get($this->request, 'title');
+            $usageSubtitle = \xd_utilities\array_get($this->request, 'subtitle');
+            $usageOffset = intval(\xd_utilities\array_get($this->request, 'offset', 0));
+            $usageWidth = intval(\xd_utilities\array_get($this->request, 'width', self::DEFAULT_WIDTH));
+            $usageHeight = intval(\xd_utilities\array_get($this->request, 'height', self::DEFAULT_HEIGHT));
+            $usageFontSize = intval(\xd_utilities\array_get($this->request, 'font_size', 3));
+            $usageShowGradient = \xd_utilities\array_get($this->request, 'show_gradient', 'y');
+            $usageShowGradient = $usageShowGradient === 'true' || $usageShowGradient === 'y';
+            $thumbnailRequested = \xd_utilities\array_get($this->request, 'thumbnail', 'n') === 'y';
 
-                if ($usageIsTimeseries) {
-                    unset($meDataSeries['drilldown']);
-                }
-
-                // Note: keep dataLabels color param set, else we lose some of the pie datalabels
-                // in the Usage chart only.
-                if ($meDataSeries['type'] === 'pie') {
-                    unset($meDataSeries['dataLabels']['y']);
-                    unset($meDataSeries['dataLabels']['style']['color']);
-                }
-            });
-
-            // Create a Usage-style chart.
-            $usageChart = array(
-                'hc_jsonstore' => $meChart,
-                'query_time' => '',
-                'query_string' => '',
-                'title' => $usageChartTitle,
-                'params_title' => html_entity_decode($usageChartSubtitle),
-                'comments' => 'comments',
-                'chart_args' => $usageChartArgsStr,
-                'reportGeneratorMeta' => array(
-                    'included_in_report' => $usageChartInPool ? 'y' : 'n',
-                ),
-                'short_title' => $usageChartShortTitle,
-                'random_id' => 'chart_' . mt_rand(), //TODO: Use a definitively-unique ID for inserting chart HTML tags.
-                'subnotes' => $usageSubnotes,
-                'group_description' => $usageChartDimensionDescription,
-                'description' => $usageChartMetricDescription,
-                'id' => $usageChartId,
-                'menu_id' => $usageChartMenuId,
-                'realm' => $usageRealm,
-                'start_date' => $this->request['start_date'],
-                'end_date' => $this->request['end_date'],
-                'chart_settings' => $usageChartSettingsJson,
-                'show_gradient' => $usageShowGradient,
-                'final_width' => $usageWidth,
-                'final_height' => $usageHeight - 4,
-                'sort_type' => $meRequest['data_series_unencoded'][0]['sort_type'],
+            // Generate the chart settings that will be returned with each chart.
+            $usageChartSettings = array(
+                'dataset_type' =>           \xd_utilities\array_get($this->request, 'dataset_type', $usageGroupByObject->getDefaultDatasetType()),
+                'display_type' =>           \xd_utilities\array_get($this->request, 'display_type', $usageGroupByObject->getDefaultDisplayType($usageGroupByObject->getDefaultDatasetType())),
+                'combine_type' =>           \xd_utilities\array_get($this->request, 'combine_type', $usageGroupByObject->getDefaultCombineMethod()),
+                'show_legend' =>            \xd_utilities\array_get($this->request, 'show_legend', $usageGroupByObject->getDefaultShowLegend()),
+                'show_guide_lines' =>       \xd_utilities\array_get($this->request, 'show_guide_lines', $usageGroupByObject->getDefaultShowGuideLines()),
+                'log_scale' =>              \xd_utilities\array_get($this->request, 'log_scale', $usageGroupByObject->getDefaultLogScale()),
+                'limit' =>                  \xd_utilities\array_get($this->request, 'limit', $usageGroupByObject->getDefaultLimit()),
+                'offset' =>                 \xd_utilities\array_get($this->request, 'offset', $usageGroupByObject->getDefaultOffset()),
+                'show_trend_line' =>        \xd_utilities\array_get($this->request, 'show_trend_line', $usageGroupByObject->getDefaultShowTrendLine()),
+                'show_error_bars' =>        \xd_utilities\array_get($this->request, 'show_error_bars', $usageGroupByObject->getDefaultShowErrorBars()),
+                'show_aggregate_labels' =>  \xd_utilities\array_get($this->request, 'show_aggregate_labels', $usageGroupByObject->getDefaultShowAggregateLabels()),
+                'show_error_labels' =>      \xd_utilities\array_get($this->request, 'show_error_labels', $usageGroupByObject->getDefaultShowErrorLabels()),
+                'hide_tooltip' =>           \xd_utilities\array_get($this->request, 'hide_tooltip', false),
+                'enable_errors' =>          \xd_utilities\array_get($this->request, 'enable_errors', $usageGroupByObject->getDefaultEnableErrors()),
+                'enable_trend_line' =>      \xd_utilities\array_get($this->request, 'enable_trend_line', $usageGroupByObject->getDefaultEnableTrendLine()),
             );
-            foreach ($meReportGeneratorMeta as $reportKey => $reportValue) {
-                if (
-                    $reportKey === 'included_in_report'
-                    || array_key_exists($reportKey, $usageChart)
-                ) {
+            $usageChartSettingsJson = json_encode($usageChartSettings);
+
+            $usageSubnotes = array();
+            if ($usageGroupBy === 'resource' || array_key_exists('resource', $this->request)) {
+                $usageSubnotes[] = '* Resources marked with asterisk do not provide processor'
+                    . ' counts per job when submitting to the '
+                    . ORGANIZATION_NAME . ' Central Database. This affects the'
+                    . ' accuracy of the following (and related) statistics: Job'
+                    . ' Size and CPU Consumption';
+            }
+
+            // Generate the title style that will be used for all charts.
+            $usageTitleFontSizeInPixels = 16 + $usageFontSize;
+            $usageTitleStyle = array(
+                'color' => '#000000',
+                'fontSize' => "${usageTitleFontSizeInPixels}px",
+            );
+
+            // Get the user's report generator chart pool.
+            $chartPool = new XDChartPool($user);
+
+            // Convert each Metric Explorer response into a Usage chart.
+            foreach ($meResponses as $meResponseIndex => $meResponse) {
+                // If the response indicates failure, skip this response.
+                $meResponseContent = $meResponse['results'];
+                if (!$meResponseContent['success']) {
                     continue;
                 }
 
-                $usageChart[$reportKey] = $reportValue;
-            }
+                // Get the request for this chart.
+                $meRequest = $meRequests[$meResponseIndex];
 
-            // Add the chart to the set of charts to return.
-            $usageCharts[] = $usageChart;
+                // Get the statistic object used by this chart request.
+                $meRequestMetric = $usageRealmAggregateClass::getStatistic($meRequest['data_series_unencoded'][0]['metric']);
+
+                // Get the chart object from the response.
+                $meChart = &$meResponseContent['data'][0];
+
+                // Extract the report generator options.
+                $meReportGeneratorMeta = \xd_utilities\array_extract($meChart, 'reportGeneratorMeta', array());
+
+                // Replace the in-chart descriptions with empty arrays.
+                $meChart['dimensions'] = array();
+                $meChart['metrics'] = array();
+
+                // Grab the dimension and metric and generate a formatted group
+                // and metric description.
+                $usageChartDimensionDescription = $usageGroupByObject->getDescription();
+                $usageChartMetricDescription = $meRequestMetric->getDescription($usageGroupByObject);
+
+                // If specified, use the given subtitle. Otherwise, get the
+                // subtitle from the title of the resulting chart.
+                //
+                // Because the function doesn't receive a custom title, if any,
+                // from this adapter, the chart's subtitle is placed in the title.
+                $usageChartSubtitle = $usageSubtitle !== null ? $usageSubtitle : $meChart['title']['text'];
+
+                // Only include the subtitle on the chart if the chart is not a
+                // thumbnail.
+                $meChart['subtitle']['text'] = $thumbnailRequested ? '' : $usageChartSubtitle;
+
+                // Generate the title and short title of this chart.
+                $usageChartShortTitle = $meRequestMetric->getLabel();
+                if ($usageTitle !== null) {
+                    $usageChartTitle = $usageTitle;
+                } else {
+                    $usageChartTitle = $usageChartShortTitle;
+                    if ($usageGroupBy !== 'none') {
+                        $usageChartTitle .= ': by ' . $usageGroupByObject->getLabel();
+                    }
+                }
+
+                // If a thumbnail was requested, do not use an in-chart title.
+                // Otherwise, use one.
+                if ($thumbnailRequested) {
+                    $meChart['title']['text'] = '';
+                } else {
+                    // If a title was provided, display that. Otherwise, use the
+                    // generated title.
+                    $meChart['title']['text'] = $usageChartTitle;
+                }
+
+                // Set the title style.
+                $meChart['title']['style'] = $usageTitleStyle;
+
+                // Generate the expected IDs for the chart.
+                $usageMetric = $meRequest['data_series_unencoded'][0]['metric'];
+                $usageChartId = "statistic_${usageRealm}_${usageGroupBy}_${usageMetric}";
+                $usageChartMenuId = "group_by_${usageRealm}_${usageGroupBy}";
+
+                // Remove extraneous x-axis properties.
+                if ($usageIsTimeseries) {
+                    unset($meChart['xAxis']['title']);
+                } else {
+                    unset($meChart['xAxis']['title']['text']);
+                    unset($meChart['xAxis']['labels']['staggerLines']);
+                }
+                unset($meChart['xAxis']['otitle']);
+                unset($meChart['xAxis']['dtitle']);
+
+                // set x-axis title, if any, bold:
+                if (isset($meChart['xAxis']['title']['style'])) {
+                    $meChart['xAxis']['title']['style']['fontWeight'] = 'bold';
+                }
+
+                // If there is a y-axis...
+                if (isset($meChart['yAxis'][0])) {
+                    // Remove extraneous y-axis properties.
+                    unset($meChart['yAxis'][0]['otitle']);
+                    unset($meChart['yAxis'][0]['dtitle']);
+                    unset($meChart['yAxis'][0]['opposite']);
+                    unset($meChart['yAxis'][0]['max']);
+                    unset($meChart['yAxis'][0]['startOnTick']);
+
+                    // If a thumbnail was requested, remove the y-axis label.
+                    if ($thumbnailRequested) {
+                        $meChart['yAxis'][0]['title']['text'] = '';
+                    }
+
+                    // set y-axis title, if any, bold:
+                    if (isset($meChart['yAxis'][0]['title']['style'])) {
+                        $meChart['yAxis'][0]['title']['style']['fontWeight'] = 'bold';
+                    }
+
+                    // Fix the x-axis labels to be the same size as the y-axis labels.
+                    $meChart['xAxis']['labels']['style']['fontSize'] =
+                        $meChart['yAxis'][0]['labels']['style']['fontSize'];
+
+                    // Restore the last y-axis label.
+                    $meChart['yAxis'][0]['showLastLabel'] = true;
+
+                    // Set the y-axis grid line dash style and color.
+                    if ($usageIsTimeseries) {
+                        $meChart['yAxis'][0]['gridLineDashStyle'] = 'Solid';
+                        $meChart['yAxis'][0]['gridLineColor'] = '#C0C0C0';
+                    } else {
+                        unset($meChart['yAxis'][0]['gridLineDashStyle']);
+                        unset($meChart['yAxis'][0]['gridLineColor']);
+                    }
+                }
+
+                // If there are x-axis categories, they are sorted by value,
+                // and this is a grouped chart, enumerate them with rank.
+                $chartSortedByValue = \xd_utilities\string_begins_with(
+                    $meRequest['data_series_unencoded'][0]['sort_type'],
+                    'value'
+                );
+                if (
+                    isset($meChart['xAxis']['categories'])
+                    && $chartSortedByValue
+                    && $usageGroupBy !== 'none'
+                ) {
+                    $meChartCategories = $meChart['xAxis']['categories'];
+                    $usageChartCategories = array();
+                    $currentCategoryRank = $usageOffset + 1;
+                    foreach ($meChartCategories as $meChartCategory) {
+                        $usageChartCategories[] = "${currentCategoryRank}. ${meChartCategory}";
+                        $currentCategoryRank++;
+                    }
+                    $meChart['xAxis']['categories'] = $usageChartCategories;
+                }
+
+                // Generate the chart arguments string for the report generator.
+                //
+                // If the controller module was specified in the request, ensure
+                // it is at the front of the arguments string. The rest of the
+                // parameters should be sorted by key.
+                $usageChartArgs = $this->request;
+                unset($usageChartArgs['height']);
+                unset($usageChartArgs['scale']);
+                unset($usageChartArgs['show_title']);
+                unset($usageChartArgs['width']);
+                ksort($usageChartArgs);
+                if (array_key_exists('controller_module', $usageChartArgs)) {
+                    $usageChartArgs = array(
+                        'controller_module' => $usageChartArgs['controller_module'],
+                    ) + $usageChartArgs;
+                }
+                $usageChartArgsStr = urldecode(http_build_query($usageChartArgs));
+
+                // Check if the user's chart pool contains this chart.
+                $usageChartInPool = $chartPool->chartExistsInQueue($usageChartArgsStr);
+
+                // For each data series...
+                $primaryDataSeriesRank = $usageOffset;
+                array_walk($meChart['series'], function (
+                    &$meDataSeries,
+                    $meDataSeriesIndex
+                ) use (
+                    $usageRealm,
+                    $usageGroupBy,
+                    $usageIsTimeseries,
+                    $thumbnailRequested,
+                    $meRequest,
+                    $meRequestMetric,
+                    $usageGroupByObject,
+                    $user,
+                    &$primaryDataSeriesRank,
+                    $chartSortedByValue
+                ) {
+                    // Determine the type of this data series.
+                    $isTrendLineSeries = \xd_utilities\string_begins_with($meDataSeries['name'], 'Trend Line: ');
+                    $isStdErrSeries = \xd_utilities\array_get($meDataSeries, 'type') === 'errorbar';
+                    $isPrimaryDataSeries = !($isTrendLineSeries || $isStdErrSeries);
+
+                    // If this is a primary data series, increment the rank of the
+                    // current primary data series. Further, if this chart is
+                    // a timeseries chart, it is sorted by value, and it is a
+                    // grouped chart, add the rank to the series label.
+                    if ($isPrimaryDataSeries) {
+                        $primaryDataSeriesRank++;
+                        if (
+                            $usageIsTimeseries
+                            && $chartSortedByValue
+                            && $usageGroupBy !== 'none'
+                        ) {
+                            $meDataSeries['name'] = "${primaryDataSeriesRank}. " . $meDataSeries['name'];
+                        }
+                    }
+
+                    // If this is the primary data series, modify the data labels
+                    // and don't specify the line style. Otherwise, just remove
+                    // the data labels.
+                    if ($isPrimaryDataSeries) {
+                        $meDataSeries['dataLabels']['y'] = -90;
+                        unset($meDataSeries['dashStyle']);
+                    } else {
+                        unset($meDataSeries['dataLabels']);
+                    }
+
+                    // If this is the primary data series and the chart is not a
+                    // thumbnail, use line markers if and only if the number of
+                    // points is less than or equal to 30.
+                    if ($isPrimaryDataSeries && !$thumbnailRequested) {
+                        $meDataSeries['marker']['enabled'] = count($meDataSeries['data']) <= 30;
+                    }
+
+                    // If this is a trend line data series...
+                    if ($isTrendLineSeries) {
+                        // Change the line style to a dotted line.
+                        $meDataSeries['dashStyle'] = 'ShortDot';
+                    }
+
+                    // If this is not a trend line series and not a thumbnail,
+                    // fill in the drilldown function.
+                    if (!$isTrendLineSeries && !$thumbnailRequested) {
+                        $drillDowns = implode(',', $user->getMostPrivilegedRole()->getQueryDescripters(
+                            'tg_usage',
+                            $usageRealm,
+                            $usageGroupBy,
+                            $meRequestMetric->getAlias()->getName()
+                        )->getDrillTargets($meRequestMetric->getAlias()));
+                        $usageGroupByUnit = $usageGroupByObject->getUnit();
+
+                        if ($usageIsTimeseries) {
+                            $drilldownDetails = $meDataSeries['drilldown'];
+                            $drilldownId = $drilldownDetails['id'];
+                            $drilldownLabel = json_encode($drilldownDetails['label']);
+                            $drilldownFunction = "function(event) {
+                                this.ts = this.x;
+                                XDMoD.Module.Usage.drillChart(
+                                    this,
+                                    '$drillDowns',
+                                    '${usageGroupBy}-${usageGroupByUnit}',
+                                    '$drilldownId',
+                                    $drilldownLabel,
+                                    'none',
+                                    'tg_usage',
+                                    '$usageRealm'
+                                );
+                            }";
+                        } else {
+                            $drilldownFunction = "function(event) {
+                                var id = this.drilldown.id;
+                                var label = this.drilldown.label;
+                                XDMoD.Module.Usage.drillChart(
+                                    this,
+                                    '$drillDowns',
+                                    '${usageGroupBy}-${usageGroupByUnit}',
+                                    id,
+                                    label,
+                                    'none',
+                                    'tg_usage',
+                                    '$usageRealm'
+                                );
+                            }";
+                        }
+
+                        $meDataSeries['point']['events']['click'] = $drilldownFunction;
+                    }
+
+                    // Set properties that are different.
+                    $meDataSeries['zIndex'] = $meDataSeriesIndex + 2;
+
+                    // Remove extraneous properties.
+                    unset($meDataSeries['otitle']);
+                    unset($meDataSeries['datasetId']);
+                    unset($meDataSeries['visible']);
+                    unset($meDataSeries['events']);
+
+                    if ($usageIsTimeseries) {
+                        unset($meDataSeries['drilldown']);
+                    }
+
+                    // Note: keep dataLabels color param set, else we lose some of the pie datalabels
+                    // in the Usage chart only.
+                    if ($meDataSeries['type'] === 'pie') {
+                        unset($meDataSeries['dataLabels']['y']);
+                        unset($meDataSeries['dataLabels']['style']['color']);
+                    }
+                });
+
+                // Create a Usage-style chart.
+                $usageChart = array(
+                    'hc_jsonstore' => $meChart,
+                    'query_time' => '',
+                    'query_string' => '',
+                    'title' => $usageChartTitle,
+                    'params_title' => html_entity_decode($usageChartSubtitle),
+                    'comments' => 'comments',
+                    'chart_args' => $usageChartArgsStr,
+                    'reportGeneratorMeta' => array(
+                        'included_in_report' => $usageChartInPool ? 'y' : 'n',
+                    ),
+                    'short_title' => $usageChartShortTitle,
+                    'random_id' => 'chart_' . mt_rand(), //TODO: Use a definitively-unique ID for inserting chart HTML tags.
+                    'subnotes' => $usageSubnotes,
+                    'group_description' => $usageChartDimensionDescription,
+                    'description' => $usageChartMetricDescription,
+                    'id' => $usageChartId,
+                    'menu_id' => $usageChartMenuId,
+                    'realm' => $usageRealm,
+                    'start_date' => $this->request['start_date'],
+                    'end_date' => $this->request['end_date'],
+                    'chart_settings' => $usageChartSettingsJson,
+                    'show_gradient' => $usageShowGradient,
+                    'final_width' => $usageWidth,
+                    'final_height' => $usageHeight - 4,
+                    'sort_type' => $meRequest['data_series_unencoded'][0]['sort_type'],
+                );
+                foreach ($meReportGeneratorMeta as $reportKey => $reportValue) {
+                    if (
+                        $reportKey === 'included_in_report'
+                        || array_key_exists($reportKey, $usageChart)
+                    ) {
+                        continue;
+                    }
+
+                    $usageChart[$reportKey] = $reportValue;
+                }
+
+                // Add the chart to the set of charts to return.
+                $usageCharts[] = $usageChart;
+            }
         }
 
         // Sort the results by short title.

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -537,7 +537,7 @@ class Usage extends Common
             unset($meChart['xAxis']['dtitle']);
 
             // set x-axis title, if any, bold:
-            if (isset ($meChart['xAxis']['title']['style']) ) {
+            if (isset($meChart['xAxis']['title']['style'])) {
                 $meChart['xAxis']['title']['style']['fontWeight'] = 'bold';
             }
 
@@ -556,7 +556,7 @@ class Usage extends Common
                 }
 
                 // set y-axis title, if any, bold:
-                if (isset ($meChart['yAxis'][0]['title']['style']) ) {
+                if (isset($meChart['yAxis'][0]['title']['style'])) {
                     $meChart['yAxis'][0]['title']['style']['fontWeight'] = 'bold';
                 }
 
@@ -621,7 +621,10 @@ class Usage extends Common
 
             // For each data series...
             $primaryDataSeriesRank = $usageOffset;
-            array_walk($meChart['series'], function(&$meDataSeries, $meDataSeriesIndex) use (
+            array_walk($meChart['series'], function (
+                &$meDataSeries,
+                $meDataSeriesIndex
+            ) use (
                 $usageRealm,
                 $usageGroupBy,
                 $usageIsTimeseries,
@@ -679,7 +682,7 @@ class Usage extends Common
                 // If this is not a trend line series and not a thumbnail,
                 // fill in the drilldown function.
                 if (!$isTrendLineSeries && !$thumbnailRequested) {
-                    $drillDowns = implode(',',$user->getMostPrivilegedRole()->getQueryDescripters(
+                    $drillDowns = implode(',', $user->getMostPrivilegedRole()->getQueryDescripters(
                         'tg_usage',
                         $usageRealm,
                         $usageGroupBy,
@@ -690,7 +693,7 @@ class Usage extends Common
                     if ($usageIsTimeseries) {
                         $drilldownDetails = $meDataSeries['drilldown'];
                         $drilldownId = $drilldownDetails['id'];
-                        $drilldownLabel = json_encode( $drilldownDetails['label'] );
+                        $drilldownLabel = json_encode($drilldownDetails['label']);
                         $drilldownFunction = "function(event) {
                             this.ts = this.x;
                             XDMoD.Module.Usage.drillChart(
@@ -1046,5 +1049,3 @@ class Usage extends Common
         ;
     }
 }
-
-?>

--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -14,116 +14,116 @@ use DataWarehouse\RoleRestrictionsStringBuilder;
 */
 class HighChart2
 {
-	protected $_swapXY;
-	protected $_chart;
-	protected $_width;
-	protected $_height;
-	protected $_scale;//deprecated
+    protected $_swapXY;
+    protected $_chart;
+    protected $_width;
+    protected $_height;
+    protected $_scale;//deprecated
 
-	protected $_aggregationUnit;
-	protected $_startDate;
-	protected $_endDate;
+    protected $_aggregationUnit;
+    protected $_startDate;
+    protected $_endDate;
 
-	protected $_total;
+    protected $_total;
 
-	protected $_dashStyles = array(
-		'Solid',
-		'ShortDash',
-		'ShortDot',
-		'ShortDashDot',
-		'ShortDashDotDot',
-		'Dot',
-		'Dash',
-		'LongDash',
-		'DashDot',
-		'LongDashDot',
-		'LongDashDotDot'
-	);
+    protected $_dashStyles = array(
+        'Solid',
+        'ShortDash',
+        'ShortDot',
+        'ShortDashDot',
+        'ShortDashDotDot',
+        'Dot',
+        'Dash',
+        'LongDash',
+        'DashDot',
+        'LongDashDot',
+        'LongDashDotDot'
+    );
 
-	protected $_dashStyleCount = 11;
+    protected $_dashStyleCount = 11;
 
-	// we love instance variables: JMS
-	protected $_shareYAxis;
-	protected $_hideTooltip;
-	protected $_showContextMenu;
-	protected $_showWarnings;
-	protected $_dataset; // ComplexDataset object, a collection of Simple*Datasets
+    // we love instance variables: JMS
+    protected $_shareYAxis;
+    protected $_hideTooltip;
+    protected $_showContextMenu;
+    protected $_showWarnings;
+    protected $_dataset; // ComplexDataset object, a collection of Simple*Datasets
 
-	protected $_xAxisDataObject; // SimpleData object
-	protected $_xAxisLabel;
-	protected $_multiRealm = false;
-	protected $_queryType = 'aggregate';
+    protected $_xAxisDataObject; // SimpleData object
+    protected $_xAxisLabel;
+    protected $_multiRealm = false;
+    protected $_queryType = 'aggregate';
 
-	protected $_subtitleText = '';
+    protected $_subtitleText = '';
 
-	/**
-	 * The role restrictions string builder used by this chart.
-	 *
-	 * @var DataWarehouse\RoleRestrictionsStringBuilder
-	 */
-	protected $roleRestrictionsStringBuilder;
+    /**
+     * The role restrictions string builder used by this chart.
+     *
+     * @var DataWarehouse\RoleRestrictionsStringBuilder
+     */
+    protected $roleRestrictionsStringBuilder;
 
-	// ---------------------------------------------------------
-	// __construct()
-	//
-	// Constructor for HighChart2 class.
-	//
-	// ---------------------------------------------------------
-	public function __construct(
-		$aggregation_unit,
-		$start_date,
-		$end_date,
-		$scale,
-		$width,
-		$height,
-		$swap_xy = false,
-		$showContextMenu = true,
-		$share_y_axis = false,
-		$hide_tooltip = false,
-		$min_aggregation_unit = null,
-		$showWarnings = true
-	)
-	{
-		$this->setDuration($start_date,$end_date,$aggregation_unit,$min_aggregation_unit);
+    // ---------------------------------------------------------
+    // __construct()
+    //
+    // Constructor for HighChart2 class.
+    //
+    // ---------------------------------------------------------
+    public function __construct(
+        $aggregation_unit,
+        $start_date,
+        $end_date,
+        $scale,
+        $width,
+        $height,
+        $swap_xy = false,
+        $showContextMenu = true,
+        $share_y_axis = false,
+        $hide_tooltip = false,
+        $min_aggregation_unit = null,
+        $showWarnings = true
+    ) {
+    
+        $this->setDuration($start_date, $end_date, $aggregation_unit, $min_aggregation_unit);
 
-		$this->_width = $width *$scale;
-		$this->_height = $height *$scale;
-		$this->_scale = 1; //deprecated
+        $this->_width = $width *$scale;
+        $this->_height = $height *$scale;
+        $this->_scale = 1; //deprecated
 
-		$this->_swapXY = $swap_xy;
-		$this->_shareYAxis = $share_y_axis;
-		$this->_hideTooltip = $hide_tooltip;
+        $this->_swapXY = $swap_xy;
+        $this->_shareYAxis = $share_y_axis;
+        $this->_hideTooltip = $hide_tooltip;
 
-		$this->_total = 0;
-		$this->_showContextMenu = $showContextMenu;
-		$this->_showWarnings = $showWarnings;
-		$this->_chart = array(
-			'chart' => array(
-				'inverted' => $this->_swapXY,
-				'zoomType' => 'xy',
-				'alignTicks' => false,
-				'showWarnings' => $this->_showWarnings,
-			),
-			'credits' => array(
-				'text' => $this->_startDate.' to '. $this->_endDate.'. Powered by XDMoD/Highcharts',
-				'href' => ''
-			),
-			'title' => array(
-				'text' => ''
-			),
-			'subtitle' => array(
-				'text' => ''
-			),
-			'xAxis' => array(
-				'categories' => array()
-			),
-			'yAxis' => array(),
-			'legend' => array(
-				'symbolWidth' => 40,
-				'backgroundColor' => '#FFFFFF',
-				'borderWidth' => 0,
-				'y' => -5,
-				'labelFormatter' => "function()
+        $this->_total = 0;
+        $this->_showContextMenu = $showContextMenu;
+        $this->_showWarnings = $showWarnings;
+        $this->_chart = array(
+            'chart' => array(
+                'inverted' => $this->_swapXY,
+                'zoomType' => 'xy',
+                'alignTicks' => false,
+                'showWarnings' => $this->_showWarnings,
+            ),
+            'credits' => array(
+                'text' => $this->_startDate.' to '. $this->_endDate.'. Powered by XDMoD/Highcharts',
+                'href' => ''
+            ),
+            'title' => array(
+                'text' => ''
+            ),
+            'subtitle' => array(
+                'text' => ''
+            ),
+            'xAxis' => array(
+                'categories' => array()
+            ),
+            'yAxis' => array(),
+            'legend' => array(
+                'symbolWidth' => 40,
+                'backgroundColor' => '#FFFFFF',
+                'borderWidth' => 0,
+                'y' => -5,
+                'labelFormatter' => "function()
 				{
 					var ret = '';
 					var x = this.name;
@@ -145,435 +145,439 @@ class HighChart2
 					return ret;
 				}
 				"
-			),
-			'series' => array(),
-			'tooltip' => array(
-				'enabled' => $this->_hideTooltip?false:true,
-				'crosshairs' => true,
-				'shared' => true,
-				'xDateFormat' => $this->getDateFormat()
-			),
-			'plotOptions' => array(
-				'series' => array(
-					'allowPointSelect' => false,
-					'connectNulls' => false,
-					'animation' => false
-				)
-			),
-			'dimensions' => array(),
-			'metrics' => array(),
-			'exporting' => array(
-				'enabled' => false
-			)
-		);
+            ),
+            'series' => array(),
+            'tooltip' => array(
+                'enabled' => $this->_hideTooltip?false:true,
+                'crosshairs' => true,
+                'shared' => true,
+                'xDateFormat' => $this->getDateFormat()
+            ),
+            'plotOptions' => array(
+                'series' => array(
+                    'allowPointSelect' => false,
+                    'connectNulls' => false,
+                    'animation' => false
+                )
+            ),
+            'dimensions' => array(),
+            'metrics' => array(),
+            'exporting' => array(
+                'enabled' => false
+            )
+        );
 
-		$this->roleRestrictionsStringBuilder = new RoleRestrictionsStringBuilder();
-	} // __construct()
+        $this->roleRestrictionsStringBuilder = new RoleRestrictionsStringBuilder();
+    } // __construct()
 
-	// ---------------------------------------------------------
-	// getPointInterval()
-	//
-	// Determine point interval for chart points, given
-	// selected aggregation unit.
-	//
-	// Returns pointInterval as milliseconds for javascript
-	// Used by the HighChartTimeseries2 class.
-	//
-	// Note: Javascript/display related
-	// ---------------------------------------------------------
-	public function getPointInterval()
-	{
-		switch($this->_aggregationUnit)
-		{
-			case 'Month':
-			case 'month':
-				$pointInterval = 28;
-			break;
-			case 'Quarter':
-			case 'quarter':
-				$pointInterval = 88;
-			break;
-			case 'Year':
-			case 'year':
-				$pointInterval = 364;
-			break;
-			default:
-			case 'Day':
-			case 'day':
-				$pointInterval = 1;
-			break;
-		}
-		return $pointInterval * 24 * 3600 * 1000;
-	} // getPointInterval()
+    // ---------------------------------------------------------
+    // getPointInterval()
+    //
+    // Determine point interval for chart points, given
+    // selected aggregation unit.
+    //
+    // Returns pointInterval as milliseconds for javascript
+    // Used by the HighChartTimeseries2 class.
+    //
+    // Note: Javascript/display related
+    // ---------------------------------------------------------
+    public function getPointInterval()
+    {
+        switch($this->_aggregationUnit)
+        {
+            case 'Month':
+            case 'month':
+                $pointInterval = 28;
+                break;
+            case 'Quarter':
+            case 'quarter':
+                $pointInterval = 88;
+                break;
+            case 'Year':
+            case 'year':
+                $pointInterval = 364;
+                break;
+            default:
+            case 'Day':
+            case 'day':
+                $pointInterval = 1;
+                break;
+        }
+        return $pointInterval * 24 * 3600 * 1000;
+    } // getPointInterval()
 
-	// ---------------------------------------------------------
-	// setDuration()
-	//
-	// Format and adjust start and end date for chart, given
-	// selected aggregation unit.
-	//
-	// Note: Data related
-	// ---------------------------------------------------------
-	public function setDuration($startDate, $endDate, $aggregationUnit, $min_aggregation_unit = null)
-	{
-		$this->_aggregationUnit = \DataWarehouse\Query\TimeAggregationUnit::deriveAggregationUnitName(
-			$aggregationUnit, $startDate, $endDate, $min_aggregation_unit);
+    // ---------------------------------------------------------
+    // setDuration()
+    //
+    // Format and adjust start and end date for chart, given
+    // selected aggregation unit.
+    //
+    // Note: Data related
+    // ---------------------------------------------------------
+    public function setDuration($startDate, $endDate, $aggregationUnit, $min_aggregation_unit = null)
+    {
+        $this->_aggregationUnit = \DataWarehouse\Query\TimeAggregationUnit::deriveAggregationUnitName(
+            $aggregationUnit,
+            $startDate,
+            $endDate,
+            $min_aggregation_unit
+        );
 
-		$s = new \DateTime($startDate);
-		$e = new \DateTime($endDate);
-		switch($this->_aggregationUnit)
-		{
-			case 'Month':
-			case 'month':
-				$startDate = $s->format('Y-m-01');
-				$endDate = $e->format('Y-m-t');
-			break;
-			case 'Quarter':
-			case 'quarter':
-				$sm = $s->format('m') - 1;
-				$sy = $s->format('Y');
-				$sq = floor($sm / 3);
-				$s->setDate($sy,($sq * 3) + 1,1);
+        $s = new \DateTime($startDate);
+        $e = new \DateTime($endDate);
+        switch($this->_aggregationUnit)
+        {
+            case 'Month':
+            case 'month':
+                $startDate = $s->format('Y-m-01');
+                $endDate = $e->format('Y-m-t');
+                break;
+            case 'Quarter':
+            case 'quarter':
+                $sm = $s->format('m') - 1;
+                $sy = $s->format('Y');
+                $sq = floor($sm / 3);
+                $s->setDate($sy, ($sq * 3) + 1, 1);
 
-				$em = $e->format('m') - 1;
-				$ey = $e->format('Y');
-				$eq = floor($em / 3);
-				$e->setDate($ey,($eq * 3) + 3,1);
+                $em = $e->format('m') - 1;
+                $ey = $e->format('Y');
+                $eq = floor($em / 3);
+                $e->setDate($ey, ($eq * 3) + 3, 1);
 
-				$startDate = $s->format('Y-m-d');
-				$endDate = $e->format('Y-m-t');
-			break;
-			case 'Year':
-			case 'year':
-				$startDate = $s->format('Y-01-01');
-				$endDate = $e->format('Y-12-31');
-			break;
-			default:
-			case 'Day':
-			case 'day':
-				//no need to adjust
-			break;
-		}
+                $startDate = $s->format('Y-m-d');
+                $endDate = $e->format('Y-m-t');
+                break;
+            case 'Year':
+            case 'year':
+                $startDate = $s->format('Y-01-01');
+                $endDate = $e->format('Y-12-31');
+                break;
+            default:
+            case 'Day':
+            case 'day':
+                //no need to adjust
+                break;
+        }
 
-		$this->_startDate = $startDate;
-		$this->_endDate = $endDate;
-	} // setDuration()
+        $this->_startDate = $startDate;
+        $this->_endDate = $endDate;
+    } // setDuration()
 
-	// ---------------------------------------------------------
-	// getDateFormat()
-	//
-	// Determine appropriate date format given selected aggregation unit.
-	//
-	// ---------------------------------------------------------
-	public function getDateFormat()
-	{
-		switch($this->_aggregationUnit)
-		{
-			case 'Month':
-			case 'month':
-				$format = '%b %Y';
-			break;
-			case 'Quarter':
-			case 'quarter':
-				$format = 'Q%Q %Y';
-			break;
-			case 'Year':
-			case 'year':
-				$format = '%Y';
-			break;
-			default:
-			case 'Day':
-			case 'day':
-				$format = '%Y-%m-%d';
-			break;
-		}
-		return $format;
-	} // getDateFormat()
+    // ---------------------------------------------------------
+    // getDateFormat()
+    //
+    // Determine appropriate date format given selected aggregation unit.
+    //
+    // ---------------------------------------------------------
+    public function getDateFormat()
+    {
+        switch($this->_aggregationUnit)
+        {
+            case 'Month':
+            case 'month':
+                $format = '%b %Y';
+                break;
+            case 'Quarter':
+            case 'quarter':
+                $format = 'Q%Q %Y';
+                break;
+            case 'Year':
+            case 'year':
+                $format = '%Y';
+                break;
+            default:
+            case 'Day':
+            case 'day':
+                $format = '%Y-%m-%d';
+                break;
+        }
+        return $format;
+    } // getDateFormat()
 
-	// ---------------------------------------------------------
-	// setDataSource()
-	//
-	// Set chart data source information for display at bottom
-	// of plotted chart.
-	//
-	// ---------------------------------------------------------
-	public function setDataSource(array $source)
-	{
-		$src = count($source) > 0? ' Src: '.implode(', ',$source).'.':'';
-		$this->_chart['credits']['text'] = $this->_startDate.' to '.
-			$this->_endDate.' '.$src.' Powered by XDMoD/Highcharts';
-	} // setDataSource()
+    // ---------------------------------------------------------
+    // setDataSource()
+    //
+    // Set chart data source information for display at bottom
+    // of plotted chart.
+    //
+    // ---------------------------------------------------------
+    public function setDataSource(array $source)
+    {
+        $src = count($source) > 0? ' Src: '.implode(', ', $source).'.':'';
+        $this->_chart['credits']['text'] = $this->_startDate.' to '.
+            $this->_endDate.' '.$src.' Powered by XDMoD/Highcharts';
+    } // setDataSource()
 
-	// ---------------------------------------------------------
-	// getTitle()
-	//
-	// Get and return chart title as text.
-	//
-	// ---------------------------------------------------------
-	public function getTitle()
-	{
-		return $this->_chart['title']['text'];
-	} // getTitle()
+    // ---------------------------------------------------------
+    // getTitle()
+    //
+    // Get and return chart title as text.
+    //
+    // ---------------------------------------------------------
+    public function getTitle()
+    {
+        return $this->_chart['title']['text'];
+    } // getTitle()
 
-	// ---------------------------------------------------------
-	// setTitle()
-	//
-	// Set chart's title text and highcharts-specific title formatting.
-	//
-	// ---------------------------------------------------------
-	public function setTitle($title, $font_size = 3)
-	{
-		$this->_chart['title']['text'] = $title;
-		$this->_chart['title']['style'] = array(
-			'color'=> '#000000',
-			'fontSize' => (16 + $font_size).'px'
-		);
-	} // setTitle()
+    // ---------------------------------------------------------
+    // setTitle()
+    //
+    // Set chart's title text and highcharts-specific title formatting.
+    //
+    // ---------------------------------------------------------
+    public function setTitle($title, $font_size = 3)
+    {
+        $this->_chart['title']['text'] = $title;
+        $this->_chart['title']['style'] = array(
+            'color'=> '#000000',
+            'fontSize' => (16 + $font_size).'px'
+        );
+    } // setTitle()
 
-	/**
-	 * @return The chart subtitle encoded as plain text.
-	 */
-	public function getSubtitleText()
-	{
-		return $this->_subtitleText;
-	}
+    /**
+     * @return The chart subtitle encoded as plain text.
+     */
+    public function getSubtitleText()
+    {
+        return $this->_subtitleText;
+    }
 
-	/**
-	 * Set chart's subtitle text and highcharts-specific subtitle formatting.
-	 * The text is automatically word wrapped based on the chart settings.
-	 *
-	 * @param $subtitle_html The charts subtitle in HTML format
-	 * @param $font_size The font size for the subtitle plus 12 px
-	 */
-	public function setSubtitle($subtitle_html, $font_size = 3)
-	{
-		if($subtitle_html !== null) {
-			$this->_subtitleText = html_entity_decode($subtitle_html);
-			$this->_chart['subtitle']['text'] = $subtitle_html;
-		} else {
-			$this->_subtitleText = '';
-			$this->_chart['subtitle']['text'] = '';
-		}
-		$this->_chart['subtitle']['style'] = array(
+    /**
+     * Set chart's subtitle text and highcharts-specific subtitle formatting.
+     * The text is automatically word wrapped based on the chart settings.
+     *
+     * @param $subtitle_html The charts subtitle in HTML format
+     * @param $font_size The font size for the subtitle plus 12 px
+     */
+    public function setSubtitle($subtitle_html, $font_size = 3)
+    {
+        if($subtitle_html !== null) {
+            $this->_subtitleText = html_entity_decode($subtitle_html);
+            $this->_chart['subtitle']['text'] = $subtitle_html;
+        } else {
+            $this->_subtitleText = '';
+            $this->_chart['subtitle']['text'] = '';
+        }
+        $this->_chart['subtitle']['style'] = array(
             'color'=> '#5078a0',
-			'fontSize' => (12 + $font_size).'px'
-		);
-		$this->_chart['subtitle']['y'] = 30 + $font_size;
-	} // setSubtitle()
+            'fontSize' => (12 + $font_size).'px'
+        );
+        $this->_chart['subtitle']['y'] = 30 + $font_size;
+    } // setSubtitle()
 
-	// ---------------------------------------------------------
-	// setLegend()
-	//
-	// Set chart's legend location and format based on user's
-	// location selection.
-	//
-	// ---------------------------------------------------------
-	public function setLegend($legend_location, $font_size = 3)
-	{
-		$this->_chart['legend']['itemStyle'] = array(
-            'fontWeight' => 'normal', 
-            'color' => '#274b6d', 
-			'fontSize' => (12  + $font_size).'px'
-		);
-		$this->_legend_location = $legend_location;
-		switch($legend_location)
-		{
-			case 'top_center':
-				$this->_chart['legend']['align'] = 'center';
-				$this->_chart['legend']['verticalAlign'] = 'top';
-				$pad = 0;
-				if($this->_chart['title']['text'] != '') 
-				{
-				    $pad += 30;
-				}
-				if($this->_chart['subtitle']['text'] != '') 
-				{
-				    $pad += 20;
-				}
-				$this->_chart['legend']['y'] = $pad;
+    // ---------------------------------------------------------
+    // setLegend()
+    //
+    // Set chart's legend location and format based on user's
+    // location selection.
+    //
+    // ---------------------------------------------------------
+    public function setLegend($legend_location, $font_size = 3)
+    {
+        $this->_chart['legend']['itemStyle'] = array(
+            'fontWeight' => 'normal',
+            'color' => '#274b6d',
+            'fontSize' => (12  + $font_size).'px'
+        );
+        $this->_legend_location = $legend_location;
+        switch($legend_location)
+        {
+            case 'top_center':
+                $this->_chart['legend']['align'] = 'center';
+                $this->_chart['legend']['verticalAlign'] = 'top';
+                $pad = 0;
+                if($this->_chart['title']['text'] != '')
+                {
+                    $pad += 30;
+                }
+                if($this->_chart['subtitle']['text'] != '')
+                {
+                    $pad += 20;
+                }
+                $this->_chart['legend']['y'] = $pad;
 
-			break;
-			//case 'bottom_right':
-			//break;
-			//case 'bottom_left':
-			//break;
-			case 'left_center':
-				$this->_chart['legend']['align'] = 'left';
-				$this->_chart['legend']['verticalAlign'] = 'middle';
-				$this->_chart['legend']['layout'] = 'vertical';
-				break;
+                break;
+            //case 'bottom_right':
+            //break;
+            //case 'bottom_left':
+            //break;
+            case 'left_center':
+                $this->_chart['legend']['align'] = 'left';
+                $this->_chart['legend']['verticalAlign'] = 'middle';
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
 
-			case 'left_top':
-				$this->_chart['legend']['align'] = 'left';
-				$this->_chart['legend']['verticalAlign'] = 'top';
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'left_bottom':
-				$this->_chart['legend']['align'] = 'left';
-				$this->_chart['legend']['verticalAlign'] = 'bottom';
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'right_center':
-				$this->_chart['legend']['align'] = 'right';
-				$this->_chart['legend']['verticalAlign'] = 'middle';
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'right_top':
-				$this->_chart['legend']['align'] = 'right';
-				$this->_chart['legend']['verticalAlign'] = 'top';
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'right_bottom':
-				$this->_chart['legend']['align'] = 'right';
-				$this->_chart['legend']['verticalAlign'] = 'bottom';
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'floating_bottom_center':
-				$this->_chart['legend']['align'] = 'center';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['y'] = -100;
-			break;
-			case 'floating_top_center':
-				$this->_chart['legend']['align'] = 'center';
-				$this->_chart['legend']['verticalAlign'] = 'top';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['y'] = 70;
-			break;
-			case 'floating_left_center':
-				$this->_chart['legend']['align'] = 'left';
-				$this->_chart['legend']['verticalAlign'] = 'middle';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['x'] = 80;
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'floating_left_top':
-				$this->_chart['legend']['align'] = 'left';
-				$this->_chart['legend']['verticalAlign'] = 'top';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['x'] = 80;
-				$this->_chart['legend']['y'] = 70;
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'floating_left_bottom':
-				$this->_chart['legend']['align'] = 'left';
-				$this->_chart['legend']['verticalAlign'] = 'bottom';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['x'] = 80;
-				$this->_chart['legend']['y'] = -100;
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'floating_right_center':
-				$this->_chart['legend']['align'] = 'right';
-				$this->_chart['legend']['verticalAlign'] = 'middle';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['x'] = -10;
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'floating_right_top':
-				$this->_chart['legend']['align'] = 'right';
-				$this->_chart['legend']['verticalAlign'] = 'top';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['x'] = -10;
-				$this->_chart['legend']['y'] = 70;
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case 'floating_right_bottom':
-				$this->_chart['legend']['align'] = 'right';
-				$this->_chart['legend']['verticalAlign'] = 'bottom';
-				$this->_chart['legend']['floating'] = true;
-				$this->_chart['legend']['x'] = -10;
-				$this->_chart['legend']['y'] = -100;
-				$this->_chart['legend']['layout'] = 'vertical';
-			break;
-			case '':
-			case 'none':
-			case 'off':
-				$this->_legend_location = 'off';
-				$this->_chart['legend']['enabled'] = false;
-			break;
-			case 'bottom_center':
-			default:
-				$this->_legend_location = 'bottom_center';
-				$this->_chart['legend']['align'] = 'center';
-				$this->_chart['legend']['margin'] = 15;
-				break;
-		}
-		if($legend_location != 'bottom_center')
-		{
-			$this->_chart['chart']['spacingBottom'] = 25;
-		}
-		if($legend_location != 'right_center' &&
-			 $legend_location != 'right_top' &&
-			 $legend_location != 'right_bottom')
-		{
-			$this->_chart['chart']['spacingRight'] = 20;
-		}
-		$this->_hasLegend = $this->_legend_location != 'off';
+            case 'left_top':
+                $this->_chart['legend']['align'] = 'left';
+                $this->_chart['legend']['verticalAlign'] = 'top';
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'left_bottom':
+                $this->_chart['legend']['align'] = 'left';
+                $this->_chart['legend']['verticalAlign'] = 'bottom';
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'right_center':
+                $this->_chart['legend']['align'] = 'right';
+                $this->_chart['legend']['verticalAlign'] = 'middle';
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'right_top':
+                $this->_chart['legend']['align'] = 'right';
+                $this->_chart['legend']['verticalAlign'] = 'top';
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'right_bottom':
+                $this->_chart['legend']['align'] = 'right';
+                $this->_chart['legend']['verticalAlign'] = 'bottom';
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'floating_bottom_center':
+                $this->_chart['legend']['align'] = 'center';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['y'] = -100;
+                break;
+            case 'floating_top_center':
+                $this->_chart['legend']['align'] = 'center';
+                $this->_chart['legend']['verticalAlign'] = 'top';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['y'] = 70;
+                break;
+            case 'floating_left_center':
+                $this->_chart['legend']['align'] = 'left';
+                $this->_chart['legend']['verticalAlign'] = 'middle';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['x'] = 80;
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'floating_left_top':
+                $this->_chart['legend']['align'] = 'left';
+                $this->_chart['legend']['verticalAlign'] = 'top';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['x'] = 80;
+                $this->_chart['legend']['y'] = 70;
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'floating_left_bottom':
+                $this->_chart['legend']['align'] = 'left';
+                $this->_chart['legend']['verticalAlign'] = 'bottom';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['x'] = 80;
+                $this->_chart['legend']['y'] = -100;
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'floating_right_center':
+                $this->_chart['legend']['align'] = 'right';
+                $this->_chart['legend']['verticalAlign'] = 'middle';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['x'] = -10;
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'floating_right_top':
+                $this->_chart['legend']['align'] = 'right';
+                $this->_chart['legend']['verticalAlign'] = 'top';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['x'] = -10;
+                $this->_chart['legend']['y'] = 70;
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case 'floating_right_bottom':
+                $this->_chart['legend']['align'] = 'right';
+                $this->_chart['legend']['verticalAlign'] = 'bottom';
+                $this->_chart['legend']['floating'] = true;
+                $this->_chart['legend']['x'] = -10;
+                $this->_chart['legend']['y'] = -100;
+                $this->_chart['legend']['layout'] = 'vertical';
+                break;
+            case '':
+            case 'none':
+            case 'off':
+                $this->_legend_location = 'off';
+                $this->_chart['legend']['enabled'] = false;
+                break;
+            case 'bottom_center':
+            default:
+                $this->_legend_location = 'bottom_center';
+                $this->_chart['legend']['align'] = 'center';
+                $this->_chart['legend']['margin'] = 15;
+                break;
+        }
+        if($legend_location != 'bottom_center')
+        {
+            $this->_chart['chart']['spacingBottom'] = 25;
+        }
+        if($legend_location != 'right_center' &&
+             $legend_location != 'right_top' &&
+             $legend_location != 'right_bottom')
+        {
+            $this->_chart['chart']['spacingRight'] = 20;
+        }
+        $this->_hasLegend = $this->_legend_location != 'off';
 
-	} // setLegend()
+    } // setLegend()
 
-	// ---------------------------------------------------------
-	// registerContextMenus()
-	//
-	// Set chart's context menus in javascript, as chart
-	// parameters. Not ideal.
-	//
-	// ---------------------------------------------------------
-	protected function registerContextMenus()
-	{
-		if($this->_showContextMenu)
-		{
-			$this->_chart['chart']['events'] = array(
-				'titleClick' => 'function(event){return XDMoD.Module.MetricExplorer.titleContextMenu(event);}',
-				'subtitleClick' => 'function(event){return XDMoD.Module.MetricExplorer.subtitleContextMenu(event);}',
-				'xAxisClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisContextMenu(axis);}',
-				'yAxisClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisContextMenu(axis);}',
-				'xAxisTitleClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisTitleContextMenu(axis);}',
-				'yAxisTitleClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisTitleContextMenu(axis);}',
-				'xAxisLabelClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisLabelContextMenu(axis);}',
-				'yAxisLabelClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisLabelContextMenu(axis);}',
-				'click' => 'function(event){return XDMoD.Module.MetricExplorer.chartContextMenu.call(this,event);}'
-			);
-		}
-	} // registerContextMenus()
+    // ---------------------------------------------------------
+    // registerContextMenus()
+    //
+    // Set chart's context menus in javascript, as chart
+    // parameters. Not ideal.
+    //
+    // ---------------------------------------------------------
+    protected function registerContextMenus()
+    {
+        if($this->_showContextMenu)
+        {
+            $this->_chart['chart']['events'] = array(
+                'titleClick' => 'function(event){return XDMoD.Module.MetricExplorer.titleContextMenu(event);}',
+                'subtitleClick' => 'function(event){return XDMoD.Module.MetricExplorer.subtitleContextMenu(event);}',
+                'xAxisClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisContextMenu(axis);}',
+                'yAxisClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisContextMenu(axis);}',
+                'xAxisTitleClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisTitleContextMenu(axis);}',
+                'yAxisTitleClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisTitleContextMenu(axis);}',
+                'xAxisLabelClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisLabelContextMenu(axis);}',
+                'yAxisLabelClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisLabelContextMenu(axis);}',
+                'click' => 'function(event){return XDMoD.Module.MetricExplorer.chartContextMenu.call(this,event);}'
+            );
+        }
+    } // registerContextMenus()
 
-	// ---------------------------------------------------------
-	// setMultiRealm()
-	//
-	// Determine whether plot contains multiple realms; set
-	// _multiRealm instance variable.
-	//
-	// called by configure()
-	// JMS, June 2015
-	//
-	// @param data_series
-	// ---------------------------------------------------------
-	protected function setMultiRealm (&$data_series )
-	{
-		foreach($data_series as $data_description_index => $data_description)
-		{
-			if(isset($pRealm) && $data_description->realm != $pRealm)
-			{
-				$this->_multiRealm = true;
-				return;
-			} else {
-				$pRealm = $data_description->realm;
-			}
-		}
-		$this->_multiRealm = false;
-	} // setMultiRealm()
+    // ---------------------------------------------------------
+    // setMultiRealm()
+    //
+    // Determine whether plot contains multiple realms; set
+    // _multiRealm instance variable.
+    //
+    // called by configure()
+    // JMS, June 2015
+    //
+    // @param data_series
+    // ---------------------------------------------------------
+    protected function setMultiRealm(&$data_series)
+    {
+        foreach($data_series as $data_description_index => $data_description)
+        {
+            if(isset($pRealm) && $data_description->realm != $pRealm)
+            {
+                $this->_multiRealm = true;
+                return;
+            } else {
+                $pRealm = $data_description->realm;
+            }
+        }
+        $this->_multiRealm = false;
+    } // setMultiRealm()
 
-	// ---------------------------------------------------------
-	// setXAxisLabel()
-	//
-	// Set XAxis label. TODO: Take another look
-	//
-	// called by configure()
-	// JMS, June 2015
-	//
-	// @param x_axis
-	// ---------------------------------------------------------
-	/*
+    // ---------------------------------------------------------
+    // setXAxisLabel()
+    //
+    // Set XAxis label. TODO: Take another look
+    //
+    // called by configure()
+    // JMS, June 2015
+    //
+    // @param x_axis
+    // ---------------------------------------------------------
+    /*
 	protected function setXAxisLabel($x_axis)
 	{
 			if (!isset($this->_xAxisDataObject) )  {
@@ -598,684 +602,692 @@ class HighChart2
 	} // setXAxisLabel()
 	*/
 
-	// ---------------------------------------------------------
-	// setXAxis()
-	//
-	// Set XAxis in _chart object. TODO: Take another look
-	//
-	// called by configure()
-	// JMS, June 2015
-	//
-	// @param x_axis
-	// ---------------------------------------------------------
-	protected function setXAxis( &$x_axis, $font_size)
-	{
-		if (!isset($this->_xAxisDataObject) )  {
-			throw new \Exception( get_class($this)." _xAxisDataObject not set ");
-		}
+    // ---------------------------------------------------------
+    // setXAxis()
+    //
+    // Set XAxis in _chart object. TODO: Take another look
+    //
+    // called by configure()
+    // JMS, June 2015
+    //
+    // @param x_axis
+    // ---------------------------------------------------------
+    protected function setXAxis(&$x_axis, $font_size)
+    {
+        if (!isset($this->_xAxisDataObject) )  {
+            throw new \Exception(get_class($this)." _xAxisDataObject not set ");
+        }
 
-		// part from setXAxisLabel(), which we may or may not keep.
-		// if we need the default and original, guess we should keep this.
-		// otherwise, just call it (see above)
-		$defaultXAxisLabel = 'xAxis';
-		$xAxisLabel = $this->_xAxisDataObject->getName() == ORGANIZATION_NAME ? '' :
-									$this->_xAxisDataObject->getName();
+        // part from setXAxisLabel(), which we may or may not keep.
+        // if we need the default and original, guess we should keep this.
+        // otherwise, just call it (see above)
+        $defaultXAxisLabel = 'xAxis';
+        $xAxisLabel = $this->_xAxisDataObject->getName() == ORGANIZATION_NAME ? '' :
+                                    $this->_xAxisDataObject->getName();
 
-		if($xAxisLabel == '') 
-		{
-		    $xAxisLabel = $defaultXAxisLabel;
-		}
-		$originalXAxisLabel = $xAxisLabel;
+        if($xAxisLabel == '')
+        {
+            $xAxisLabel = $defaultXAxisLabel;
+        }
+        $originalXAxisLabel = $xAxisLabel;
 
-		if(isset($x_axis->{$xAxisLabel}))
-		{
-			$config = $x_axis->{$xAxisLabel};
-			if(isset($config->title)) 
-			{
-			    $xAxisLabel = $config->title;
-			}
-		}
-		if($xAxisLabel == $defaultXAxisLabel) 
-		{
-		    $xAxisLabel = '';
-		}
+        if(isset($x_axis->{$xAxisLabel}))
+        {
+            $config = $x_axis->{$xAxisLabel};
+            if(isset($config->title))
+            {
+                $xAxisLabel = $config->title;
+            }
+        }
+        if($xAxisLabel == $defaultXAxisLabel)
+        {
+            $xAxisLabel = '';
+        }
 
-		// --- set xAxis in _chart object ---
-		$this->_chart['xAxis'] = array(
-				'title' => array(
-						'text' => $xAxisLabel,
-						'margin' => 15 + $font_size,
-						'style' => array(
-								'color'=> '#000000',
-								'fontWeight'=> 'bold',
-								'fontSize' => (12 + $font_size).'px'
-						)
-				),
-				'otitle' => $originalXAxisLabel,
-				'dtitle' => $defaultXAxisLabel,
+        // --- set xAxis in _chart object ---
+        $this->_chart['xAxis'] = array(
+                'title' => array(
+                        'text' => $xAxisLabel,
+                        'margin' => 15 + $font_size,
+                        'style' => array(
+                                'color'=> '#000000',
+                                'fontWeight'=> 'bold',
+                                'fontSize' => (12 + $font_size).'px'
+                        )
+                ),
+                'otitle' => $originalXAxisLabel,
+                'dtitle' => $defaultXAxisLabel,
 
-				// set chart labels:
-				'labels' => $this->_swapXY ? array(
-						'enabled' => true,
-						'staggerLines' => 1,
-						'step' => $this->_xAxisDataObject->getCount() < 20 ? 0  :round( $this->_xAxisDataObject->getCount() / 20 ),
-						'style' => array(
-								'fontWeight'=> 'normal',
-								'fontSize' => (11 + $font_size).'px'
-						),
-						'formatter' => "function(){
+                // set chart labels:
+                'labels' => $this->_swapXY ? array(
+                        'enabled' => true,
+                        'staggerLines' => 1,
+                        'step' => $this->_xAxisDataObject->getCount() < 20 ? 0  :round($this->_xAxisDataObject->getCount() / 20 ),
+                        'style' => array(
+                                'fontWeight'=> 'normal',
+                                'fontSize' => (11 + $font_size).'px'
+                        ),
+                        'formatter' => "function(){
 								var maxL = ".floor($this->_width*20/580).";
 								var x  = (this.value.length>maxL-3)?this.value.substring(0,maxL-3)+'...':this.value;
 								return x;
 						}
 						" //x.wordWrap(".floor($this->_width*($this->limit<11?22:22)/580).",'<br/>');
-				) // !($this->_swapXY)
-				: array(
-						'enabled' => true,
-						'staggerLines' => 1,
-						'rotation' => $this->_xAxisDataObject->getCount()<= 8?0: -90,
-						'align' => $this->_xAxisDataObject->getCount()<= 8?'center':'right',
-						'step' => $this->_xAxisDataObject->getCount()< 20?0:round($this->_xAxisDataObject->getCount()/20),
-						'style' => array('fontSize' => (11 + $font_size).'px'),
-						'formatter' => "function(){
+                ) // !($this->_swapXY)
+                : array(
+                        'enabled' => true,
+                        'staggerLines' => 1,
+                        'rotation' => $this->_xAxisDataObject->getCount()<= 8?0: -90,
+                        'align' => $this->_xAxisDataObject->getCount()<= 8?'center':'right',
+                        'step' => $this->_xAxisDataObject->getCount()< 20?0:round($this->_xAxisDataObject->getCount()/20),
+                        'style' => array('fontSize' => (11 + $font_size).'px'),
+                        'formatter' => "function(){
 								var maxL = ".floor($this->_height*($this->limit<11?30:15)/400).";
 								var x  = (this.value.length>maxL-3)?this.value.substring(0,maxL-3)+'...':''+this.value;
 								return x.wordWrap(".floor($this->_height*($this->limit<11?18:18)/400).",'<br/>');
 						}
 						"
-				),
-				'lineWidth' => 2 + $font_size / 4,
-				'categories' => $this->_xAxisDataObject->getValues()
-		);
-	}   // setXAxis()
+                ),
+                'lineWidth' => 2 + $font_size / 4,
+                'categories' => $this->_xAxisDataObject->getValues()
+        );
+    }   // setXAxis()
 
-	// ---------------------------------------------------------
-	// setAxes()
-	//
-	// Set xAxis obj and yAxis data array for plotting. Account for summarizeDataseries
-	// parameter to enable pre-truncation of dataset for summarization.
-	//
-	// supports: multiple y axes,
-	//      multiple dataseries,
-	//      standard error labels
-	//      truncation is done in the SQL itself (or in PHP for Usage),
-	//      complex dataset
-	//      user interactivity
-	//      average, min, max, count of N others
-	//
-	// Used by configure()
-	//
-	// @return yAxisArray
-	//
-	// ---------------------------------------------------------
-	protected function setAxes($summarizeDataseries, $offset, $x_axis, $font_size)
-	{
-	    //  ----------- set up xAxis and yAxis, assign to chart -----------
+    // ---------------------------------------------------------
+    // setAxes()
+    //
+    // Set xAxis obj and yAxis data array for plotting. Account for summarizeDataseries
+    // parameter to enable pre-truncation of dataset for summarization.
+    //
+    // supports: multiple y axes,
+    //      multiple dataseries,
+    //      standard error labels
+    //      truncation is done in the SQL itself (or in PHP for Usage),
+    //      complex dataset
+    //      user interactivity
+    //      average, min, max, count of N others
+    //
+    // Used by configure()
+    //
+    // @return yAxisArray
+    //
+    // ---------------------------------------------------------
+    protected function setAxes($summarizeDataseries, $offset, $x_axis, $font_size)
+    {
+        //  ----------- set up xAxis and yAxis, assign to chart -----------
 
- 		// Enable summarization/truncation of datasets:
-		// Usage tab coexistence hack: If summarizeDataseries is true (Usage/Metric
-		// Explorer pie charts), set X axis and Y axis contents
-		// without specifying a limit on count of records returned from query.
-		// If ME and non-pie, use $this->limit (default 10) to enable paging thru dataset.
-		$queryLim = $summarizeDataseries ? null : $this->limit;
+        // Enable summarization/truncation of datasets:
+        // Usage tab coexistence hack: If summarizeDataseries is true (Usage/Metric
+        // Explorer pie charts), set X axis and Y axis contents
+        // without specifying a limit on count of records returned from query.
+        // If ME and non-pie, use $this->limit (default 10) to enable paging thru dataset.
+        $queryLim = $summarizeDataseries ? null : $this->limit;
 
-		$this->_xAxisDataObject = $this->_dataset->getXAxis(false, $queryLim, $offset);
-		$this->_total = $this->_dataset->getTotalX(); //has to be called after getXAxis
+        $this->_xAxisDataObject = $this->_dataset->getXAxis(false, $queryLim, $offset);
+        $this->_total = $this->_dataset->getTotalX(); //has to be called after getXAxis
 
-		//$this->setXAxisLabel($x_axis);
-		$this->setXAxis( $x_axis, $font_size, $queryLim );
+        //$this->setXAxisLabel($x_axis);
+        $this->setXAxis($x_axis, $font_size, $queryLim );
 
-		$yAxisArray = $this->_dataset->getYAxis($queryLim, $offset, $this->_shareYAxis);
-		return $yAxisArray;
-	}
+        $yAxisArray = $this->_dataset->getYAxis($queryLim, $offset, $this->_shareYAxis);
+        return $yAxisArray;
+    }
 
-	// ---------------------------------------------------------
-	// configure()
-	//
-	// Given chart data series and parameters, build ComplexDataset,
-	// set all needed chart parameters.
-	//
-	// supports: multiple y axes,
-	//      multiple dataseries,
-	//      standard error labels
-	//      truncation is done in the SQL itself (or in PHP for Usage),
-	//      complex dataset
-	//      user interactivity
-	//      average, min, max, count of N others
-	//
-	// Used by MetricExplorer, Summary, AppKernel, CustomQueries, Usage, etc.
-	//
-	// ---------------------------------------------------------
-	public function configure(
-		&$data_series,
-		&$x_axis,
-		&$y_axis,
-		&$legend,
-		&$show_filters,
-		&$global_filters,
-		$font_size,
-		$limit = NULL,  // default 10 from Metric Explorer
-		$offset = NULL,
-		$summarizeDataseries = false)   // JMS: clearly we do not have enough parameters.
-										// support min/max/average 'truncation' of dataset
-	{
+    // ---------------------------------------------------------
+    // configure()
+    //
+    // Given chart data series and parameters, build ComplexDataset,
+    // set all needed chart parameters.
+    //
+    // supports: multiple y axes,
+    //      multiple dataseries,
+    //      standard error labels
+    //      truncation is done in the SQL itself (or in PHP for Usage),
+    //      complex dataset
+    //      user interactivity
+    //      average, min, max, count of N others
+    //
+    // Used by MetricExplorer, Summary, AppKernel, CustomQueries, Usage, etc.
+    //
+    // ---------------------------------------------------------
+    public function configure(
+        &$data_series,
+        &$x_axis,
+        &$y_axis,
+        &$legend,
+        &$show_filters,
+        &$global_filters,
+        $font_size,
+        $limit = null,
+        // default 10 from Metric Explorer
+        $offset = null,
+        $summarizeDataseries = false
+    ) {   // JMS: clearly we do not have enough parameters.
+                                        // support min/max/average 'truncation' of dataset
+    
 
-		$this->limit = $limit;
-		$this->show_filters = $show_filters;
-		$this->setMultiRealm( $data_series );
-		$this->registerContextMenus();
+        $this->limit = $limit;
+        $this->show_filters = $show_filters;
+        $this->setMultiRealm($data_series );
+        $this->registerContextMenus();
 
-		// Instantiate the color generator:
-		$colorGenerator = new \DataWarehouse\Visualization\ColorGenerator();
+        // Instantiate the color generator:
+        $colorGenerator = new \DataWarehouse\Visualization\ColorGenerator();
 
-		// Instantiate the ComplexDataset to plot
-		$this->_dataset = new \DataWarehouse\Data\ComplexDataset();
+        // Instantiate the ComplexDataset to plot
+        $this->_dataset = new \DataWarehouse\Data\ComplexDataset();
 
-		list(
-			$dimensions,
-			$metrics,
-			//$yAxisArray,
-			$globalFilterDescriptions,
-			$dataSources
-		) = $this->_dataset->init(
-			$this->_startDate,
-			$this->_endDate,
-			$this->_aggregationUnit,
-			$data_series,
-			$global_filters,
-			$this->_queryType
-		);
+        list(
+            $dimensions,
+            $metrics,
+            //$yAxisArray,
+            $globalFilterDescriptions,
+            $dataSources
+        ) = $this->_dataset->init(
+            $this->_startDate,
+            $this->_endDate,
+            $this->_aggregationUnit,
+            $data_series,
+            $global_filters,
+            $this->_queryType
+        );
 
-		$this->_chart['metrics'] = $metrics;
-		$this->_chart['dimensions'] = $dimensions;
-		$this->setDataSource(array_keys($dataSources));
+        $this->_chart['metrics'] = $metrics;
+        $this->_chart['dimensions'] = $dimensions;
+        $this->setDataSource(array_keys($dataSources));
 
-		if($this->show_filters)
-		{
-			$subtitle_separator = " -- ";
-			$subtitle = implode($subtitle_separator, array_unique($globalFilterDescriptions));
-			$this->setSubtitle($subtitle, $font_size);
-		}
+        if($this->show_filters)
+        {
+            $subtitle_separator = " -- ";
+            $subtitle = implode($subtitle_separator, array_unique($globalFilterDescriptions));
+            $this->setSubtitle($subtitle, $font_size);
+        }
 
-		//  ----------- set up xAxis and yAxis, assign to chart -----------
+        //  ----------- set up xAxis and yAxis, assign to chart -----------
 
-		$yAxisArray = $this->setAxes($summarizeDataseries, $offset, $x_axis, $font_size);
-		$yAxisCount = count($yAxisArray);
+        $yAxisArray = $this->setAxes($summarizeDataseries, $offset, $x_axis, $font_size);
+        $yAxisCount = count($yAxisArray);
 
-		// ------------ prepare to plot ------------
+        // ------------ prepare to plot ------------
 
-		// --- If ME, Does any dataset specify a pie chart? If so, set to truncate/summarize -- //
-		// This corrects the 'pie charts are wrong' bug...
-		if ( !$summarizeDataseries )
-		{
-			foreach($yAxisArray as $yAxisIndex => $yAxisObject)
-			{
-				foreach ($yAxisObject->series as $data_object)
-				{
-					if ( $data_object['data_description']->display_type=='pie' )
-					{
-						// set to summarize, then break both loops.
-						$summarizeDataseries = true;
-						continue 2;
-					}
-				}
+        // --- If ME, Does any dataset specify a pie chart? If so, set to truncate/summarize -- //
+        // This corrects the 'pie charts are wrong' bug...
+        if ( !$summarizeDataseries )
+        {
+            foreach($yAxisArray as $yAxisIndex => $yAxisObject)
+            {
+                foreach ($yAxisObject->series as $data_object)
+                {
+                    if ( $data_object['data_description']->display_type=='pie' )
+                    {
+                        // set to summarize, then break both loops.
+                        $summarizeDataseries = true;
+                        continue 2;
+                    }
+                }
             } // foreach($yAxisArray ...
 
-			// if we have just reset summarizeDatasets, recompute limit, xAxis, and yAxis
-			// with the new limit in place. Reset dataset _total to 1 to disable paging.
-			if ($summarizeDataseries)
-			{
-				$yAxisArray = $this->setAxes($summarizeDataseries, $offset, $x_axis, $font_size);
-				$yAxisCount = count($yAxisArray);
+            // if we have just reset summarizeDatasets, recompute limit, xAxis, and yAxis
+            // with the new limit in place. Reset dataset _total to 1 to disable paging.
+            if ($summarizeDataseries)
+            {
+                $yAxisArray = $this->setAxes($summarizeDataseries, $offset, $x_axis, $font_size);
+                $yAxisCount = count($yAxisArray);
 
-				// disable ME paging by setting dataset size to 1
-				$this->_total = 1;
-			}
-		} // !$summarizeDatasets
+                // disable ME paging by setting dataset size to 1
+                $this->_total = 1;
+            }
+        } // !$summarizeDatasets
 
-		// OK, now let's plot something...
-		// Each of the yAxisObjects returned from getYAxis()
-		foreach($yAxisArray as $yAxisIndex => $yAxisObject)
-		{
-			if(count($yAxisObject->series) < 1) 
-			{
-			    continue;
-			}
+        // OK, now let's plot something...
+        // Each of the yAxisObjects returned from getYAxis()
+        foreach($yAxisArray as $yAxisIndex => $yAxisObject)
+        {
+            if(count($yAxisObject->series) < 1)
+            {
+                continue;
+            }
 
-			$first_data_description = $yAxisObject->series[0]['data_description'];
+            $first_data_description = $yAxisObject->series[0]['data_description'];
 
-			// set initial dataset's plot color:
-			$yAxisColorValue = ($first_data_description->color == 'auto' || $first_data_description->color == 'FFFFFF')
-																? $colorGenerator->getColor()
-																: $colorGenerator->getConfigColor( hexdec($first_data_description->color) );
-			$yAxisColor = '#'.str_pad(dechex($yAxisColorValue),6,'0',STR_PAD_LEFT);
+            // set initial dataset's plot color:
+            $yAxisColorValue = ($first_data_description->color == 'auto' || $first_data_description->color == 'FFFFFF')
+                                                                ? $colorGenerator->getColor()
+                                                                : $colorGenerator->getConfigColor(hexdec($first_data_description->color) );
+            $yAxisColor = '#'.str_pad(dechex($yAxisColorValue), 6, '0', STR_PAD_LEFT);
 
-			// set axis labels
-			$defaultYAxisLabel = 'yAxis'.$yAxisIndex;
-			$yAxisLabel = $yAxisObject->title;
-			if($this->_shareYAxis) 
-			{
-		        $yAxisLabel = $defaultYAxisLabel;	
-			}
-			$originalYAxisLabel = $yAxisLabel;
+            // set axis labels
+            $defaultYAxisLabel = 'yAxis'.$yAxisIndex;
+            $yAxisLabel = $yAxisObject->title;
+            if($this->_shareYAxis)
+            {
+                $yAxisLabel = $defaultYAxisLabel;
+            }
+            $originalYAxisLabel = $yAxisLabel;
 
-			$yAxisMin = $first_data_description->log_scale?null:0;
-			$yAxisMax = null;
-			$config = $this->getAxisOverrides($y_axis, $yAxisLabel, $yAxisIndex);
-			if($config !== null)
-			{
-				if(isset($config->title)) 
-				{
-				    $yAxisLabel = $config->title;
-				}
-				if(isset($config->min))
-				{
-				    $yAxisMin = $first_data_description->log_scale && $config->min <= 0?null:$config->min;
-				}
-				if(isset($config->max)) 
-				{
-				    $yAxisMax = $config->max;
-				}
-			}
-			if($yAxisLabel == $defaultYAxisLabel) 
-			{
-			    $yAxisLabel = '';
-			}
+            $yAxisMin = $first_data_description->log_scale?null:0;
+            $yAxisMax = null;
+            $config = $this->getAxisOverrides($y_axis, $yAxisLabel, $yAxisIndex);
+            if($config !== null)
+            {
+                if(isset($config->title))
+                {
+                    $yAxisLabel = $config->title;
+                }
+                if(isset($config->min))
+                {
+                    $yAxisMin = $first_data_description->log_scale && $config->min <= 0?null:$config->min;
+                }
+                if(isset($config->max))
+                {
+                    $yAxisMax = $config->max;
+                }
+            }
+            if($yAxisLabel == $defaultYAxisLabel)
+            {
+                $yAxisLabel = '';
+            }
 
-			// populate the yAxis:
-			$yAxis = array(
-				'title' => array(
-					'text' => $yAxisLabel ,
-					'style' => array(
-						'color'=> $yAxisColor,
-						'fontWeight'=> 'bold',
-						'fontSize' => (12 + $font_size).'px'
-					)
-				),
-				'otitle' => $originalYAxisLabel,
-				'dtitle' => $defaultYAxisLabel,
-				'labels' => array(
-					'style' => array(
-						'fontWeight'=> 'normal',
-						'fontSize' => (11 + $font_size).'px'
-					)
-				),
-				'startOnTick' => $yAxisMin == null,
-				'endOnTick' => $yAxisMax == null,
-				'opposite' => $yAxisIndex % 2 == 1,
-				'min' => $yAxisMin,
-				'max' => $yAxisMax,
-				'type' => $yAxisObject->log_scale? 'logarithmic' : 'linear',
-				'showLastLabel' => $this->_chart['title']['text'] != '',
-				'gridLineWidth' => $yAxisCount > 1 ?0: 1 + ($font_size/8),
-				'lineWidth' => 2 + $font_size/4,
-				'allowDecimals' => $yAxisObject->decimals > 0,
-				'tickInterval' => $yAxisObject->log_scale ?1:null,
-				'maxPadding' => max(0.05,($yAxisObject->value_labels?0.25:0.0) + ($yAxisObject->std_err?.25:0))
-			);
+            // populate the yAxis:
+            $yAxis = array(
+                'title' => array(
+                    'text' => $yAxisLabel ,
+                    'style' => array(
+                        'color'=> $yAxisColor,
+                        'fontWeight'=> 'bold',
+                        'fontSize' => (12 + $font_size).'px'
+                    )
+                ),
+                'otitle' => $originalYAxisLabel,
+                'dtitle' => $defaultYAxisLabel,
+                'labels' => array(
+                    'style' => array(
+                        'fontWeight'=> 'normal',
+                        'fontSize' => (11 + $font_size).'px'
+                    )
+                ),
+                'startOnTick' => $yAxisMin == null,
+                'endOnTick' => $yAxisMax == null,
+                'opposite' => $yAxisIndex % 2 == 1,
+                'min' => $yAxisMin,
+                'max' => $yAxisMax,
+                'type' => $yAxisObject->log_scale? 'logarithmic' : 'linear',
+                'showLastLabel' => $this->_chart['title']['text'] != '',
+                'gridLineWidth' => $yAxisCount > 1 ?0: 1 + ($font_size/8),
+                'lineWidth' => 2 + $font_size/4,
+                'allowDecimals' => $yAxisObject->decimals > 0,
+                'tickInterval' => $yAxisObject->log_scale ?1:null,
+                'maxPadding' => max(0.05, ($yAxisObject->value_labels?0.25:0.0) + ($yAxisObject->std_err?.25:0))
+            );
 
-			$this->_chart['yAxis'][] = $yAxis;
+            $this->_chart['yAxis'][] = $yAxis;
 
-			// for each of the dataseries on this yAxisObject:
-			foreach($yAxisObject->series as $data_description_index => $yAxisDataObjectAndDescription)
-			{
-				$yAxisDataObject = $yAxisDataObjectAndDescription['yAxisDataObject']; // SimpleData object
-				$data_description = $yAxisDataObjectAndDescription['data_description'];
-				$decimals = $yAxisDataObjectAndDescription['decimals'];
-				$semDecimals = $yAxisDataObjectAndDescription['semDecimals'];
-				$filterParametersTitle =  $yAxisDataObjectAndDescription['filterParametersTitle'];
+            // for each of the dataseries on this yAxisObject:
+            foreach($yAxisObject->series as $data_description_index => $yAxisDataObjectAndDescription)
+            {
+                $yAxisDataObject = $yAxisDataObjectAndDescription['yAxisDataObject']; // SimpleData object
+                $data_description = $yAxisDataObjectAndDescription['data_description'];
+                $decimals = $yAxisDataObjectAndDescription['decimals'];
+                $semDecimals = $yAxisDataObjectAndDescription['semDecimals'];
+                $filterParametersTitle =  $yAxisDataObjectAndDescription['filterParametersTitle'];
 
-				// ============= truncate (e.g. take average, min, max, sum of remaining values) ==========
+                // ============= truncate (e.g. take average, min, max, sum of remaining values) ==========
 
-				// Usage tab charts and ME pie charts will have their datasets summarized as follows:
-				$dataSeriesSummarized = false;
-				if ( $summarizeDataseries )
-				{
-						$valuesCount = $yAxisDataObject->getCount( true );
+                // Usage tab charts and ME pie charts will have their datasets summarized as follows:
+                $dataSeriesSummarized = false;
+                if ( $summarizeDataseries )
+                {
+                        $valuesCount = $yAxisDataObject->getCount(true );
 
-						if($valuesCount - $this->limit >= 1)
-						{
-								// only compute average (2nd parameter) if not drawing pie chart
-								$yAxisDataObject->truncate($this->limit, $data_description->display_type!=='pie');
+                    if($valuesCount - $this->limit >= 1)
+                        {
+                        // only compute average (2nd parameter) if not drawing pie chart
+                        $yAxisDataObject->truncate($this->limit, $data_description->display_type!=='pie');
 
-								// now merge the x labels, if needed, from multiple datasets:
-								$mergedlabels = $yAxisDataObject->getXValues();
-								foreach( $mergedlabels as $idx => $label) {
-									if ($label === null) {
-										$tmp = $this->_xAxisDataObject->getValues();
-										$mergedlabels[$idx] = $tmp[$idx];
-									}
-								}
-								$this->_xAxisDataObject->setValues($mergedlabels);
-								$this->_xAxisDataObject->getCount(true);
-								$this->setXAxis( $x_axis, $font_size);
-								$dataSeriesSummarized = true;
-						}
-				} // summarizeDataseries
+                        // now merge the x labels, if needed, from multiple datasets:
+                        $mergedlabels = $yAxisDataObject->getXValues();
+                        foreach( $mergedlabels as $idx => $label) {
+                            if ($label === null) {
+                                $tmp = $this->_xAxisDataObject->getValues();
+                                $mergedlabels[$idx] = $tmp[$idx];
+                            }
+                        }
+                        $this->_xAxisDataObject->setValues($mergedlabels);
+                        $this->_xAxisDataObject->getCount(true);
+                        $this->setXAxis($x_axis, $font_size);
+                        $dataSeriesSummarized = true;
+                    }
+                } // summarizeDataseries
 
-				//  ================ set color ================
+                //  ================ set color ================
 
-				// If the first data set in the series, pick up the yAxisColorValue.
-				if($data_description_index == 0)
-				{
-						$color_value = $yAxisColorValue;
-				} else {
-						$color_value = $colorGenerator->getColor();
-				}
-				$color = '#'.str_pad(dechex($color_value),6,'0',STR_PAD_LEFT);
-				$lineColor = '#'.str_pad(dechex(\DataWarehouse\Visualization::alterBrightness($color_value,-70)),6,'0',STR_PAD_LEFT);
+                // If the first data set in the series, pick up the yAxisColorValue.
+                if($data_description_index == 0)
+                {
+                        $color_value = $yAxisColorValue;
+                } else {
+                        $color_value = $colorGenerator->getColor();
+                }
+                $color = '#'.str_pad(dechex($color_value), 6, '0', STR_PAD_LEFT);
+                $lineColor = '#'.str_pad(dechex(\DataWarehouse\Visualization::alterBrightness($color_value, -70)), 6, '0', STR_PAD_LEFT);
 
-				$std_err_labels_enabled = property_exists($data_description, 'std_err_labels') && $data_description->std_err_labels;
-				$dataLabelsConfig = array(
-					'enabled' => $data_description->value_labels || $std_err_labels_enabled,
-					'style' => array(
-						'fontSize' => (11 + $font_size).'px',
-						'fontWeight' => 'normal',
-						'color' => $color,
+                $std_err_labels_enabled = property_exists($data_description, 'std_err_labels') && $data_description->std_err_labels;
+                $dataLabelsConfig = array(
+                    'enabled' => $data_description->value_labels || $std_err_labels_enabled,
+                    'style' => array(
+                        'fontSize' => (11 + $font_size).'px',
+                        'fontWeight' => 'normal',
+                        'color' => $color,
                         'textShadow' => false
-					)
-				);
+                    )
+                );
 
-				$tooltipConfig = array();
-				$values = array();
+                $tooltipConfig = array();
+                $values = array();
 
-				// to display as pie chart:
-				if($data_description->display_type == 'pie')
-				{
-					$this->_chart['chart']['inverted'] = false;
+                // to display as pie chart:
+                if($data_description->display_type == 'pie')
+                {
+                    $this->_chart['chart']['inverted'] = false;
 
-					foreach( $yAxisDataObject->getValues() as $index => $value)
-					{
-						// If the first value, give it the yAxisColor so we don't skip
-						// that color in the dataset. Otherwise, pick the next color.
-						$point = array(
-							'name' => $this->_xAxisDataObject->getValue($index),
-							'y' => $value,
-							'color' => ($index == 0) ? $yAxisColor
-									: '#'.str_pad(dechex( $colorGenerator->getColor() ),6,'0',STR_PAD_LEFT)
-						);
+                    foreach( $yAxisDataObject->getValues() as $index => $value)
+                    {
+                        // If the first value, give it the yAxisColor so we don't skip
+                        // that color in the dataset. Otherwise, pick the next color.
+                        $point = array(
+                            'name' => $this->_xAxisDataObject->getValue($index),
+                            'y' => $value,
+                            'color' => ($index == 0) ? $yAxisColor
+                                    : '#'.str_pad(dechex($colorGenerator->getColor() ), 6, '0', STR_PAD_LEFT)
+                        );
 
-						// N.B.: These are drilldown labels.
-						// X axis labels will be the same, but are plotted
-						// from the x axis object instance variable.
-						// See setXAxis() and _xAxisDataObject.
-						$point['drilldown'] = array(
-							'id' => $yAxisDataObject->getXId($index),
-							'label' => $yAxisDataObject->getXValue($index)
-						);
-						$values[] = $point;
+                        // N.B.: These are drilldown labels.
+                        // X axis labels will be the same, but are plotted
+                        // from the x axis object instance variable.
+                        // See setXAxis() and _xAxisDataObject.
+                        $point['drilldown'] = array(
+                            'id' => $yAxisDataObject->getXId($index),
+                            'label' => $yAxisDataObject->getXValue($index)
+                        );
+                        $values[] = $point;
 
-					} // foreach
+                    } // foreach
 
-					$dataLabelsConfig  = array_merge(
-						$dataLabelsConfig,
-						array(
-							'color' => '#000000',
-							'formatter' => "function(){
+                    $dataLabelsConfig  = array_merge(
+                        $dataLabelsConfig,
+                        array(
+                            'color' => '#000000',
+                            'formatter' => "function(){
 								var maxL = ".floor($this->_width*($this->limit<11?30:15)/580).";
 								var x = (this.point.name.length>maxL+3)?this.point.name.substring(0,maxL-3)+'...':this.point.name;
 								return '<b>'+x.wordWrap( ".floor($this->_width*($this->limit<11?15:15)/580).
-											",'</b><br/><b>')+'</b><br/>'+Highcharts.numberFormat(this.y, $decimals);
+                                            ",'</b><br/><b>')+'</b><br/>'+Highcharts.numberFormat(this.y, $decimals);
 							}"
-						 )
-					);
+                         )
+                    );
 
-					$tooltipConfig = array_merge(
-						$tooltipConfig,
-						array(
-							'pointFormat' => "{series.name}: {point.y} <b>({point.percentage:.1f}%)</b>",
-							'percentageDecimals' => 1,
-							'valueDecimals' => $decimals
-						)
-					);
+                    $tooltipConfig = array_merge(
+                        $tooltipConfig,
+                        array(
+                            'pointFormat' => "{series.name}: {point.y} <b>({point.percentage:.1f}%)</b>",
+                            'percentageDecimals' => 1,
+                            'valueDecimals' => $decimals
+                        )
+                    );
 
-					$this->_chart['tooltip']['shared'] = false;
-				}
-				else // ($data_description->display_type !== 'pie')
-				{
-					if ($data_description->value_labels && $std_err_labels_enabled) {
-						$dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals)+' [+/-'+Highcharts.numberFormat(this.percentage, $decimals)+']';}";
-					} else if ($std_err_labels_enabled) {
-						$dataLabelsConfig['formatter'] = "function(){ return '+/-'+Highcharts.numberFormat(this.percentage, $decimals);}";
-					} else {
-						$dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals);}";
-					}
+                    $this->_chart['tooltip']['shared'] = false;
+                }
+                else // ($data_description->display_type !== 'pie')
+                {
+                    if ($data_description->value_labels && $std_err_labels_enabled) {
+                        $dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals)+' [+/-'+Highcharts.numberFormat(this.percentage, $decimals)+']';}";
+                    } elseif ($std_err_labels_enabled) {
+                        $dataLabelsConfig['formatter'] = "function(){ return '+/-'+Highcharts.numberFormat(this.percentage, $decimals);}";
+                    } else {
+                        $dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals);}";
+                    }
 
-					if($this->_swapXY)
-					{
-						$dataLabelsConfig  = array_merge(
-							$dataLabelsConfig,
-							array(
-								'x' => 70
-							)
-						);
-						$this->_chart['xAxis']['labels']['rotation'] = 0;
-					}
-					else // (!$this->_swapXY)
-					{
-						$dataLabelsConfig  = array_merge(
-							$dataLabelsConfig,
-							array(
-								'rotation' => -90,
-								'align' => 'center',
-								'y' => -70,
-							)
-						);
-					} // _swapXY
+                    if($this->_swapXY)
+                    {
+                        $dataLabelsConfig  = array_merge(
+                            $dataLabelsConfig,
+                            array(
+                                'x' => 70
+                            )
+                        );
+                        $this->_chart['xAxis']['labels']['rotation'] = 0;
+                    }
+                    else // (!$this->_swapXY)
+                    {
+                        $dataLabelsConfig  = array_merge(
+                            $dataLabelsConfig,
+                            array(
+                                'rotation' => -90,
+                                'align' => 'center',
+                                'y' => -70,
+                            )
+                        );
+                    } // _swapXY
 
-					// set the label for each value:
-					foreach( $yAxisDataObject->getValues() as $index => $value)
-					{
-						$point = array(
-							'y' => $yAxisObject->log_scale && $value == 0 ? null : $value//,
-						);
+                    // set the label for each value:
+                    foreach( $yAxisDataObject->getValues() as $index => $value)
+                    {
+                        $point = array(
+                            'y' => $yAxisObject->log_scale && $value == 0 ? null : $value//,
+                        );
 
-						// N.B.: The following are drilldown labels.
-						// Labels on the x axis come from the x axis object
-						// (Though they are the same labels...)
-						$point['drilldown'] = array(
-							'id' => $yAxisDataObject->getXId($index),
-							'label' => $yAxisDataObject->getXValue($index)
-						);
+                        // N.B.: The following are drilldown labels.
+                        // Labels on the x axis come from the x axis object
+                        // (Though they are the same labels...)
+                        $point['drilldown'] = array(
+                            'id' => $yAxisDataObject->getXId($index),
+                            'label' => $yAxisDataObject->getXValue($index)
+                        );
 
-						try {
-							$point['percentage'] = $yAxisDataObject->getError($index);
-						} catch (\Exception $e) {}
+                        try {
+                            $point['percentage'] = $yAxisDataObject->getError($index);
+                        } catch (\Exception $e) {
 
-						$values[] = $point ;
-					} // foreach
+                        }
 
-					$tooltipConfig = array_merge(
-						$tooltipConfig,
-						array(
-							'valueDecimals' => $decimals
-						)
-					);
-				} // if ($data_description->display_type == 'pie')
+                        $values[] = $point ;
+                    } // foreach
 
-				$values_count = count($values);
-				if ($dataSeriesSummarized && $values_count > 0) {
-					$values[$values_count - 1]['isRemainder'] = true;
-				}
+                    $tooltipConfig = array_merge(
+                        $tooltipConfig,
+                        array(
+                            'valueDecimals' => $decimals
+                        )
+                    );
+                } // if ($data_description->display_type == 'pie')
 
-				$zIndex = isset($data_description->z_index) ? $data_description->z_index : $data_description_index;
+                $values_count = count($values);
+                if ($dataSeriesSummarized && $values_count > 0) {
+                    $values[$values_count - 1]['isRemainder'] = true;
+                }
 
-				$dataSeriesName = $yAxisDataObject->getName();
-				if ($data_description->restrictedByRoles && $this->_showWarnings) {
-					$dataSeriesName .= $this->roleRestrictionsStringBuilder->registerRoleRestrictions($data_description->roleRestrictionsParameters);
-				}
-				if($this->_multiRealm) {
-					$dataSeriesName = $data_description->realm . ': ' . $dataSeriesName;
-				}
+                $zIndex = isset($data_description->z_index) ? $data_description->z_index : $data_description_index;
 
-				$formattedDataSeriesName = str_replace('style=""','style="color:'.$yAxisColor.'"',$dataSeriesName);
-				$formattedDataSeriesName = str_replace('y_axis_title',$yAxisLabel,$formattedDataSeriesName);
-				$formattedDataSeriesName.= $filterParametersTitle;
+                $dataSeriesName = $yAxisDataObject->getName();
+                if ($data_description->restrictedByRoles && $this->_showWarnings) {
+                    $dataSeriesName .= $this->roleRestrictionsStringBuilder->registerRoleRestrictions($data_description->roleRestrictionsParameters);
+                }
+                if($this->_multiRealm) {
+                    $dataSeriesName = $data_description->realm . ': ' . $dataSeriesName;
+                }
 
-				$lookupDataSeriesName = $formattedDataSeriesName;
-				if(isset($legend->{$formattedDataSeriesName}))
-				{
-					$config = $legend->{$formattedDataSeriesName};
-					if(isset($config->title)) 
-					{
-					   $lookupDataSeriesName = $config->title; 
-					}
-				}
-				$visible = true;
-				if(isset($data_description->visibility) && isset($data_description->visibility->{$formattedDataSeriesName}))
-				{
-					$visible = $data_description->visibility->{$formattedDataSeriesName};
-				}
-				$seriesClick = 'function(event){'.($this->_showContextMenu?'XDMoD.Module.MetricExplorer.seriesContextMenu(this,false,'.
+                $formattedDataSeriesName = str_replace('style=""', 'style="color:'.$yAxisColor.'"', $dataSeriesName);
+                $formattedDataSeriesName = str_replace('y_axis_title', $yAxisLabel, $formattedDataSeriesName);
+                $formattedDataSeriesName.= $filterParametersTitle;
+
+                $lookupDataSeriesName = $formattedDataSeriesName;
+                if(isset($legend->{$formattedDataSeriesName}))
+                {
+                    $config = $legend->{$formattedDataSeriesName};
+                    if(isset($config->title))
+                    {
+                        $lookupDataSeriesName = $config->title;
+                    }
+                }
+                $visible = true;
+                if(isset($data_description->visibility) && isset($data_description->visibility->{$formattedDataSeriesName}))
+                {
+                    $visible = $data_description->visibility->{$formattedDataSeriesName};
+                }
+                $seriesClick = 'function(event){'.($this->_showContextMenu?'XDMoD.Module.MetricExplorer.seriesContextMenu(this,false,'.
                             $data_description->id.');':'').'}';
-				$legendItemClick = $this->_showContextMenu?'function(event){XDMoD.Module.MetricExplorer.seriesContextMenu(this,true,'.
+                $legendItemClick = $this->_showContextMenu?'function(event){XDMoD.Module.MetricExplorer.seriesContextMenu(this,true,'.
                             $data_description->id.'); return false;}':'function(event){return true;}';
-				$pointClick = 'function(event){'.($this->_showContextMenu?'XDMoD.Module.MetricExplorer.pointContextMenu(this,'.
+                $pointClick = 'function(event){'.($this->_showContextMenu?'XDMoD.Module.MetricExplorer.pointContextMenu(this,'.
                             $data_description->id.');':'').'}';
 
-				$data_series_desc = array(
-					'name' => $lookupDataSeriesName,
-					'otitle' => $formattedDataSeriesName,
-					'datasetId' => $data_description->id,
-					'zIndex' => $zIndex,
-					'color'=> $data_description->display_type == 'pie' ?
-														NULL : $color,
-					'type' => $data_description->display_type,
-					'trackByArea'=>  $data_description->display_type == 'area' ||
-														$data_description->display_type == 'areaspline',
-					'dashStyle' => $data_description->line_type,
-					'shadow' => $data_description->shadow,
-					'groupPadding' => 0.05,
-					'pointPadding' => 0,
-					'borderWidth' => 0,
-					'yAxis' => $yAxisIndex,
-					'lineWidth' => $data_description->display_type !== 'scatter' ?
-														$data_description->line_width + $font_size / 4 : 0,
-					'marker' => array(
-						'enabled' => $data_description->display_type == 'scatter' ||
-														($values_count < 21 &&
-														$this->_width > \DataWarehouse\Visualization::$thumbnail_width),
-						'lineWidth' => 1,
-						'lineColor' => $lineColor,
-						'radius' => $font_size / 4 + 5
-					),
-					'tooltip' => $tooltipConfig,
-					'showInLegend' => true,
-					'dataLabels' => $dataLabelsConfig,
-					'data' => $values,
-					'cursor' => 'pointer',
-					'visible' => $visible,
-					'events' => array(
-						'legendItemClick' => $legendItemClick
-					),
-					'point' => array(
-						'events' => array(
-							'click' => $pointClick
-						)
-					),
-					'isRestrictedByRoles' => $data_description->restrictedByRoles,
-				); // $data_series_desc
+                $data_series_desc = array(
+                    'name' => $lookupDataSeriesName,
+                    'otitle' => $formattedDataSeriesName,
+                    'datasetId' => $data_description->id,
+                    'zIndex' => $zIndex,
+                    'color'=> $data_description->display_type == 'pie' ?
+                                                        null : $color,
+                    'type' => $data_description->display_type,
+                    'trackByArea'=>  $data_description->display_type == 'area' ||
+                                                        $data_description->display_type == 'areaspline',
+                    'dashStyle' => $data_description->line_type,
+                    'shadow' => $data_description->shadow,
+                    'groupPadding' => 0.05,
+                    'pointPadding' => 0,
+                    'borderWidth' => 0,
+                    'yAxis' => $yAxisIndex,
+                    'lineWidth' => $data_description->display_type !== 'scatter' ?
+                                                        $data_description->line_width + $font_size / 4 : 0,
+                    'marker' => array(
+                        'enabled' => $data_description->display_type == 'scatter' ||
+                                                        ($values_count < 21 &&
+                                                        $this->_width > \DataWarehouse\Visualization::$thumbnail_width),
+                        'lineWidth' => 1,
+                        'lineColor' => $lineColor,
+                        'radius' => $font_size / 4 + 5
+                    ),
+                    'tooltip' => $tooltipConfig,
+                    'showInLegend' => true,
+                    'dataLabels' => $dataLabelsConfig,
+                    'data' => $values,
+                    'cursor' => 'pointer',
+                    'visible' => $visible,
+                    'events' => array(
+                        'legendItemClick' => $legendItemClick
+                    ),
+                    'point' => array(
+                        'events' => array(
+                            'click' => $pointClick
+                        )
+                    ),
+                    'isRestrictedByRoles' => $data_description->restrictedByRoles,
+                ); // $data_series_desc
 
-								// set stacking
-				if($data_description->display_type!=='line')
-				{
-					if(	$data_description->combine_type=='stack')
-					{
-						// ask the highcharts library to connect nulls for stacking
-						$data_series_desc['stacking'] = 'normal';
-						$data_series_desc['connectNulls'] = true;
-					}
-					else if($data_description->combine_type=='percent' && !$data_description->log_scale)
-					{
-						$data_series_desc['stacking'] = 'percent';
-					}
-				}
-				$this->_chart['series'][] = $data_series_desc;
+                                // set stacking
+                if($data_description->display_type!=='line')
+                {
+                    if(     $data_description->combine_type=='stack')
+                    {
+                        // ask the highcharts library to connect nulls for stacking
+                        $data_series_desc['stacking'] = 'normal';
+                        $data_series_desc['connectNulls'] = true;
+                    }
+                    elseif($data_description->combine_type=='percent' && !$data_description->log_scale)
+                    {
+                        $data_series_desc['stacking'] = 'percent';
+                    }
+                }
+                $this->_chart['series'][] = $data_series_desc;
 
-				// build error data series and add it to chart
-				$this->buildErrorDataSeries($data_description,
-											$legend,
-											$color_value,
-											$yAxisDataObject,
-											$formattedDataSeriesName,
-											$yAxisIndex,
-											$semDecimals,
-											$zIndex,
-											$legendItemClick,
-											$pointClick);
+                // build error data series and add it to chart
+                $this->buildErrorDataSeries(
+                    $data_description,
+                    $legend,
+                    $color_value,
+                    $yAxisDataObject,
+                    $formattedDataSeriesName,
+                    $yAxisIndex,
+                    $semDecimals,
+                    $zIndex,
+                    $legendItemClick,
+                    $pointClick
+                );
 
-			} // foreach($yAxisObject->series as $data_description_index => $yAxisDataObjectAndDescription)
-		}
+            } // foreach($yAxisObject->series as $data_description_index => $yAxisDataObjectAndDescription)
+        }
 
-		if ($this->_showWarnings) {
-			$this->addRestrictedDataWarning();
-		}
+        if ($this->_showWarnings) {
+            $this->addRestrictedDataWarning();
+        }
 
-		$this->addChartExtensions();
+        $this->addChartExtensions();
 
-		// set title and subtitle for chart
-		$this->setChartTitleSubtitle($font_size);
+        // set title and subtitle for chart
+        $this->setChartTitleSubtitle($font_size);
 
-	} // configure()
+    } // configure()
 
-	// ---------------------------------------------------------
-	// buildErrorDataSeries()
-	//
-	// @param ...
-	//
-	// for Timeseries, questions include: drilldown?
-	// ---------------------------------------------------------
-	protected function buildErrorDataSeries(&$data_description,
-		&$legend,
-		$color_value,
-		&$yAxisDataObject,
-		$formattedDataSeriesName,
-		$yAxisIndex,
-		$semDecimals,
-		$zIndex,
-		$legendItemClick,
-		$pointClick)
-	{
-		// build error data series and add it to chart
-		if($data_description->std_err == 1 && $data_description->display_type != 'pie')
-		{
-			$error_color_value = \DataWarehouse\Visualization::alterBrightness($color_value,-70);
-			$error_color = '#'.str_pad(dechex($error_color_value),6,'0',STR_PAD_LEFT);
+    // ---------------------------------------------------------
+    // buildErrorDataSeries()
+    //
+    // @param ...
+    //
+    // for Timeseries, questions include: drilldown?
+    // ---------------------------------------------------------
+    protected function buildErrorDataSeries(
+        &$data_description,
+        &$legend,
+        $color_value,
+        &$yAxisDataObject,
+        $formattedDataSeriesName,
+        $yAxisIndex,
+        $semDecimals,
+        $zIndex,
+        $legendItemClick,
+        $pointClick
+    ) {
+    
+        // build error data series and add it to chart
+        if($data_description->std_err == 1 && $data_description->display_type != 'pie')
+        {
+            $error_color_value = \DataWarehouse\Visualization::alterBrightness($color_value, -70);
+            $error_color = '#'.str_pad(dechex($error_color_value), 6, '0', STR_PAD_LEFT);
 
-			$error_series = array();
-			$errorCount = $yAxisDataObject->getErrorCount();
-			for($i = 0 ; $i < $errorCount; $i++)
-			{
-				// build the error bar and set for display
-				$v = $yAxisDataObject->getValue($i);
-				$e = $yAxisDataObject->getError($i);
-				$has_value = isset($v) && $v != 0;
-				$error_series[] = array(
-							'x' => $i,
-							'low' => $has_value ? $v-$e : null,
-							'high' => $has_value ? $v+$e : null,
-							'stderr' => $e
-				);
-			}
+            $error_series = array();
+            $errorCount = $yAxisDataObject->getErrorCount();
+            for($i = 0; $i < $errorCount; $i++)
+            {
+                // build the error bar and set for display
+                $v = $yAxisDataObject->getValue($i);
+                $e = $yAxisDataObject->getError($i);
+                $has_value = isset($v) && $v != 0;
+                $error_series[] = array(
+                            'x' => $i,
+                            'low' => $has_value ? $v-$e : null,
+                            'high' => $has_value ? $v+$e : null,
+                            'stderr' => $e
+                );
+            }
 
-			// -- set error dataseries name and visibility --
-			$dsn = 'Std Err: '.$formattedDataSeriesName;
+            // -- set error dataseries name and visibility --
+            $dsn = 'Std Err: '.$formattedDataSeriesName;
 
-			// update the name of the dataseries:
-			$lookupDataSeriesName = $dsn;
-			if(isset($legend->{$dsn}))
-			{
-				$config = $legend->{$dsn};
-				if(isset($config->title))
-				{
-				    $lookupDataSeriesName = $config->title;
-				}
-			}
-			$visible = true;
-			if(isset($data_description->visibility) && isset($data_description->visibility->{$dsn}))
-			{
-				$visible = $data_description->visibility->{$dsn};
-			}
+            // update the name of the dataseries:
+            $lookupDataSeriesName = $dsn;
+            if(isset($legend->{$dsn}))
+            {
+                $config = $legend->{$dsn};
+                if(isset($config->title))
+                {
+                    $lookupDataSeriesName = $config->title;
+                }
+            }
+            $visible = true;
+            if(isset($data_description->visibility) && isset($data_description->visibility->{$dsn}))
+            {
+                $visible = $data_description->visibility->{$dsn};
+            }
 
             $err_series_tooltip = "function() { ".
                 "var fErr = Highcharts.numberFormat(this.stderr, $semDecimals); ".
@@ -1284,51 +1296,51 @@ class HighChart2
                     "<b>+/-' + fErr + '</b><br/>';".
                 "}";
 
-			// create the data series description:
-			$err_data_series_desc = array(
-				//'name' => $dsn,
-				'name' => $lookupDataSeriesName,
+            // create the data series description:
+            $err_data_series_desc = array(
+                //'name' => $dsn,
+                'name' => $lookupDataSeriesName,
                 'showInLegend' => true,
-				'otitle' => $dsn,
-				'datasetId' => $data_description->id,
-				'zIndex' => $zIndex,
-				'color'=> $error_color,
-				'type' => 'errorbar',
-				'shadow' => $data_description->shadow,
-				'groupPadding' => 0.05,
-				'pointPadding' => 0,
-				'lineWidth' => 2,
-				'yAxis' => $yAxisIndex,
-				'tooltip' => array(
+                'otitle' => $dsn,
+                'datasetId' => $data_description->id,
+                'zIndex' => $zIndex,
+                'color'=> $error_color,
+                'type' => 'errorbar',
+                'shadow' => $data_description->shadow,
+                'groupPadding' => 0.05,
+                'pointPadding' => 0,
+                'lineWidth' => 2,
+                'yAxis' => $yAxisIndex,
+                'tooltip' => array(
                         'pointFormatter' => $err_series_tooltip
-					),
-				'data' => $error_series,
-				'cursor' => 'pointer',
-				'visible' => $visible,
-				'events' => array(
-					'legendItemClick' => $legendItemClick
-				),
-				'point' => array(
-					'events' => array(
-						'click' => $pointClick
-						)
-					),
-				'isRestrictedByRoles' => $data_description->restrictedByRoles,
-				);
-			if(! $data_description->log_scale)
-			{
-				$this->_chart['series'][] = $err_data_series_desc;
-			}
-		} // if not pie
-	} // function buildErrorDataSeries
+                    ),
+                'data' => $error_series,
+                'cursor' => 'pointer',
+                'visible' => $visible,
+                'events' => array(
+                    'legendItemClick' => $legendItemClick
+                ),
+                'point' => array(
+                    'events' => array(
+                        'click' => $pointClick
+                        )
+                    ),
+                'isRestrictedByRoles' => $data_description->restrictedByRoles,
+                );
+            if(! $data_description->log_scale)
+            {
+                $this->_chart['series'][] = $err_data_series_desc;
+            }
+        } // if not pie
+    } // function buildErrorDataSeries
 
-		/**
-		 * Add extension functions to the chart.
-		 */
-		protected function addChartExtensions() {
-			// Allow for multiple event handlers for certain events.
-			// Based on: https://stackoverflow.com/a/22337004
-			$this->_chart['chart']['events']['load'] = 'function () {
+        /**
+         * Add extension functions to the chart.
+         */
+    protected function addChartExtensions() {
+        // Allow for multiple event handlers for certain events.
+        // Based on: https://stackoverflow.com/a/22337004
+        $this->_chart['chart']['events']['load'] = 'function () {
 					var eventHandlers = this.options.chart.events.loadHandlers;
 					if (!eventHandlers) {
 							return;
@@ -1337,7 +1349,7 @@ class HighChart2
 							eventHandlers[i].apply(this, arguments);
 					}
 			}';
-			$this->_chart['chart']['events']['redraw'] = 'function () {
+        $this->_chart['chart']['events']['redraw'] = 'function () {
 					var eventHandlers = this.options.chart.events.redrawHandlers;
 					if (!eventHandlers) {
 							return;
@@ -1347,10 +1359,10 @@ class HighChart2
 					}
 			}';
 
-			// Add function to add a background color to a chart element.
-			// (This is for chart elements that don't support this natively.)
-			// Idea for using rectangles as background color from: https://stackoverflow.com/a/21625239
-			$this->_chart['chart']['events']['helperFunctions']['addBackgroundColor'] = 'function (element, color) {
+        // Add function to add a background color to a chart element.
+        // (This is for chart elements that don't support this natively.)
+        // Idea for using rectangles as background color from: https://stackoverflow.com/a/21625239
+        $this->_chart['chart']['events']['helperFunctions']['addBackgroundColor'] = 'function (element, color) {
 					var xPadding = 3;
 					var yPadding = 2;
 					var rectCornerRadius = 1;
@@ -1368,9 +1380,9 @@ class HighChart2
 					}).add(element.parentGroup);
 			}';
 
-			// Add functions to handle aligned labels.
-			// Based on: https://stackoverflow.com/a/19326076
-			$this->_chart['chart']['events']['helperFunctions']['alignAlignedLabels'] = 'function (chart) {
+        // Add functions to handle aligned labels.
+        // Based on: https://stackoverflow.com/a/19326076
+        $this->_chart['chart']['events']['helperFunctions']['alignAlignedLabels'] = 'function (chart) {
 					var alignedLabels = chart.alignedLabels;
 					if (!alignedLabels) {
 							return;
@@ -1392,7 +1404,7 @@ class HighChart2
 							}
 					}
 			}';
-			$this->_chart['chart']['events']['loadHandlers'][] = 'function () {
+        $this->_chart['chart']['events']['loadHandlers'][] = 'function () {
 					var chart = this;
 					var alignedLabelsOptions = chart.options.alignedLabels;
 					if (!alignedLabelsOptions) {
@@ -1414,13 +1426,13 @@ class HighChart2
 					}
 					chart.options.chart.events.helperFunctions.alignAlignedLabels(chart);
 			}';
-			$this->_chart['chart']['events']['redrawHandlers'][] = 'function () {
+        $this->_chart['chart']['events']['redrawHandlers'][] = 'function () {
 					var chart = this;
 					chart.options.chart.events.helperFunctions.alignAlignedLabels(chart);
 			}';
 
-			// Add functions to style labels for data series restricted by roles.
-			$this->_chart['chart']['events']['loadHandlers'][] = 'function () {
+        // Add functions to style labels for data series restricted by roles.
+        $this->_chart['chart']['events']['loadHandlers'][] = 'function () {
 					var chart = this;
 					if (!chart.series || chart.options.chart.showWarnings === false) {
 							return;
@@ -1435,67 +1447,67 @@ class HighChart2
 							chart.options.chart.events.helperFunctions.addBackgroundColor(series.legendItem, "#DFDFDF");
 					}
 			}';
-		}
+    }
 
-		/**
-		 * Add a warning to the chart that data may be restricted.
-		 */
-		protected function addRestrictedDataWarning() {
-			$roleRestrictionsStrings = $this->roleRestrictionsStringBuilder->getRoleRestrictionsStrings();
-			if (empty($roleRestrictionsStrings)) {
-					return;
-			}
+        /**
+         * Add a warning to the chart that data may be restricted.
+         */
+    protected function addRestrictedDataWarning() {
+        $roleRestrictionsStrings = $this->roleRestrictionsStringBuilder->getRoleRestrictionsStrings();
+        if (empty($roleRestrictionsStrings)) {
+                return;
+        }
 
-			$this->_chart['alignedLabels']['items'][] = array(
-					'html' => implode('<br />', $roleRestrictionsStrings),
+        $this->_chart['alignedLabels']['items'][] = array(
+            'html' => implode('<br />', $roleRestrictionsStrings),
 
-					'align' => 'left',
-					'backgroundColor' => '#DFDFDF',
-					'verticalAlign' => 'bottom',
-					'y' => 15,
-			);
-		}
+            'align' => 'left',
+            'backgroundColor' => '#DFDFDF',
+            'verticalAlign' => 'bottom',
+            'y' => 15,
+        );
+    }
 
-	// ---------------------------------------------------------
-	// setChartTitleSubtitle()
-	//
-	// @param font_size
-	//
-	// ---------------------------------------------------------
-	protected function setChartTitleSubtitle($font_size)
-	{
-		// set title and subtitle for chart
-		if($this->_chart['title']['text'] == '' && $this->_chart['subtitle']['text'] != '')
-		{
-			$this->setTitle($this->_chart['subtitle']['text'],$font_size);
-			$this->setSubtitle('',$font_size);
-		}
-	} // function setChartTitleSubtitle
+    // ---------------------------------------------------------
+    // setChartTitleSubtitle()
+    //
+    // @param font_size
+    //
+    // ---------------------------------------------------------
+    protected function setChartTitleSubtitle($font_size)
+    {
+        // set title and subtitle for chart
+        if($this->_chart['title']['text'] == '' && $this->_chart['subtitle']['text'] != '')
+        {
+            $this->setTitle($this->_chart['subtitle']['text'], $font_size);
+            $this->setSubtitle('', $font_size);
+        }
+    } // function setChartTitleSubtitle
 
-	// ---------------------------------------------------------
-	// exportJsonStore()
-	//
-	// Export chart object as JSON, indicate count.
-	//
-	// Note that $limit is not in use. Note also that I've made
-	// it an instance variable here  --JMS, 1 Sep 15
-	// ---------------------------------------------------------
-	public function exportJsonStore(
-		$limit = NULL,
-		$offset = NULL
-	)
-	{
-		$returnData = array(
-			'totalCount' => $this->_total,
-			'success' => true,
-			'message' => 'success',
-			'data' => array(
-				$this->_chart
-			)
-		);
+    // ---------------------------------------------------------
+    // exportJsonStore()
+    //
+    // Export chart object as JSON, indicate count.
+    //
+    // Note that $limit is not in use. Note also that I've made
+    // it an instance variable here  --JMS, 1 Sep 15
+    // ---------------------------------------------------------
+    public function exportJsonStore(
+        $limit = null,
+        $offset = null
+    ) {
+    
+        $returnData = array(
+            'totalCount' => $this->_total,
+            'success' => true,
+            'message' => 'success',
+            'data' => array(
+                $this->_chart
+            )
+        );
 
-		return $returnData;
-	} // exportJsonStore()
+        return $returnData;
+    } // exportJsonStore()
 
     /**
      * @function getOriginalAxisDefn
@@ -1516,5 +1528,3 @@ class HighChart2
         return null;
     }
 } // class HighChart2
-
-?>

--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -555,17 +555,20 @@ class HighChart2
     // ---------------------------------------------------------
     protected function setMultiCategory(&$data_series)
     {
+        // For each data series, check if the category matches the category of
+        // the previous data series. If not, there is more than one category
+        // being used in this plot.
         foreach($data_series as $data_description_index => $data_description)
         {
             $category = DataWarehouse::getCategoryForRealm(
                 $data_description->realm
             );
-            if(isset($pCategory) && $category != $pCategory)
+            if(isset($prevCategory) && $category != $prevCategory)
             {
                 $this->_multiCategory = true;
                 return;
             } else {
-                $pCategory = $category;
+                $prevCategory = $category;
             }
         }
         $this->_multiCategory = false;

--- a/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
+++ b/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
@@ -160,11 +160,11 @@ class HighChartTimeseries2 extends HighChart2
         {
             // set multiCategory true or false
             $category = DataWarehouse::getCategoryForRealm($data_description->realm);
-            if(isset($pCategory) && $category != $pCategory)
+            if(isset($prevCategory) && $category != $prevCategory)
             {
                 $multiCategory = true;
             } else {
-                $pCategory = $category;
+                $prevCategory = $category;
             }
 
             // Determine statistic name. In this case use the Aggregate classname to get the stat.

--- a/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
+++ b/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
@@ -1,6 +1,8 @@
 <?php
 namespace DataWarehouse\Visualization;
 
+use DataWarehouse;
+
 /*
 *
 * @author Amin Ghadersohi
@@ -42,7 +44,7 @@ class HighChartTimeseries2 extends HighChart2
         $min_aggregation_unit = null,
         $showWarnings = true
     ) {
-    
+
         parent::__construct(
             $aggregation_unit,
             $start_date,
@@ -138,7 +140,7 @@ class HighChartTimeseries2 extends HighChart2
     ) {   // JMS: clearly we do not have enough parameters.
                                         // support min/max/average 'truncation' of dataset
 
-    
+
         $this->show_filters = $show_filters;
 
         $this->registerContextMenus();
@@ -153,15 +155,16 @@ class HighChartTimeseries2 extends HighChart2
 
         // prepare yAxisArray for each yAxis we will plot:
         $yAxisArray = array();
-        $multiRealm = false;
+        $multiCategory = false;
         foreach($data_series as $data_description_index => $data_description)
         {
-            // set multirealm true or false
-            if(isset($pRealm) && $data_description->realm != $pRealm)
+            // set multiCategory true or false
+            $category = DataWarehouse::getCategoryForRealm($data_description->realm);
+            if(isset($pCategory) && $category != $pCategory)
             {
-                $multiRealm = true;
+                $multiCategory = true;
             } else {
-                $pRealm = $data_description->realm;
+                $pCategory = $category;
             }
 
             // Determine statistic name. In this case use the Aggregate classname to get the stat.
@@ -293,7 +296,7 @@ class HighChartTimeseries2 extends HighChart2
                 // Note that while this var name is a ComplexDataset in the parent class
                 // the item it contains is a Simple*Dataset.
                 // so when we iterate over datasets in parent class we are fiddling with SImple*Datsets
-            
+
                 $dataset = new \DataWarehouse\Data\SimpleTimeseriesDataset($query);
 
                 // JMS: to here we have the ComplexDataset::init() function
@@ -661,9 +664,13 @@ class HighChartTimeseries2 extends HighChart2
                         {
                             $dataSeriesName .= $this->roleRestrictionsStringBuilder->registerRoleRestrictions($data_description->roleRestrictionsParameters);
                         }
-                        if($multiRealm)
+                        if($multiCategory)
                         {
-                            $dataSeriesName = $data_description->realm . ': ' . $dataSeriesName;
+                            $dataSeriesName = (
+                                DataWarehouse::getCategoryForRealm($data_description->realm)
+                                . ': '
+                                . $dataSeriesName
+                            );
                         }
                         $formattedDataSeriesName = $dataSeriesName;
                         if ($areMultipleDataSeries)
@@ -830,7 +837,7 @@ class HighChartTimeseries2 extends HighChart2
                                 );
                                 $this->_chart['series'][] = $data_series_desc;
                             } // if($new_values_count > 1)
-                        
+
                         } // if(isset($data_description->trend_line) && $data_description->trend_line == 1 && $data_description->display_type != 'pie' )
 
 

--- a/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
+++ b/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
@@ -23,10 +23,10 @@ class HighChartTimeseries2 extends HighChart2
 {
     // ---------------------------------------------------------
     // __construct()
-    // 
+    //
     // Constructor for HighChart2Timeseries class.
     //
-    // note that showContextMenu has default false in HC2T class. 
+    // note that showContextMenu has default false in HC2T class.
     // ---------------------------------------------------------
     public function __construct(
         $aggregation_unit,
@@ -41,8 +41,8 @@ class HighChartTimeseries2 extends HighChart2
         $hide_tooltip = false,
         $min_aggregation_unit = null,
         $showWarnings = true
-    )
-    {
+    ) {
+    
         parent::__construct(
             $aggregation_unit,
             $start_date,
@@ -62,13 +62,13 @@ class HighChartTimeseries2 extends HighChart2
     }
 
     //-------------------------------------------------
-    // useMean( $stat ) 
-    // Based on inspection of the Statistic Alias for the dataset, 
+    // useMean( $stat )
+    // Based on inspection of the Statistic Alias for the dataset,
     // should the mean of the values be computed for the remainder set?
-    // 
+    //
     // @param is $dataObj->getStatistic()->getAlias(); or $data_description->metric
     //-------------------------------------------------
-    private function useMean( $stat ) {
+    private function useMean($stat) {
             $retVal
                 = strpos($stat, 'avg_') !== false
                 || strpos($stat, 'count') !== false
@@ -79,19 +79,19 @@ class HighChartTimeseries2 extends HighChart2
     }
 
     //-------------------------------------------------
-    // getDataname( $stat, $limit ) 
-    // 
-    // Based on inspection of the Statistic Alias for the dataset, 
+    // getDataname( $stat, $limit )
+    //
+    // Based on inspection of the Statistic Alias for the dataset,
     // what operation should be reported for the remainder set?
     //
     // @param is $dataObj->getStatistic()->getAlias(); or $data_description->metric
     // @param is number of full datasets to represent in chart
     //-------------------------------------------------
-    private function getDataname( $stat, $limit ) {
+    private function getDataname($stat, $limit) {
 
             // use statistics alias for object
             //$stat = $dataObj->getStatistic()->getAlias(); or $data_description->metric
-            $useMean = $this->useMean( $stat );
+            $useMean = $this->useMean($stat );
 
             $isMin = strpos($stat, 'min_') !== false ;
             $isMax = strpos($stat, 'max_') !== false ;
@@ -102,25 +102,25 @@ class HighChartTimeseries2 extends HighChart2
                 . ($this->_total - $limit)
                 . ' Others';
 
-            if ($isMin) {
-                $dataname
-                    = 'Minimum over all '
-                    . ($this->_total - $limit)
-                    . ' others';
-            } elseif ($isMax) {
-                $dataname
-                    = 'Maximum over all '
-                    . ($this->_total - $limit)
-                    . ' others';
-            } // if $isMin
+        if ($isMin) {
+            $dataname
+            = 'Minimum over all '
+            . ($this->_total - $limit)
+            . ' others';
+        } elseif ($isMax) {
+            $dataname
+            = 'Maximum over all '
+            . ($this->_total - $limit)
+            . ' others';
+        } // if $isMin
 
             return $dataname;
-       }
+    }
 
     // ---------------------------------------------------------
     // configure()
-    // 
-    // Given chart data series and parameters, build 
+    //
+    // Given chart data series and parameters, build
     // SimpleTimeseriesDataset, set all needed chart parameters.
     //
     // ---------------------------------------------------------
@@ -132,12 +132,13 @@ class HighChartTimeseries2 extends HighChart2
         &$show_filters,
         &$global_filters,
         $font_size,
-        $limit = NULL,
-        $offset = NULL,
-        $summarizeDataseries = false)   // JMS: clearly we do not have enough parameters.
+        $limit = null,
+        $offset = null,
+        $summarizeDataseries = false
+    ) {   // JMS: clearly we do not have enough parameters.
                                         // support min/max/average 'truncation' of dataset
 
-    {
+    
         $this->show_filters = $show_filters;
 
         $this->registerContextMenus();
@@ -235,7 +236,7 @@ class HighChartTimeseries2 extends HighChart2
                     {
                         if(isset($global_filter->checked) && $global_filter->checked == 1)
                         {
-                            if(!isset($groupedRoleParameters[$global_filter->dimension_id])) 
+                            if(!isset($groupedRoleParameters[$global_filter->dimension_id]))
                             {
                                 $groupedRoleParameters[$global_filter->dimension_id] = array();
                             }
@@ -288,7 +289,7 @@ class HighChartTimeseries2 extends HighChart2
                 $query->addOrderByAndSetSortInfo($data_description);
 
                 // JMS:
-                // and here we instantiate the dataset. 
+                // and here we instantiate the dataset.
                 // Note that while this var name is a ComplexDataset in the parent class
                 // the item it contains is a Simple*Dataset.
                 // so when we iterate over datasets in parent class we are fiddling with SImple*Datsets
@@ -303,10 +304,10 @@ class HighChartTimeseries2 extends HighChart2
                 $defaultYAxisLabel = 'yAxis'.$yAxisIndex;
                 $yAxisLabel = ($data_description->combine_type=='percent'? '% of ':'').(
                                 ($this->_hasLegend && $dataSeriesCount > 1)
-                                    ? $dataset->getColumnUnit($data_description->metric,false)
-                                    : $dataset->getColumnLabel($data_description->metric,false)
+                                    ? $dataset->getColumnUnit($data_description->metric, false)
+                                    : $dataset->getColumnLabel($data_description->metric, false)
                                 );
-                if($this->_shareYAxis) 
+                if($this->_shareYAxis)
                 {
                     $yAxisLabel = $defaultYAxisLabel;
                 }
@@ -316,7 +317,7 @@ class HighChartTimeseries2 extends HighChart2
                 $config = $this->getAxisOverrides($y_axis, $yAxisLabel, $yAxisIndex);
                 if($config !== null)
                 {
-                    if(isset($config->title)) 
+                    if(isset($config->title))
                     {
                         $yAxisLabel = $config->title;
                     }
@@ -324,23 +325,23 @@ class HighChartTimeseries2 extends HighChart2
                     {
                         $yAxisMin = $data_description->log_scale && $config->min <= 0?null:$config->min;
                     }
-                    if(isset($config->max)) 
+                    if(isset($config->max))
                     {
                         $yAxisMax = $config->max;
                     }
                 }
-                if($yAxisLabel == $defaultYAxisLabel) 
+                if($yAxisLabel == $defaultYAxisLabel)
                 {
                     $yAxisLabel = '';
                 }
 
                 if($yAxis == null)
                 {
-                    // set initial dataset's plot color: 
+                    // set initial dataset's plot color:
                     $yAxisColorValue = ($data_description->color == 'auto' || $data_description->color == 'FFFFFF')
                                 ? $colorGenerator->getColor()
-                                : $colorGenerator->getConfigColor( hexdec($data_description->color) );
-                    $yAxisColor = '#'.str_pad(dechex($yAxisColorValue),6,'0',STR_PAD_LEFT);
+                                : $colorGenerator->getConfigColor(hexdec($data_description->color) );
+                    $yAxisColor = '#'.str_pad(dechex($yAxisColorValue), 6, '0', STR_PAD_LEFT);
                     $yAxisColorUsedBySeries = false;
 
                     $yAxis = array(
@@ -387,7 +388,7 @@ class HighChartTimeseries2 extends HighChart2
                 }
                 $pointInterval = $this->getPointInterval();
 
-                // set x axis if needed 
+                // set x axis if needed
                 if(!isset($xAxis))
                 {
                     $defaultXAxisLabel = 'xAxis';
@@ -397,12 +398,12 @@ class HighChartTimeseries2 extends HighChart2
                     if(isset($x_axis->{$xAxisLabel}))
                     {
                         $config = $x_axis->{$xAxisLabel};
-                        if(isset($config->title)) 
+                        if(isset($config->title))
                         {
                             $xAxisLabel = $config->title;
                         }
                     }
-                    if($xAxisLabel == $defaultXAxisLabel) 
+                    if($xAxisLabel == $defaultXAxisLabel)
                     {
                         $xAxisLabel = '';
                     }
@@ -454,7 +455,7 @@ class HighChartTimeseries2 extends HighChart2
                      $this->_chart['xAxis'] = $xAxis;
                 } // if(!isset($xAxis))
 
-                //  ----------- set up yAxis, assign to chart ... eventually ----------- 
+                //  ----------- set up yAxis, assign to chart ... eventually -----------
 
                 if($data_description->std_err == 1)
                 {
@@ -462,33 +463,39 @@ class HighChartTimeseries2 extends HighChart2
                     $semDecimals = $semStatisticObject->getDecimals();
                 }
 
-                // get the full dataset count: how many unique values in the dimension we group by? 
-                $datagroupFullCount = $dataset->getUniqueCount($data_description->group_by, 
-                                                                     $data_description->realm);
+                // get the full dataset count: how many unique values in the dimension we group by?
+                $datagroupFullCount = $dataset->getUniqueCount(
+                    $data_description->group_by,
+                    $data_description->realm
+                );
                 $this->_total = max($this->_total, $datagroupFullCount);
 
-                // If summarizeDataseries (Usage), use $limit to minimize the number of sorted 
-                // queries we must execute. If ME, use the $limit (default 10) to enable paging 
-                // thru dataset.  
+                // If summarizeDataseries (Usage), use $limit to minimize the number of sorted
+                // queries we must execute. If ME, use the $limit (default 10) to enable paging
+                // thru dataset.
 
                 // Query for the top $limit categories in the realm, over the selected time period
-                //$datagroupDataObject = $dataset->getColumnSortedMax($data_description->metric, 
-                //                                                        'dim_'.$data_description->group_by, 
+                //$datagroupDataObject = $dataset->getColumnSortedMax($data_description->metric,
+                //                                                        'dim_'.$data_description->group_by,
                 //                                                        $limit,
-                //                                                        $offset, 
+                //                                                        $offset,
                 //                                                        $data_description->realm);
                 // Roll back to the 'old way' of getting top-n sorted dimension values:
-                $datagroupDataObject = $dataset->getColumnUniqueOrdered( 'dim_'.$data_description->group_by, 
-                                                                        $limit,
-                                                                        $offset, 
-                                                                        $data_description->realm);
+                $datagroupDataObject = $dataset->getColumnUniqueOrdered(
+                    'dim_'.$data_description->group_by,
+                    $limit,
+                    $offset,
+                    $data_description->realm
+                );
 
                 // Use the top $limit categories to build an iterator with $limit objects inside:
-                $yAxisDataObjectsIterator = $dataset->getColumnIteratorBy('met_'.$data_description->metric,
-                                                                          $datagroupDataObject);
+                $yAxisDataObjectsIterator = $dataset->getColumnIteratorBy(
+                    'met_'.$data_description->metric,
+                    $datagroupDataObject
+                );
 
                 // --- Set up dataset truncation for Usage tab support: ----
-                // Populate an array with our iterator contents, but only up to $limit. 
+                // Populate an array with our iterator contents, but only up to $limit.
                 // (implicitly) run the queries and populate the array, but only up to $limit:
                 // that is taken care of by the limit on datagroupDataObject above.
                 $yAxisDataObjectsArray = array();
@@ -503,21 +510,23 @@ class HighChartTimeseries2 extends HighChart2
                     // Run one more query containing everything that was NOT in the top n.
                     // Populate SimpleTimeseriesData object yAxisTruncateObj with this
                     // summary information
-                    $yAxisTruncateObj = $dataset->getSummarizedColumn( $data_description->metric,
-                                                                       $data_description->group_by, 
-                                                                       $this->_total - $limit,
-                                                                       $yAxisDataObjectsIterator->getLimitIds(),
-                                                                       $data_description->realm);
+                    $yAxisTruncateObj = $dataset->getSummarizedColumn(
+                        $data_description->metric,
+                        $data_description->group_by,
+                        $this->_total - $limit,
+                        $yAxisDataObjectsIterator->getLimitIds(),
+                        $data_description->realm
+                    );
 
                     // set the remainder dataset label for plotting
-                    $dataname = $this->getDataname( $data_description->metric, $limit );
-                    $yAxisTruncateObj->setGroupName( $dataname ); 
+                    $dataname = $this->getDataname($data_description->metric, $limit );
+                    $yAxisTruncateObj->setGroupName($dataname );
                     // set label on the dataseries' legend
-                    $yAxisTruncateObj->setName( $dataname ); 
+                    $yAxisTruncateObj->setName($dataname );
 
                     $yAxisDataObjectsArray[] = $yAxisTruncateObj;
                     $dataTruncated = true;
-                } 
+                }
                 unset($yAxisDataObjectsIterator);
 
                 // operate on each yAxisDataObject, a SimpleTimeseriesData object
@@ -526,7 +535,7 @@ class HighChartTimeseries2 extends HighChart2
                 $numYAxisDataObjects = count($yAxisDataObjectsArray);
                 foreach($yAxisDataObjectsArray as $yIndex => $yAxisDataObject)
                 {
-                    if( $yAxisDataObject != NULL)
+                    if( $yAxisDataObject != null)
                     {
                         $yAxisDataObject->joinTo($xAxisData, null);
 
@@ -539,10 +548,10 @@ class HighChartTimeseries2 extends HighChart2
                             $color_value = $colorGenerator->getColor();
                         }
 
-                        $color = '#'.str_pad(dechex($color_value),6,'0',STR_PAD_LEFT);
-                        $lineColor = '#'.str_pad(dechex(\DataWarehouse\Visualization::alterBrightness($color_value,-70)),6,'0',STR_PAD_LEFT);
+                        $color = '#'.str_pad(dechex($color_value), 6, '0', STR_PAD_LEFT);
+                        $lineColor = '#'.str_pad(dechex(\DataWarehouse\Visualization::alterBrightness($color_value, -70)), 6, '0', STR_PAD_LEFT);
 
-                        //highcharts chokes on datasets that are all null so detect them and replace 
+                        //highcharts chokes on datasets that are all null so detect them and replace
                         // all with zero. this will give the user the right impression. (hopefully)
                         $all_null = true;
                         foreach($yAxisDataObject->getValues() as $value)
@@ -553,7 +562,7 @@ class HighChartTimeseries2 extends HighChart2
                                 break;
                             }
                         }
-                        if($all_null) 
+                        if($all_null)
                         {
                             continue;
                         }
@@ -586,13 +595,13 @@ class HighChartTimeseries2 extends HighChart2
                         $seriesValues = array();
                         if($data_description->display_type == 'pie')
                         {
-                           throw new \Exception( get_class($this)." ERROR: chart display_type 'pie' reached in timeseries plot."); 
+                            throw new \Exception(get_class($this)." ERROR: chart display_type 'pie' reached in timeseries plot.");
                         }
                         else // ($data_description->display_type != 'pie')
                         {
                             if ($data_description->value_labels && $std_err_labels_enabled) {
                                 $dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals)+' [+/-'+Highcharts.numberFormat(this.percentage, $decimals)+']';}";
-                            } else if ($std_err_labels_enabled) {
+                            } elseif ($std_err_labels_enabled) {
                                 $dataLabelsConfig['formatter'] = "function(){ return '+/-'+Highcharts.numberFormat(this.percentage, $decimals);}";
                             } else {
                                 $dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals);}";
@@ -630,7 +639,9 @@ class HighChartTimeseries2 extends HighChart2
 
                                 try {
                                     $seriesValue['percentage'] = $yAxisDataObject->getError($i);
-                                } catch (\Exception $e) {}
+                                } catch (\Exception $e) {
+
+                                }
 
                                 $seriesValues[] = $seriesValue;
                             }
@@ -646,16 +657,16 @@ class HighChartTimeseries2 extends HighChart2
 
                         $areMultipleDataSeries = $dataSeriesCount > 1;
                         $dataSeriesName = $areMultipleDataSeries ? $yAxisDataObject->getName() : $yAxisDataObject->getGroupName();
-                        if ($data_description->restrictedByRoles && $this->_showWarnings) 
+                        if ($data_description->restrictedByRoles && $this->_showWarnings)
                         {
                             $dataSeriesName .= $this->roleRestrictionsStringBuilder->registerRoleRestrictions($data_description->roleRestrictionsParameters);
                         }
-                        if($multiRealm) 
+                        if($multiRealm)
                         {
                             $dataSeriesName = $data_description->realm . ': ' . $dataSeriesName;
                         }
                         $formattedDataSeriesName = $dataSeriesName;
-                        if ($areMultipleDataSeries) 
+                        if ($areMultipleDataSeries)
                         {
                             $dataUnit = $yAxisDataObject->getUnit();
                             $formattedDataSeriesName .= " [<span style=\"color:$yAxisColor\">$dataUnit</span>]";
@@ -666,7 +677,7 @@ class HighChartTimeseries2 extends HighChart2
                         if(isset($legend->{$formattedDataSeriesName}))
                         {
                             $config = $legend->{$formattedDataSeriesName};
-                            if(isset($config->title)) 
+                            if(isset($config->title))
                             {
                                 $lookupDataSeriesName = $config->title;
                             }
@@ -689,7 +700,7 @@ class HighChartTimeseries2 extends HighChart2
                             'datasetId' => $data_description->id,
                             'zIndex' => $zIndex,
                             'drilldown' => $drilldown,
-                            'color'=> $data_description->display_type == 'pie'? NULL: $color,
+                            'color'=> $data_description->display_type == 'pie'? null: $color,
                             'trackByArea'=>  $data_description->display_type == 'area' ||  $data_description->display_type == 'areaspline',
                             'type' => $data_description->display_type,
                             'dashStyle' => $data_description->line_type,
@@ -724,7 +735,7 @@ class HighChartTimeseries2 extends HighChart2
                             'pointRange' => $pointInterval,
                             'isRemainder' => $isRemainder,
                             'isRestrictedByRoles' => $data_description->restrictedByRoles
-                        ); // $data_series_desc 
+                        ); // $data_series_desc
 
                         if($data_description->display_type!=='line')
                         {
@@ -734,7 +745,7 @@ class HighChartTimeseries2 extends HighChart2
                                 $data_series_desc['stacking'] = 'normal';
                                 $data_series_desc['connectNulls'] = true;
                             }
-                            else if($data_description->combine_type=='percent' && !$data_description->log_scale )
+                            elseif($data_description->combine_type=='percent' && !$data_description->log_scale )
                             {
                                 $data_series_desc['stacking'] = 'percent';
                             }
@@ -766,15 +777,15 @@ class HighChartTimeseries2 extends HighChart2
                                     }
                                 }
 
-                                $trend_formula = (number_format($m,2)==0?number_format($m,3):number_format($m,2)).'x '.($b>0?'+':'').number_format($b,2);
+                                $trend_formula = (number_format($m, 2)==0?number_format($m, 3):number_format($m, 2)).'x '.($b>0?'+':'').number_format($b, 2);
 
-                                $dsn = 'Trend Line: '.$formattedDataSeriesName.' ('.$trend_formula.'), R-Squared='.number_format($r_squared,2);
+                                $dsn = 'Trend Line: '.$formattedDataSeriesName.' ('.$trend_formula.'), R-Squared='.number_format($r_squared, 2);
 
                                 $lookupDataSeriesName = $dsn;
                                 if(isset($legend->{$dsn}))
                                 {
                                     $config = $legend->{$dsn};
-                                    if(isset($config->title)) 
+                                    if(isset($config->title))
                                     {
                                         $lookupDataSeriesName = $config->title;
                                     }
@@ -825,13 +836,13 @@ class HighChartTimeseries2 extends HighChart2
 
                         if($data_description->std_err == 1 && $data_description->display_type != 'pie')
                         {
-                            $error_color_value = \DataWarehouse\Visualization::alterBrightness($color_value,-70);
-                            $error_color = '#'.str_pad(dechex($error_color_value),6,'0',STR_PAD_LEFT);
+                            $error_color_value = \DataWarehouse\Visualization::alterBrightness($color_value, -70);
+                            $error_color = '#'.str_pad(dechex($error_color_value), 6, '0', STR_PAD_LEFT);
 
                             $errorCount = $yAxisDataObject->getErrorCount();
                             $error_series = array();
 
-                            for($i = 0 ; $i < $errorCount; $i++)
+                            for($i = 0; $i < $errorCount; $i++)
                             {
                                 // build the error bar and set for display
                                 $v = $yAxisDataObject->getValue($i);
@@ -850,16 +861,16 @@ class HighChartTimeseries2 extends HighChart2
                             if(isset($legend->{$dsn}))
                             {
                                 $config = $legend->{$dsn};
-                                if(isset($config->title)) 
+                                if(isset($config->title))
                                 {
                                     $lookupDataSeriesName = $config->title;
                                 }
                             }
                             $visible = true;
-                                if(isset($data_description->visibility) && isset($data_description->visibility->{$dsn}))
+                            if(isset($data_description->visibility) && isset($data_description->visibility->{$dsn}))
                                 {
-                                    $visible = $data_description->visibility->{$dsn};
-                                }
+                                $visible = $data_description->visibility->{$dsn};
+                            }
 
                             $err_series_tooltip = "function() { ".
                                 "var fErr = Highcharts.numberFormat(this.stderr, $semDecimals); ".
@@ -929,4 +940,3 @@ class HighChartTimeseries2 extends HighChart2
 
     } // function configure()
 } // class HighChartTimeseries2
-

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -6,133 +6,132 @@ $roles = $user->getAllRoles(true);
 
 $roleDescriptors = array();
 foreach ($roles as $activeRole) {
-	$shortRole = $activeRole->getIdentifier();
-	$us_pos = strpos($shortRole, '_');
-	if($us_pos > 0)
-	{
-		$shortRole = substr($shortRole, 0, $us_pos);
-	}
+    $shortRole = $activeRole->getIdentifier();
+    $us_pos = strpos($shortRole, '_');
+    if ($us_pos > 0)
+    {
+        $shortRole = substr($shortRole, 0, $us_pos);
+    }
 
-	if (array_key_exists($shortRole, $roleDescriptors)) {
-		continue;
-	}
+    if (array_key_exists($shortRole, $roleDescriptors)) {
+        continue;
+    }
 
-	// If enabled, try to lookup answer in cache first.
-	$cache_enabled = xd_utilities\getConfiguration('internal', 'dw_desc_cache') === 'on';
-	$cache_data_found = false;
-	if ($cache_enabled)
-	{
-		$db = \CCR\DB::factory('database');
-		$db->execute('create table if not exists dw_desc_cache (role char(5), response mediumtext, index (role) ) ');
-		$cachedResults = $db->query('select response from dw_desc_cache where role=:role',array('role' => $shortRole));
-		if(count($cachedResults) > 0)
-		{
-			$roleDescriptors[$shortRole] = unserialize($cachedResults[0]['response']);
-			$cache_data_found = true;
-		}
-	}
+    // If enabled, try to lookup answer in cache first.
+    $cache_enabled = xd_utilities\getConfiguration('internal', 'dw_desc_cache') === 'on';
+    $cache_data_found = false;
+    if ($cache_enabled)
+    {
+        $db = \CCR\DB::factory('database');
+        $db->execute('create table if not exists dw_desc_cache (role char(5), response mediumtext, index (role) ) ');
+        $cachedResults = $db->query('select response from dw_desc_cache where role=:role', array('role' => $shortRole));
+        if(count($cachedResults) > 0)
+        {
+            $roleDescriptors[$shortRole] = unserialize($cachedResults[0]['response']);
+            $cache_data_found = true;
+        }
+    }
 
-	// If the cache was not used or was not useful, get descriptors from code.
-	if (!$cache_data_found)
-	{ 
-		$realms = array();
-		$groupByObjects = array();
-		
-		$query_group_name = 'tg_usage'; 
-		$query_descripter_realms = $activeRole->getQueryDescripters($query_group_name);
-	 
-		foreach($query_descripter_realms as $query_descripter_realm => $query_descripter_groups)
-		{
+    // If the cache was not used or was not useful, get descriptors from code.
+    if (!$cache_data_found)
+    {
+        $realms = array();
+        $groupByObjects = array();
+
+        $query_group_name = 'tg_usage';
+        $query_descripter_realms = $activeRole->getQueryDescripters($query_group_name);
+
+        foreach($query_descripter_realms as $query_descripter_realm => $query_descripter_groups)
+        {
             $seenstats = array();
-			
-			$realms[$query_descripter_realm] = array('text' => $query_descripter_realm, 'dimensions' => array(), 'metrics' => array());
-			foreach($query_descripter_groups as $query_descripter_group)
-			{
-				foreach($query_descripter_group as $query_descripter)
-				{
+
+            $realms[$query_descripter_realm] = array('text' => $query_descripter_realm, 'dimensions' => array(), 'metrics' => array());
+            foreach($query_descripter_groups as $query_descripter_group)
+            {
+                foreach($query_descripter_group as $query_descripter)
+                {
                     if($query_descripter->getDisableMenu()) {
                         continue;
                     }
 
-					$groupByName = $query_descripter->getGroupByName();
-					$group_by_object = $query_descripter->getGroupByInstance();
-					$permittedStatistics = $group_by_object->getPermittedStatistics();
+                    $groupByName = $query_descripter->getGroupByName();
+                    $group_by_object = $query_descripter->getGroupByInstance();
+                    $permittedStatistics = $group_by_object->getPermittedStatistics();
 
-					$groupByObjects[$query_descripter_realm.'_'.$groupByName] = array(
-						'object' => $group_by_object,
-						'permittedStats' => $permittedStatistics);
-					$realms[$query_descripter_realm]['dimensions'][$groupByName] = array(
-						'text' => $groupByName=='none'?'None':$group_by_object->getLabel(),
-						'info' => $group_by_object->getInfo()
-					);
+                    $groupByObjects[$query_descripter_realm.'_'.$groupByName] = array(
+                        'object' => $group_by_object,
+                        'permittedStats' => $permittedStatistics);
+                    $realms[$query_descripter_realm]['dimensions'][$groupByName] = array(
+                        'text' => $groupByName=='none'?'None':$group_by_object->getLabel(),
+                        'info' => $group_by_object->getInfo()
+                    );
 
-					$stats = array_diff($permittedStatistics, $seenstats);
-					if(empty($stats)){
-						continue;
-					}
+                    $stats = array_diff($permittedStatistics, $seenstats);
+                    if(empty($stats)){
+                        continue;
+                    }
 
-					$statsObjects = $query_descripter->getStatisticsClasses($stats);
-					foreach($statsObjects as $realm_group_by_statistic => $statistic_object)
-					{
-						if($statistic_object->isVisible())
-						{
-							$realms[$query_descripter_realm]['metrics'][$realm_group_by_statistic] =
-								array(
-									'text' => $statistic_object->getLabel(),
-									'info' => $statistic_object->getInfo(),
-									'std_err' => in_array('sem_'.$realm_group_by_statistic, $permittedStatistics)
-								);
-						}
-						$seenstats[] = $realm_group_by_statistic;
-					}
-				}
-			}
-			$texts = array();
-			foreach($realms[$query_descripter_realm]['metrics'] as $key => $row)
-			{
-				$texts[$key] = $row['text'];
-			}
-			array_multisort($texts, SORT_ASC, $realms[$query_descripter_realm]['metrics']);
-		}
-		$texts = array();
-		foreach($realms as $key => $row)
-		{
-			$texts[$key] = $row['text'];
-		}
-		array_multisort($texts, SORT_ASC, $realms);
-	
-		$roleDescriptors[$shortRole] = array('totalCount'=> 1, 'data' => array(array( 'realms' => $realms)));
-		
-		// Cache the results if the cache is enabled.
-		if ($cache_enabled)
-		{
-			$db->execute('insert into dw_desc_cache (role, response) values (:role, :response)',array('role' =>$shortRole, 'response' => serialize($roleDescriptors[$shortRole])));
-		}
-	}
+                    $statsObjects = $query_descripter->getStatisticsClasses($stats);
+                    foreach($statsObjects as $realm_group_by_statistic => $statistic_object)
+                    {
+                        if($statistic_object->isVisible())
+                        {
+                            $realms[$query_descripter_realm]['metrics'][$realm_group_by_statistic] =
+                                array(
+                                    'text' => $statistic_object->getLabel(),
+                                    'info' => $statistic_object->getInfo(),
+                                    'std_err' => in_array('sem_'.$realm_group_by_statistic, $permittedStatistics)
+                                );
+                        }
+                        $seenstats[] = $realm_group_by_statistic;
+                    }
+                }
+            }
+            $texts = array();
+            foreach($realms[$query_descripter_realm]['metrics'] as $key => $row)
+            {
+                $texts[$key] = $row['text'];
+            }
+            array_multisort($texts, SORT_ASC, $realms[$query_descripter_realm]['metrics']);
+        }
+        $texts = array();
+        foreach($realms as $key => $row)
+        {
+            $texts[$key] = $row['text'];
+        }
+        array_multisort($texts, SORT_ASC, $realms);
+
+        $roleDescriptors[$shortRole] = array('totalCount'=> 1, 'data' => array(array( 'realms' => $realms)));
+
+        // Cache the results if the cache is enabled.
+        if ($cache_enabled)
+        {
+            $db->execute('insert into dw_desc_cache (role, response) values (:role, :response)', array('role' =>$shortRole, 'response' => serialize($roleDescriptors[$shortRole])));
+        }
+    }
 }
 
 $combinedRealmDescriptors = array();
 foreach ($roleDescriptors as $roleDescriptor) {
-	foreach ($roleDescriptor['data'][0]['realms'] as $realm => $realmDescriptor) {
-		if (!isset($combinedRealmDescriptors[$realm])) {
-			$combinedRealmDescriptors[$realm] = array(
-				'metrics' => array(),
-				'dimensions' => array(),
-				'text' => $realmDescriptor['text'],
-			);
-		}
+    foreach ($roleDescriptor['data'][0]['realms'] as $realm => $realmDescriptor) {
+        if (!isset($combinedRealmDescriptors[$realm])) {
+            $combinedRealmDescriptors[$realm] = array(
+                'metrics' => array(),
+                'dimensions' => array(),
+                'text' => $realmDescriptor['text'],
+            );
+        }
 
-		$combinedRealmDescriptors[$realm]['metrics'] += $realmDescriptor['metrics'];
-		$combinedRealmDescriptors[$realm]['dimensions'] += $realmDescriptor['dimensions'];
-	}
+        $combinedRealmDescriptors[$realm]['metrics'] += $realmDescriptor['metrics'];
+        $combinedRealmDescriptors[$realm]['dimensions'] += $realmDescriptor['dimensions'];
+    }
 }
 
 xd_controller\returnJSON(array(
-	'totalCount' => 1,
-	'data' => array(
-		array(
-			'realms' => $combinedRealmDescriptors,
-		),
-	),
+    'totalCount' => 1,
+    'data' => array(
+        array(
+            'realms' => $combinedRealmDescriptors,
+        ),
+    ),
 ));
-?>

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -45,7 +45,12 @@ foreach ($roles as $activeRole) {
         {
             $seenstats = array();
 
-            $realms[$query_descripter_realm] = array('text' => $query_descripter_realm, 'dimensions' => array(), 'metrics' => array());
+            $realms[$query_descripter_realm] = array(
+                'text' => $query_descripter_realm,
+                'category' => DataWarehouse::getCategoryForRealm($query_descripter_realm),
+                'dimensions' => array(),
+                'metrics' => array(),
+            );
             foreach($query_descripter_groups as $query_descripter_group)
             {
                 foreach($query_descripter_group as $query_descripter)
@@ -119,6 +124,7 @@ foreach ($roleDescriptors as $roleDescriptor) {
                 'metrics' => array(),
                 'dimensions' => array(),
                 'text' => $realmDescriptor['text'],
+                'category' => $realmDescriptor['category'],
             );
         }
 

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -710,8 +710,8 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
         });
         var formItems = [
             {
-                fieldLabel: 'Realm',
-                name: 'realm',
+                fieldLabel: 'Category',
+                name: 'category',
                 xtype: 'combo',
                 mode: 'local',
                 editable: false,
@@ -723,7 +723,9 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
                     data: realmData // data is local
                 }),
                 disabled: true,
-                value: this.record.data.realm,
+                value: XDMoD.Module.MetricExplorer.getCategoryForRealm(
+                    this.record.data.realm
+                ),
                 valueField: 'id',
                 displayField: 'id',
                 triggerAction: 'all'

--- a/html/gui/js/common/data_warehouse/FilterStore.js
+++ b/html/gui/js/common/data_warehouse/FilterStore.js
@@ -39,6 +39,7 @@ XDMoD.DataWarehouse.createFilterStore = function(config) {
                 'value_id',
                 'value_name',
                 'dimension_id',
+                'categories',
                 'realms',
                 'checked'
             ]

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -513,7 +513,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                 var disableNode = false;
 
                 for (var i = 0; i < CCR.xdmod.ui.disabledMenus.length && !disableNode; i++) {
-                    disableNode = n.attributes.group_by == CCR.xdmod.ui.disabledMenus[i].group_by && n.attributes.realm == CCR.xdmod.ui.disabledMenus[i].realm;
+                    disableNode = n.attributes.group_by == CCR.xdmod.ui.disabledMenus[i].group_by && n.attributes.category == CCR.xdmod.ui.disabledMenus[i].category;
                 }
 
                 if (disableNode) {
@@ -626,8 +626,8 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
                         treeLoader.baseParams.query_group = 'tg_usage';
 
-                        if (node.attributes.realm) {
-                            treeLoader.baseParams.realm = node.attributes.realm;
+                        if (node.attributes.category) {
+                            treeLoader.baseParams.category = node.attributes.category;
                         }
 
                         if (node.attributes.group_by) {
@@ -681,7 +681,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
             root: {
                 nodeType: 'async',
                 draggable: false,
-                id: 'realm_', //set this to 'realms' to put realms under nodes
+                id: 'category_', //set this to 'realms' to put realms under nodes
                 filter: false
             },
 


### PR DESCRIPTION
## Description
This pull request allows related realms to be grouped together in categories. Further, it reorganizes the web client's UI to be based around categories rather than realms.

## Motivation and Context
In order to prepare and present grant data addressing different focuses, the in-development Value Analytics module currently provides two realms: `ValueAnalyticsGrants`, which operates on data for individual grants as a whole, and `ValueAnalyticsGrantRoles`, which operates on each assignment onto each grant. However, presenting these realms as separate entities in the Open XDMoD web client led to confusion about what the different entities meant and where to find all of the metrics that pertained to the subject of grants.

To begin to address this problem, this pull request introduces categories. A realm may now declare a category that it falls under, and in the UI, that realm's dimensions and metrics will be grouped together with those of other realms under the same category. If a realm does not declare a category, it is placed into a category with the same name as the realm. From a web client user's perspective, realms have been effectively replaced by categories, but the flow of the interface  remains the same.

**Usage Tab Menu Before**

![Usage Tab Before Change](https://cloud.githubusercontent.com/assets/8796171/23274917/82150a0e-f9d2-11e6-9a57-6fee98e513e9.png)

**Usage Tab Menu After**

![Usage Tab After Change](https://cloud.githubusercontent.com/assets/8796171/23274938/92addfee-f9d2-11e6-9755-8aefdc3a299d.png)

Despite their removal from a web client user's perspective, realms remain important to defining and requesting data in Open XDMoD. Realms continue to have a one-to-one relationship with related sets of fact tables, and they are still populated with dimensions and metrics pertaining to the data represented by those fact tables. For example, the `ValueAnalyticsGrants` realm still represents individual, whole grant data stored in the `modw_aggregates.va_grant_fact_by_*` tables. Realms are also still the basis for most functionality related to the data warehouse for two reasons: 1) It allows the category layer of the data warehouse hierarchy to be treated largely as a cosmetic layer, allowing it to be changed while only impacting the UI, and 2) It reduces the amount of change introduced to the system as a whole, allowing pre-existing data and most API calls to continue working without change.

An important consideration with this change is that metrics from different realms may have different sets of dimensions which can be used to group or filter them. A category-based UI makes this concept even more difficult to convey than the current realm-based UI, as metrics under the same category may not all work with the same dimensions. This issue does not need to be addressed immediately, as all realms currently in Open XDMoD and released official modules have a one-to-one relationship with categories, but it does need to be addressed before multi-realm categories are officially supported.

### Bug Fix

As a part of this change, a minor bug has also been fixed in the Metric Explorer where an old entry in the Filters drop-down panel would not update the list of realms a filter applied to when that list of realms changed. For example, if a chart with a resource filter was created and saved in a vanilla instance of Open XDMoD, the list of applicable realms for that filter would only include the Jobs realm. If the SUPReMM module is then installed and that chart is opened again, the filter pane would continue to say the filter only applied to the Jobs realm, even though it now applies to the SUPReMM realm as well. By looking up this information at load time instead of using saved information, this information will stay up to date with whatever realms are present and available to a user.

## Tests performed
I manually tested a wide variety of features and use cases in the Summary, Usage, Metric Explorer, and Report Generator tabs, involving both pre-existing charts and new charts, using Chrome. I also ran automated UI tests with Firefox and verified that no new errors occurred.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
