### PR TITLE
Fix the node selection algorithm broken in #117

### DIFF
--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -909,7 +909,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                 return;
             }
 
-            var token = CCR.tokenize(Ext.History.getToken());
+            var token = CCR.tokenize(document.location.hash);
             var params = Ext.urlDecode(token.params);
 
             if (params.job) {
@@ -920,9 +920,10 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             if (!params.realm) {
                 return;
             }
+            var selectionModel = this.searchHistoryPanel.getSelectionModel();
 
             var path = this._getPath(token.raw);
-            var isSelected = this.compareNodePath(this.currentNode, path);
+            var isSelected = this.compareNodePath(this.currentNode, path) && selectionModel && CCR.exists(selectionModel.getSelectedNode());
 
             if (!isSelected) {
                 this.searchHistoryPanel.fireEvent('expand_node', path);


### PR DESCRIPTION
## Description
The algorithm that determines whether a node should be selected
was incorrectly broken in the cleanup task in #117. This pull request
restores the original code.

## Motivation and Context
manual revert of erroneous change

## Tests performed
Ran the automated UI tests 


XDMoD
  General
    ✓ Verify Logo and Title (859ms)

  Login
    ✓ Click the login link (642ms)
    ✓ Should Login (345ms)
    ✓ Display Logged in Users Name (698ms)

Job Viewer
  ✓ Selected (739ms)
  ✓ Has Instructions (12ms)
  ✓ Instructions look the same as previous run (1702ms)
  Quick Lookup
    No results
      ✓ Click the search button (188ms)
      ✓ Perform a basic search (478ms)
      ✓ Have no results (343ms)
      ✓ Cancel search (90ms)
    With results
      ✓ Click the search button (43ms)
      ✓ Perform a basic search (1021ms)
      ✓ View saved job then delete it. (2692ms)

  Advanced Search
    Simple single filter lookup
      ✓ Click the search button (60ms)
      ✓ Add filters; Run Search (1886ms)
      ✓ Select Search Results (424ms)
      ✓ View saved job then delete it. (2847ms)

  Tree Sort Order
    ✓ Click the search button (117ms)
    ✓ Perform a basic search (1171ms)
    ✓ View saved job. (1534ms)
    ✓ Change sort order (1616ms)
    ✓ View saved job then delete it. (1217ms)

  Job Tab Clicks
    ✓ Click the search button (54ms)
    ✓ Perform a basic search (919ms)
    ✓ View saved job timeseries. (4681ms)

  Edit Search
    Testing 'edit search' on a Quick Lookup Search 
      Create a Quick Lookup Search
        ✓ Click the search button (70ms)
        ✓ Perform a Quick Lookup (978ms)
      Perform 'Edit' action on newly created Quick Lookup
        ✓ Perform 'Edit Search' Action (1058ms)
        ✓ Validate that the search parameters have been set correctly. (33ms)
        ✓ Change the Job Number (762ms)
        ✓ Perform 'Edit Search' Action Again (981ms)
        ✓ Validate that the search parameters have been set correctly. (652ms)
      Delete Basic search
        ✓ Perform Delete (1323ms)
    Testing 'edit search' on an Advanced Search
      Create Advanced Search
        ✓ Click the search button (54ms)
        ✓ Fill in Advanced Search Parameters (2081ms)
        ✓ Save Advanced Search Parameters (60ms)
      Edit the newly created Advanced Search
        ✓ Perform the 'Edit Search' action (1312ms)
        ✓ Validate that the search criteria was set correctly (353ms)
        ✓ Validate that we have the correct number of results set (352ms)
        ✓ Change the selected records (484ms)
      Delete the Advanced Search
        ✓ Perform Delete Action (2112ms)
    Edit a Metric Explorer Search
      ✓ Click the Metric Explorer Tab (2143ms)
      ✓ Open the SUPREMM metrics (2108ms)
      ✓ Save the chart title for later (170ms)
      ✓ Click the first data point for the first data series (125ms)
      ✓ Open 'Show Raw Data' Window (427ms)
      ✓ Select an entry in the 'Show Raw Data' window (434ms)
      ✓ verify that we have the correct job open (830ms)
      ✓ Verify that the 'Edit Search' action is disabled (550ms)
      Delete the Metric Explorer Search
        ✓ Perform Delete Action (221ms)

  Save coverage report
    ✓ Get the report and save (5ms)

Logout
  ✓ Click the logout link (130ms)
  ✓ Display Logged out State (452ms)
Update Screenshot Repository
  ✓ Should upload screenshots (0ms)


55 passing (47.70s)
