### PR TITLE
Travis: Exclude redundant jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
         - TEST_SUITE=style
         - TEST_SUITE=unit
         - TEST_SUITE=build
+matrix:
+    exclude:
+        - php: '5.4'
+          env: TEST_SUITE=style
 
 # Add dependency directories to the Travis cache
 cache:


### PR DESCRIPTION
## Description
This pull request prevents redundant jobs from running on Travis. Specifically, it ensures the style tests are only run once instead of once per PHP version tested.

If approved, similar pull requests will be opened for the module repositories.

## Motivation and Context
@plessbd pointed this out as a waste of resources, and wasting resources is bad, especially when they're donated.

## Tests Performed
Started [a run with the updated config file](https://travis-ci.org/tyearke/xdmod/builds/229988298) and verified that the set of tests was correct.

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
