### PR TITLE
Remove redundant tokenize code

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1357,94 +1357,33 @@ CCR.getParameter = function (name, source) {
             ? ""
             : decodeURIComponent(results[1].replace(/\+/g, " "));
 };
+/*
+ * Process the location hash string. The string should have the form:
+ *  PATH?PARAMS
+ *
+ * with an optional # prefix. PATH is a ':' delimited path leading to a component of the form
+ *   ROOT:TAB:SUBTAB
+ *
+ *  If the path only contains one entry then it is treated as
+ *   TAB
+ */
 CCR.tokenize = function (hash) {
-    var exists = CCR.exists;
-    var root, tab, params;
+    var matches = hash.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
 
-    function select(value, delimiter, index) {
-        if (exists(value) && exists(delimiter) && exists(index) &&
-                exists(value.indexOf) && typeof index === 'number' &&
-                index >= 0 && value.indexOf(delimiter) >= 0) {
-            return value.split(delimiter)[index];
-        } else {
-            return value;
-        }
+    var tokens = {
+        raw: hash,
+        content: matches[1],
+        root: matches[2],
+        tab: matches[3],
+        subtab: matches[4],
+        params: matches[5]
+    };
+    if (tokens.tab === '') {
+        // Support for legacy path syntax
+        tokens.tab = tokens.root;
+        tokens.root = '';
     }
-
-    function first(value, delimiter) {
-        return select(value, delimiter, 0);
-    }
-
-    function second(value, delimiter) {
-        return select(value, delimiter, 1);
-    }
-
-    if (exists(hash)) {
-        var tabDelimIndex = hash.indexOf(CCR.xdmod.ui.tokenDelimiter);
-        var paramDelimIndex = hash.indexOf('?');
-        var equalIndex = hash.indexOf('=');
-
-        var result = {
-            raw: hash,
-            content: second(hash, '#')
-        };
-
-        if (tabDelimIndex >= 0 && paramDelimIndex >= 0) {
-
-            // We have a well formed hash: parent:child?name=value...
-            root = first(
-                    first(result.content, CCR.xdmod.ui.tokenDelimiter)
-                    , '?'
-            );
-
-            tab = first(
-                    second(result.content, CCR.xdmod.ui.tokenDelimiter),
-                    '?'
-            );
-
-            params = second(result.content, '?');
-
-            if (params === result.content) {
-                params = '';
-            }
-
-            result['root'] = root;
-            result['tab'] = tab;
-            result['params'] = params;
-        } else if (tabDelimIndex < 0 && paramDelimIndex < 0 && equalIndex >= 0) {
-
-            // We have a hash that looks like: name=value
-            result['root'] = '';
-            result['tab'] = '';
-            result['params'] = result.content;
-        } else if (tabDelimIndex < 0 && paramDelimIndex < 0) {
-            result['root'] = '';
-            result['tab'] = result.content;
-            result['params'] = '';
-        } else if (tabDelimIndex >= 0 && paramDelimIndex < 0) {
-
-            // We have a hash that looks like: parent:child
-            root = first(result.content, CCR.xdmod.ui.tokenDelimiter);
-            tab = second(result.content, CCR.xdmod.ui.tokenDelimiter);
-            params = '';
-
-            result['root'] = root;
-            result['tab'] = tab;
-            result['params'] = params;
-        } else if (tabDelimIndex < 0 && paramDelimIndex >= 0) {
-
-            // We have a hash that looks like: child?name=value
-            root = '';
-            tab = first(result.content, '?');
-            params = second(result.content, '?');
-
-            result['root'] = root;
-            result['tab'] = tab;
-            result['params'] = params;
-        }
-        return result;
-    }
-    return {};
+    return tokens;
 };
 
 /**

--- a/html/gui/js/Viewer.js
+++ b/html/gui/js/Viewer.js
@@ -417,7 +417,7 @@ Ext.extend(CCR.xdmod.ui.Viewer, Ext.Viewport, {
 
         // DEFINE: the token that we came in with.
         var mainTabToken = 'main_tab_panel';
-        var token = CCR.tokenize(document.location.hash);
+          var token = CCR.tokenize(document.location.hash);
         var tabToken;
 
         for (var i = 0; i < tabs.length; i++) {

--- a/html/gui/js/Viewer.js
+++ b/html/gui/js/Viewer.js
@@ -417,7 +417,7 @@ Ext.extend(CCR.xdmod.ui.Viewer, Ext.Viewport, {
 
         // DEFINE: the token that we came in with.
         var mainTabToken = 'main_tab_panel';
-        var token = CCR.xdmod.ui.Viewer.viewerInstance.tokenize(document.location.hash);
+        var token = CCR.tokenize(document.location.hash);
         var tabToken;
 
         for (var i = 0; i < tabs.length; i++) {
@@ -471,117 +471,6 @@ Ext.extend(CCR.xdmod.ui.Viewer, Ext.Viewport, {
     CCR.xdmod.ui.Viewer.viewerInstance = this;
 
   }, //initComponent
-  tokenize: function(hash) {
-    if (hash !== undefined &&
-      hash !== null &&
-      typeof hash === 'string' &&
-      hash.length > 0) {
-
-      function first(value, delimiter) {
-        if (value !== null &&
-          value !== undefined &&
-          typeof value === 'string') {
-          if (value.indexOf(delimiter) >= 0) {
-            return value.split(delimiter)[0];
-          } else {
-            return value;
-          }
-        }
-        return value;
-      };
-
-      function second(value, delimiter) {
-        if (value !== null &&
-          value !== undefined &&
-          typeof value === 'string') {
-          if (value.indexOf(delimiter) >= 0) {
-            return value.split(delimiter)[1];
-          } else {
-            return value;
-          }
-        }
-        return value;
-      };
-
-      function third(value, delimiter) {
-        if (value !== null &&
-          value !== undefined &&
-          typeof value === 'string') {
-          if (value.indexOf(delimiter) >= 0 && value.lastIndexOf(delimiter) > value.indexOf(delimiter)) {
-            return value.split(delimiter)[2];
-          } else {
-            return value;
-          }
-        }
-        return value;
-      };
-
-      var tabDelimIndex = hash.indexOf(CCR.xdmod.ui.tokenDelimiter);
-      var paramDelimIndex = hash.indexOf('?');
-
-      var result = {
-        raw: hash,
-        content: second(hash, '#')
-      };
-      if (tabDelimIndex >= 0 && paramDelimIndex >= 0) {
-
-        // We have a well formed hash: parent:child:subchild?name=value...
-        var root = first(
-          first(result.content, CCR.xdmod.ui.tokenDelimiter), '?'
-        );
-
-        var tab = second(first(result.content, '?'), CCR.xdmod.ui.tokenDelimiter);
-        var subtab = third(first(result.content, '?'), CCR.xdmod.ui.tokenDelimiter);
-        if (subtab === first(result.content, '?')) {
-          subtab = '';
-        }
-
-        var params = second(result.content, '?');
-
-        if (params === result.content) {
-          params = '';
-        }
-
-        result['root'] = root;
-        result['tab'] = tab;
-        result['subtab'] = subtab;
-        result['params'] = params;
-      } else if (tabDelimIndex < 0 && paramDelimIndex < 0) {
-
-        // We have a hash that looks like: name=value
-        result['root'] = '';
-        result['tab'] = '';
-        result['params'] = result.content;
-      } else if (tabDelimIndex >= 0 && paramDelimIndex < 0) {
-
-        // We have a hash that looks like: parent:child:subchild
-        root = first(result.content, CCR.xdmod.ui.tokenDelimiter);
-        tab = second(result.content, CCR.xdmod.ui.tokenDelimiter);
-        var subtab = third(result.content, CCR.xdmod.ui.tokenDelimiter);
-        if (subtab === result.content) {
-          subtab = '';
-        }
-
-        result['root'] = root;
-        result['tab'] = tab;
-        result['subtab'] = subtab;
-        result['params'] = '';
-      } else if (tabDelimIndex < 0 && paramDelimIndex >= 0) {
-
-        // We have a hash that looks like: child?name=value
-        root = '';
-        tab = first(result.content, '?');
-        params = second(result.content, '?');
-
-        result['root'] = root;
-        result['tab'] = tab;
-        result['params'] = params;
-      }
-
-      return result;
-    }
-    return {};
-  },
   getParameterByName: function(name, source) {
     name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
     var regex = new RegExp("[\\?&#]" + name + "=([^&#]*)"),

--- a/html/unit_tests/coverage.html
+++ b/html/unit_tests/coverage.html
@@ -41,9 +41,11 @@
         coverjs [SRC FILE] -o lib-cov
   -->
   <script data-cover src="lib-cov/ChangeStack.js"></script>
+  <script data-cover src="lib-cov/CCR.js"></script>
 
   <!-- Test specification files -->
   <script src="spec/ChangeStackSpec.js"></script>
+  <script src="spec/CCRTokenizeSpec.js"></script>
 
   <script>
     mocha.checkLeaks();

--- a/html/unit_tests/index.html
+++ b/html/unit_tests/index.html
@@ -26,9 +26,11 @@
                                       
   <!-- Files to test -->
   <script data-cover src="../gui/js/ChangeStack.js"></script>
+  <script data-cover src="../gui/js/CCR.js"></script>
 
   <!-- Test specification files -->
   <script src="spec/ChangeStackSpec.js"></script>
+  <script src="spec/CCRTokenizeSpec.js"></script>
 
   <script>
     mocha.checkLeaks();

--- a/html/unit_tests/spec/.eslintrc.json
+++ b/html/unit_tests/spec/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+    "env": {
+        "mocha": true
+    },
+    "globals": {
+        "expect": false
+    }
+}
+

--- a/html/unit_tests/spec/CCRTokenizeSpec.js
+++ b/html/unit_tests/spec/CCRTokenizeSpec.js
@@ -1,0 +1,71 @@
+describe('XDMoD.Viewer', function () {
+    describe('Various Successful Tokenizations', function () {
+        it('tab panel / tab', function () {
+            var token = CCR.tokenize('#main_tab_panel:tg_summary');
+
+            expect(token).to.deep.equal({
+                raw: '#main_tab_panel:tg_summary',
+                content: 'main_tab_panel:tg_summary',
+                root: 'main_tab_panel',
+                tab: 'tg_summary',
+                subtab: '',
+                params: ''
+            });
+        });
+
+        it('tab only', function () {
+            var token = CCR.tokenize('#tg_summary');
+
+            expect(token).to.deep.equal({
+                raw: '#tg_summary',
+                content: 'tg_summary',
+                root: '',
+                tab: 'tg_summary',
+                subtab: '',
+                params: ''
+            });
+        });
+
+        it('tab only params', function () {
+            var content = 'tg_usage?node=statistic_Jobs_none_total_cpu_hours';
+            var token = CCR.tokenize('#' + content);
+
+            expect(token).to.deep.equal({
+                raw: '#' + content,
+                content: content,
+                root: '',
+                tab: 'tg_usage',
+                subtab: '',
+                params: 'node=statistic_Jobs_none_total_cpu_hours'
+            });
+        });
+
+        it('tab panel / tab w/ params', function () {
+            var content = 'main_tab_panel:job_viewer?realm=SUPREMM&recordid=29&jobid=7193418&infoid=0';
+            var token = CCR.tokenize('#' + content);
+
+            expect(token).to.deep.equal({
+                raw: '#' + content,
+                content: content,
+                root: 'main_tab_panel',
+                tab: 'job_viewer',
+                subtab: '',
+                params: 'realm=SUPREMM&recordid=29&jobid=7193418&infoid=0'
+            });
+        });
+
+        it('tab panel / tab / subtab w/ params', function () {
+            var content = 'main_tab_panel:app_kernels:app_kernel_viewer?kernel=29&start=2017-03-01&end=2017-03-31';
+            var token = CCR.tokenize('#' + content);
+
+            expect(token).to.deep.equal({
+                raw: '#' + content,
+                content: content,
+                root: 'main_tab_panel',
+                tab: 'app_kernels',
+                subtab: 'app_kernel_viewer',
+                params: 'kernel=29&start=2017-03-01&end=2017-03-31'
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Description
This change removes the unnecessary duplicate tokenize code. It also
replaces the function with a much simpler one that has full unit test
coverage.

## Motivation and Context
General cleanup in preparation for deep linking support.

## Tests performed
Ran the javascript unit_tests to confirm that the location hashes are parsed correctly. Ran code coverage
tools to confirm the new code has 100% test coverage (although the tools cannot check that all possible states have been hit in the regex state machine).