### PR TITLE
Remove ETL specific filter_var fix and use new fix in xd_utilities

### DIFF
--- a/classes/ETL/Aggregator/AggregatorOptions.php
+++ b/classes/ETL/Aggregator/AggregatorOptions.php
@@ -166,5 +166,4 @@ class AggregatorOptions extends aOptions
         $this->options[$property] = $value;
         return $this;
     }  // __set()
-
 }  // class AggregatorOptions

--- a/classes/ETL/Aggregator/AggregatorOptions.php
+++ b/classes/ETL/Aggregator/AggregatorOptions.php
@@ -114,7 +114,7 @@ class AggregatorOptions extends aOptions
             case 'optimize_query':
             case 'disable_keys':
                 $origValue = $value;
-                $value = \ETL\Utilities::filterBooleanVar($value);
+                $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                 if ( null === $value ) {
                     $msg = get_class($this) . ": '$property' must be a boolean (type = " . gettype($origValue) . ")";
                     throw new Exception($msg);

--- a/classes/ETL/DbEntity/Column.php
+++ b/classes/ETL/DbEntity/Column.php
@@ -107,7 +107,7 @@ implements iTableItem
                 // "NO"
                 $tmp = strtolower($value);
                 $tmp = ( "null" == $tmp ? true : $tmp );
-                $value = $value = \ETL\Utilities::filterBooleanVar($value);
+                $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                 break;
 
             case 'extra':

--- a/classes/ETL/DbEntity/Column.php
+++ b/classes/ETL/DbEntity/Column.php
@@ -16,8 +16,7 @@ namespace ETL\DbEntity;
 use \Log;
 use \stdClass;
 
-class Column extends aNamedEntity
-implements iTableItem
+class Column extends aNamedEntity implements iTableItem
 {
     // Column type (free-form string)
     private $type = null;
@@ -265,10 +264,10 @@ implements iTableItem
                 if ( null !== $destExtra ) {
                     // Extra has changed (destination has a value)
                     return -1;
-                } else if ( null === $destDefault ) {
+                } elseif ( null === $destDefault ) {
                     // Default has changed from NULL to something
                     return -1;
-                } else if ( strtolower($srcDefault) != strtolower($destDefault)
+                } elseif ( strtolower($srcDefault) != strtolower($destDefault)
                             && ( ("0" == "$srcDefault" && '0000-00-00 00:00:00' != $destDefault)
                                  || ("0" != "$srcDefault" && $srcDefault . ' 00:00:00' != $destDefault) ) )
                 {
@@ -285,7 +284,7 @@ implements iTableItem
             if ( null !== $srcDefault && null !== $srcExtra ) {
                 if ( strtolower($srcExtra) != strtolower($destExtra) ) {
                     return -1;
-                } else if ( strtolower($srcDefault) != strtolower($destDefault)
+                } elseif ( strtolower($srcDefault) != strtolower($destDefault)
                             && ( ("0" == "$srcDefault" && '0000-00-00 00:00:00' != $destDefault)
                                  || ("0" != "$srcDefault" && $srcDefault . ' 00:00:00' != $destDefault)) )
                 {
@@ -396,11 +395,11 @@ implements iTableItem
                  "x'" == substr($this->default, 0, 2) ||
                  "X'" == substr($this->default, 0, 2) ) {
                 $parts[] = "DEFAULT " . $this->default;
-            } else if ( ($this->nullable && null === $this->default) ) {
+            } elseif ( ($this->nullable && null === $this->default) ) {
                 $parts[] = "DEFAULT NULL";
             } elseif (is_bool($this->default)) {
                 $parts[] = "DEFAULT " . ($this->default ? "TRUE" : "FALSE");
-            } else if ( "'" == substr( $this->default, 0, 1) && "'" == substr( $this->default, -1) ) {
+            } elseif ( "'" == substr($this->default, 0, 1) && "'" == substr($this->default, -1) ) {
                 $parts[] = "DEFAULT " . addslashes($this->default);
             }
             else {
@@ -475,5 +474,4 @@ implements iTableItem
         return $data;
 
     }  // toJsonObj()
-
 }  // class Column

--- a/classes/ETL/EtlOverseerOptions.php
+++ b/classes/ETL/EtlOverseerOptions.php
@@ -400,7 +400,7 @@ class EtlOverseerOptions extends Loggable implements \Iterator
     {
         if ( null === $date ) {
             $this->lastModifiedStartDate = null;
-        } else if ( false === ( $ts = strtotime($date)) ) {
+        } elseif ( false === ( $ts = strtotime($date)) ) {
             $msg = get_class($this) . ": Could not parse last modified start date '$date'";
             throw new Exception($msg);
         } else {
@@ -435,7 +435,7 @@ class EtlOverseerOptions extends Loggable implements \Iterator
     {
         if ( null === $date ) {
             $this->lastModifiedEndDate = null;
-        } else if ( false === ( $ts = strtotime($date)) ) {
+        } elseif ( false === ( $ts = strtotime($date)) ) {
             $msg = get_class($this) . ": Could not parse last modified start date '$date'";
             throw new Exception($msg);
         } else {
@@ -877,5 +877,4 @@ class EtlOverseerOptions extends Loggable implements \Iterator
 
         $this->etlPeriodChunkList = $chunkList;
     }  // generateEtlChunkList()
-
 }  // class EtlOverseerOptions

--- a/classes/ETL/EtlOverseerOptions.php
+++ b/classes/ETL/EtlOverseerOptions.php
@@ -568,7 +568,7 @@ class EtlOverseerOptions extends Loggable implements \Iterator
     public function setForce($flag = true)
     {
         $origFlag = $flag;
-        $flag = Utilities::filterBooleanVar($flag);
+        $flag = \xd_utilities\filter_var($flag, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         if ( null === $flag ) {
             $msg = get_class($this) . ": Force flag is not a boolean: '$origFlag'";
             throw new Exception($msg);
@@ -599,7 +599,7 @@ class EtlOverseerOptions extends Loggable implements \Iterator
     public function setDryrun($flag = true)
     {
         $origFlag = $flag;
-        $flag = Utilities::filterBooleanVar($flag);
+        $flag = \xd_utilities\filter_var($flag, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         if ( null === $flag ) {
             $msg = get_class($this) . ": Dryrun flag is not a boolean: '$origFlag'";
             throw new Exception($msg);
@@ -630,7 +630,7 @@ class EtlOverseerOptions extends Loggable implements \Iterator
     public function setVerbose($flag = true)
     {
         $origFlag = $flag;
-        $flag = Utilities::filterBooleanVar($flag);
+        $flag = \xd_utilities\filter_var($flag, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         if ( null === $flag ) {
             $msg = get_class($this) . ": Verbose flag is not a boolean: '$origFlag'";
             throw new Exception($msg);

--- a/classes/ETL/Ingestor/IngestorOptions.php
+++ b/classes/ETL/Ingestor/IngestorOptions.php
@@ -167,5 +167,4 @@ class IngestorOptions extends aOptions
         $this->options[$property] = $value;
         return $this;
     }  // __set()
-
 }  // class IngestorOptions

--- a/classes/ETL/Ingestor/IngestorOptions.php
+++ b/classes/ETL/Ingestor/IngestorOptions.php
@@ -118,7 +118,7 @@ class IngestorOptions extends aOptions
             case 'ignore_source':
             case 'force_load_data_infile_replace_into':
                 $origValue = $value;
-                $value = \ETL\Utilities::filterBooleanVar($value);
+                $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                 if ( null === $value ) {
                     $msg = get_class($this) . ": '$property' must be a boolean (type = " . gettype($origValue) . ")";
                     throw new Exception($msg);

--- a/classes/ETL/Maintenance/MaintenanceOptions.php
+++ b/classes/ETL/Maintenance/MaintenanceOptions.php
@@ -56,26 +56,26 @@ class MaintenanceOptions extends aOptions
 
         switch ( $property ) {
 
-        case 'enabled':
-        case 'stop_on_exception':
-        case 'truncate_destination':
-            $origValue = $value;
-            $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-            if ( null === $value ) {
-                $msg = get_class($this) . ": '$property' must be a boolean (type = " . gettype($origValue) . ")";
-                throw new Exception($msg);
-            }
-            break;
+            case 'enabled':
+            case 'stop_on_exception':
+            case 'truncate_destination':
+                $origValue = $value;
+                $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                if ( null === $value ) {
+                    $msg = get_class($this) . ": '$property' must be a boolean (type = " . gettype($origValue) . ")";
+                    throw new Exception($msg);
+                }
+                break;
 
-        case 'paths':
-            if ( ! is_object($value) ) {
-                $msg = get_class($this) . ": paths must be an object";
-                throw new Exception($msg);
-            }
-            break;
+            case 'paths':
+                if ( ! is_object($value) ) {
+                    $msg = get_class($this) . ": paths must be an object";
+                    throw new Exception($msg);
+                }
+                break;
 
-        default:
-            break;
+            default:
+                break;
         }
 
         $this->verifyProperty($property, $value);
@@ -83,5 +83,4 @@ class MaintenanceOptions extends aOptions
         $this->options[$property] = $value;
         return $this;
     }  // __set()
-
 }  // class MaintenanceOptions

--- a/classes/ETL/Maintenance/MaintenanceOptions.php
+++ b/classes/ETL/Maintenance/MaintenanceOptions.php
@@ -60,7 +60,7 @@ class MaintenanceOptions extends aOptions
         case 'stop_on_exception':
         case 'truncate_destination':
             $origValue = $value;
-            $value = \ETL\Utilities::filterBooleanVar($value);
+            $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
             if ( null === $value ) {
                 $msg = get_class($this) . ": '$property' must be a boolean (type = " . gettype($origValue) . ")";
                 throw new Exception($msg);

--- a/classes/ETL/aOptions.php
+++ b/classes/ETL/aOptions.php
@@ -142,7 +142,7 @@ abstract class aOptions extends \stdClass
             case 'truncate_destination':
             case 'stop_on_exception':
                 $origValue = $value;
-                $value = Utilities::filterBooleanVar($value);
+                $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                 if ( null === $value ) {
                     $msg = get_class($this) . ": '$property' must be a boolean (type = " . gettype($origValue) . ")";
                     throw new Exception($msg);

--- a/libraries/utilities.php
+++ b/libraries/utilities.php
@@ -556,7 +556,15 @@ EOF;
 }
 
 /**
- * A temporary shim function to use while our supported PHP version is < 5.4.8
+ * A temporary shim function to use while our supported PHP version is < 5.4.8 because 5.3
+ * incorrectly returns NULL in the following case:
+ *
+ * filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)
+ *
+ * See
+ * https://bugs.php.net/bug.php?id=49510 and
+ * http://php.net/manual/en/function.filter-var.php and
+ * http://stackoverflow.com/questions/9132274/php-validation-booleans-using-filter-var
  *
  * @param mixed $value to be filtered
  * @param int $filter the type of filter to apply
@@ -564,7 +572,10 @@ EOF;
  * @return bool|mixed false if the value is logically false, else the results of
  * \filter_var($value, $filter, $options)
  */
+
 function filter_var($value, $filter = FILTER_DEFAULT, $options = null)
 {
-    return ( false === $value ? false : \filter_var($value, $filter, $options) );
+    return ( FILTER_VALIDATE_BOOLEAN == $filter && false === $value
+             ? false
+             : \filter_var($value, $filter, $options) );
 }


### PR DESCRIPTION
## Description

@ryanrath added a fix for the PHP 5.3 filter_var bug in xd_utilities. Remove the ETL specific filter_var fix and use new fix in xd_utilities. Also added a test for the specific case where filter_var() fails.

## Motivation and Context
Cleaner code

## Tests performed
Re-ran ETLv2 after changes were made.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
