### PR TITLE
 Resolving Firefox MetricExplorer menu bug

### DIFF
--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -5674,7 +5674,12 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                     return true;
                 }
 
-                return h.call(this.scope || this, e, this.menu);
+                // Ensure that we only call the KeyNav handlers if this is a NavKey Press.
+                if (e.isNavKeyPress()) {
+                    return h.call(this.scope || this, e, this.menu);
+                }
+
+                return true;
             };
 
             /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Typing a '%' character in a form field contained within the
  MetricExplorer chart options menu would not have the desired effect. Instead,
  the whole menu would close and the '%' character would not be recorded in the
  field. The reason for this was because of an interaction between the FireFox
  browser and the Ext.KeyNav / Ext.MenuNav components. In FireFox, when the '%'
  character was entered into a form field contained within a menu, the
  Ext.KeyNav.relay function would fire, interpret the keyCode value of '37' to
  be the 'left' key, for which the Ext.MenuNav component has a handler. This
  handler would then merrily went about closing the menu ( because that's what
  you do when you press the left key? I'm guessing to support navigating a menu
  / toolbar via the arrow keys. ). Now, when Ext identifies the browser as
  Gecko ( which is what Firefox is identified as ), it just returns true so as
  to not interrupt any further events that need to be interpreted. If the
  browser is not Firefox then it executes the same code as in the original
  handler.

## Motivation and Context
Attempting to enter a '%' character while using Firefox into the name / title text boxes in the Metric Explorer would result in the menu that contains the text boxes to be closed and the character text box values to not be updated. 

## Tests performed
- Manually tested using the left / right keys in the text boxes inside this menu on NIX / OSX
- Manually tested using all non-alpha numeric characters I could think of available via keyboard. 
- Automated tests will be added shortly ( they have been added to the XSEDE module )

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
