### PR TITLE
Improve handling of the "MySQL server has gone away" error

### DIFF
--- a/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
+++ b/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
@@ -75,7 +75,15 @@ abstract class aRdbmsEndpoint extends aDataEndpoint
         }
 
         // Since the name is arbitrary, do not use it for the unique key
-        $this->key = md5(implode($this->keySeparator, array($this->type, $this->config, $this->schema)));
+        $this->key = md5(implode(
+            $this->keySeparator,
+            array(
+                $this->type,
+                $this->config,
+                $this->schema,
+                $this->createSchemaIfNotExists
+            )
+        ));
 
     }  // __construct()
 

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -778,6 +778,8 @@ class pdoIngestor extends aIngestor
             $result = $this->sourceHandle->query(
                 "SHOW SESSION VARIABLES WHERE Variable_name = 'net_write_timeout'"
             );
+
+            $currentTimeout = 0;
             if ( 0 != count($result) ) {
                 $currentTimeout = $result[0]['Value'];
                 $this->logger->debug("Current net_write_timeout = $currentTimeout");

--- a/configuration/etl/etl.d/jobs_hpc.json
+++ b/configuration/etl/etl.d/jobs_hpc.json
@@ -120,6 +120,8 @@
             "enabled": true,
             "truncate_destination": false,
             "table_prefix": "jobfact_by_",
+            "#": "Be sure to exclude the same resources as the ingestor or their records will be deleted here",
+            "exclude_resource_codes": ["OSG", "TACC-WRANGLER"],
             "aggregation_units": ["day", "month", "quarter", "year"]
         }
     ]

--- a/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
+++ b/configuration/etl/etl_tables.d/jobs/jobfact_hpc_aggregation.json
@@ -209,31 +209,6 @@
                 "nullable": true,
                 "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
             },{
-                "name": "task_local_charge_xdsu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_local_charge_nu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_adjusted_charge_su",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of local SUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_adjusted_charge_xdsu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of XDSUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
-                "name": "task_adjusted_charge_nu",
-                "type": "decimal(18,0)",
-                "nullable": true,
-                "comment": "FACT: The amount of NUs charged to jobs pertaining to this day. If a job took more than one day, its local_charge is distributed linearly across the days it used."
-            },{
                 "name": "sum_local_charge_xdsu_squared",
                 "type": "decimal(36,4)",
                 "nullable": true,


### PR DESCRIPTION

## Description

On a busy server, it is possible that the mysql server will close the connection on us if we are using an unbuffered query and the loading of the data takes longer than the net_write_timeout (See https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_net_write_timeout)

This may happen using an unbuffered query because the server writes result data to the connection (presumably there is some buffer) and the client reads the data, transforms it, and adds it to a load file. When the number of records hits a threshold, the files are loaded and the process does not read from the connection during loading. If loading takes longer than the net_write_timeout, the server will close the connection on us. The client will read whatever is left in the result buffer and assume that all is well until another operation is attempted on the connection at which point we will get the ambiguous "MySQL server has gone away" error (see https://dev.mysql.com/doc/refman/5.7/en/gone-away.html).

Also added the `create_schema_if_not_exists` option to the generation of RDBMS data endpoint keys.

## Motivation and Context

ETL v2 hardening

## Tests performed

Completely re-ingested OSG data

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
