### PR TITLE
Update JobViewer activate function in preparation for deep linking code.

### DIFF
--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -929,7 +929,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                 return;
             }
 
-            if (params.realm && params.recordid && params.jobid) {
+            if (params.recordid && params.jobid) {
                 if (params.infoid) {
                     this.fireEvent('process_view_node', path);
                 } else {

--- a/html/unit_tests/coverage.html
+++ b/html/unit_tests/coverage.html
@@ -32,6 +32,17 @@
   <script type="text/javascript" src="../gui/lib/extjs/adapter/ext/ext-base.js"></script>
   <script type="text/javascript" src="../gui/lib/extjs/ext-all-debug-w-comments.js"></script>
   <script type="text/javascript" src="../gui/lib/extjs/src/debug.js"></script>
+  <script type="text/javascript" src="../gui/lib/CheckColumn.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/ProgressBarPager.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridSorter.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridColumnResizer.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridNodeUI.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridLoader.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridColumns.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGrid.js"></script>
+  <script type="text/javascript" src="../gui/lib/rsvp/rsvp-1979d5ad89293dadbe7656dd53d152f7426fa35e.min.js"></script>
+  <script type="text/javascript" src="../gui/lib/groupdataview.js"></script>
+  <script type="text/javascript" src="../gui/lib/groupcombo.js"></script>
                                       
   <!-- Files to test
     These files must be the instrumented versions of the orignal code.
@@ -40,12 +51,31 @@
         npm install coverjs
         coverjs [SRC FILE] -o lib-cov
   -->
+  <script>
+Ext.ns('CCR', 'CCR.xdmod', 'CCR.xdmod.ui', 'XDMoD.REST');
+  </script>
   <script data-cover src="lib-cov/ChangeStack.js"></script>
   <script data-cover src="lib-cov/CCR.js"></script>
+
+  <script type="text/javascript" src="../gui/js/PortalModule.js"></script>
+  <script type="text/javascript" src="../gui/js/RealTimeValidatingTextField.js"></script>
+  <script type="text/javascript" src="../gui/js/plugins/CollapsedPanelTitlePlugin.js"></script>
+
+  <script data-cover type="text/javascript" src="lib-cov/JobViewer.js"></script>
+
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/ChartPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/AnalyticChartPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/TimeSeriesStore.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/SearchPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/SearchHistoryTree.js" ></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/SearchHistoryPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/JobPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/NestedViewPanel.js"></script>
 
   <!-- Test specification files -->
   <script src="spec/ChangeStackSpec.js"></script>
   <script src="spec/CCRTokenizeSpec.js"></script>
+  <script src="spec/JobViewerSpec.js"></script>
 
   <script>
     mocha.checkLeaks();

--- a/html/unit_tests/index.html
+++ b/html/unit_tests/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -23,14 +24,44 @@
   <script type="text/javascript" src="../gui/lib/extjs/adapter/ext/ext-base.js"></script>
   <script type="text/javascript" src="../gui/lib/extjs/ext-all-debug-w-comments.js"></script>
   <script type="text/javascript" src="../gui/lib/extjs/src/debug.js"></script>
+  <script type="text/javascript" src="../gui/lib/CheckColumn.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/ProgressBarPager.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridSorter.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridColumnResizer.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridNodeUI.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridLoader.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGridColumns.js"></script>
+  <script type="text/javascript" src="../gui/lib/extjs/examples/ux/treegrid/TreeGrid.js"></script>
+  <script type="text/javascript" src="../gui/lib/rsvp/rsvp-1979d5ad89293dadbe7656dd53d152f7426fa35e.min.js"></script>
+  <script type="text/javascript" src="../gui/lib/groupdataview.js"></script>
+  <script type="text/javascript" src="../gui/lib/groupcombo.js"></script>
                                       
   <!-- Files to test -->
+  <script>
+Ext.ns('CCR', 'CCR.xdmod', 'CCR.xdmod.ui', 'XDMoD.REST');
+  </script>
   <script data-cover src="../gui/js/ChangeStack.js"></script>
   <script data-cover src="../gui/js/CCR.js"></script>
+
+  <script type="text/javascript" src="../gui/js/PortalModule.js"></script>
+  <script type="text/javascript" src="../gui/js/RealTimeValidatingTextField.js"></script>
+  <script type="text/javascript" src="../gui/js/plugins/CollapsedPanelTitlePlugin.js"></script>
+
+  <script data-cover type="text/javascript" src="../gui/js/modules/job_viewer/JobViewer.js"></script>
+
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/ChartPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/AnalyticChartPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/TimeSeriesStore.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/SearchPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/SearchHistoryTree.js" ></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/SearchHistoryPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/JobPanel.js"></script>
+  <script type="text/javascript" src="../gui/js/modules/job_viewer/NestedViewPanel.js"></script>
 
   <!-- Test specification files -->
   <script src="spec/ChangeStackSpec.js"></script>
   <script src="spec/CCRTokenizeSpec.js"></script>
+  <script src="spec/JobViewerSpec.js"></script>
 
   <script>
     mocha.checkLeaks();

--- a/html/unit_tests/spec/.eslintrc.json
+++ b/html/unit_tests/spec/.eslintrc.json
@@ -4,6 +4,9 @@
     },
     "globals": {
         "expect": false
+    },
+    "rules": {
+        "no-unused-expressions": "off"
     }
 }
 

--- a/html/unit_tests/spec/JobViewerSpec.js
+++ b/html/unit_tests/spec/JobViewerSpec.js
@@ -1,0 +1,85 @@
+describe('XDMoD.JobViewer', function () {
+    var jv = new XDMoD.Module.JobViewer();
+
+    describe('compareNodePath tests', function () {
+        it('matching', function () {
+            var node = {
+                attributes: {
+                    dtype: 'b',
+                    b: 2
+                },
+                parentNode: {
+                    attributes: {
+                        dtype: 'a',
+                        a: 1
+                    },
+                    parentNode: {}
+                }
+            };
+
+            var path = [{ dtype: 'a', value: '1' }, { dtype: 'b', value: '2' }];
+
+            expect(jv.compareNodePath(node, path)).to.be.true;
+        });
+
+        it('diff dtype', function () {
+            var node = {
+                attributes: {
+                    dtype: 'b',
+                    b: 2
+                },
+                parentNode: {
+                    attributes: {
+                        dtype: 'z',
+                        z: 1
+                    },
+                    parentNode: {}
+                }
+            };
+
+            var path = [{ dtype: 'a', value: '1' }, { dtype: 'b', value: '2' }];
+
+            expect(jv.compareNodePath(node, path)).to.be.false;
+        });
+
+        it('diff array longer', function () {
+            var node = {
+                attributes: {
+                    dtype: 'b',
+                    b: 2
+                },
+                parentNode: {
+                    attributes: {
+                        dtype: 'a',
+                        a: 1
+                    },
+                    parentNode: {}
+                }
+            };
+
+            var path = [{ dtype: 'a', value: '1' }, { dtype: 'b', value: '2' }, { dtype: 'c', value: '3' }];
+
+            expect(jv.compareNodePath(node, path)).to.be.false;
+        });
+
+        it('diff node path longer', function () {
+            var node = {
+                attributes: {
+                    dtype: 'b',
+                    b: 2
+                },
+                parentNode: {
+                    attributes: {
+                        dtype: 'a',
+                        a: 1
+                    },
+                    parentNode: {}
+                }
+            };
+
+            var path = [{ dtype: 'b', value: '2' }];
+
+            expect(jv.compareNodePath(node, path)).to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
## Description

The job viewer activate function needs to be updated to support the deep
linking feature. A review of the existing code found some dead code
paths and redundant code. This is removed in this pull request. 

Note that I had to add an eslint override to allow calls to the existing underscore prefix function. The eslint rule is poorly implemented because it prevents _calls_ to badly named existing functions, rather than preventing function declarations.

## Motivation and Context
prep work for deep linking support.

## Tests performed
Added unit tests for the replacement compareNodePath() function (this function has 100% unit tests coverage).

Manually tested that the job viewer navigation works identically in Firefox linux and Chrome linux. 
