### PR TITLE
Changes to accompany issues found in OSG modifications

### DIFF
--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -503,23 +503,27 @@ class pdoAggregator extends aAggregator
 
         if ( null === $startDayIdField || null === $endDayIdField ) {
 
-            $t = Utilities::substituteVariables(
+            $fromTable = Utilities::substituteVariables(
                 $firstTable->getFullName(false),
                 $this->variableMap,
                 $this,
                 "Undefined macros found in FROM table name"
             );
 
-            $this->logger->debug("Discover table $t");
-            $firstTableDef = Table::discover($t, $this->sourceEndpoint, null, $this->logger);
+            $this->logger->debug("Discover table $fromTable");
+            $firstTableDef = Table::discover($fromTable, $this->sourceEndpoint, null, $this->logger);
 
             // If we are in dryrun mode the table may not have been created yet but we still want to
             // be able to display the generated queries so simply set the start and end day id
             // fields.
 
-            if ( false === $firstTableDef && $this->getEtlOverseerOptions()->isDryrun() ) {
-                $startDayIdField = "start_day_id";
-                $endDayIdField = "end_day_id";
+            if ( false === $firstTableDef ) {
+                if ( $this->getEtlOverseerOptions()->isDryrun() ) {
+                    $startDayIdField = "start_day_id";
+                    $endDayIdField = "end_day_id";
+                } else {
+                    $this->logAndThrowException("Table does not exist: $fromTable");
+                }
             } else {
 
                 $missing = array();

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -635,7 +635,7 @@ class pdoIngestor extends aIngestor
 
         $totalRecordsProcessed = $this->destinationHandle->execute($sql);
         $this->logger->info(
-            sprintf('%s: Processed %d records', get_class($this), number_format($totalRecordsProcessed))
+            sprintf('%s: Processed %s records', get_class($this), number_format($totalRecordsProcessed))
         );
 
         return $totalRecordsProcessed;
@@ -848,7 +848,7 @@ class pdoIngestor extends aIngestor
 
                 if (0 == $totalRecordsProcessed % self::NUM_RECORDS_PER_LOG_MSG) {
                     $this->logger->info(
-                        sprintf('%s: Processed %d records', get_class($this), number_format($totalRecordsProcessed))
+                        sprintf('%s: Processed %s records', get_class($this), number_format($totalRecordsProcessed))
                     );
                 }
 
@@ -858,7 +858,9 @@ class pdoIngestor extends aIngestor
                     foreach ( $loadStatementList as $etlTableKey => $loadStatement ) {
                         try {
                             $this->_dest_helper->executeStatement($loadStatement);
-                            $this->logger->debug("Loaded $numRecordsInFile records into '$etlTableKey'");
+                            $this->logger->debug(
+                                sprintf("Loaded %s records into '%s'", number_format($numRecordsInFile), $etlTableKey)
+                            );
 
                             // Clear the infile
 
@@ -887,7 +889,9 @@ class pdoIngestor extends aIngestor
             foreach ( $loadStatementList as $etlTableKey => $loadStatement ) {
                 try {
                     $this->_dest_helper->executeStatement($loadStatement);
-                    $this->logger->debug("Loaded $numRecordsInFile records into '$etlTableKey'");
+                    $this->logger->debug(
+                        sprintf("Loaded %s records into '%s'", number_format($numRecordsInFile), $etlTableKey)
+                    );
                 }
                 catch (Exception $e) {
                     $msg = array('message'    => $e->getMessage(),
@@ -906,8 +910,9 @@ class pdoIngestor extends aIngestor
             }  // foreach ( $this->etlDestinationTableList as $etlTableKey => $etlTable )
         }  // if ( $numRecordsInFile)
 
-        $msg = sprintf('%s: Processed %d records (%d source records)', get_class($this), $totalRecordsProcessed, $numSourceRecordsProcessed);
-        $this->logger->info($msg);
+        $this->logger->info(
+            sprintf('%s: Processed %s records (%s source records)', get_class($this), number_format($totalRecordsProcessed), number_format($numSourceRecordsProcessed))
+        );
 
         // Return buffering to its original state.  This is a MySQL specific optimization.
 

--- a/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
+++ b/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
@@ -158,18 +158,20 @@
                 "comment": "FACT: (seconds) The wallduration of the jobs that were running during this period. This will only count the walltime of the jobs that fell during this day. If a job started in the previous day(s) the wall time for that day will be added to that day. Same logic is true if a job ends not in this day, but upcoming days."
             },{
                 "name": "sum_wallduration_squared",
-                "type": "double",
+                "type": "decimal(36,4)",
                 "nullable": true,
                 "comment": "FACT: (seconds) The sum of the square of wallduration of the jobs that were running during this period. This will only count the walltime of the jobs that fell during this day. If a job started in the previous day(s) the wall time for that day will be added to that day. Same logic is true if a job ends not in this day, but upcoming days."
             },{
                 "name": "waitduration",
                 "type": "decimal(18,0)",
                 "nullable": true,
+                "default": null,
                 "comment": "FACT: (seconds) The amount of time jobs waited to execute during this day."
             },{
                 "name": "sum_waitduration_squared",
-                "type": "double",
+                "type": "decimal(36,4)",
                 "nullable": true,
+                "default": null,
                 "comment": "FACT: (seconds) The sum of the square of the amount of time jobs waited to execute during this day."
             },{
                 "name": "local_charge_su",
@@ -233,7 +235,7 @@
                 "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
             },{
                 "name": "sum_local_charge_xdsu_squared",
-                "type": "double",
+                "type": "decimal(36,4)",
                 "nullable": true,
                 "comment": "FACT: The sum of the square of local_charge of jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
             },{
@@ -243,7 +245,7 @@
                 "comment": "FACT: (seconds) The amount of the cpu time (processor_count * wallduration) of the jobs pertaining to this day. If a job took more than one day, its cpu_time is distributed linearly across the days it used."
             },{
                 "name": "sum_cpu_time_squared",
-                "type": "double",
+                "type": "decimal(36,4)",
                 "nullable": true,
                 "comment": "FACT: (seconds) The sum of the square of the amount of the cpu_time of the jobs pertaining to this day. If a job took more than one day, its cpu_time is distributed linearly across the days it used."
             },{
@@ -253,7 +255,7 @@
                 "comment": "FACT: (seconds) The amount of the node time (nodes * wallduration) of the jobs pertaining to this day. If a job took more than one day, its node_time is distributed linearly across the days it used."
             },{
                 "name": "sum_node_time_squared",
-                "type": "double",
+                "type": "decimal(36,4)",
                 "nullable": true,
                 "comment": "FACT: (seconds) The sum of the square of the amount of the node_time of the jobs pertaining to this day. If a job took more than one day, its node_time is distributed linearly across the days it used."
             },{
@@ -394,15 +396,15 @@
             "started_job_count": "SUM( IF(task.start_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, 1, 0) )",
             "running_job_count": "SUM(1)",
             "wallduration": "COALESCE(SUM( ${wallduration_case_statement}), 0)",
-            "sum_wallduration_squared": "COALESCE(SUM( pow(${wallduration_case_statement}, 2)), 0)",
-            "waitduration": "SUM( IF(task.start_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, task.waitduration, 0) )",
-            "sum_waitduration_squared": "SUM( IF(task.start_day_id = ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, pow(task.waitduration, 2), 0) )",
+            "sum_wallduration_squared": "COALESCE(SUM( CAST(POW(${wallduration_case_statement}, 2) AS DECIMAL(36,4)) ), 0)",
+            "waitduration": "SUM( IF(task.start_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, task.waitduration, NULL) )",
+            "sum_waitduration_squared": "SUM( CAST(IF(task.start_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, pow(task.waitduration, 2), NULL) AS DECIMAL(36,4)) )",
             "local_charge_xdsu": "SUM(${local_charge_xdsu_case_statement})",
-            "sum_local_charge_xdsu_squared": "SUM(pow(${local_charge_xdsu_case_statement}, 2))",
+            "sum_local_charge_xdsu_squared": "SUM( CAST(POW(${local_charge_xdsu_case_statement}, 2) AS DECIMAL(36,4)) )",
             "cpu_time": "COALESCE(SUM(task.processor_count * ${wallduration_case_statement}), 0)",
-            "sum_cpu_time_squared": "COALESCE(SUM(pow(task.processor_count * ${wallduration_case_statement}, 2)), 0)",
+            "sum_cpu_time_squared": "COALESCE(SUM( CAST(POW(task.processor_count * ${wallduration_case_statement}, 2) AS DECIMAL(36,4)) ), 0)",
             "node_time": "COALESCE(SUM(task.node_count * ${wallduration_case_statement}), 0)",
-            "sum_node_time_squared": "COALESCE(SUM( pow(task.node_count * ${wallduration_case_statement}, 2)), 0)",
+            "sum_node_time_squared": "COALESCE(SUM( CAST(POW(task.node_count * ${wallduration_case_statement}, 2) AS DECIMAL(36,4)) ), 0)",
             "sum_weighted_expansion_factor": "SUM( ((task.wallduration + task.waitduration) / task.wallduration) * task.node_count * COALESCE(${wallduration_case_statement}, 0))",
             "sum_job_weights": "SUM(task.node_count * COALESCE(${wallduration_case_statement}, 0))"
         },

--- a/tools/dev/verify_table_data.php
+++ b/tools/dev/verify_table_data.php
@@ -446,7 +446,7 @@ function compareTableData(
 
     $roundColumns = array();
     foreach ( $scriptOptions['round-columns'] as $column ) {
-        $parts = explode('=', $column);
+        $parts = explode(',', $column);
         $roundColumns[$parts[0]] = ( 2 == count($parts) ? $parts[1] : 0 );
     }
 
@@ -496,7 +496,7 @@ LEFT OUTER JOIN $destTableName dest ON (" . join("\nAND ", $constraints) . ")"
     $numRows = $stmt->rowCount();
 
     if ( 0 != $numRows ) {
-        $logger->warning(sprintf("Missing %d rows in %s.%s", $numRows, $destTable, $destSchema));
+        $logger->warning(sprintf("Missing %d rows in %s.%s", $numRows, $destSchema, $destTable));
         while ( $row = $stmt->fetch(PDO::FETCH_ASSOC) ) {
             $logger->warning(sprintf("Missing row: %s", print_r($row, 1)));
         }
@@ -541,7 +541,7 @@ Usage: {$argv[0]}
     -n, --num-missing-rows <number_of_rows>
     Display this number of missing rows. If not specified, all missing rows are displayed.
 
-    -r, --round-column <column>[=<digits>]
+        -r, --round-column <column>[,<digits>]
     Round the values in the specified column before comparing. If <digits> is specified round to that number of digits (default 0). This is useful when comparing doubles or values that have been computed and may differ in decimal precision.
 
     -s, --source-schema <source_schema>

--- a/tools/dev/verify_table_data.php
+++ b/tools/dev/verify_table_data.php
@@ -491,7 +491,7 @@ function compareTableData(
 SELECT src.*
 FROM $srcTableName src
 LEFT OUTER JOIN $destTableName dest ON (" . join("\nAND ", $constraints) . ")"
-        . ( 0 != count($where) ? "\nWHERE " . implode("\nAND", $where) : "" )
+        . ( 0 != count($where) ? "\nWHERE " . implode("\nAND ", $where) : "" )
         . ( null !== $scriptOptions['num-missing-rows']
             ? "\nLIMIT " . $scriptOptions['num-missing-rows']
             : "" );
@@ -551,7 +551,7 @@ Usage: {$argv[0]}
     -n, --num-missing-rows <number_of_rows>
     Display this number of missing rows. If not specified, all missing rows are displayed.
 
-        -r, --round-column <column>[,<digits>]
+    -r, --round-column <column>[,<digits>]
     Round the values in the specified column before comparing. If <digits> is specified round to that number of digits (default 0). This is useful when comparing doubles or values that have been computed and may differ in decimal precision.
 
     -s, --source-schema <source_schema>


### PR DESCRIPTION
Changes to accompany issues found in OSG modifications

See ubccr/xdmod-xsede#23

## Description

The aggregation query for job records and tasks now uses a datatype of `DECIMAL(36,4)` rather than `DOUBLE` for the `sum_wallduration_squared`, `sum_waitduration_squared`, `sum_cpu_time_squared`, `sum_local_charge_xdsu_squared`, and `sum_node_time_squared` columns. The waitduration has been defaulted to `NULL` to support cases when we do not have this information (e.g., OSG).

Several enhancements to the table comparison tool were made:
- Ability to ignore number of columns between source and destination tables. This is useful for comparing tables with added columns to baseline tables
- Ability to ignore column types between source and destination tables. This is useful for comparing data when migrating column types from `double` to `decimal(m,n)`
- Ability to round values during comparison, useful when comparing data that may differ in the number of significant digits

## Motivation and Context

When comparing new data as the result of a change to baseline data it is helpful to use the `DECIMAL(M,N)` data type rather than `DOUBLE` which may use approximate representation of floating point numbers. This makes data verification much easier.

## Tests performed

The XSEDE job pipeline was run before and after changes to the aggregation query. Running the table verificaiton tool, data was identical with the exception of cases where the baseline used an approximate representation of the data (e.g., `4.1038701667445064e16`). In these cases the squared values were off by up to .00000000000000017%

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement to existing functionality

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
