### PR TITLE
Fix misspelling of utility class name

### DIFF
--- a/classes/ETL/Maintenance/VerifyDatabase.php
+++ b/classes/ETL/Maintenance/VerifyDatabase.php
@@ -88,7 +88,7 @@ class VerifyDatabase extends aAction implements iAction
             'LAST_MODIFIED_END_DATE'
         );
 
-        $localVariableMap = Utility::quoteVariables($varsToQuote, $this->variableMap, $this->sourceEndpoint);
+        $localVariableMap = Utilities::quoteVariables($varsToQuote, $this->variableMap, $this->sourceEndpoint);
         $this->variableMap = array_merge($this->variableMap, $localVariableMap);
 
         // Our source query can be either a query specified directly in the definition file, or a


### PR DESCRIPTION
Fix misspelling of utility class name.

## Description

Fix misspelling of utility class name in `VerifyDatabase.php`

## Motivation and Context

Bugfix.

## Tests performed

```
$ php etl_overseer.php -c ../../../etc/etl/etl.json -a VerifyXsedeJobReporting -n 5 -v info
2017-04-05 09:15:06 [info] Command: 'etl_overseer.php' '-c' '../../../etc/etl/etl.json' '-a' 'VerifyXsedeJobReporting' '-n' '5' '-v' 'info'
2017-04-05 09:15:06 [notice] dw_extract_transform_load start (process_start_time: 2017-04-05 09:15:06)
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/action_state_setup.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/jobs_cloud.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/test_suite.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/accounts_realm.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/maintenance.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/resource_allocations.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/verify.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/osg.json
2017-04-05 09:15:06 [info] Loading configuration file /home/smgallo/xdmod-6.6-test/etc/etl/etl.d/jobs_hpc.json
2017-04-05 09:15:06 [info] Verifying endpoint: ('Utility DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-04-05 09:15:06 [info] Verifying endpoint: ('XDCDB accounting', class=ETL\DataEndpoint\Postgres, config=tgcdbmirror, schema=acct, host=128.205.41.164:5432, user=dtfpgadm)
2017-04-05 09:15:06 [info] Create action VerifyXsedeJobReporting (ETL\Maintenance\VerifyDatabase)
2017-04-05 09:15:06 [info] Parse definition file: '/home/smgallo/xdmod-6.6-test/etc/etl/etl_tables.d/verify/verify_job_reporting.json'
2017-04-05 09:15:06 [info] Verifying action: VerifyXsedeJobReporting (ETL\Maintenance\VerifyDatabase)
2017-04-05 09:15:06 [info] Obtaining lock file '/var/lock/xdmod/etlv2_11633'
2017-04-05 09:15:06 [info] start (action_name: VerifyXsedeJobReporting, action: VerifyXsedeJobReporting (ETL\Maintenance\VerifyDatabase), start_date: , end_date: )
2017-04-05 09:15:49 [info] 0 matches found
2017-04-05 09:15:49 [notice] (action: VerifyXsedeJobReporting (ETL\Maintenance\VerifyDatabase), start_time: 1491398106.2353, end_time: 1491398149.2519, elapsed_time: 43.01658)
2017-04-05 09:15:49 [info] end (action_name: VerifyXsedeJobReporting, action: VerifyXsedeJobReporting (ETL\Maintenance\VerifyDatabase))
2017-04-05 09:15:49 [info] Releasing lock '/var/lock/xdmod/etlv2_11633'
2017-04-05 09:15:49 [notice] dw_extract_transform_load end (process_end_time: 2017-04-05 09:15:49)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
