### PR TITLE
Add SUPReMM ETL framework to Open XDMoD package

### DIFF
--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -11,7 +11,6 @@
             "/composer.json",
             "/composer.lock",
             "/docs",
-            "/etl",
             "/html/gui/js/modules/Module.template",
             "/logs",
             "/phpcs.xml",
@@ -29,6 +28,7 @@
         "data": [
             "classes",
             "db",
+            "etl",
             "external_libraries",
             "html",
             "libraries",


### PR DESCRIPTION
The SUPReMM ETL framework was previously included in the SUPReMM Open
XDMoD module package.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes build configuration to include the SUPReMM ETL framework in the Open XDMoD package.

See ubccr/xdmod-supremm#40

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

What is referred to here as the SUPReMM ETL framework is not specific to SUPReMM and is considered part of the base Open XDMoD package.  Therefore, it should be packaged as such.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Installed Open XDMoD and the SUPReMM module before and after this change.  Compared both installations to ensure that all the same files are installed.  Also compared contents of tarballs before and after the changes to ensure the files were present where expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
