### PR TITLE
Remove unused columns. Add resource restrictions to XSEDE job ingestor.

### DIFF
--- a/configuration/etl/etl.d/jobs_hpc.json
+++ b/configuration/etl/etl.d/jobs_hpc.json
@@ -120,6 +120,8 @@
             "enabled": true,
             "truncate_destination": false,
             "table_prefix": "jobfact_by_",
+            "#": "Be sure to exclude the same resources as the ingestor or their records will be deleted here",
+            "exclude_resource_codes": ["OSG", "TACC-WRANGLER"],
             "aggregation_units": ["day", "month", "quarter", "year"]
         }
     ]

--- a/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
+++ b/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
@@ -209,31 +209,6 @@
                 "nullable": true,
                 "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
             },{
-                "name": "task_local_charge_xdsu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_local_charge_nu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_adjusted_charge_su",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_adjusted_charge_xdsu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_adjusted_charge_nu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
                 "name": "sum_local_charge_xdsu_squared",
                 "type": "decimal(36,4)",
                 "nullable": true,


### PR DESCRIPTION
Remove unused columns. Add resource restrictions to XSEDE job ingestor.

## Description

Remove unused columns from XDCDB jobs aggregator. Add resource restrictions to HPC jobs aggregator so we don't remove those records from the aggregation table (i.e., OSG records are excluded from ingestion and are handled by their own ingestor so don't delete them from the aggregate table when handling the other HPC jobs).

## Motivation and Context

Keeping ETL configurations consistent.

## Tests performed

Re-ran ingestion.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
