### PR TITLE
Added PHP dependancies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,14 @@ may be found [here][repo-format]. Once you have made the desired changes, run
 ### Dependencies
 
   - [PHP](https://secure.php.net/)
-    * php-curl (Ubuntu: php7.0-curl)
-    * php-gmp (Ubuntu: php-gmp)
+  - PHP Extension Packages
+    - CentOS 6
+      - `php-xml`
+    - CentOS 7
+      - None
+    - Ubuntu 16.04
+      - `php-curl`
+      - `php-gmp`
   - [Composer](https://getcomposer.org/)
   - [PEAR](https://pear.php.net/)
   - [PEAR Log Module](https://pear.php.net/package/Log/)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ may be found [here][repo-format]. Once you have made the desired changes, run
 ### Dependencies
 
   - [PHP](https://secure.php.net/)
+    * php-curl (Ubuntu: php7.0-curl)
+    * php-gmp (Ubuntu: php-gmp)
   - [Composer](https://getcomposer.org/)
   - [PEAR](https://pear.php.net/)
   - [PEAR Log Module](https://pear.php.net/package/Log/)


### PR DESCRIPTION
XDMoD requires two additional PHP deps to build
These deps are required to build on Ubuntu.

Until those deps are pulled in by one of the build tools, we should specify those in the README.