### PR TITLE
Add Auto running of javascript unit tests

### DIFF
--- a/.travis.build.sh
+++ b/.travis.build.sh
@@ -112,7 +112,7 @@ elif [ "$TEST_SUITE" = "style" ]; then
         fi
     done
 elif [ "$TEST_SUITE" = "unit" ]; then
-    open_xdmod/modules/xdmod/tests/runtests.sh
+    open_xdmod/modules/xdmod/tests/runtests.sh && phantomjs html/unit_tests/phantom.js
     if [ $? != 0 ]; then
         build_exit_value=2
     fi

--- a/html/unit_tests/.eslintrc.json
+++ b/html/unit_tests/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "phantomjs": true,
+    "mocha": true
+  }
+}
+

--- a/html/unit_tests/phantom.js
+++ b/html/unit_tests/phantom.js
@@ -1,0 +1,12 @@
+var page = require('webpage').create();
+page.open('file://' + phantom.libraryPath + '/index.html', function (status) {
+    var failures = -1;
+    if (status === 'success') {
+        failures = page.evaluate(function () {
+            return mocha.run().failures;
+        });
+    }
+    console.log('Javascript Unit Test Failures: ' + failures);
+    phantom.exit(failures);
+});
+


### PR DESCRIPTION
## Description
Have javascript unit tests run as part of travis using phantomJS to do testing

## Motivation and Context
Allow javascript unit test failures to prevent merging

## Tests performed
ran test travis builds on my own branch

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
