### PR TITLE
Fix exception throw in XdmodTestHelper

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/XdmodTestHelper.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/XdmodTestHelper.php
@@ -111,7 +111,7 @@ class XdmodTestHelper
     public function authenticate($userrole)
     {
         if (! isset($this->config['role'][$userrole])) {
-            throw \Exception("User role $userrole not defined in .secrets file");
+            throw new \Exception("User role $userrole not defined in .secrets file");
         }
 
         $this->setauthvariables(null);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
New keyword was omitted on exception invocation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Attempt to throw an exception was throwing an exception.

## Tests performed
Tested during development of integration tests for xdmod-supremm pull request 28 (https://github.com/ubccr/xdmod-supremm/pull/28/)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
