### PR TITLE
Fixed exception instantiations in BaseControllerProvider

### DIFF
--- a/classes/NewRest/Controllers/BaseControllerProvider.php
+++ b/classes/NewRest/Controllers/BaseControllerProvider.php
@@ -11,9 +11,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use DataWarehouse\Query\Exceptions\AccessDeniedException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 
 /**
@@ -223,7 +222,8 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      *                         missing.
      * @return \Symfony\Component\HttpFoundation\JsonResponse if and only if
      *                         the user is missing a token or an ip.
-     * @throws AccessDeniedException
+     *
+     * @throws Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      */
     public static function authenticate(Request $request, Application $app)
     {
@@ -234,7 +234,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
 
         $user = Authentication::authenticateUser($request);
         if ($user === null) {
-            throw new AccessDeniedException('You must be logged in to access this endpoint.', 401);
+            throw new UnauthorizedHttpException('xdmod', 'You must be logged in to access this endpoint.'); // 401 from framework
         } else {
             $request->attributes->set(BaseControllerProvider::_USER, $user);
         }
@@ -260,7 +260,9 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      *                        is false.
      * @return \XDUser The user that was checked and is authorized according to
      *                the given parameters.
-     * @throws AccessDeniedException
+     *
+     * @throws  Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
+     *          Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
     public function authorize(Request $request, array $requirements = null, $blacklist = false)
     {
@@ -283,9 +285,9 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
         // limits with their current permissions.
         if (!$success) {
             if ($user->isPublicUser()) {
-                throw new AccessDeniedException($message, 401);
+                throw new UnauthorizedHttpException('xdmod', $message); // 401 from framework
             } else {
-                throw new AccessDeniedHttpException($message, 403);
+                throw new AccessDeniedHttpException($message); // 403 from framework
             }
         }
 


### PR DESCRIPTION
Framework exceptions were being instantiated incorrectly (symfony). 

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
Some home-grown exceptions were also being thrown. These were replaced with Symfony framework exceptions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes bug; allows rest stack to throw exceptions.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Thoroughly exercised as part of https://github.com/ubccr/xdmod-supremm/pull/28 integration tests; working on unit test now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Caveats
Pull requests that depend on this fix are: 
- https://github.com/ubccr/xdmod-supremm/pull/28
- https://github.com/ubccr/xdmod/pull/73 (xdmod repo)
- https://github.com/ubccr/xdmod-appkernels/pull/12