### PR TITLE
Remove auto_login option. Always prompt for login if login required.

### DIFF
--- a/classes/OpenXdmod/Migration/Version660ToVersion700/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version660ToVersion700/ConfigFilesMigration.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Jeffrey T. Palmer <jtpalmer@buffalo.edu>
+ */
+
+namespace OpenXdmod\Migration\Version660To700;
+
+use OpenXdmod\Migration\ConfigFilesMigration as AbstractConfigFilesMigration;
+
+/**
+ * Update config files from version 6.6.0 to 7.0.0.
+ */
+class ConfigFilesMigration extends AbstractConfigFilesMigration
+{
+    /**
+     * Execute the migration.
+     */
+    public function execute()
+    {
+        // Make sure all the config files that will be changed are writable.
+        $this->assertPortalSettingsIsWritable();
+
+        // Set new options in portal_settings.ini.
+        $this->writePortalSettingsFile();
+    }
+}

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -64,11 +64,6 @@ version = "v1"
 ;         * Apereo CAS
 basic_auth = "on"
 
-[auto_login]
-; tabs is a comma delimited list of tab ids that will trigger the login
-; page to show up if presented in an non-authenticated state.
-tabs = "app_kernels"
-
 [mailer]
 sender_name = "Open XDMoD Mailer"
 sender_email = ""

--- a/html/gui/general/login.php
+++ b/html/gui/general/login.php
@@ -375,16 +375,8 @@ $xsedeLogin = xd_utilities\getConfiguration('features', 'xsede') == 'on';
 
                         presentLoginResponse('Welcome, ' + Ext.util.Format.htmlEncode(data.results.name) + '.', true, "login_response");
 
-                        var token = CCR.tokenize(parent.XDMoD.referer);
-
-                        if (token && token.tab && parent.CCR.xdmod.tabs.indexOf(token.tab) >= 0) {
-                            parent.location.href = '../../index.php' + token.raw;
-                            parent.location.hash = token.raw;
-                        }
-                        else{
-                            parent.location.href = '../../index.php';
-                            parent.location.hash = '';
-                        }
+                        parent.location.href = '../../index.php' + parent.XDMoD.referer;
+                        parent.location.hash = parent.XDMoD.referer;
                         parent.location.reload();
                     } else {
                         XDMoD.TrackEvent('Login Window', 'Successful login', txtLoginUsername.getValue());

--- a/html/gui/js/Viewer.js
+++ b/html/gui/js/Viewer.js
@@ -444,6 +444,15 @@ Ext.extend(CCR.xdmod.ui.Viewer, Ext.Viewport, {
         //Conditionally present the profile if an e-mail address has not been set
         xsedeProfilePrompt();
 
+          // The login dialog is presented if the user is not logged in
+          // and the location requests an unavailable tab.
+          if (CCR.xdmod.publicUser && token.tab) {
+              var match = tabPanel.find('id', token.tab);
+              if (match.length === 0) {
+                  CCR.xdmod.ui.actionLogin();
+              }
+          }
+
         var hasToken = token && token.content && token.content.length > 2;
         var hasTabToken = tabToken && tabToken.length > 2;
         if (hasToken) {

--- a/html/index.php
+++ b/html/index.php
@@ -302,13 +302,6 @@
             }
             print "CCR.xdmod.use_captcha = " . $useCaptcha .";";
             if (!$userLoggedIn) {
-               $tabs = "";
-               try {
-                  $tabs =  xd_utilities\getConfiguration('auto_login', 'tabs');
-               } catch (exception $ex) {
-                  print "console.warn(\"" . $ex->getMessage() . "\");\n";
-               }
-               print "CCR.xdmod.tabs ='". $tabs ."';\n";
                $auth = null;
                try {
                   $auth = new Authentication\SAML\XDSamlAuthentication();
@@ -497,18 +490,6 @@
 
          <?php if (!$userLoggedIn): ?>
          Ext.onReady(xdmodviewer.init, xdmodviewer);
-
-         Ext.onReady(function() {
-            CCR.xdmod.tabs = CCR.xdmod.tabs.split(',');
-            var hash = document.location.hash;
-            var hasHash = hash !== null && hash !== undefined && hash !== '';
-            if (hasHash) {
-               var token = CCR.xdmod.ui.Viewer.viewerInstance.tokenize(hash);
-               if (token && token.tab && CCR.xdmod.tabs.indexOf(token.tab) >= 0) {
-                  CCR.xdmod.ui.actionLogin();
-               }
-            }
-         });
          <?php else: ?>
          <?php
             if (isset($_SESSION['cached_call']) && !empty($_SESSION['cached_call'])) {

--- a/templates/portal_settings.template
+++ b/templates/portal_settings.template
@@ -64,11 +64,6 @@ version = "[:rest_version:]"
 ;         * Apereo CAS
 basic_auth = "[:rest_basic_auth:]"
 
-[auto_login]
-; tabs is a comma delimited list of tab ids that will trigger the login
-; page to show up if presented in an non-authenticated state.
-tabs = "[:auto_login_tabs:]"
-
 [mailer]
 sender_name = "[:mailer_sender_name:]"
 sender_email = "[:mailer_sender_email:]"


### PR DESCRIPTION
## Description

The non-module-capable auto_login option is removed. The behaviour now
is that a login box is created if you try to browse to a tab that is
only available to logged in users.

## Motivation and Context

Preliminary changes to support deep linking into the job viewer.

## Tests performed

Yes
