### PR TITLE
Back Porting 6.7 Metric Explorer fix to 6.6

### DIFF
--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -5674,7 +5674,12 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                     return true;
                 }
 
-                return h.call(this.scope || this, e, this.menu);
+                // Ensure that we only call the KeyNav handlers if this is a NavKey Press.
+                if (e.isNavKeyPress()) {
+                    return h.call(this.scope || this, e, this.menu);
+                }
+
+                return true;
             };
 
             /**


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Back porting fix for NavKey handlers being executed for non-NavKey key presses.


## Motivation and Context
Making sure that this fix gets into 6.6 as well as 6.7

## Tests performed
- Manual Testing 
- Automated Test added to xsede/tests/automated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
