### PR TITLE
Metric Explorer: Fixed errors not displaying if help graphic active

### DIFF
--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -5527,6 +5527,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                 'An error occurred while loading the chart.',
                 responseMessage
             );
+            this.chartViewPanel.getLayout().setActiveItem(this.highChartPanel.getId());
 
             this.unmask();
 


### PR DESCRIPTION
## Description
The Metric Explorer has a help graphic that is active when there is no data to display (for example, when a new chart has been created). If a user chooses an invalid configuration while this graphic is active, the error message will still be written on the chart, but the chart is hidden by the graphic. This pull request ensures that the chart will not be hidden if an error message is written on it.

## Motivation and Context
It is important to inform users why their settings are invalid and not just appear to do nothing.

## Tests performed
Ran automated UI tests and verified that they ran the same as before. Performed manual testing in Chrome and Firefox to ensure other Metric Explorer functionality was not impacted.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
