### PR TITLE
Updated style guide for JavaScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,15 +10,11 @@
       "error",
       "all"
     ],
-    "block-scoped-var": "warn",
-    "no-extra-parens": [
-      "warn",
-      "all"
-    ],
-    "dot-notation": [
-      "warn",
+    "brace-style": [
+      "error",
+      "1tbs",
       {
-        "allowPattern": "^[a-z]+(_[a-z]+)+$"
+        "allowSingleLine": false
       }
     ],
     "no-implicit-coercion": [
@@ -32,6 +28,54 @@
     "consistent-this": [
       "warn",
       "self"
-    ]
+    ],
+    "indent": [
+      "error",
+      4,
+      {
+        "SwitchCase": 1,
+        "VariableDeclarator": 1,
+        "outerIIFEBody": 1,
+        "FunctionDeclaration": {
+          "parameters": 1,
+          "body": 1
+        },
+        "FunctionExpression": {
+          "parameters": 1,
+          "body": 1
+        }
+      }
+    ],
+    "func-names": "off",
+    "vars-on-top": "off",
+    "new-cap": [
+      "error",
+      {
+        "newIsCap": true,
+        "newIsCapExceptions": [],
+        "capIsNew": false,
+        "capIsNewExceptions": [
+          "Immutable.Map",
+          "Immutable.Set",
+          "Immutable.List"
+        ],
+        "properties": false
+      }
+    ],
+    "max-len": [
+      "error",
+      512,
+      4,
+      {
+        "ignoreUrls": true,
+        "ignoreComments": false,
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true
+      }
+    ],
+    "no-continue": "off",
+    "no-plusplus": "off",
+    "no-prototype-builtins": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,64 +3,64 @@
   "globals": {},
   "extends": "eslint:recommended",
   "rules": {
-    "curly": 2,
-    "guard-for-in": 2,
-    "no-extend-native": 2,
-    "block-scoped-var": 1,
-    "no-use-before-define": 2,
-    "no-caller": 2,
-    "no-sequences": 2,
-    "no-new": 2,
-    "no-extra-parens": 1,
+    "curly": "error",
+    "guard-for-in": "error",
+    "no-extend-native": "error",
+    "block-scoped-var": "warn",
+    "no-use-before-define": "error",
+    "no-caller": "error",
+    "no-sequences": "error",
+    "no-new": "error",
+    "no-extra-parens": "warn",
     "dot-notation": [
-      1,
+      "warn",
       {
         "allowPattern": "^[a-z]+(_[a-z]+)+$"
       }
     ],
     "no-implicit-coercion": [
-      2,
+      "error",
       {
         "boolean": true,
         "number": true,
         "string": false
       }
     ],
-    "no-multi-spaces": 2,
+    "no-multi-spaces": "error",
     "key-spacing": [
-      2,
+      "error",
       {
         "beforeColon": false,
         "afterColon": true
       }
     ],
     "comma-spacing": [
-      2,
+      "error",
       {
         "before": false,
         "after": true
       }
     ],
     "semi-spacing": [
-      2,
+      "error",
       {
         "before": false,
         "after": true
       }
     ],
-    "no-spaced-func": 2,
-    "no-trailing-spaces": 2,
-    "eol-last": 2,
-    "semi": 2,
-    "space-infix-ops": 2,
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "eol-last": "error",
+    "semi": "error",
+    "space-infix-ops": "error",
     "consistent-this": [
-      1,
+      "warn",
       "self"
     ],
     "linebreak-style": [
-      2,
+      "error",
       "unix"
     ],
-    "keyword-spacing": 1
+    "keyword-spacing": "warn"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,20 @@
 {
-  "env": {},
+  "extends": "airbnb-base/legacy",
+  "env": {
+    "browser": false,
+    "node": false
+  },
   "globals": {},
-  "extends": "eslint:recommended",
   "rules": {
-    "curly": "error",
-    "guard-for-in": "error",
-    "no-extend-native": "error",
+    "curly": [
+      "error",
+      "all"
+    ],
     "block-scoped-var": "warn",
-    "no-use-before-define": "error",
-    "no-caller": "error",
-    "no-sequences": "error",
-    "no-new": "error",
-    "no-extra-parens": "warn",
+    "no-extra-parens": [
+      "warn",
+      "all"
+    ],
     "dot-notation": [
       "warn",
       {
@@ -26,41 +29,9 @@
         "string": false
       }
     ],
-    "no-multi-spaces": "error",
-    "key-spacing": [
-      "error",
-      {
-        "beforeColon": false,
-        "afterColon": true
-      }
-    ],
-    "comma-spacing": [
-      "error",
-      {
-        "before": false,
-        "after": true
-      }
-    ],
-    "semi-spacing": [
-      "error",
-      {
-        "before": false,
-        "after": true
-      }
-    ],
-    "no-spaced-func": "error",
-    "no-trailing-spaces": "error",
-    "eol-last": "error",
-    "semi": "error",
-    "space-infix-ops": "error",
     "consistent-this": [
       "warn",
       "self"
-    ],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
-    "keyword-spacing": "warn"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "description": "An open framework for collecting and analyzing HPC metrics.",
     "dependencies": {},
     "devDependencies": {
-        "eslint": "^3.16.1"
+        "eslint": "^3.16.1",
+        "eslint-config-airbnb-base": "^11.1.0",
+        "eslint-plugin-import": "^2.2.0"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "An open framework for collecting and analyzing HPC metrics.",
     "dependencies": {},
     "devDependencies": {
-        "eslint": "^3.8.1"
+        "eslint": "^3.16.1"
     },
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Description
This pull request updates the style guide for JavaScript code and enforces the changes with ESLint.

The commits in this pull request:

1. Update ESLint to a newer version compatible with the latest version of the [Airbnb ES5 rules][airbnb-es5].
1. Modify the ESLint config file to use strings instead of integers for clarity (e.g. `"error"` instead of `2`).
1. Apply the [Airbnb ES5 rules][airbnb-es5]. This commit also removes redundant custom rules and ensures that conflicting custom rules are still applied. (See [this][eslint-overrides] for more information on how rule overrides work in ESLint.)
1. Tweaked custom rules further based on team preferences.

## Motivation and Context
Our current style guide is a good start, but it leaves room for a number of inconsistencies. When ESLint's auto-fixer is run, it can produce results that don't mesh with our implicit, existing style, like the example below.

```javascript
// current
if (config) jQuery.extend(true, conf, config);

// ESLint auto-fix result
if (config) {jQuery.extend(true, conf, config)};

// desired result
if (config) {
    jQuery.extend(true, conf, config);
}
```

This pull request aims to tighten up the rules by using a more thorough style guide as a basis for ours. Since there is no official or semi-official style guide for JavaScript along the lines of PHP's PSR-2 or Python's PEP 8, a popular third-party guide was chosen - namely, the [ES5 variant](airbnb-es5) of [Airbnb's guide][airbnb].

I've made a handful of tweaks to their guide already based on discussions with various team members, but our style guide should be something the whole team feels comfortable with. If there are any rules you would like to add, modify, or delete, please comment. (I recommend running ESLint on some sample files with the new ruleset to see what it does and doesn't flag.)

The overrides of Airbnb's rules, both preexisting and new, are listed in the table below. If an option for a custom rule in the `.eslintrc.json` file is not described below, it is likely because it was copied from the Airbnb config due to [how ESLint handles rule overrides][eslint-overrides].

Airbnb Rule|Custom Rule|Explanation|ESLint Setting
---|---|---|---
Allow brace-less single-line control statement bodies.|Require braces for all code blocks.|A consistent structure for code blocks makes it easier and less error prone to extend a one-line block.|`curly`, 1st option
Allow opening and closing braces of code blocks to be on same line.|Require opening and closing braces of code blocks to be on different lines.|A consistent structure for code blocks makes it easier and less error prone to extend a one-line block.|`brace-style`, 2nd option, `allowSingleLine`
Allow all implicit type conversions.|Disallow implicit conversions to numbers and booleans.|Implicit conversions can make code harder to follow than when explicit conversions are used.|`no-implicit-coercion`
Allow assignment of `this` to any variable.|Require `this` to be assigned to variables named `self`.|Consistent variable names for capturing execution context makes code easier to follow.|`consistent-this`
Indent using 2 spaces.|Indent using 4 spaces.|Most code in Open XDMoD, JavaScript or otherwise, uses 4 spaces already.|`indent`, 1st option
Require function expressions to have a name.|Allow function expressions to be anonymous.|Naming functions assigned to variables can be handy for debugging, but it is not worth throwing errors over.|`func-names`
Require variables to be declared at the top of their scope.|Don't require variables to be declared at the top of their scope.|Variables should be declared near where they are first used for readability.|`vars-on-top`
Require constructor functions start with a capital letter when the function is a property of an object.|Don't require constructor functions start with a capital letter when the function is a property of an object.|Ext JS stores some constructor functions in objects using camel-case names (e.g., `recordType` in stores).|`new-cap`, 1st option, `properties`
Use maximum line length of 100 characters.|Use maximum line length of 512 characters.|100 characters is on the small side, and 512 is the limit Open XDMoD's PHP code uses.|`max-len`, 1st option
Disallow usage of the `continue` keyword.|Allow usage of the `continue` keyword.|Appropriate usage of `continue` can significantly reduce indentation in lengthy and/or nested loops, making them easier to read.|`no-continue`
Disallow unary increments and decrements.|Allow unary increments and decrements.|[The concerns that led to the creation of this rule](http://eslint.org/docs/rules/no-plusplus) are not applicable with the semicolon/spacing rules being used for this project.|`no-plusplus`
Disallow calling `Object.prototype` methods from `Object` instances.|Allow calling `Object.prototype` methods from `Object` instances.|[The JavaScript feature described by the rule](http://eslint.org/docs/rules/no-prototype-builtins) is not one we make use of, and even if it were, the error it attempts to prevent should be obvious when run.|`no-prototype-builtins`

Removals of preexisting custom rules in favor of Airbnb defaults are explained in the table below.

Old Custom Rule|Airbnb Rule|Explanation|ESLint Setting
---|---|---|---
Treat variables as if they were block scoped. (Warning)|Treat variables as if they were block scoped. (Error)|The only difference between the two rulesets was the severity of the error.|`block-scoped-var`
Disallow extra parentheses.|Allow extra parentheses.|Extra parentheses can be helpful for code readability.|`no-extra-parens`
Require dot notation for accessing object properties using static keys, except for keys matching regex `^[a-z]+(_[a-z]+)+$`.|Require dot notation for accessing object properties using static keys.|Consistently using dot notation for static keys and bracket notation for dynamic keys improves code readability.|`dot-notation`

## Tests Performed

Ran ESLint with new plugin and custom rules and verified that it worked as expected.

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.

[airbnb]: https://github.com/airbnb/javascript
[airbnb-es5]: https://github.com/airbnb/javascript/tree/es5-deprecated/es5
[eslint-overrides]: http://eslint.org/docs/user-guide/configuring#extending-configuration-files
