### PR TITLE
Move ETLv2 job files from xdmod-xsede to xdmod repo

### DIFF
--- a/configuration/etl/etl.d/jobs_hpc.json
+++ b/configuration/etl/etl.d/jobs_hpc.json
@@ -1,0 +1,68 @@
+{
+    "defaults": {
+
+        "global": {
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "Cloud redesign test DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_cloud"
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "Cloud timing test DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_cloud",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        }
+    },
+
+    "#": "Current HPC job ingestion from the XDCDB mirror",
+
+    "xdcdb-jobs": [
+        {
+            "name": "XdcdbJobRecordIngestor",
+            "class": "DatabaseIngestor",
+            "namespace": "ETL\\Ingestor",
+            "options_class": "IngestorOptions",
+            "#": "Table definition relative to paths.table_config_dir if path not specified",
+            "definition_file": "jobs/job_record_hpc.json",
+            "description": "Ingest HPC job records from the XDCDB",
+            "enabled": true,
+            "truncate_destination": false,
+            "#": "By default, ingestors use unbuffered queries",
+            "optimize_query": true,
+            "exclude_resource_codes": ["OSG", "TACC-WRANGLER"],
+            "endpoints": {
+                "source": {
+                    "type": "postgres",
+                    "name": "XDCDB xras",
+                    "config": "tgcdbmirror",
+                    "schema": "acct"
+                }
+            }
+        },{
+            "name": "XdcdbPostIngestJobUpdates",
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions",
+            "description": "Post-ingest updates for XDCDB job records",
+            "class": "ExecuteSql",
+            "enabled": true,
+            "sql_file_list": [ "jobs/job_record_hpc_post_ingest_updates.sql" ]
+        },{
+            "name": "XdcdbJobRecordAggregator",
+            "namespace": "ETL\\Aggregator",
+            "options_class": "AggregatorOptions",
+            "class": "SimpleAggregator",
+            "description": "Aggregate HPC job records",
+            "definition_file": "jobs/jobfact_hpc_aggregation.json",
+            "enabled": true,
+            "truncate_destination": false,
+            "table_prefix": "jobfact_by_",
+            "aggregation_units": ["day", "month", "quarter", "year"]
+        }
+    ]
+}

--- a/configuration/etl/etl_macros.d/jobs/xdcdb_start_time_calc.sql
+++ b/configuration/etl/etl_macros.d/jobs/xdcdb_start_time_calc.sql
@@ -1,0 +1,17 @@
+-- ------------------------------------------------------------------------------------------
+--  If start_time > end_time or start_time <= EPOCH then calculate it based on end_time -
+--  wallduration. Note that wallduration is only trusted if start > end otherwise it is
+--  recalculated as the delta between end_time and start_time.
+--  ------------------------------------------------------------------------------------------
+
+CASE
+  WHEN (start_time > end_time) OR (EXTRACT(epoch FROM start_time) <= 0)
+    THEN TO_TIMESTAMP(EXTRACT(epoch FROM end_time) -
+      CASE
+        WHEN start_time > end_time AND wallduration > 0
+          THEN wallduration
+        ELSE ABS(EXTRACT(epoch FROM end_time) - EXTRACT(epoch FROM start_time))
+      END
+    )
+  ELSE start_time
+END

--- a/configuration/etl/etl_macros.d/jobs/xdcdb_start_time_ts_calc.sql
+++ b/configuration/etl/etl_macros.d/jobs/xdcdb_start_time_ts_calc.sql
@@ -1,0 +1,16 @@
+-- ------------------------------------------------------------------------------------------
+--  If start_time > end_time or start_time <= EPOCH then calculate it based on end_time -
+--  wallduration. Note that wallduration is only trusted if start > end otherwise it is
+--  recalculated as the delta between end_time and start_time.
+-- ------------------------------------------------------------------------------------------
+
+CASE
+  WHEN (start_time > end_time) OR (EXTRACT(epoch FROM start_time) <= 0)
+    THEN EXTRACT(epoch FROM end_time) -
+      CASE
+        WHEN (EXTRACT(epoch FROM end_time) - EXTRACT(epoch FROM start_time) < 0) AND wallduration > 0
+          THEN wallduration
+        ELSE ABS(EXTRACT(epoch FROM end_time) - EXTRACT(epoch FROM start_time))
+      END
+  ELSE EXTRACT(epoch FROM start_time)
+END

--- a/configuration/etl/etl_macros.d/jobs/xdcdb_wallduration_calc.sql
+++ b/configuration/etl/etl_macros.d/jobs/xdcdb_wallduration_calc.sql
@@ -1,0 +1,12 @@
+-- ------------------------------------------------------------------------------------------
+-- We can't always trust the wallduration stored in the XDCDB (see job_id = 26924663 where
+-- wallduration is 50 and local_charge is 768 but according to the start and end dates it should be
+-- 86450). If start > end and wallduration > 0 then start is suspect so trust wallduration,
+-- otherwise re-calculate it as the delta between end_time and start_time.
+-- ------------------------------------------------------------------------------------------
+
+CASE
+   WHEN start_time > end_time AND wallduration > 0
+     THEN wallduration
+   ELSE ABS(EXTRACT(epoch FROM end_time) - EXTRACT(epoch FROM start_time))
+END

--- a/configuration/etl/etl_sql.d/jobs/job_record_hpc_post_ingest_updates.sql
+++ b/configuration/etl/etl_sql.d/jobs/job_record_hpc_post_ingest_updates.sql
@@ -1,0 +1,168 @@
+-- ------------------------------------------------------------------------------------------
+-- Post-job ingestion updates
+--
+-- We assume that the wallduration and end_time_ts haven both been calculated:
+--
+-- end_time_ts = EXTRACT(epoch FROM end_time)
+--
+-- wallduration =
+-- CASE
+--    WHEN (EXTRACT(epoch FROM end_time) - EXTRACT(epoch FROM start_time) < 0) AND wallduration > 0
+--      THEN wallduration
+--    ELSE ABS(EXTRACT(epoch FROM end_time) - EXTRACT(epoch FROM start_time))
+-- END
+-- ------------------------------------------------------------------------------------------
+
+
+-- Update the processor count for jobs recently ingested. If a resource is not present in the
+-- resource specs table records for that job will not be modified
+--
+-- IF (resource is keenland) THEN
+--   Use the special case processor_count = processor_count * processors_per_node
+-- ELSE IF (processor_count is not null AND processor_count != 0) THEN
+--   processor_count = processor_count
+-- ELSE
+--   IF (node_count > total nodes available) OR (node_count * processors_per_node > total_nodes_available) THEN
+--     processors = node_count
+--   ELSE
+--     processor_count = node_count * processors_per_node
+--   END IF
+-- END IF
+--
+-- Also if the resource has no entry in the resourcespecs table use the nodecount.
+--
+-- NOTE: job start/end timestamps are in UTC/GMT while ETL start/end dates are in the timezone of
+-- the server, but FROM_UNIXTIME() returns the value in the current timezone.
+
+UPDATE 
+    ${DESTINATION_SCHEMA}.job_tasks task
+    JOIN modw.resourcespecs rs ON task.resource_id = rs.resource_id
+SET
+    processor_count =
+    CASE
+        WHEN 2800 = task.resource_id
+        THEN task.processor_count * rs.q_ppn
+        ELSE
+            CASE
+                WHEN task.processor_count IS NULL OR 0 = task.processor_count
+                THEN
+                    CASE
+                        WHEN (task.node_count > rs.q_nodes) OR (task.node_count * rs.q_ppn > rs.q_nodes)
+                        THEN task.node_count
+                        ELSE task.node_count * rs.q_ppn
+                    END
+                ELSE task.processor_count
+            END
+    END
+WHERE
+    rs.q_ppn IS NOT NULL
+    AND task.last_modified >= ${LAST_MODIFIED}
+//
+
+-- Set the CPU time for each job and update the submit time and wait duration. These are done here
+-- to make the ingestion query less complex as they depend on the start_time and wallduration being
+-- normalized. This assumes wallduration and processor counts have been normalized.
+--
+-- NOTE: job start/end timestamps are in UTC/GMT while ETL start/end dates are in the timezone of
+-- the server, but FROM_UNIXTIME() returns the value in the current timezone.
+
+UPDATE 
+    ${DESTINATION_SCHEMA}.job_tasks task
+SET
+    cpu_time = wallduration * processor_count,
+    submit_time_ts =
+    CASE
+      WHEN (submit_time_ts > start_time_ts) OR submit_time_ts <= 0
+        THEN start_time_ts
+      ELSE submit_time_ts
+    END,
+    waitduration = start_time_ts -
+    CASE
+      WHEN (submit_time_ts > start_time_ts) OR submit_time_ts <= 0
+        THEN start_time_ts
+      ELSE submit_time_ts
+    END
+WHERE
+    task.last_modified >= ${LAST_MODIFIED}
+//
+
+-- ------------------------------------------------------------------------------------------
+-- Update historical data
+-- ------------------------------------------------------------------------------------------
+
+-- Update any people that have changed in both the record and task tables as these may reference
+-- different people
+
+UPDATE
+    ${DESTINATION_SCHEMA}.job_records record,
+    ${UTILITY_SCHEMA}.person_mapper pm
+SET
+    record.person_id = pm.new_person_id
+WHERE
+    record.person_id = pm.old_person_id
+//
+
+UPDATE
+    ${DESTINATION_SCHEMA}.job_tasks task,
+    ${UTILITY_SCHEMA}.person_mapper pm
+SET
+    task.person_id = pm.new_person_id
+WHERE
+    task.person_id = pm.old_person_id
+//
+
+-- If a person changed, also update their organization id and nsf status code
+--
+-- Note that we use the max mysql datetime value of '9999-12-31 23:59:59' in several places to
+-- indicate an infinate date in the future. Be aware that calling UNIX_TIMESTAMP('9999-12-31
+-- 23:59:59') hits the 2038 32-bit integer bug and returns 0 in mysql (x86_64 v5.5.10) so making a
+-- comparison such as `end_time_ts <= UNIX_TIMESTAMP(valid_until)` may very well not work.
+
+UPDATE 
+    ${DESTINATION_SCHEMA}.job_records record,
+    ${UTILITY_SCHEMA}.personhistory ph
+SET
+    record.person_organization_id = ph.organization_id,
+    record.person_nsfstatuscode_id = ph.nsfstatuscode_id
+WHERE
+    record.person_id = ph.person_id
+    AND ( record.person_organization_id != ph.organization_id OR record.person_nsfstatuscode_id != ph.nsfstatuscode_id)
+    AND FROM_UNIXTIME(record.submit_time_ts) BETWEEN ph.valid_from AND ph.valid_to
+//
+
+UPDATE 
+    ${DESTINATION_SCHEMA}.job_tasks task,
+    ${UTILITY_SCHEMA}.personhistory ph
+SET
+    task.person_organization_id = ph.organization_id,
+    task.person_nsfstatuscode_id = ph.nsfstatuscode_id
+WHERE
+    task.person_id = ph.person_id
+    AND ( task.person_organization_id != ph.organization_id OR task.person_nsfstatuscode_id != ph.nsfstatuscode_id)
+    AND FROM_UNIXTIME(task.submit_time_ts) BETWEEN ph.valid_from AND ph.valid_to
+//
+
+-- If the PI changed, update the person id and the PI organization
+
+UPDATE
+    ${DESTINATION_SCHEMA}.job_records record,
+    ${UTILITY_SCHEMA}.principalinvestigatorhistory h
+SET
+    record.principalinvestigator_person_id = h.person_id
+WHERE
+    record.request_id = h.request_id
+    AND record.principalinvestigator_person_id != h.person_id
+    AND FROM_UNIXTIME(record.submit_time_ts) BETWEEN h.valid_from AND h.valid_to
+//
+
+
+UPDATE
+    ${DESTINATION_SCHEMA}.job_records record,
+    ${UTILITY_SCHEMA}.personhistory h
+SET
+    record.piperson_organization_id = h.organization_id
+WHERE
+    record.principalinvestigator_person_id = h.person_id
+    AND record.piperson_organization_id != h.organization_id
+    AND FROM_UNIXTIME(record.submit_time_ts) BETWEEN h.valid_from AND h.valid_to
+//

--- a/configuration/etl/etl_tables.d/jobs/job_record_hpc.json
+++ b/configuration/etl/etl_tables.d/jobs/job_record_hpc.json
@@ -1,0 +1,742 @@
+{
+    "#": "Load HPC job records from the XDCDB.",
+    "#": "HPC jobs are broken into 2 parts: the job record storing a request for resources and zero or",
+    "#": "more job tasks recording consumption of the requested resources. For typical HPC jobs there",
+    "#": "will be 1 record and 1 task but a job reservation or job array will have 1 record with 0 or",
+    "#": "more tasks.",
+
+    "table_definition": [
+        {
+	        "name": "job_records",
+	        "engine": "MyISAM",
+	        "comment": "Request for resources by a user",
+	        "columns": [
+	            {
+		            "name": "job_record_id",
+		            "type": "bigint(20) unsigned",
+		            "nullable": false
+	            },{
+		            "name": "resource_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Resource where the job was initiated"
+                },{
+                    "name": "resourcetype_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The type of the resource on which the jobs ran. References the resourcetype.id"
+                },{
+                    "name": "resource_state_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The state where the resource resides"
+                },{
+                    "name": "resource_country_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The country where the resource resides"
+                },{
+                    "name": "resource_organization_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The organization where the resource resides"
+                },{
+                    "name": "resource_organization_type_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The type of organization where the resource resides"
+	            },{
+		            "name": "allocation_resource_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Resource associated with the allocation. May be a grid resource."
+	            },{
+		            "name": "person_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Person requesting resources"
+                },{
+                    "name": "person_organization_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The organization of the person requesting resources"
+                },{
+                    "name": "person_nsfstatuscode_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The NSF status code of the person requesting resources. References person.nsfstatuscode_id"
+	            },{
+		            "name": "account_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Account the job will be charged to"
+	            },{
+		            "name": "allocation_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Allocation (resource, account) that will be charged for this job"
+	            },{
+		            "name": "request_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Request record for this allocation (used for primary field of science)"
+                },{
+                    "name": "fos_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The field of science of the project to which the jobs belong"
+	            },{
+		            "name": "principalinvestigator_person_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "The PI that owns the allocation. XDMoD adds this on ingest, otherwise it is linked to a request in XDCDB. References principalinvestigator.person_id"
+                },{
+                    "name": "piperson_organization_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The organization of the PI that owns the allocation. References piperson.organization_id"
+	            },{
+		            "name": "job_record_type_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Type of job: hpc, cloud, hpc-reservation, ..."
+	            },{
+		            "name": "submission_venue_id",
+		            "type": "int(11) unsigned",
+		            "nullable": false,
+		            "comment": "Method used to submit this job: cli, gateway, ..."
+	            },{
+		            "name": "queue",
+		            "type": "varchar(32)",
+		            "nullable": true,
+		            "comment": "Resource queue where the job ran"
+                },{
+		            "name": "submit_time_ts",
+		            "type": "int(11)",
+		            "nullable": true,
+		            "comment": "Job submission time in seconds since epoch (UTC)"
+	            },{
+		            "name": "start_time_ts",
+		            "type": "int(11)",
+		            "nullable": false,
+		            "comment": "Job start time in seconds since epoch (UTC)"
+	            },{
+		            "name": "end_time_ts",
+		            "type": "int(11)",
+		            "nullable": true,
+		            "comment": "Job completion time in seconds since epoch (UTC), may be unknown"
+                },{
+                    "name": "start_day_id",
+                    "type": "int(11) unsigned",
+                    "nullable": false,
+                    "comment": "Day id of the job start time in format YYYY00DDD, e.g. 201600143. This is the day in the timezone of the LOCAL database and NOT UTC!"
+                },{
+                    "name": "end_day_id",
+                    "type": "int(11) unsigned",
+                    "nullable": false,
+                    "comment": "Day id of the job end time in format YYYY00DDD, e.g. 201600143. This is the day in the timezone of the LOCAL database and NOT UTC!"
+	            },{
+		            "name": "local_charge_su",
+		            "type": "decimal(18,3)",
+		            "nullable": false,
+		            "default": "0.000",
+		            "comment": "Local resource SUs charged"
+	            },{
+		            "name": "adjusted_charge_su",
+		            "type": "decimal(18,3)",
+		            "nullable": false,
+		            "default": "0.000",
+		            "comment": "Local resource SUs charged after SP adjustments"
+	            },{
+		            "name": "local_charge_xdsu",
+		            "type": "decimal(18,3)",
+		            "nullable": true,
+		            "comment": "XDSUs charged. Uses current resource conv factor"
+	            },{
+		            "name": "adjusted_charge_xdsu",
+		            "type": "decimal(18,3)",
+		            "nullable": true,
+		            "comment": "XDSUs charged after SP adjustments"
+	            },{
+		            "name": "local_charge_nu",
+		            "type": "decimal(18,3)",
+		            "nullable": true,
+		            "comment": "NUs charged. XDSU * 21.576"
+	            },{
+		            "name": "adjusted_charge_nu",
+		            "type": "decimal(18,3)",
+		            "nullable": true,
+		            "comment": "NUs charged after SP adjustments. XDSU * 21.576"
+	            },{
+		            "name": "conversion_factor",
+		            "type": "double",
+		            "nullable": true,
+		            "comment": "Factor used to normalize local SU to TG Roaming (XDSU)"
+	            },{
+		            "name": "completed",
+		            "type": "tinyint(1)",
+		            "nullable": false,
+		            "default": 0,
+		            "comment": "Boolean flag 1 = job complete"
+	            },{
+		            "name": "last_modified",
+		            "type": "timestamp"
+	            },{
+		            "name": "is_deleted",
+		            "type": "tinyint(1)",
+		            "nullable": false,
+		            "default": 0,
+		            "comment": "Boolean flag 1 = job has been deleted"
+	            }
+	        ],
+	        "indexes": [
+	            {
+		            "name": "PRIMARY",
+		            "columns": [
+		                "job_record_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": true
+                },{
+		            "name": "completed",
+		            "columns": [
+		                "completed"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "fk_account",
+		            "columns": [
+		                "account_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "fk_allocation",
+		            "columns": [
+		                "allocation_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "fk_request",
+		            "columns": [
+		                "request_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "fk_job_record_type",
+		            "columns": [
+		                "job_record_type_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "fk_person",
+		            "columns": [
+		                "person_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "fk_resource",
+		            "columns": [
+		                "resource_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "fk_submission_venue",
+		            "columns": [
+		                "submission_venue_id"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+	            },{
+		            "name": "deleted",
+		            "columns": [
+		                "is_deleted"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+                },{
+                    "name": "aggregation_index",
+                    "columns": [
+                        "start_day_id",
+                        "end_day_id"
+                    ],
+                    "type": "BTREE",
+                    "is_unique": false
+                }
+	        ],
+	        "triggers": []
+        },
+
+        {
+            "name": "job_tasks",
+            "engine": "MyISAM",
+            "comment": "Consumption of resources",
+            "columns": [
+                {
+                    "name": "job_record_id",
+                    "type": "bigint(20) unsigned",
+                    "nullable": false,
+                    "comment": "Job record this task falls under"
+                },{
+                    "name": "creation_time",
+                    "type": "datetime",
+                    "nullable": false,
+                    "comment": "Time that the data was originally recorded at the source"
+                },{
+                    "name": "local_jobid",
+                    "type": "varchar(128)",
+                    "nullable": true,
+                    "comment": "Job or vm instance identifier from resource manager"
+                },{
+                    "name": "resource_id",
+                    "type": "int(11) unsigned",
+                    "nullable": false,
+                    "comment": "Resource where the task executed"
+                },{
+                    "name": "systemaccount_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "DIMENSION: The id of the resource system account (local username) under which the job ran. References systemaccount.id"
+                },{
+                    "name": "person_id",
+                    "type": "int(11) unsigned",
+                    "nullable": false,
+                    "comment": "Person executing this task"
+                },{
+                    "name": "person_organization_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The organization of the person who ran the task"
+                },{
+                    "name": "person_nsfstatuscode_id",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "The NSF status code of the person who ran the task"
+                },{
+                    "name": "job_task_type_id",
+                    "type": "int(11) unsigned",
+                    "nullable": false,
+                    "comment": "Task type or event"
+                },{
+                    "name": "name",
+                    "type": "varchar(256)",
+                    "nullable": true,
+                    "comment": "User-specified job name"
+                },{
+                    "name": "submit_time_ts",
+                    "type": "int(11)",
+                    "nullable": true,
+                    "comment": "Task submission time in seconds since epoch (UTC)"
+                },{
+                    "name": "start_time_ts",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "Task start time in seconds since epoch (UTC)"
+                },{
+                    "name": "end_time_ts",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "Task completion time in seconds since epoch (UTC)"
+                },{
+                    "name": "start_day_id",
+                    "type": "int(11) unsigned",
+                    "nullable": false,
+                    "comment": "Day id of the job start time in format YYYY00DDD, e.g. 201600143. This is the day in the timezone of the LOCAL database and NOT UTC!"
+
+                },{
+                    "name": "end_day_id",
+                    "type": "int(11) unsigned",
+                    "nullable": false,
+                    "comment": "Day id of the job end time in format YYYY00DDD, e.g. 201600143. This is the day in the timezone of the LOCAL database and NOT UTC!"
+                },{
+                    "name": "node_count",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": "-1",
+                    "comment": "Number of nodes consumed"
+                },{
+                    "name": "processor_count",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": "-1",
+                    "comment": "Number of processor cores consumed"
+                },{
+                    "name": "memory_kb",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "default": "-1",
+                    "comment": "Memory consumed"
+                },{
+                    "name": "wallduration",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "Overall job duration in seconds"
+                },{
+                    "name": "waitduration",
+                    "type": "int(11)",
+                    "nullable": false,
+                    "comment": "Time the job waited in the queue"
+                },{
+                    "name": "cpu_time",
+                    "type": "decimal(18,0)",
+                    "nullable": true,
+                    "comment": "The amount of the cpu time (processor_count * wallduration)"
+                },{
+                    "name": "local_charge_su",
+                    "type": "decimal(18,3)",
+                    "nullable": false,
+                    "default": "0.000",
+                    "comment": "Local resource SUs charged"
+                },{
+                    "name": "adjusted_charge_su",
+                    "type": "decimal(18,3)",
+                    "nullable": false,
+                    "default": "0.000",
+                    "comment": "Local resource SUs charged after SP adjustments"
+                },{
+                    "name": "local_charge_xdsu",
+                    "type": "decimal(18,3)",
+                    "nullable": true,
+                    "comment": "XDSUs charged. Uses current resource conv factor"
+                },{
+                    "name": "adjusted_charge_xdsu",
+                    "type": "decimal(18,3)",
+                    "nullable": true,
+                    "comment": "XDSUs charged after SP adjustments"
+                },{
+                    "name": "local_charge_nu",
+                    "type": "decimal(18,3)",
+                    "nullable": true,
+                    "comment": "NUs charged. XDSU * 21.576"
+                },{
+                    "name": "adjusted_charge_nu",
+                    "type": "decimal(18,3)",
+                    "nullable": true,
+                    "comment": "NUs charged after SP adjustments. XDSU & 21.576"
+                },{
+                    "name": "conversion_factor",
+                    "type": "double",
+                    "nullable": true,
+                    "comment": "Factor used to normalize local SU to TG Roaming (XDSU)"
+                },{
+                    "name": "completed",
+                    "type": "tinyint(1)",
+                    "nullable": false,
+                    "default": 0,
+                    "comment": "Boolean flag 1 = job complete"
+                },{
+                    "name": "last_modified",
+                    "type": "timestamp"
+                },{
+		            "name": "is_deleted",
+		            "type": "tinyint(1)",
+		            "nullable": false,
+		            "default": 0,
+		            "comment": "Boolean flag 1 = job has been deleted"
+	            }
+            ],
+            "indexes": [
+                {
+                    "name": "PRIMARY",
+                    "columns": [
+                        "job_record_id",
+                        "creation_time"
+                    ],
+                    "type": "BTREE",
+                    "is_unique": true
+                },{
+                    "name": "completed",
+                    "columns": [
+                        "completed"
+                    ],
+                    "type": "BTREE",
+                    "is_unique": false
+                },{
+                    "name": "fk_job_task_type",
+                    "columns": [
+                        "job_task_type_id"
+                    ],
+                    "type": "BTREE",
+                    "is_unique": false
+                },{
+                    "name": "fk_person",
+                    "columns": [
+                        "person_id"
+                    ],
+                    "type": "BTREE",
+                    "is_unique": false
+                },{
+                    "name": "fk_resource",
+                    "columns": [
+                        "resource_id"
+                    ],
+                    "type": "BTREE",
+                    "is_unique": false
+                },{
+                    "name": "aggregation_index",
+                    "columns": [
+                        "start_day_id",
+                        "end_day_id"
+                    ],
+                    "type": "BTREE",
+                    "is_unique": false
+                },{
+		            "name": "deleted",
+		            "columns": [
+		                "is_deleted"
+		            ],
+		            "type": "BTREE",
+		            "is_unique": false
+                }
+            ],
+            "triggers": []
+        }
+    ],
+
+    "source_query": {
+        
+        "#": "Note that start_date, end_date refer to the start/end of the ingestion window, not job start/end dates",
+        "#": "Since the XDCDB is in America/San_Diego time zone, convert job end dates to the timezone of the XDMoD",
+        "#": "server for comparison.",
+
+        "overseer_restrictions": {
+            "start_date": "(j.end_time AT TIME ZONE '${TIMEZONE}')::timestamp >= ${VALUE}::timestamp",
+            "# end_date": "(j.end_time AT TIME ZONE '${TIMEZONE}')::timestamp < ${VALUE}::timestamp + INTERVAL '1 second'",
+            "end_date": "(j.end_time AT TIME ZONE '${TIMEZONE}')::timestamp <= ${VALUE}::timestamp",
+            "include_only_resource_codes": "j.resource_id IN ${VALUE}",
+            "exclude_resource_codes": "j.resource_id NOT IN ${VALUE}"
+        },
+        
+	    "records": {
+            "job_id": "j.job_id",
+            "local_job_id": "j.local_jobid",
+            "creation_time": "j.ts",
+            "resource_id": "res.resource_id",
+            "resourcetype_id": "res.resource_type_id",
+            "request_id": "req.request_id",
+            "account_id": "j.account_id",
+            "allocation_id": "j.allocation_id",
+            "allocation_resource_id": "ares.resource_id",
+            "fos_id": "req.primary_fos_id",
+            "job_record_type_id": 1,
+            "submission_venue_id": 1,
+            "job_task_type_id": 1,
+
+            "job_name": "j.jobname",
+            "queue": "COALESCE(j.queue, 'NA')",
+            "node_count": "j.nodecount",
+
+            "systemaccount_id": "sa.system_account_id",
+            "person_id": "p.person_id",
+            "person_organization_id": "p.organization_id",
+	        "person_nsfstatuscode_id": "p.nsf_status_code_id",
+	        "principalinvestigator_person_id": "pi_map.person_id",
+	        "piperson_organization_id": "pi.organization_id",
+            
+            "resource_state_id": "o.state_id",
+            "resource_country_id": "o.country_id",
+            "resource_organization_id": "o.organization_id",
+            "resource_organization_type_id": "o.org_type_id",
+
+            "wallduration": "${wallduration_statement}",
+            "start_time_ts": "${start_time_ts_statement}",
+            "end_time_ts": "EXTRACT(epoch FROM end_time)",
+
+            "#": "Because the start_day_id and end_day_id will be compared to the modw.days table and modw.days records",
+            "#": "are calculated based on the local timezone of the server (EDT in our case) we need to explicitly",
+            "#": "convert to that time zone when calculating the start and end days",
+            "start_day_id": "EXTRACT(year FROM (${start_time_statement} AT TIME ZONE '${TIMEZONE}')::timestamp) * 100000 + EXTRACT(doy FROM (${start_time_statement} AT TIME ZONE '${TIMEZONE}')::timestamp)",
+            "end_day_id": "EXTRACT(year FROM (j.end_time AT TIME ZONE '${TIMEZONE}')::timestamp) * 100000 + EXTRACT(doy FROM (j.end_time AT TIME ZONE '${TIMEZONE}')::timestamp)",
+
+            "local_charge_su": "j.local_charge",
+            "adjusted_charge_su": "j.adjusted_charge",
+            "local_charge_xdsu": "(COALESCE(aladj.conversion_factor, 1.0) * j.local_charge)::decimal(18,3)",
+            "adjusted_charge_xdsu": "(COALESCE(aladj.conversion_factor, 1.0) * j.adjusted_charge)::decimal(18,3)",
+            "local_charge_nu": "(COALESCE(aladj.conversion_factor, 1.0) * j.local_charge * 21.576)::decimal(18,3)",
+            "adjusted_charge_nu": "(COALESCE(aladj.conversion_factor, 1.0) * j.adjusted_charge * 21.576)::decimal(18,3)",
+	        "conversion_factor": "aladj.conversion_factor",
+	        "completed": 1,
+            "memory_kb": -1,
+
+            "#": "The following fields depend on a re-calculated start time, which in turn depends on a re-calculated wall_time",
+            "#": "so these are handled in a post-processing query while the wall_time and start_time are calculated here.",
+            "submit_time_ts": "EXTRACT(epoch FROM submit_time)",
+            "waitduration": 0,
+
+            "#": "We will normalize processor counts in the post-processing step since this needs access",
+            "#": "to the XDMoD data warehouse resource specs table",
+            "processor_count": "j.processors",
+            "#": "CPU time will be calculated in the post-processing step as wallduration * processor_count",
+            "cpu_time": 0
+
+	    },
+        
+	    "joins": [
+            {
+                "name": "jobs",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "j"
+            },{
+                "name": "allocations",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "alloc",
+	            "on": "alloc.allocation_id = j.allocation_id"
+            },{
+                "name": "requests",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "req",
+	            "on": "req.account_id = j.account_id AND alloc.initial_start_date = req.start_date"
+            },{
+                "name": "system_accounts",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "sa",
+	            "on": "sa.username = j.username AND sa.person_id = j.person_id AND sa.resource_id = j.resource_id"
+            },{
+                "name": "resources",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "res",
+	            "on": "res.resource_id = j.resource_id"
+            },{
+                "name": "resources",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "ares",
+	            "on": "ares.resource_id = alloc.resource_id"
+            },{
+                "name": "people",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "p",
+	            "on": "p.person_id = j.person_id"
+            },{
+                "name": "principal_investigators",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "pi_map",
+	            "on": "pi_map.request_id = req.request_id"
+            },{
+                "name": "people",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "pi",
+	            "on": "pi.person_id = pi_map.person_id"
+            },{
+                "name": "organizations",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "o",
+	            "on": "o.organization_id = res.organization_id"
+            },{
+                "name": "allocation_adjustments",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "aladj",
+	            "on": "aladj.site_resource_id = j.resource_id AND  aladj.alloc_resource_id = 1546 AND date(j.end_time) between aladj.start_date and COALESCE(aladj.end_date, now())"
+	        }
+        ],
+        
+        "#": "Exclude HPC jobs with nodecount = 0, which appear to be reservations.",
+        "#": "Exclude jobs with end_time < EPOCH",
+
+        "where": [
+            "j.nodecount <> 0",
+            "j.nodecount IS NOT NULL",
+            "EXTRACT(epoch FROM end_time) > 0"
+        ],
+
+        "macros": [
+            {
+                "name": "wallduration_statement",
+                "file": "jobs/xdcdb_wallduration_calc.sql"
+            },{
+                "name": "start_time_statement",
+                "file": "jobs/xdcdb_start_time_calc.sql"
+            },{
+                "name": "start_time_ts_statement",
+                "file": "jobs/xdcdb_start_time_ts_calc.sql"
+            }
+        ]
+
+    },
+
+    "destination_record_map": {
+        "job_records": {
+            "job_record_id": "job_id",
+            "resource_id": "resource_id",
+            "resourcetype_id": "resourcetype_id",
+            "request_id": "request_id",
+            "account_id": "account_id",
+            "allocation_id": "allocation_id",
+            "allocation_resource_id": "allocation_resource_id",
+            "fos_id": "fos_id",
+
+            "queue": "queue",
+
+            "person_id": "person_id",
+            "person_organization_id": "person_organization_id",
+            "person_nsfstatuscode_id": "person_nsfstatuscode_id",
+            "principalinvestigator_person_id": "principalinvestigator_person_id",
+            "piperson_organization_id": "piperson_organization_id",
+
+            "resource_state_id": "resource_state_id",
+            "resource_country_id": "resource_country_id",
+            "resource_organization_id": "resource_organization_id",
+            "resource_organization_type_id": "resource_organization_type_id",
+
+            "job_record_type_id": "job_record_type_id",
+            "submission_venue_id": "submission_venue_id",
+
+            "submit_time_ts": "submit_time_ts",
+            "start_time_ts": "start_time_ts",
+            "end_time_ts": "end_time_ts",
+            "start_day_id": "start_day_id",
+            "end_day_id": "end_day_id",
+
+            "local_charge_su": "local_charge_su",
+            "adjusted_charge_su": "adjusted_charge_su",
+            "local_charge_xdsu": "local_charge_xdsu",
+            "adjusted_charge_xdsu": "adjusted_charge_xdsu",
+            "local_charge_nu": "local_charge_nu",
+            "adjusted_charge_nu": "adjusted_charge_nu",
+
+            "conversion_factor": "conversion_factor",
+            "completed": "completed"
+
+        },
+        "job_tasks": {
+            "job_record_id": "job_id",
+            "creation_time": "creation_time",
+            "local_jobid": "local_job_id",
+            "job_task_type_id": "job_task_type_id",
+            "resource_id": "resource_id",
+
+            "name": "job_name",
+            "node_count": "node_count",
+            "processor_count": "processor_count",
+
+            "systemaccount_id": "systemaccount_id",
+            "person_id": "person_id",
+            "person_organization_id": "person_organization_id",
+            "person_nsfstatuscode_id": "person_nsfstatuscode_id",
+
+            "wallduration": "wallduration",
+            "waitduration": "waitduration",
+            "cpu_time": "cpu_time",
+            "submit_time_ts": "submit_time_ts",
+            "start_time_ts": "start_time_ts",
+            "end_time_ts": "end_time_ts",
+            "start_day_id": "start_day_id",
+            "end_day_id": "end_day_id",
+
+            "local_charge_su": "local_charge_su",
+            "adjusted_charge_su": "adjusted_charge_su",
+            "local_charge_xdsu": "local_charge_xdsu",
+            "adjusted_charge_xdsu": "adjusted_charge_xdsu",
+            "local_charge_nu": "local_charge_nu",
+            "adjusted_charge_nu": "adjusted_charge_nu",
+            "conversion_factor": "conversion_factor",
+            "memory_kb": "memory_kb",
+            "completed": "completed"
+        }
+    }
+}

--- a/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
+++ b/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
@@ -1,0 +1,486 @@
+{
+    "#": "Aggregation of HPC job records and tasks ingested from the XDCDB",
+
+    "table_definition": {
+        "name": "jobfact_by_",
+        "engine": "MyISAM",
+        "comment": "Jobfacts aggregated by ${AGGREGATION_UNIT}.",
+        "columns": [
+            {
+                "name": "${AGGREGATION_UNIT}_id",
+                "type": "int(10) unsigned",
+                "nullable": false,
+                "comment": "DIMENSION: The id related to modw.${AGGREGATION_UNIT}s."
+            },{
+                "name": "year",
+                "type": "smallint(5) unsigned",
+                "nullable": false,
+                "comment": "DIMENSION: The year of the ${AGGREGATION_UNIT}"
+            },{
+                "name": "${AGGREGATION_UNIT}",
+                "type": "smallint(5) unsigned",
+                "nullable": false,
+                "comment": "DIMENSION: The ${AGGREGATION_UNIT} of the year."
+            },{
+                "name": "record_resource_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The resource on which the request was made"
+            },{
+                "name": "task_resource_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The resource on which the jobs ran"
+            },{
+                "name": "resource_organization_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The organization of the resource that the jobs ran on."
+            },{
+                "name": "resourcetype_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The type of the resource on which the jobs ran. References resourcetype.id"
+            },{
+                "name": "systemaccount_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The id of the resource system account (local username) under which the job ran. References systemaccount.id"
+            },{
+                "name": "submission_venue_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The method used to submit this job: cli, gateway, ..."
+            },{
+                "name": "job_record_type_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: Task type or event."
+            },{
+                "name": "job_task_type_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: Type of job: hpc, cloud, hpc-reservation, ...."
+            },{
+                "name": "queue",
+                "type": "char(50)",
+                "nullable": false,
+                "comment": "DIMENSION: The queue of the resource on which the jobs ran."
+            },{
+                "name": "allocation_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The id of allocation these jobs used to run"
+            },{
+                "name": "account_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The id of the account record from which one can get charge number"
+            },{
+                "name": "requesting_person_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The id of the person that requested the resources (e.g., made the reservation or submitted the job."
+            },{
+                "name": "person_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The id of the person that ran the jobs."
+            },{
+                "name": "person_organization_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The organization of the person that ran the jobs."
+            },{
+                "name": "person_nsfstatuscode_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The NSF status code of the person that ran the jobs. References person.nsfstatuscode_id"
+            },{
+                "name": "fos_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The field of science of the project to which the jobs belong."
+            },{
+                "name": "principalinvestigator_person_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The PI that owns the allocations that these jobs ran under. References principalinvestigator.person_id"
+            },{
+                "name": "piperson_organization_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: The organization of the PI that owns the project that funds these jobs. References piperson.organization_id"
+            },{
+                "name": "job_time_bucket_id",
+                "type": "int(4)",
+                "nullable": false,
+                "comment": "DIMENSION: Job time is bucketing of wall time based on prechosen intervals in the modw.job_times table."
+            },{
+                "name": "node_count",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: Number of nodes each of the jobs used."
+            },{
+                "name": "processor_count",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "DIMENSION: Number of processors each of the jobs used."
+            },{
+                "name": "processorbucket_id",
+                "type": "int(4)",
+                "nullable": true,
+                "comment": "FACT: Pre-determined processor bucket sizes. References processorbucket.id"
+            },{
+                "name": "submitted_job_count",
+                "type": "int(11)",
+                "nullable": true,
+                "comment": "FACT: The number of jobs that started during this day."
+            },{
+                "name": "ended_job_count",
+                "type": "int(11)",
+                "nullable": true,
+                "comment": "FACT: The number of jobs that ended during this day."
+            },{
+                "name": "started_job_count",
+                "type": "int(11)",
+                "nullable": true,
+                "comment": "FACT: The number of jobs that started during this day."
+            },{
+                "name": "running_job_count",
+                "type": "int(11)",
+                "nullable": true,
+                "comment": "FACT: The number of jobs that were running during this day."
+            },{
+                "name": "wallduration",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: (seconds) The wallduration of the jobs that were running during this period. This will only count the walltime of the jobs that fell during this day. If a job started in the previous day(s) the wall time for that day will be added to that day. Same logic is true if a job ends not in this day, but upcoming days."
+            },{
+                "name": "sum_wallduration_squared",
+                "type": "double",
+                "nullable": true,
+                "comment": "FACT: (seconds) The sum of the square of wallduration of the jobs that were running during this period. This will only count the walltime of the jobs that fell during this day. If a job started in the previous day(s) the wall time for that day will be added to that day. Same logic is true if a job ends not in this day, but upcoming days."
+            },{
+                "name": "waitduration",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: (seconds) The amount of time jobs waited to execute during this day."
+            },{
+                "name": "sum_waitduration_squared",
+                "type": "double",
+                "nullable": true,
+                "comment": "FACT: (seconds) The sum of the square of the amount of time jobs waited to execute during this day."
+            },{
+                "name": "local_charge_su",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "local_charge_xdsu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "local_charge_nu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "adjusted_charge_su",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "adjusted_charge_xdsu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "adjusted_charge_nu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "task_local_charge_su",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "task_local_charge_xdsu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "task_local_charge_nu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "task_adjusted_charge_su",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "task_adjusted_charge_xdsu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "task_adjusted_charge_nu",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "sum_local_charge_xdsu_squared",
+                "type": "double",
+                "nullable": true,
+                "comment": "FACT: The sum of the square of local_charge of jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
+            },{
+                "name": "cpu_time",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: (seconds) The amount of the cpu time (processor_count * wallduration) of the jobs pertaining to this day. If a job took more than one day, its cpu_time is distributed linearly across the days it used."
+            },{
+                "name": "sum_cpu_time_squared",
+                "type": "double",
+                "nullable": true,
+                "comment": "FACT: (seconds) The sum of the square of the amount of the cpu_time of the jobs pertaining to this day. If a job took more than one day, its cpu_time is distributed linearly across the days it used."
+            },{
+                "name": "node_time",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: (seconds) The amount of the node time (nodes * wallduration) of the jobs pertaining to this day. If a job took more than one day, its node_time is distributed linearly across the days it used."
+            },{
+                "name": "sum_node_time_squared",
+                "type": "double",
+                "nullable": true,
+                "comment": "FACT: (seconds) The sum of the square of the amount of the node_time of the jobs pertaining to this day. If a job took more than one day, its node_time is distributed linearly across the days it used."
+            },{
+                "name": "sum_weighted_expansion_factor",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: This is the sum of expansion factor per job multiplied by node_count and the [adjusted] duration of jobs that ran in this days."
+            },{
+                "name": "sum_job_weights",
+                "type": "decimal(18,0)",
+                "nullable": true,
+                "comment": "FACT: this is the sum of (node_count multipled by the [adjusted] duration) for jobs that ran in this days."
+            }
+        ],
+
+        "indexes": [
+            {
+                "name": "index_account",
+                "columns": [ "account_id" ]
+            },{
+                "name": "index_allocation",
+                "columns": [ "allocation_id" ]
+            },{
+                "name": "index_fos",
+                "columns": [ "fos_id" ]
+            },{
+                "name": "index_job_time_bucket_id",
+                "columns": [ "job_time_bucket_id" ]
+            },{
+                "name": "index_node_count",
+                "columns": [ "node_count" ]
+            },{
+                "name": "index_resource_organization",
+                "columns": [ "resource_organization_id" ]
+            },{
+                "name": "index_person",
+                "columns": [ "person_id" ]
+            },{
+                "name": "index_person_nsf_status_code",
+                "columns": [ "person_nsfstatuscode_id" ]
+            },{
+                "name": "index_person_organization",
+                "columns": [ "person_organization_id" ]
+            },{
+                "name": "index_pi_organization",
+                "columns": [ "piperson_organization_id" ]
+            },{
+                "name": "index_pi_person",
+                "columns": [ "principalinvestigator_person_id" ]
+            },{
+                "name": "index_processor_count",
+                "columns": [ "processor_count" ]
+            },{
+                "name": "index_queue",
+                "columns": [ "queue" ]
+            },{
+                "name": "index_resource_type",
+                "columns": [ "resourcetype_id" ]
+            },{
+                "name": "index_resource",
+                "columns": [ "record_resource_id" ]
+            },{
+                "name": "index_system_account",
+                "columns": [ "systemaccount_id" ]
+            },{
+                "name": "index_period_value",
+                "columns": [ "${AGGREGATION_UNIT}" ]
+            },{
+                "name": "index_period",
+                "columns": [ "${AGGREGATION_UNIT}_id" ]
+            }]
+    },
+
+    "#": "The aggregation period query determines which periods need to be aggregated based on added or modified",
+    "#": "records. The overseer_restrictions block specifies the criteria for selecting periods requiring",
+    "#": "aggregation. If this clause is not specified or no restrictions match then all records will be",
+    "#": "considered. The first table specified in source_query.joins will be used to determine periods that",
+    "#": "need aggregation.",
+
+    "aggregation_period_query": {
+        "overseer_restrictions": {
+            "last_modified_start_date": "last_modified >= ${VALUE}",
+            "last_modified_end_date": "last_modified <= ${VALUE}",
+            "include_only_resource_codes": "resource_id IN ${VALUE}",
+            "exclude_resource_codes": "resource_id NOT IN ${VALUE}"
+        }
+    },
+
+    "#": "The destination query block allows us to specify overseer restrictions that apply to operations on",
+    "#": "the destination table (e.g., deleting records from the table during aggregation).  If no restrictions",
+    "#": "are specified then the entire aggregation period will be deleted. Note that if there is a restriction",
+    "#": "on the source_query block it is possible to delete an aggregation period from the destination table",
+    "#": "with no restictions and replace it with aggregated data that has been restricted.",
+
+    "destination_query": {
+        "overseer_restrictions": {
+            "include_only_resource_codes": "record_resource_id IN ${VALUE}",
+            "exclude_resource_codes": "record_resource_id NOT IN ${VALUE}"
+        }
+    },
+
+    "source_query": {
+
+        "overseer_restrictions": {
+            "include_only_resource_codes": "record.resource_id IN ${VALUE}",
+            "exclude_resource_codes": "record.resource_id NOT IN ${VALUE}"
+        },
+
+        "query_hint": "SQL_NO_CACHE",
+        "records": {
+            "${AGGREGATION_UNIT}_id": "${:PERIOD_ID}",
+            "year": "${:YEAR_VALUE}",
+            "${AGGREGATION_UNIT}": "${:PERIOD_VALUE}",
+            "record_resource_id": "record.resource_id",
+            "task_resource_id": "task.resource_id",
+            "resource_organization_id": "requested_resource.organization_id",
+            "resourcetype_id": "requested_resource.resourcetype_id",
+            "systemaccount_id": "task.systemaccount_id",
+            "submission_venue_id": "record.submission_venue_id",
+            "job_record_type_id": "record.job_record_type_id",
+            "job_task_type_id": "task.job_task_type_id",
+            "queue": "record.queue",
+            "allocation_id": "record.allocation_id",
+            "account_id": "record.account_id",
+            "requesting_person_id": "record.person_id",
+            "person_id": "task.person_id",
+            "person_organization_id": "task.person_organization_id",
+            "person_nsfstatuscode_id": "task.person_nsfstatuscode_id",
+            "fos_id": "record.fos_id",
+            "principalinvestigator_person_id": "record.principalinvestigator_person_id",
+            "piperson_organization_id": "COALESCE(record.piperson_organization_id, 0)",
+            "job_time_bucket_id": "(SELECT id FROM ${UTILITY_SCHEMA}.job_times jt WHERE task.wallduration >= jt.min_duration AND task.wallduration <= jt.max_duration)",
+            "node_count": "task.node_count",
+            "processor_count": "task.processor_count",
+            "processorbucket_id": "(SELECT id FROM ${UTILITY_SCHEMA}.processor_buckets pb WHERE task.processor_count BETWEEN pb.min_processors AND pb.max_processors)",
+            "submitted_job_count": "SUM( IF(task.submit_time_ts BETWEEN ${:PERIOD_START_TS} AND ${:PERIOD_END_TS}, 1, 0) )",
+            "ended_job_count": "SUM( IF(task.end_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, 1, 0) )",
+            "started_job_count": "SUM( IF(task.start_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, 1, 0) )",
+            "running_job_count": "SUM(1)",
+            "wallduration": "COALESCE(SUM( ${wallduration_case_statement}), 0)",
+            "sum_wallduration_squared": "COALESCE(SUM( pow(${wallduration_case_statement}, 2)), 0)",
+            "waitduration": "SUM( IF(task.start_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, task.waitduration, 0) )",
+            "sum_waitduration_squared": "SUM( IF(task.start_day_id = ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, pow(task.waitduration, 2), 0) )",
+            "local_charge_xdsu": "SUM(${local_charge_xdsu_case_statement})",
+            "sum_local_charge_xdsu_squared": "SUM(pow(${local_charge_xdsu_case_statement}, 2))",
+            "cpu_time": "COALESCE(SUM(task.processor_count * ${wallduration_case_statement}), 0)",
+            "sum_cpu_time_squared": "COALESCE(SUM(pow(task.processor_count * ${wallduration_case_statement}, 2)), 0)",
+            "node_time": "COALESCE(SUM(task.node_count * ${wallduration_case_statement}), 0)",
+            "sum_node_time_squared": "COALESCE(SUM( pow(task.node_count * ${wallduration_case_statement}, 2)), 0)",
+            "sum_weighted_expansion_factor": "SUM( ((task.wallduration + task.waitduration) / task.wallduration) * task.node_count * COALESCE(${wallduration_case_statement}, 0))",
+            "sum_job_weights": "SUM(task.node_count * COALESCE(${wallduration_case_statement}, 0))"
+        },
+
+        "groupby": [
+            "${AGGREGATION_UNIT}_id",
+            "year",
+            "${AGGREGATION_UNIT}",
+            "piperson_organization_id",
+            "job_time_bucket_id",
+            "node_count",
+            "processor_count",
+            "person_id",
+            "resource_organization_id",
+            "person_organization_id",
+            "person_nsfstatuscode_id",
+            "record_resource_id",
+            "resourcetype_id",
+            "queue",
+            "fos_id",
+            "account_id",
+            "systemaccount_id",
+            "allocation_id",
+            "principalinvestigator_person_id"
+        ],
+
+        "joins": [
+            {
+                "name": "job_tasks",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "task"
+            },{
+                "name": "job_records",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "record",
+                "on": "record.job_record_id = task.job_record_id",
+                "type": "STRAIGHT"
+            },{
+                "name": "resourcefact",
+                "schema": "${UTILITY_SCHEMA}",
+                "alias": "requested_resource",
+                "on": "requested_resource.id = record.resource_id"
+            },{
+                "name": "resourcefact",
+                "schema": "${UTILITY_SCHEMA}",
+                "alias": "task_resource",
+                "on": "task_resource.id = task.resource_id"
+            }            
+        ],
+
+        "where": [
+            "task.start_day_id <= ${:PERIOD_END_DAY_ID} AND task.end_day_id >= ${:PERIOD_START_DAY_ID}",
+	        "task.is_deleted = 0"
+        ],
+
+        "macros": [{
+            "name": "wallduration_case_statement",
+            "file": "statistic_ratio_case.sql",
+            "args": {
+                "statistic": "task.wallduration",
+                "max": "${:PERIOD_SECONDS}",
+                "src_start_ts": "task.start_time_ts",
+                "src_end_ts": "task.end_time_ts",
+                "dest_start_ts": "${:PERIOD_START_TS}",
+                "dest_end_ts": "${:PERIOD_END_TS}"
+            }
+        },{
+            "name": "local_charge_xdsu_case_statement",
+            "file": "statistic_ratio_as_datatype_case.sql",
+            "args": {
+                "data_type": "DECIMAL(18,3)",
+                "statistic": "task.local_charge_xdsu",
+                "max": "${:PERIOD_SECONDS}",
+                "src_start_ts": "task.start_time_ts",
+                "src_end_ts": "task.end_time_ts",
+                "dest_start_ts": "${:PERIOD_START_TS}",
+                "dest_end_ts": "${:PERIOD_END_TS}"
+            }
+        }]
+    }
+}


### PR DESCRIPTION
Move ETLv2 job ingest/aggregation files from xdmod-xsede to xdmod repo as a foundation for Open XDMoD cloud development.

See ubccr/xdmod-xsede#17

## Motivation and Context
These files are no longer XSEDE-specific.

## Tests performed
Re-built code and ran XSEDE job ingestion.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Maintenance

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
