### PR TITLE
Bumped build_packager script memory limit

### DIFF
--- a/open_xdmod/build_scripts/build_package.php
+++ b/open_xdmod/build_scripts/build_package.php
@@ -8,6 +8,8 @@
 
 require_once __DIR__ . '/../../configuration/linker.php';
 
+ini_set('memory_limit', '256M');
+
 use CCR\Log;
 use OpenXdmod\Build\Packager;
 

--- a/open_xdmod/build_scripts/build_package.php
+++ b/open_xdmod/build_scripts/build_package.php
@@ -8,7 +8,7 @@
 
 require_once __DIR__ . '/../../configuration/linker.php';
 
-ini_set('memory_limit', '256M');
+ini_set('memory_limit', -1);
 
 use CCR\Log;
 use OpenXdmod\Build\Packager;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- When executing a local deploy ( as opposed to pulling down the source from a
  git repo ) this script consistently runs out of memory. Bumping the limit to
  256M alleviates this issue.


## Motivation and Context
The script was running out of memory, now it does not. 

## Tests performed
- Manual testing, running a local deploy completes successfully
- Manual testing, running a remote deploy ( from git ) completes successfully

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
