### PR TITLE
Fix function signatures in child classes of GroupBy

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPI.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPI.php
@@ -152,7 +152,7 @@ class GroupByPI extends \DataWarehouse\Query\Jobs\GroupBy
 		return $parameters;*/
 	}
 	
-	public function getPossibleValues($hint = NULL, $limit = NULL, $offset = NULL, array $parameters = array())
+	public function getPossibleValues($hint = null, $limit = null, $offset = null, array $parameters = array(), $base_query = null, $filter = null)
 	{
 		if($this->_possible_values_query == NULL)
 		{

--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPerson.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPerson.php
@@ -136,9 +136,9 @@ class GroupByPerson extends \DataWarehouse\Query\Jobs\GroupBy
 							"select long_name as field_label from modw.person  where id in (_filter_) order by order_id");
 	}
 	
-	public function getPossibleValues($hint = NULL, $limit = NULL, $offset = NULL, array $parameters = array())
+	public function getPossibleValues($hint = null, $limit = null, $offset = null, array $parameters = array(), $base_query = null, $filter = null)
 	{
-		if($this->_possible_values_query == NULL)
+		if($this->_possible_values_query == null)
 		{
 			return array();
 		}

--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByUsername.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByUsername.php
@@ -150,7 +150,7 @@ class GroupByUsername extends \DataWarehouse\Query\Jobs\GroupBy
 		return $parameters;*/
 	}
 	
-	public function getPossibleValues($hint = NULL, $limit = NULL, $offset = NULL, array $parameters = array())
+	public function getPossibleValues($hint = null, $limit = null, $offset = null, array $parameters = array(), $base_query = null, $filter = null)
 	{
 		if($this->_possible_values_query == NULL)
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change fixes signatures for the function getPossibleValues() in the case of child classes that failed to specify default params matching that of their parent class (GroupBy.php).

## Motivation and Context
We do like consistency.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
