### PR TITLE
Add a development tools directory

### DIFF
--- a/tools/dev/verify_table_data.php
+++ b/tools/dev/verify_table_data.php
@@ -1,0 +1,533 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Verify the structure and data in multiple tables. Useful for verifying ETL changes.
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ */
+
+require __DIR__ . '/../../configuration/linker.php';
+restore_exception_handler();
+
+use CCR\Log;
+use CCR\DB;
+
+// ==========================================================================================
+// Script options with defaults
+
+// Allow initialization of some options from the configuration file
+
+$scriptOptions = array(
+    // Tables for comparison
+    'compare-tables'   => array(),
+    // Configuration section to use when connecting to the database
+    'database-config'  => "datawarehouse",
+    // Destination table schema, defaults to source table schema if not set
+    'dest-schema'      => null,
+    // Exclude these columns from tables
+    'exclude-columns'  => array(),
+    // Map these column names from source to destination tables
+    'map-columns'      => array(),
+    // Number of missing rows to display, all rows if NULL
+    'num-missing-rows' => null,
+    // Source table schema
+    'source-schema'    => null,
+    // Apply where clauses to query
+    'wheres'           => array(),
+    'verbosity'        => Log::NOTICE
+);
+
+// ==========================================================================================
+// Process command line arguments
+
+$options = array(
+    'h'   => 'help',
+    'c:'  => 'database-config:',
+    'd:'  => 'dest-schema:',
+    'n:'  => 'num-missing-rows:',
+    's:'  => 'source-schema:',
+    't:'  => 'table:',
+    'v:'  => 'verbosity:',
+    'w:'  => 'where:',
+    'x:'  => 'exclude-column:'
+    );
+
+$args = getopt(implode('', array_keys($options)), $options);
+
+foreach ($args as $arg => $value) {
+    switch ($arg) {
+
+        case 'c':
+        case 'database-config':
+            $scriptOptions['database-config'] = $value;
+            break;
+
+        case 'd':
+        case 'dest-schema':
+            $scriptOptions['dest-schema'] = $value;
+            break;
+
+        case 'n':
+        case 'num-missing-rows':
+            $scriptOptions['num-missing-rows'] = $value;
+            break;
+
+        case 's':
+        case 'source-schema':
+            $scriptOptions['source-schema'] = $value;
+            break;
+
+        case 't':
+        case 'table':
+            $value = ( is_array($value) ? $value : array($value) );
+            foreach ( $value as $option ) {
+                $parts = explode('=', $option);
+                if ( 1 == count($parts) ) {
+                    $scriptOptions['compare-tables'][] = array($parts[0], $parts[0]);
+                } elseif ( 2 == count($parts) ) {
+                    $scriptOptions['compare-tables'][] = array($parts[0], $parts[1]);
+                } else {
+                    usage_and_exit("Tables must be in the form 'table' or 'source_table=dest_table'");
+                }
+            }
+            break;
+
+        case 'x':
+        case 'exclude-column':
+            // Merge array because long and short options are grouped separately
+            $scriptOptions['exclude-columns'] = array_merge(
+                $scriptOptions['exclude-columns'],
+                ( is_array($value) ? $value : array($value) )
+            );
+            break;
+
+        case 'w':
+        case 'where':
+            // Merge array because long and short options are grouped separately
+            $scriptOptions['wheres'] = array_merge(
+                $scriptOptions['wheres'],
+                ( is_array($value) ? $value : array($value) )
+            );
+            break;
+
+        case 'v':
+        case 'verbosity':
+            switch ( $value ) {
+                case 'debug':
+                    $scriptOptions['verbosity'] = Log::DEBUG;
+                    break;
+                case 'info':
+                    $scriptOptions['verbosity'] = Log::INFO;
+                    break;
+                case 'notice':
+                    $scriptOptions['verbosity'] = Log::NOTICE;
+                    break;
+                case 'warning':
+                    $scriptOptions['verbosity'] = Log::WARNING;
+                    break;
+                case 'quiet':
+                    $scriptOptions['verbosity'] = Log::EMERG;
+                    break;
+                default:
+                    usage_and_exit("Invalid verbosity level: $value");
+                    break;
+            }  // switch ( $value )
+            break;
+
+        case 'h':
+        case 'help':
+            usage_and_exit();
+            break;
+
+        default:
+            usage_and_exit("Invalid option: $arg");
+            break;
+    }
+}  // foreach ($args as $arg => $value)
+
+if ( null === $scriptOptions['source-schema'] ) {
+    usage_and_exit("Source schema not specified");
+}
+
+if ( 0 == count($scriptOptions['compare-tables']) ) {
+    usage_and_exit("No tables specified for comparison");
+}
+
+if ( null === $scriptOptions['dest-schema'] ) {
+    $scriptOptions['dest-schema'] = $scriptOptions['source-schema'];
+}
+
+// ------------------------------------------------------------------------------------------
+// Set up the logger
+
+$conf = array(
+    'mail' => false
+);
+
+if ( null !== $scriptOptions['verbosity'] ) {
+    $conf['consoleLogLevel'] = $scriptOptions['verbosity'];
+}
+
+$logger = Log::factory('ETLv2', $conf);
+
+try {
+    $dbh = DB::factory($scriptOptions['database-config']);
+} catch (Exception $e) {
+    exit("Error connecting to database: " . $e->getMessage() . "\n");
+}
+
+// ------------------------------------------------------------------------------------------
+// Verify the tables
+
+$success = true;
+
+foreach ($scriptOptions['compare-tables'] as $table ) {
+
+    list($srcTable, $destTable) = $table;
+    $retval = compareTables($srcTable, $destTable);
+    $success = $success && $retval;
+}
+
+exit($success ? 0 : 1);
+
+/* ------------------------------------------------------------------------------------------
+ * Compare the structure and contents of 2 tables.
+ * -------------------------------------------------------------------------------------------
+ */
+
+function compareTables($srcTable, $destTable)
+{
+    global $scriptOptions, $logger;
+
+    $srcSchema = $scriptOptions['source-schema'];
+    $destSchema = $scriptOptions['dest-schema'];
+
+    // Tables may already contain a schema specification. If it does, override the defdault schema.
+
+    if ( false !== strpos($srcTable, '.') ) {
+        $parts = explode('.', $srcTable);
+        if ( 2 != count($parts) ) {
+            $logger->err("Too many dots in source table name: '$srcTable'");
+            return false;
+        }
+        list($srcSchema, $srcTable) = $parts;
+    }
+
+    if ( false !== strpos($destTable, '.') ) {
+        $parts = explode('.', $destTable);
+        if ( 2 != count($parts) ) {
+            $logger->err("Too many dots in destination table name: '$destTable'");
+            return false;
+        }
+        list($destSchema, $destTable) = $parts;
+    }
+
+    $qualifiedSrcTable = sprintf("%s.%s", $srcSchema, $srcTable);
+    $qualifiedDestTable = sprintf("%s.%s", $destSchema, $destTable);
+    $logger->notice(sprintf("Compare tables src=%s, dest=%s", $qualifiedSrcTable, $qualifiedDestTable));
+    if ( 0 != count($scriptOptions['exclude-columns']) ) {
+        $logger->info("Exclude columns: " . implode(', ', $scriptOptions['exclude-columns']));
+    }
+
+    if ( $qualifiedSrcTable == $qualifiedDestTable ){
+        $logger->warning(sprintf(
+            "Cannot compare a table to itself: %s.%s == %s.%s",
+            $qualifiedSrcTable,
+            $qualifiedDestTable
+        ));
+        return false;
+    }
+
+    // Verify number and type of columns
+
+    $srcTableColumns = getTableColumns($srcTable, $srcSchema, $scriptOptions['exclude-columns']);
+    $destTableColumns = getTableColumns($destTable, $destSchema, $scriptOptions['exclude-columns']);
+    $numSrcColumns = count($srcTableColumns);
+    $numDestColumns = count($destTableColumns);
+
+    if ( $numSrcColumns != $numDestColumns ) {
+        $logger->err(sprintf(
+            "Column number mismatch %s (%d); dest %s (%d)",
+            $qualifiedSrcTable,
+            $numSrcColumns,
+            $qualifiedDestTable,
+            $numDestColumns
+        ));
+        $missing = array_diff(array_keys($srcTableColumns), array_keys($destTableColumns));
+        if ( 0 != count($missing) ) {
+            $logger->err(sprintf("%s missing columns: %s", $qualifiedDestTable, implode(', ', $missing)));
+        }
+        return false;
+    }
+
+    $logger->info(sprintf("%d columns", $numSrcColumns));
+
+    $mismatch = false;
+    foreach ( $srcTableColumns as $k => $v ) {
+        if ( ! array_key_exists($k, $destTableColumns) ) {
+            $logger->warning(
+                sprintf("Dest missing %s type=%s key=%s", $k, $v['type'], $v['key_type'])
+            );
+            $mismatch = true;
+        } elseif ( $v != $destTableColumns[$k] ) {
+            $logger->err(sprintf(
+                "Column mismatch %s: src type = %s key = %s, dest type = %s key = %s",
+                $k,
+                $v['type'],
+                $v['key_type'],
+                $destTableColumns[$k]['type'],
+                $destTableColumns[$k]['key_type']
+            ));
+            $mismatch = true;
+        }
+    }
+    if ( $mismatch ) {
+        return false;
+    }
+
+    $numSrcRows = getTableRows($srcTable, $srcSchema);
+    $numDestRows = getTableRows($destTable, $destSchema);
+    $logger->info(sprintf(
+        "Row counts: %s = %s; %s = %s",
+        $qualifiedSrcTable,
+        number_format($numSrcRows),
+        $qualifiedDestTable,
+        number_format($numDestRows)
+    ));
+
+    return compareTableData(
+        $srcTable,
+        $destTable,
+        $srcSchema,
+        $destSchema,
+        array_keys($srcTableColumns),
+        array_keys($destTableColumns)
+    );
+
+}  // compareTables()
+
+/* ------------------------------------------------------------------------------------------
+ * Query the information schema for table column information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+function getTableColumns($table, $schema, array $excludeColumns)
+{
+    global $dbh, $logger;
+    $tableName = "`$schema`.`$table`";
+
+    $where = array(
+        "table_schema = :schema",
+        "table_name = :tablename",
+    );
+
+    if ( 0 != count($excludeColumns) ) {
+        $excludeColumns = array_map(
+            function ($c) {
+                return "'$c'";
+            },
+            $excludeColumns
+        );
+        $where[] = "column_name NOT IN (" . implode(',', $excludeColumns) . ")";
+    }
+
+    $sql = "SELECT
+column_name as name,
+column_type as type,
+column_key as key_type
+FROM information_schema.columns
+" . ( 0 != count($where) ? "WHERE " . implode(' AND ', $where) : "" ) ."
+ORDER BY ordinal_position ASC";
+
+    $params = array(
+        ":schema" => $schema,
+        ":tablename"  => $table
+    );
+
+    try {
+        $stmt = $dbh->prepare($sql);
+        $stmt->execute($params);
+    } catch ( Exception $e ) {
+        $logger->err("Error retrieving column names for '$tableName': " . $e->getMessage());
+        exit();
+    }
+
+    $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if ( 0 == count($result) ) {
+        $logger->err("Table '$tableName' does not exist");
+        exit();
+    }
+
+    $retval = array();
+
+    foreach ( $result as $row) {
+        $retval[$row['name']] = $row;
+    }
+
+    // Sort the columns because there is no guarantee the order they are returned
+    ksort($retval);
+
+    return $retval;
+}  // getTableColumns()
+
+/* ------------------------------------------------------------------------------------------
+ * Query the information schema for the number of table rows
+ * -------------------------------------------------------------------------------------------
+ */
+
+function getTableRows($table, $schema)
+{
+    global $dbh, $logger;
+    $tableName = "`$schema`.`$table`";
+
+    $where = array(
+        "table_schema = :schema",
+        "table_name = :tablename",
+    );
+
+    $sql = "SELECT
+table_rows
+FROM information_schema.tables
+" . ( 0 != count($where) ? "WHERE " . implode(' AND ', $where) : "" );
+
+    $params = array(
+        ":schema" => $schema,
+        ":tablename"  => $table
+    );
+
+    try {
+        $stmt = $dbh->prepare($sql);
+        $stmt->execute($params);
+    } catch ( Exception $e ) {
+        $logger->err("Error retrieving table information for '$tableName': " . $e->getMessage());
+        exit();
+    }
+
+    $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if ( 0 == count($result) ) {
+        $logger->err("Table '$tableName' does not exist");
+        exit();
+    }
+
+    $row = array_shift($result);
+
+    return $row['table_rows'];
+
+}  // getTableRows()
+
+/* ------------------------------------------------------------------------------------------
+ * Compare the data in two tables
+ * -------------------------------------------------------------------------------------------
+ */
+
+function compareTableData(
+    $srcTable,
+    $destTable,
+    $srcSchema,
+    $destSchema,
+    array $srcTableColumns,
+    array $destTableColumns
+) {
+    global $dbh, $logger, $scriptOptions;
+    $srcTableName = "`$srcSchema`.`$srcTable`";
+    $destTableName = "`$destSchema`.`$destTable`";
+    $firstCol = current($srcTableColumns);
+
+    $constraints = array_map(
+        function ($c1, $c2) {
+            // Note the use of the null-safe operator <=>
+            return sprintf("src.%s <=> dest.%s", $c1, $c2);
+        },
+        $srcTableColumns,
+        $destTableColumns
+    );
+
+    $where = array(
+        "dest.$firstCol IS NULL"
+    );
+
+    if ( 0 != count($scriptOptions['wheres']) ) {
+        $where = array_merge($where, $scriptOptions['wheres']);
+    }
+
+    $sql = "
+SELECT src.*
+FROM $srcTableName src
+LEFT OUTER JOIN $destTableName dest ON (" . join(' AND ', $constraints) . ")
+" . ( 0 != count($where) ? "WHERE " . implode(' AND ', $where) : "" );
+
+    $logger->debug($sql);
+
+    $stmt = $dbh->prepare($sql);
+    $stmt->execute();
+    $numRows = $stmt->rowCount();
+
+    $rowsDisplayed = 0;
+    $rowsToDisplay = ( null === $scriptOptions['num-missing-rows'] ? PHP_INT_MAX : $scriptOptions['num-missing-rows'] );
+
+    if ( 0 != $numRows ) {
+        $logger->warning(sprintf("Missing %d rows in %s.%s", $numRows, $destTable, $destSchema));
+        while ( $rowsDisplayed < $rowsToDisplay && $row = $stmt->fetch(PDO::FETCH_ASSOC) ) {
+            $logger->warning(sprintf("Missing row: %s", print_r($row, 1)));
+            $rowsDisplayed++;
+        }
+    } else {
+        $logger->notice("Identical");
+    }
+
+    return (0 == $numRows);
+
+}  // compareTableData()
+
+/* ------------------------------------------------------------------------------------------
+ * Display usage text and exit with error status.
+ * ------------------------------------------------------------------------------------------
+ */
+
+function usage_and_exit($msg = null)
+{
+    global $argv, $scriptOptions;
+
+    if ($msg !== null) {
+        fwrite(STDERR, "\n$msg\n\n");
+    }
+
+    fwrite(
+        STDERR,
+        <<<"EOMSG"
+Usage: {$argv[0]}
+
+    -h, --help
+    Display this help
+
+    -c, --database-config
+    The portal_settings.ini section to use for database configuration parameters
+
+    -d, --dest-schema <destination_schema>
+    The schema for the destination tables. If not specified the source schema will be used.
+
+    -n, --num-missing-rows <number_of_rows>
+    Display this number of missing rows. If not specified, all missing rows are displayed.
+
+    -s, --source-schema <source_schema>
+    The schema for the source tables.
+
+    -t, --table <table_name>
+    -t, --table <source_table_name>=<dest_table_name>
+    A table to compare between the source and destination schemas. Use the 2nd form to specify different names for the source and destination tables. Table names may also include a schema designation, in which case the default schema will not be added. May be specified multiple times.
+
+    -w, --where <where_clause_fragment>
+    Add a WHERE clause to the table comparison. The table aliass "src" and "dest" refer to the source and destination tables, respectively.
+
+    -x, --exclude-column
+    Exclude this column from the comparison. May be specified multiple times.
+
+    -v, --verbosity {debug, info, notice, warning, quiet} [default notice]
+    Level of verbosity to output from the ETL process
+
+EOMSG
+    );
+
+    exit(1);
+}
+?>


### PR DESCRIPTION
Add a place to keep useful development tools.

## Description

The `verify_table_data.php` script is based on the script from @plessbd and @jpwhite4 but has been extended with features that were needed to make verification of ETL changes easier. This script compares 2 tables, first the structure and then the contents. The following checks are made and if any fail the table does not match:
1. The number of columns in both tables must be the same. If a column is excluded using `--exclude-column` then that column will not be used for the comparison.
2. The type and key type for each column must be the same
3. The data in the tables must be the same such that a left join of the source to the destination on all columns (except those that were explicitly excluded) does not return empty rows in the destination table.

```
Usage: ./tools/dev/verify_table_data.php

    -h, --help
    Display this help

    -c, --database-config
    The portal_settings.ini section to use for database configuration parameters

    -d, --dest-schema <destination_schema>
    The schema for the destination tables. If not specified the source schema will be used.

    -n, --num-missing-rows <number_of_rows>
    Display this number of missing rows. If not specified, all missing rows are displayed.

    -s, --source-schema <source_schema>
    The schema for the source tables.

    -t, --table <table_name>
    -t, --table <source_table_name>=<dest_table_name>
    A table to compare between the source and destination schemas. Use the 2nd form to specify different names for the source and destination tables. Table names may also include a schema designation, in which case the default schema will not be added. May be specified multiple times.

    -w, --where <where_clause_fragment>
    Add a WHERE clause to the table comparison. The table alias "src" and "dest" refer to the source and destination tables, respectively.

    -x, --exclude-column
    Exclude this column from the comparison. May be specified multiple times.

    -v, --verbosity {debug, info, notice, warning, quiet} [default notice]
    Level of verbosity to output from the ETL process
```

### Examples

An identical table.

```
php verify_table_data.php -s modw_baseline -d modw_etltest -v info -t resource_allocations

2017-03-27 09:43:22 [notice] Compare tables src=modw_baseline.resource_allocations, dest=modw_etltest.resource_allocations
2017-03-27 09:43:22 [info] 10 columns
2017-03-27 09:43:22 [info] Row counts: modw_baseline.resource_allocations = 468; modw_etltest.resource_allocations = 468
2017-03-27 09:43:22 [notice] Identical
```

Since the data between the baseline and test databases was ingested at different times, all of the `last_modified` values will be different.  Exclude this column and the tables are identical.

```
php verify_table_data.php -s modw_baseline -d modw_etltest -v info -n 1  -t job_records 
2017-03-27 15:15:58 [notice] Compare tables src=modw_baseline.job_records, dest=modw_etltest.job_records
2017-03-27 15:15:58 [info] 35 columns
2017-03-27 15:15:58 [info] Row counts: modw_baseline.job_records = 2,653,896; modw_etltest.job_records = 2,653,896
2017-03-27 15:16:39 [warning] Missing 2653896 rows in job_records.modw_etltest
2017-03-27 15:16:39 [warning] Missing row: Array
(
    [job_record_id] => 46843237
    [resource_id] => 2796
    [resourcetype_id] => 3
    [resource_state_id] => 6
    [resource_country_id] => 210
    [resource_organization_id] => 856
    [resource_organization_type_id] => 5
    [allocation_resource_id] => 2796
    [person_id] => 9967
    [person_organization_id] => 105
    [person_nsfstatuscode_id] => 11
    [account_id] => 4838
    [allocation_id] => 40599
    [request_id] => 20222
    [fos_id] => 71
    [principalinvestigator_person_id] => 172
    [piperson_organization_id] => 105
    [job_record_type_id] => 1
    [submission_venue_id] => 1
    [queue] => normal
    [submit_time_ts] => 1476344990
    [start_time_ts] => 1476345010
    [end_time_ts] => 1476345322
    [start_day_id] => 201600287
    [end_day_id] => 201600287
    [local_charge_su] => 4.000
    [adjusted_charge_su] => 4.000
    [local_charge_xdsu] => 19.728
    [adjusted_charge_xdsu] => 19.728
    [local_charge_nu] => 425.651
    [adjusted_charge_nu] => 425.651
    [conversion_factor] => 4.932
    [completed] => 1
    [last_modified] => 2017-03-24 16:23:43
    [is_deleted] => 0
)
```

```
php verify_table_data.php -s modw_baseline -d modw_etltest -v debug -x last_modified -n 1  -t job_records 
2017-03-27 15:18:37 [notice] Compare tables src=modw_baseline.job_records, dest=modw_etltest.job_records
2017-03-27 15:18:37 [info] Exclude columns: last_modified
2017-03-27 15:18:37 [info] 34 columns
2017-03-27 15:18:37 [info] Row counts: modw_baseline.job_records = 2,653,896; modw_etltest.job_records = 2,653,896
2017-03-27 15:18:37 [debug] 
SELECT src.*
FROM `modw_baseline`.`job_records` src
LEFT OUTER JOIN `modw_etltest`.`job_records` dest ON (src.account_id <=> dest.account_id AND src.adjusted_charge_nu <=> dest.adjusted_charge_nu AND src.adjusted_charge_su <=> dest.adjusted_charge_su AND src.adjusted_charge_xdsu <=> dest.adjusted_charge_xdsu AND src.allocation_id <=> dest.allocation_id AND src.allocation_resource_id <=> dest.allocation_resource_id AND src.completed <=> dest.completed AND src.conversion_factor <=> dest.conversion_factor AND src.end_day_id <=> dest.end_day_id AND src.end_time_ts <=> dest.end_time_ts AND src.fos_id <=> dest.fos_id AND src.is_deleted <=> dest.is_deleted AND src.job_record_id <=> dest.job_record_id AND src.job_record_type_id <=> dest.job_record_type_id AND src.local_charge_nu <=> dest.local_charge_nu AND src.local_charge_su <=> dest.local_charge_su AND src.local_charge_xdsu <=> dest.local_charge_xdsu AND src.person_id <=> dest.person_id AND src.person_nsfstatuscode_id <=> dest.person_nsfstatuscode_id AND src.person_organization_id <=> dest.person_organization_id AND src.piperson_organization_id <=> dest.piperson_organization_id AND src.principalinvestigator_person_id <=> dest.principalinvestigator_person_id AND src.queue <=> dest.queue AND src.request_id <=> dest.request_id AND src.resource_country_id <=> dest.resource_country_id AND src.resource_id <=> dest.resource_id AND src.resource_organization_id <=> dest.resource_organization_id AND src.resource_organization_type_id <=> dest.resource_organization_type_id AND src.resource_state_id <=> dest.resource_state_id AND src.resourcetype_id <=> dest.resourcetype_id AND src.start_day_id <=> dest.start_day_id AND src.start_time_ts <=> dest.start_time_ts AND src.submission_venue_id <=> dest.submission_venue_id AND src.submit_time_ts <=> dest.submit_time_ts)
WHERE dest.account_id IS NULL
2017-03-27 15:18:37 [notice] Identical
```
## Motivation and Context

Share tools that folks have created to make code development, testing, and verification easier.

## Tests performed

The `verify_table_data.php` script was used to test PR #77

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
