### PR TITLE
Adding Logging to Query.php

### DIFF
--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -237,7 +237,7 @@ class Query
 
         $query_string = $this->getQueryString($limit);
 
-        $debug = filter_var(\xd_utilities\getConfiguration('general', 'sql_debug_mode'), FILTER_VALIDATE_BOOLEAN);
+        $debug = \xd_utilities\filter_var(\xd_utilities\getConfiguration('general', 'sql_debug_mode'), FILTER_VALIDATE_BOOLEAN);
         if ($debug == true) {
             $class = get_class($this);
             $this->log->debug(sprintf("%s: \n%s", $class, $query_string));

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -21,6 +21,7 @@ class Query
     public $filterParameterDescriptions;
     private $pdoparams;
     private $pdoindex;
+    private $log;
 
     /**
      * Tracks whether or not role restrictions have been applied to this query.
@@ -118,7 +119,13 @@ class Query
 
         $this->roleParameterDescriptions = array();
         $this->filterParameterDescriptions = array();
-
+        $this->log = \CCR\Log::factory('xms.query', array(
+            'console' => false,
+            'db' => false,
+            'mail' => false,
+            'file' => LOG_DIR . '/query.log',
+            'fileLogLevel' => PEAR_LOG_DEBUG
+        ));
     }
 
 
@@ -229,6 +236,13 @@ class Query
     {
 
         $query_string = $this->getQueryString($limit);
+
+        $debug = filter_var(\xd_utilities\getConfiguration('general', 'sql_debug_mode'), FILTER_VALIDATE_BOOLEAN);
+        if ($debug == true) {
+            $class = get_class($this);
+            $this->log->debug(sprintf("%s: \n%s", $class, $query_string));
+        }
+
         $time_start = microtime(true);
         $results = DB::factory($this->_db_profile)->query($query_string, $this->pdoparams);
 

--- a/libraries/utilities.php
+++ b/libraries/utilities.php
@@ -554,3 +554,17 @@ EOF;
 
     return $use_center_logo;
 }
+
+/**
+ * A temporary shim function to use while our supported PHP version is < 5.4.8
+ *
+ * @param mixed $value to be filtered
+ * @param int $filter the type of filter to apply
+ * @param mixed $options the options to be supplied to the filter
+ * @return bool|mixed false if the value is logically false, else the results of
+ * \filter_var($value, $filter, $options)
+ */
+function filter_var($value, $filter = FILTER_DEFAULT, $options = null)
+{
+    return ( false === $value ? false : \filter_var($value, $filter, $options) );
+}


### PR DESCRIPTION
## Description
- Added a file logger to Query.php ( query.log )
- Added logic to the function 'execute' such that, when called and 
  'sql_debug_mode' is true, the query string that is about to be executed is logged.

## Motivation and Context
It allows some visibility into the queries being generated / executed by the Query class.

## Tests performed
- I deployed the change to my cloud instance ( rr-db1 ), verified there were no issues creating the log file.
- verified that when 'sql_debug_mode' was set to 'on' queries were logged as expected. 
- verified that when 'sql_debug_mode' was set to 'off' queries were not logged as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
