### PR TITLE
Fixed ETLv2 file endpoint verification

### DIFF
--- a/classes/ETL/DataEndpoint/File.php
+++ b/classes/ETL/DataEndpoint/File.php
@@ -123,8 +123,6 @@ implements iDataEndpoint
 
     public function verify($dryrun = false, $leaveConnected = false)
     {
-        parent::verify();
-
         $readModes = array("r", "r+", "w+", "a+", "x+", "c+");
         $writeModes = array("r+", "w", "w+", "a", "a+", "x", "x+", "c", "c+");
 


### PR DESCRIPTION
## Description
When `verify()` was consolidated into `initialize()` in `classes/ETL/aEtlObject.php`, the call to `verify()` from `classes/ETL/DataEndpoint/File.php` was not removed. When that call is made, the system crashes. This pull request removes that call from `File`.

## Motivation and Context
crashing bad. working good

## Tests performed
I performed this fix on a test instance that uses file endpoints and verified that it no longer crashed.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
