### PR TITLE
Fixed non-aggregate metrics being allowed in aggregate datasets

### DIFF
--- a/classes/DataWarehouse/Data/ComplexDataset.php
+++ b/classes/DataWarehouse/Data/ComplexDataset.php
@@ -2,6 +2,8 @@
 
 namespace DataWarehouse\Data;
 
+use Exception;
+
 /**
  * Models a dataset comprised of multiple x and y axes.
  *
@@ -76,9 +78,16 @@ class ComplexDataset
 
             try {
                 $stat = $query_classname::getStatistic($data_description->metric);
-                $metrics[$stat->getLabel(false)] = $stat->getInfo();
+                $statLabel = $stat->getLabel(false);
+                $metrics[$statLabel] = $stat->getInfo();
             } catch (\Exception $ex) {
                 continue;
+            }
+
+            if (!$stat->usesTimePeriodTablesForAggregate()) {
+                throw new Exception(
+                    "Metric $statLabel cannot be used in aggregate form. Please switch to a timeseries chart or modify/delete the metric."
+                );
             }
 
             $query = new $query_classname(

--- a/classes/DataWarehouse/Data/ComplexDataset.php
+++ b/classes/DataWarehouse/Data/ComplexDataset.php
@@ -23,12 +23,12 @@ class ComplexDataset
 
     // --------------------------------------------------------------
     // init()
-    // Instantiate and set up each Query, then instantiate 
+    // Instantiate and set up each Query, then instantiate
     // its Simple*Dataset and add it to $this->_dataDescripters.
     //
     // Does not compute combined x axis. @refer getXAxis().
     // Now general for Simple or SimpleTimeseries Dataset types.
-    // 
+    //
     // Annotated with JMS notes from 29 Apr 2014
     //
     //  @param $startDate -- format YYYY-MM-DD
@@ -40,7 +40,7 @@ class ComplexDataset
     //
     //  @return array $globalFilterDescriptions -- Descriptions of the global filters
     //  @return array $yAxisArray  --  elided due to lack of interest, JMS
-    //  @return array $metrics -- name (key) and description (value) of data metric 
+    //  @return array $metrics -- name (key) and description (value) of data metric
     //  @return array $dimensions -- name (key) and description (value) of data dimension
     //  @return array $dataSources -- text data source name (key)
     // --------------------------------------------------------------
@@ -54,7 +54,9 @@ class ComplexDataset
     ) {
         // JMS: please improve this when possible.
         if ( !in_array($query_type, array('aggregate','timeseries') ) ) {
-            throw new \Exception( get_class($this)." unsupported query_type found: ".$query_type);
+            throw new \Exception(
+                get_class($this)." unsupported query_type found: ".$query_type
+            );
         }
 
         $globalFilterDescriptions = array();
@@ -66,14 +68,14 @@ class ComplexDataset
         foreach ($data_series as $data_description_index => $data_description) {
 
             // Determine query class, then instantiate it
-            // this is quite horrible, and I apologize, but it beats 900 lines of 
+            // this is quite horrible, and I apologize, but it beats 900 lines of
             // redundant code, no? --JMS
-            $query_classname = '\\DataWarehouse\\Query\\' . 
-                $data_description->realm .  '\\' . 
+            $query_classname = '\\DataWarehouse\\Query\\' .
+                $data_description->realm .  '\\' .
                 ( $query_type == "aggregate" ? "Aggregate" : "Timeseries");
 
             try {
-                $stat = $query_classname::getStatistic( $data_description->metric);
+                $stat = $query_classname::getStatistic($data_description->metric);
                 $metrics[$stat->getLabel(false)] = $stat->getInfo();
             } catch (\Exception $ex) {
                 continue;
@@ -136,7 +138,7 @@ class ComplexDataset
             // Create the Simple*Dataset; add to $this->_dataDescripters[]
             $this->addDataset($data_description, $query);
 
-        } // foreach ($data_series as $data_description_index => $data_description) 
+        } // foreach ($data_series as $data_description_index => $data_description)
 
         return array(
             $dimensions,
@@ -155,13 +157,13 @@ class ComplexDataset
     // @param data_description
     // @param query object
     // --------------------------------------------------------------
-    protected function addDataset( $data_description, $query ) 
+    protected function addDataset($data_description, $query)
     {
         // what type is this query?
         $query_type = $query->getQueryType();
 
-        $datasetClassname  
-            = $query_type == "aggregate" 
+        $datasetClassname
+            = $query_type == "aggregate"
             ? '\DataWarehouse\Data\SimpleDataset'
             : '\DataWarehouse\Data\SimpleTimeseriesDataset';
 
@@ -182,7 +184,9 @@ class ComplexDataset
     public function getTotalX() {
 
         if (!isset($this->_xAxisDataObject) )  {
-            throw new \Exception( get_class($this)." _xAxisDataObject not set; _totalX=". $this->_totalX );
+            throw new \Exception(
+                get_class($this)." _xAxisDataObject not set; _totalX=". $this->_totalX
+            );
         }
         return $this->_totalX;
     } // function getTotalX()
@@ -196,17 +200,19 @@ class ComplexDataset
 
         // TODO JMS note: I may want to be able to return 0 here..
         if (empty($this->_dataDescripters) )  {
-            throw new \Exception( get_class($this)." _dataDescripters array is empty" );
+            throw new \Exception(
+                get_class($this)." _dataDescripters array is empty"
+            );
         }
         return count($this->_dataDescripters);
     } // function getTotalDatasetCount()
 
     // ---------------------------------------------
     // setOrderBy()
-    // Set sort and order by for a single SimpleDataset. 
-    // These parameters are used to sort the store. 
+    // Set sort and order by for a single SimpleDataset.
+    // These parameters are used to sort the store.
     // This is called by init() for the ComplexDataset.
-    // 
+    //
     // @return Query
     // ---------------------------------------------
     protected function setOrderBy(&$data_description, &$query) {
@@ -215,9 +221,9 @@ class ComplexDataset
     } // function setOrderBy()
 
     // ---------------------------------------------------------------
-    // determineRoleParameters() 
-    // 
-    // Set role parameters for a single SimpleDataset. 
+    // determineRoleParameters()
+    //
+    // Set role parameters for a single SimpleDataset.
     //  Role parameters: grouped with global filters.
     //      User-added filters added to chart
     //      implicit role-associated filters
@@ -249,7 +255,7 @@ class ComplexDataset
                     $groupedRoleParameters[$global_filter->dimension_id][]
                         = $global_filter->value_id;
                 }
-            } // foreach ($global_filters...) 
+            } // foreach ($global_filters...)
         }
         return $groupedRoleParameters;
     } // function determineRoleParameters()
@@ -258,7 +264,7 @@ class ComplexDataset
     // --------------------------------------------------------------
     // getXAxis()
     //
-    // Interleave the x axes for the multiple SimpleDatasets that 
+    // Interleave the x axes for the multiple SimpleDatasets that
     // constitute this ComplexDataset. Assumes init() has been called.
     // Call this function prior to determining $this->_totalX.
     //
@@ -276,7 +282,7 @@ class ComplexDataset
 
         // init() should be called before this function.
         if (!isset($this->_dataDescripters) )  {
-            throw new \Exception( get_class($this)." _dataDescripters not set" );
+            throw new \Exception(get_class($this)." _dataDescripters not set");
         }
 
         if (!isset($this->_xAxisDataObject) || $force_reexec === true) {
@@ -326,26 +332,30 @@ class ComplexDataset
             } // foreach ($this->_dataDescripters ... )
 
             // set the _xAxisDataObject. Since this is Aggregate data it is a dimension not a metric
-            $this->_xAxisDataObject = new \DataWarehouse\Data\SimpleData('','dim');
-            $this->_xAxisDataObject->setUnit( 'X Axis' );
+            $this->_xAxisDataObject = new \DataWarehouse\Data\SimpleData('', 'dim');
+            $this->_xAxisDataObject->setUnit('X Axis');
 
-            // tempXDataObject contains properly sorted values. 
+            // tempXDataObject contains properly sorted values.
             $sortedVals = $this->sortTempXArray($sort_type, $tempXDataObject);
-            $this->_xAxisDataObject->setValues(  $sortedVals );
+            $this->_xAxisDataObject->setValues($sortedVals);
 
             // Determine total number of points on x axis:
             $this->_totalX = $this->_xAxisDataObject->getCount();
 
             // Assign name for x axis from the names of constituent datasets:
-            $this->_xAxisDataObject->setName(implode(' / ',array_unique($names)));
+            $this->_xAxisDataObject->setName(implode(' / ', array_unique($names)));
 
-        } // if (!isset($this->_xAxisDataObject) || $force_reexec === true) 
+        } // if (!isset($this->_xAxisDataObject) || $force_reexec === true)
 
         // Slice array according to supplied limit and offset, reset count:
-        $this->_xAxisDataObject->setValues( array_slice($this->_xAxisDataObject->getValues(), 
-                                                        $offset, 
-                                                        $limit) );
-        $this->_xAxisDataObject->getCount( true );
+        $this->_xAxisDataObject->setValues(
+            array_slice(
+                $this->_xAxisDataObject->getValues(),
+                $offset,
+                $limit
+            )
+        );
+        $this->_xAxisDataObject->getCount(true);
 
         return $this->_xAxisDataObject;
     } // function getXAxis
@@ -353,7 +363,7 @@ class ComplexDataset
     // --------------------------------------------------------------
     // sortTempXArray()
     // Given a sort type (value or label, asc or desc) and a temp data object
-    // consisting of array of x values, order ids, and y values, return a 
+    // consisting of array of x values, order ids, and y values, return a
     // sorted array of x values.
     //
     // @return array
@@ -369,7 +379,7 @@ class ComplexDataset
             $orders[$key] = $vArray['order'];
         }
 
-        // sort the x axis values as specified 
+        // sort the x axis values as specified
         switch ($sort_type) {
             case 'value_asc':
                 array_multisort(
@@ -409,21 +419,21 @@ class ComplexDataset
         }
 
         return $labels;
-    } // function sortTempXArray() 
+    } // function sortTempXArray()
 
 
     // --------------------------------------------------------------
     // getYAxis()
-    // 
-    //    @return array 
+    //
+    //    @return array
     //          $returnYAxis[$yAxisIndex] = $yAxisObject;
-    //    containing yAxisObjects. 
+    //    containing yAxisObjects.
     //
     //  Each element has format:
     //              $yAxisObject->series[] = array(
-    //                   'yAxisDataObject',      SimpleData 
-    //                   'data_description',     ...   ?? 
-    //                   'decimals',             integer 
+    //                   'yAxisDataObject',      SimpleData
+    //                   'data_description',     ...   ??
+    //                   'decimals',             integer
     //                   'semDecimals',          integer
     //                   'filterParametersTitle' string??
     //                );
@@ -443,10 +453,8 @@ class ComplexDataset
 
         // For each item on the _dataDescripters array, generate an axisId (name)
         // and push the dataset onto a yAxisArray. If shared y axis, push onto
-        // subarray. 
-        foreach ( $this->_dataDescripters
-            as $data_description_index => $dataDescripterAndDataset
-        ) {
+        // subarray.
+        foreach ($this->_dataDescripters as $data_description_index => $dataDescripterAndDataset) {
             $data_description = $dataDescripterAndDataset->data_description;
 
             $query_classname
@@ -475,7 +483,7 @@ class ComplexDataset
         } // foreach _dataDescripter ... => dataDescripterAndDataset
 
         $returnYAxis = array();
-        foreach ( array_values($yAxisArray) as $yAxisIndex => $yAxisDataDescriptions) 
+        foreach ( array_values($yAxisArray) as $yAxisIndex => $yAxisDataDescriptions)
         {
 
             // build up a default class structure and accumulate values inside it:
@@ -532,7 +540,9 @@ class ComplexDataset
                         = ' {' . $filterParametersTitle . '}';
                 }
 
-                if ($this->_xAxisDataObject->getCount() <= 0) { continue; }
+                if ($this->_xAxisDataObject->getCount() <= 0) {
+                    continue;
+                }
 
                 $newValues = array_fill(
                     0,
@@ -567,7 +577,7 @@ class ComplexDataset
                         true
                     );
 
-                    if ($found !== FALSE) {
+                    if ($found !== false) {
                         $newValues[$found] = $yAxisDataObject->getValue($xIndex);
                         $xIds[$found]      = $subXAxisObject->getId($xIndex);
                         $xValues[$found]   = $subXAxisObject->getValue($xIndex);
@@ -597,7 +607,7 @@ class ComplexDataset
                 $decimals = $statisticObject->getDecimals();
 
                 $yAxisObject->decimals = max($yAxisObject->decimals, $decimals);
-                $yAxisDataObject->setValues ( $newValues );
+                $yAxisDataObject->setValues($newValues);
 
                 // following used only to id drilldown for pie charts. (!!)
                 $yAxisDataObject->setXIds($xIds);
@@ -631,9 +641,8 @@ class ComplexDataset
             } // foreach ($yAxisDataDescriptions as $dataDescripterAndDataset) {
 
             $returnYAxis[$yAxisIndex] = $yAxisObject;
-        } // foreach ( array_values($yAxisArray) ... => $yAxisDataDescriptions) 
+        } // foreach ( array_values($yAxisArray) ... => $yAxisDataDescriptions)
 
         return $returnYAxis;
     } // getYAxis()
 } // class ComplexDataset
-

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageCPUHoursStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageCPUHoursStatistic.php
@@ -12,12 +12,19 @@ class AverageCPUHoursStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
     public function __construct($query_instance = null)
     {
-        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-        parent::__construct('coalesce(sum(jf.cpu_time/3600.0)/sum(jf.'.$job_count_formula.'),0)', 'avg_cpu_hours', 'CPU Hours: Per Job', 'CPU Hour', 2);
+        parent::__construct('coalesce(sum(jf.cpu_time/3600.0)/sum(jf.running_job_count),0)', 'avg_cpu_hours', 'CPU Hours: Per Job', 'CPU Hour', 2);
     }
 
     public function getInfo()
     {
         return 'The average CPU hours (number of CPU cores x wall time hours) per '.ORGANIZATION_NAME.' job.<br/>For each job, the CPU usage is aggregated. For example, if a job used 1000 CPUs for one minute, it would be aggregated as 1000 CPU minutes or 16.67 CPU hours.';
+    }
+
+    /**
+     * @see DataWarehouse\Query\Statistic
+     */
+    public function usesTimePeriodTablesForAggregate()
+    {
+        return false;
     }
 }

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageCPUHoursStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageCPUHoursStatistic.php
@@ -1,25 +1,23 @@
 <?php
 namespace DataWarehouse\Query\Jobs\Statistics;
 
-/* 
+/*
 * @author Amin Ghadersohi
 * @date 2011-Feb-07
 *
-* class for calculating the average  cpu hours 
+* class for calculating the average  cpu hours
 */
 
 class AverageCPUHoursStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
-	public function __construct($query_instance = NULL)
-	{
-		$job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-		parent::__construct('coalesce(sum(jf.cpu_time/3600.0)/sum(jf.'.$job_count_formula.'),0)', 'avg_cpu_hours', 'CPU Hours: Per Job', 'CPU Hour',2);
-	}
-	
-	public function getInfo()
-	{
-		return 'The average CPU hours (number of CPU cores x wall time hours) per '.ORGANIZATION_NAME.' job.<br/>For each job, the CPU usage is aggregated. For example, if a job used 1000 CPUs for one minute, it would be aggregated as 1000 CPU minutes or 16.67 CPU hours.';
-	}
+    public function __construct($query_instance = null)
+    {
+        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
+        parent::__construct('coalesce(sum(jf.cpu_time/3600.0)/sum(jf.'.$job_count_formula.'),0)', 'avg_cpu_hours', 'CPU Hours: Per Job', 'CPU Hour', 2);
+    }
+
+    public function getInfo()
+    {
+        return 'The average CPU hours (number of CPU cores x wall time hours) per '.ORGANIZATION_NAME.' job.<br/>For each job, the CPU usage is aggregated. For example, if a job used 1000 CPUs for one minute, it would be aggregated as 1000 CPU minutes or 16.67 CPU hours.';
+    }
 }
- 
-?>

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageNodeHoursStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageNodeHoursStatistic.php
@@ -12,9 +12,8 @@ class AverageNodeHoursStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
     public function __construct($query_instance = null)
     {
-        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
         parent::__construct(
-            'coalesce(sum(jf.node_time/3600.0)/sum(jf.'.$job_count_formula.'),0)',
+            'coalesce(sum(jf.node_time/3600.0)/sum(jf.running_job_count),0)',
             'avg_node_hours',
             'Node Hours: Per Job',
             'Node Hour',
@@ -25,5 +24,13 @@ class AverageNodeHoursStatistic extends \DataWarehouse\Query\Jobs\Statistic
     public function getInfo()
     {
         return 'The average node hours (number of nodes x wall time hours) per '.ORGANIZATION_NAME.' job.';
+    }
+
+    /**
+     * @see DataWarehouse\Query\Statistic
+     */
+    public function usesTimePeriodTablesForAggregate()
+    {
+        return false;
     }
 }

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageNodeHoursStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageNodeHoursStatistic.php
@@ -1,26 +1,29 @@
 <?php
 namespace DataWarehouse\Query\Jobs\Statistics;
 
-/* 
+/*
 * @author Amin Ghadersohi
 * @date 2013-8-29
 *
-* class for calculating the average node hours 
+* class for calculating the average node hours
 */
 
 class AverageNodeHoursStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
-	public function __construct($query_instance = NULL)
-	{
-		$job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-		parent::__construct('coalesce(sum(jf.node_time/3600.0)/sum(jf.'.$job_count_formula.'),0)', 
-							'avg_node_hours', 'Node Hours: Per Job', 'Node Hour',2);
-	}
-	
-	public function getInfo()
-	{
-		return 'The average node hours (number of nodes x wall time hours) per '.ORGANIZATION_NAME.' job.';
-	}
+    public function __construct($query_instance = null)
+    {
+        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
+        parent::__construct(
+            'coalesce(sum(jf.node_time/3600.0)/sum(jf.'.$job_count_formula.'),0)',
+            'avg_node_hours',
+            'Node Hours: Per Job',
+            'Node Hour',
+            2
+        );
+    }
+
+    public function getInfo()
+    {
+        return 'The average node hours (number of nodes x wall time hours) per '.ORGANIZATION_NAME.' job.';
+    }
 }
- 
-?>

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageProcessorCountStatistic.php
@@ -12,13 +12,20 @@ class AverageProcessorCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
     public function __construct($query_instance = null)
     {
-        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-        parent::__construct('coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.'),0)', 'avg_processors', 'Job Size: Per Job', 'Core Count', 1);
+        parent::__construct('coalesce(sum(jf.processors*jf.running_job_count)/sum(jf.running_job_count),0)', 'avg_processors', 'Job Size: Per Job', 'Core Count', 1);
     }
 
     public function getInfo()
     {
         return  "The average job size per  ".ORGANIZATION_NAME." job.<br>
         <i>Job Size: </i>The number of processor cores used by a (parallel) job.";
+    }
+
+    /**
+     * @see DataWarehouse\Query\Statistic
+     */
+    public function usesTimePeriodTablesForAggregate()
+    {
+        return false;
     }
 }

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageProcessorCountStatistic.php
@@ -1,26 +1,24 @@
 <?php
 namespace DataWarehouse\Query\Jobs\Statistics;
 
-/* 
+/*
 * @author Amin Ghadersohi
 * @date 2011-Feb-07
 *
-* class for calculating the average processor count 
+* class for calculating the average processor count
 */
 
 class AverageProcessorCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
-	public function __construct($query_instance = NULL)
-	{
-		$job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-		parent::__construct('coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.'),0)', 'avg_processors', 'Job Size: Per Job', 'Core Count',1);
-	}
+    public function __construct($query_instance = null)
+    {
+        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
+        parent::__construct('coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.'),0)', 'avg_processors', 'Job Size: Per Job', 'Core Count', 1);
+    }
 
-	public function getInfo()
-	{
-		return 	"The average job size per  ".ORGANIZATION_NAME." job.<br>
-		<i>Job Size: </i>The number of processor cores used by a (parallel) job.";
-	}
+    public function getInfo()
+    {
+        return  "The average job size per  ".ORGANIZATION_NAME." job.<br>
+        <i>Job Size: </i>The number of processor cores used by a (parallel) job.";
+    }
 }
- 
-?>

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageWallHoursStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageWallHoursStatistic.php
@@ -12,13 +12,20 @@ class AverageWallHoursStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
     public function __construct($query_instance = null)
     {
-        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-        parent::__construct('coalesce(sum(jf.wallduration/3600.0)/sum(jf.'.$job_count_formula.'),0)', 'avg_wallduration_hours', 'Wall Hours: Per Job', 'Hour', 2);
+        parent::__construct('coalesce(sum(jf.wallduration/3600.0)/sum(jf.running_job_count),0)', 'avg_wallduration_hours', 'Wall Hours: Per Job', 'Hour', 2);
     }
 
     public function getInfo()
     {
         return  "The average time, in hours, a ".ORGANIZATION_NAME." job takes to execute.<br/>
         <i>Wall Time:</i> Wall time is defined as the linear time between start and end time of execution for a particular job.";
+    }
+
+    /**
+     * @see DataWarehouse\Query\Statistic
+     */
+    public function usesTimePeriodTablesForAggregate()
+    {
+        return false;
     }
 }

--- a/classes/DataWarehouse/Query/Jobs/Statistics/AverageWallHoursStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/AverageWallHoursStatistic.php
@@ -1,26 +1,24 @@
 <?php
 namespace DataWarehouse\Query\Jobs\Statistics;
 
-/* 
+/*
 * @author Amin Ghadersohi
 * @date 2011-Feb-07
 *
-* class for calculating the average wall duration in hours 
+* class for calculating the average wall duration in hours
 */
 
 class AverageWallHoursStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
-	public function __construct($query_instance = NULL)
-	{
-		$job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-		parent::__construct('coalesce(sum(jf.wallduration/3600.0)/sum(jf.'.$job_count_formula.'),0)', 'avg_wallduration_hours', 'Wall Hours: Per Job' , 'Hour',2);
-	}
+    public function __construct($query_instance = null)
+    {
+        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
+        parent::__construct('coalesce(sum(jf.wallduration/3600.0)/sum(jf.'.$job_count_formula.'),0)', 'avg_wallduration_hours', 'Wall Hours: Per Job', 'Hour', 2);
+    }
 
-	public function getInfo()
-	{
-		return 	"The average time, in hours, a ".ORGANIZATION_NAME." job takes to execute.<br/>
-		<i>Wall Time:</i> Wall time is defined as the linear time between start and end time of execution for a particular job.";
-	}
+    public function getInfo()
+    {
+        return  "The average time, in hours, a ".ORGANIZATION_NAME." job takes to execute.<br/>
+        <i>Wall Time:</i> Wall time is defined as the linear time between start and end time of execution for a particular job.";
+    }
 }
- 
-?>

--- a/classes/DataWarehouse/Query/Jobs/Statistics/NormalizedAverageProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/NormalizedAverageProcessorCountStatistic.php
@@ -12,13 +12,20 @@ class NormalizedAverageProcessorCountStatistic extends \DataWarehouse\Query\Jobs
 {
     public function __construct($query_instance = null)
     {
-        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-        parent::__construct('100.0*coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.')/(select sum(rrf.processors) from modw.resourcespecs rrf where find_in_set(rrf.resource_id,group_concat(distinct jf.resource_id)) <> 0 and '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts >= rrf.start_date_ts and (rrf.end_date_ts is null or '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts <= rrf.end_date_ts)),0)', 'normalized_avg_processors', 'Job Size: Normalized', '% of Total Cores', 1);
+        parent::__construct('100.0*coalesce(sum(jf.processors*jf.running_job_count)/sum(jf.running_job_count)/(select sum(rrf.processors) from modw.resourcespecs rrf where find_in_set(rrf.resource_id,group_concat(distinct jf.resource_id)) <> 0 and '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts >= rrf.start_date_ts and (rrf.end_date_ts is null or '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts <= rrf.end_date_ts)),0)', 'normalized_avg_processors', 'Job Size: Normalized', '% of Total Cores', 1);
     }
 
     public function getInfo()
     {
         return  "The percentage average size ".ORGANIZATION_NAME." job over total machine cores.<br>
         <i>Normalized Job Size: </i>The percentage total number of processor cores used by a (parallel) job over the total number of cores on the machine.";
+    }
+
+    /**
+     * @see DataWarehouse\Query\Statistic
+     */
+    public function usesTimePeriodTablesForAggregate()
+    {
+        return false;
     }
 }

--- a/classes/DataWarehouse/Query/Jobs/Statistics/NormalizedAverageProcessorCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/NormalizedAverageProcessorCountStatistic.php
@@ -1,26 +1,24 @@
 <?php
 namespace DataWarehouse\Query\Jobs\Statistics;
 
-/* 
+/*
 * @author Amin Ghadersohi
 * @date 2011-Feb-07
 *
-* class for calculating the normalized average processor count 
+* class for calculating the normalized average processor count
 */
 
 class NormalizedAverageProcessorCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
-	public function __construct($query_instance = NULL)
-	{
-		$job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
-		parent::__construct('100.0*coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.')/(select sum(rrf.processors) from modw.resourcespecs rrf where find_in_set(rrf.resource_id,group_concat(distinct jf.resource_id)) <> 0 and '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts >= rrf.start_date_ts and (rrf.end_date_ts is null or '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts <= rrf.end_date_ts)),0)', 'normalized_avg_processors', 'Job Size: Normalized', '% of Total Cores',1);
-	}
+    public function __construct($query_instance = null)
+    {
+        $job_count_formula = $query_instance->getQueryType() == 'aggregate'?'job_count':'running_job_count';
+        parent::__construct('100.0*coalesce(sum(jf.processors*jf.'.$job_count_formula.')/sum(jf.'.$job_count_formula.')/(select sum(rrf.processors) from modw.resourcespecs rrf where find_in_set(rrf.resource_id,group_concat(distinct jf.resource_id)) <> 0 and '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts >= rrf.start_date_ts and (rrf.end_date_ts is null or '.$query_instance->getAggregationUnit()->getUnitName().'_end_ts <= rrf.end_date_ts)),0)', 'normalized_avg_processors', 'Job Size: Normalized', '% of Total Cores', 1);
+    }
 
-	public function getInfo()
-	{
-		return 	"The percentage average size ".ORGANIZATION_NAME." job over total machine cores.<br>
-		<i>Normalized Job Size: </i>The percentage total number of processor cores used by a (parallel) job over the total number of cores on the machine.";
-	}
+    public function getInfo()
+    {
+        return  "The percentage average size ".ORGANIZATION_NAME." job over total machine cores.<br>
+        <i>Normalized Job Size: </i>The percentage total number of processor cores used by a (parallel) job over the total number of cores on the machine.";
+    }
 }
- 
-?>

--- a/classes/DataWarehouse/Query/Jobs/Statistics/RunningJobCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/RunningJobCountStatistic.php
@@ -23,4 +23,12 @@ class RunningJobCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
     {
         return true;
     }
+
+    /**
+     * @see DataWarehouse\Query\Statistic
+     */
+    public function usesTimePeriodTablesForAggregate()
+    {
+        return false;
+    }
 }

--- a/classes/DataWarehouse/Query/Jobs/Statistics/RunningJobCountStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/RunningJobCountStatistic.php
@@ -1,7 +1,7 @@
 <?php
 namespace DataWarehouse\Query\Jobs\Statistics;
 
-/* 
+/*
 * @author Amin Ghadersohi
 * @date 2011-Feb-07
 *
@@ -9,19 +9,18 @@ namespace DataWarehouse\Query\Jobs\Statistics;
 */
 class RunningJobCountStatistic extends \DataWarehouse\Query\Jobs\Statistic
 {
-	public function __construct($query_instance = NULL)
-	{
-		parent::__construct('coalesce(sum(jf.running_job_count),0)', 'running_job_count', 'Number of Jobs Running', 'Number of Jobs',0); 
-	}
+    public function __construct($query_instance = null)
+    {
+        parent::__construct('coalesce(sum(jf.running_job_count),0)', 'running_job_count', 'Number of Jobs Running', 'Number of Jobs', 0);
+    }
 
-	public function getInfo()
-	{
-		return 	"The total number of running ".ORGANIZATION_NAME." jobs.<br/>
-		<i>Job: </i>A scheduled process for a computer resource in a batch processing environment.";
-	}
-	public function isVisible()
-	{
-		return true;
-	}
+    public function getInfo()
+    {
+        return  "The total number of running ".ORGANIZATION_NAME." jobs.<br/>
+        <i>Job: </i>A scheduled process for a computer resource in a batch processing environment.";
+    }
+    public function isVisible()
+    {
+        return true;
+    }
 }
-?>

--- a/classes/DataWarehouse/Query/Statistic.php
+++ b/classes/DataWarehouse/Query/Statistic.php
@@ -275,4 +275,19 @@ abstract class Statistic extends \DataWarehouse\Query\Model\FormulaField
     {
         return null;
     }
+
+    /**
+     * Indicates if this statistic can use tables where data is rolled up
+     * by time period to perform the calculation for an aggregate chart.
+     *
+     * Returns true unless overriden. Subclasses should override this to return
+     * false if their calculations require access to raw data and cannot be
+     * perfomed using data that has been rolled up by fixed time periods.
+     *
+     * @return bool
+     */
+    public function usesTimePeriodTablesForAggregate()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
## Description
This pull request prevents metrics that cannot be accurately calculated from data that has been aggregated by fixed time periods from appearing in aggregate charts and datasets.

In the Metric Explorer, attempting to use one of these metrics on an aggregate chart will result in an error suggesting that the chart be switched to timeseries or that the metric in question be modified or deleted. In the Usage tab, since the only available option for any given chart is to switch to a timeseries chart, this is done automatically.

## Motivation and Context
XDMoD should not be displaying data that isn't being calculated correctly. These metrics could be calculated correctly over arbitrary time periods if access to the raw data were readily available. However, getting access may require extensive rework, and this solves the issue in the short term.

## Tests performed
I manually tested tabs with charts using Chrome to ensure modified metrics still worked and did not display in aggregate form. I also ran automated UI tests with Firefox and found no new regressions.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
