### PR TITLE
Fix chart last modified date (metric explorer)

### DIFF
--- a/classes/NewRest/Controllers/MetricExplorerControllerProvider.php
+++ b/classes/NewRest/Controllers/MetricExplorerControllerProvider.php
@@ -256,6 +256,7 @@ class MetricExplorerControllerProvider extends BaseControllerProvider
      * values of the following form params ( if provided ):
      *   - name
      *   - config
+     *   - timestamp
      *
      * @param Request $request
      * @param Application $app
@@ -286,13 +287,18 @@ class MetricExplorerControllerProvider extends BaseControllerProvider
                         $jsonData = json_decode($data, true);
                         $name = isset($jsonData['name']) ? $jsonData['name'] : null;
                         $config = isset($jsonData['config']) ? $jsonData['config'] : null;
+                        $ts = isset($jsonData['ts']) ? $jsonData['ts'] : microtime(true);
                     } else {
                         $name = $this->getStringParam($request, 'name');
                         $config = $this->getStringParam($request, 'config');
+                        $ts = $this->getDateTimeFromUnixParam($request, 'ts');
                     }
 
                     if (isset($name)) $query['name'] = $name;
                     if (isset($config)) $query['config'] = $config;
+                    if (isset($ts)) {
+                        $query['ts'] = $ts;
+                    }
 
                     $queries->upsert($id, $query);
 

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -2285,6 +2285,8 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                 index = this.queriesStore.indexOf(rec);
                 this.selectRowByIndex.call(this, index);
             } else {
+                // update the last-modified timestamp on the chart definition:
+                rec.set('ts', Date.now() / 1000);
                 this.queriesStore.save();
             }
             rec.stack.mark();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Change to Metric Explorer javascript updates the timestamp on the current record of the queries store when a chart is saved.
- Change to Metric Explorer controller parses the current timestamp from the request object and saves it, when saving the "query" associated with an existing chart. This step was previously missing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses xdmod6.6 bug: https://app.asana.com/0/14787510600562/335273737938313

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests run by hand:
- Alter existing ME charts, check displayed timestamp before and after saving and reloading.
- Verify that no change is made to proper behavior: save existing chart under new name
- Verify that no change is made to proper behavior: create new chart

Ran all unit and integration tests
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
