### PR TITLE
Use Git to manage XDMoD test artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 env:
     global:
         - NODE_VERSION=6
+        - XDMOD_TEST_ARTIFACTS_MIRROR="$HOME/xdmod-test-artifacts.git"
     matrix:
         - TEST_SUITE=syntax
         - TEST_SUITE=style
@@ -25,6 +26,7 @@ cache:
         - $HOME/.npm
         - $HOME/.composer/cache
         - /tmp/pear/cache
+        - $XDMOD_TEST_ARTIFACTS_MIRROR
 
 # Delegate the installation step to the custom Travis installation script
 install: ./.travis.install.sh

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
-        "ubccr/xdmod-test-artifacts": "@dev",
         "squizlabs/php_codesniffer": "2.8.0"
     },
     "repositories": [
@@ -369,10 +368,6 @@
                     "installer-name": "commons-logging"
                 }
             }
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/ubccr/xdmod-test-artifacts.git"
         }
     ],
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0538f717752f90e1898bee194ced712",
+    "content-hash": "ceeef77ecbe7a0be2763939f54b3ba06",
     "packages": [
         {
             "name": "apache/commons-beanutils",
@@ -2688,35 +2688,12 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2015-07-26T08:59:42+00:00"
-        },
-        {
-            "name": "ubccr/xdmod-test-artifacts",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ubccr/xdmod-test-artifacts.git",
-                "reference": "aa431c5969c30511a8dbe56f758a43543406c2a0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ubccr/xdmod-test-artifacts/zipball/aa431c5969c30511a8dbe56f758a43543406c2a0",
-                "reference": "aa431c5969c30511a8dbe56f758a43543406c2a0",
-                "shasum": ""
-            },
-            "type": "library",
-            "description": "Test artifacts for XDMoD and XDMoD submodules",
-            "support": {
-                "source": "https://github.com/ubccr/xdmod-test-artifacts/tree/master",
-                "issues": "https://github.com/ubccr/xdmod-test-artifacts/issues"
-            },
-            "time": "2017-04-26 17:59:22"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "openid/php-openid": 20,
-        "ubccr/xdmod-test-artifacts": 20
+        "openid/php-openid": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/open_xdmod/modules/xdmod/tests/artifacts/.gitignore
+++ b/open_xdmod/modules/xdmod/tests/artifacts/.gitignore
@@ -1,0 +1,1 @@
+/xdmod-test-artifacts

--- a/open_xdmod/modules/xdmod/tests/artifacts/update-artifacts.sh
+++ b/open_xdmod/modules/xdmod/tests/artifacts/update-artifacts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+xdmod_test_artifacts_source="https://github.com/ubccr/xdmod-test-artifacts.git"
+using_xdmod_test_artifacts_mirror="false"; [ -n "$XDMOD_TEST_ARTIFACTS_MIRROR" ] && using_xdmod_test_artifacts_mirror="true"
+
+# Change directory to this script's directory.
+cd "$(dirname $0)" || exit 1
+
+# If using a mirror of the xdmod-test-artifacts repo, create or update it.
+#
+# Travis will create any directories that are set up for caching if they do
+# not exist, so also check if the directory has contents.
+if "$using_xdmod_test_artifacts_mirror"; then
+    if [ -d "$XDMOD_TEST_ARTIFACTS_MIRROR" ] && [ -n "$(ls -A "$XDMOD_TEST_ARTIFACTS_MIRROR")" ]; then
+        echo "Updating xdmod-test-artifacts mirror..."
+        git -C "$XDMOD_TEST_ARTIFACTS_MIRROR" remote update
+    else
+        echo "Creating mirror of xdmod-test-artifacts..."
+        git clone --mirror "$xdmod_test_artifacts_source" "$XDMOD_TEST_ARTIFACTS_MIRROR"
+    fi
+fi
+
+# If the xdmod-test-artifacts repo already exists locally, update it.
+# Otherwise, clone it.
+artifacts_dir="./xdmod-test-artifacts"
+if [ -d "$artifacts_dir" ]; then
+    echo "Updating local xdmod-test-artifacts clone..."
+    git -C "$artifacts_dir" pull
+else
+    echo "Cloning xdmod-test-artifacts into local directory..."
+    if "$using_xdmod_test_artifacts_mirror"; then
+        local_clone_source="$XDMOD_TEST_ARTIFACTS_MIRROR"
+    else
+        local_clone_source="$xdmod_test_artifacts_source"
+    fi
+    git clone "$local_clone_source" "$artifacts_dir"
+fi

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/Configuration/ConfigurationTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/Configuration/ConfigurationTest.php
@@ -13,8 +13,8 @@ use ETL\Configuration\Configuration;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/configuration/input";
-    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/configuration/output";
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/output";
 
     /**
      * Test JSON parse errors

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/Configuration/EtlConfigurationTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/Configuration/EtlConfigurationTest.php
@@ -13,8 +13,8 @@ use ETL\Configuration\EtlConfiguration;
 
 class EtlConfigurationTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/configuration/input";
-    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/configuration/output";
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/output";
     const TMPDIR = '/tmp/xdmod-etl-configuration-test';
 
     /**

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/Configuration/Rfc6901Test.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/Configuration/Rfc6901Test.php
@@ -14,8 +14,8 @@ use ETL\Configuration\JsonReferenceTransformer;
 
 class Rfc6901Test extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/configuration/input";
-    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/configuration/output";
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/output";
 
     private $config = null;
     private $transformer = null;

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/FileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/FileTest.php
@@ -17,8 +17,8 @@ use ETL\DataEndpoint\DataEndpointOptions;
 
 class FileTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
-    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
     private $logger = null;
 
     public function __construct()

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
@@ -15,8 +15,8 @@ use ETL\DataEndpoint\DataEndpointOptions;
 
 class StructuredFileTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
-    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
     private $logger = null;
 
     public function __construct()

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
@@ -21,8 +21,8 @@ use ETL\Configuration\EtlConfiguration;
 
 class DbModelTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dbmodel/input";
-    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dbmodel/output";
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dbmodel/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dbmodel/output";
     private $logger = null;
 
     public function __construct()

--- a/open_xdmod/modules/xdmod/tests/runtests.sh
+++ b/open_xdmod/modules/xdmod/tests/runtests.sh
@@ -14,5 +14,7 @@ if [ ! -x "$phpunit" ]; then
     exit 127
 fi
 
+./artifacts/update-artifacts.sh
+
 $phpunit ${PHPUNITARGS} .
 exit $?


### PR DESCRIPTION
## Description
This pull request moves responsibility for retrieval of `xdmod-test-artifacts` from Composer to the scripts that use it.

## Motivation and Context
Copying/paraphrasing from an email exchange between @smgallo, @jpwhite4, and I:

Composer's design is built around pulling in runtime and development software packages in a consistent, well-considered manner, and the lock file's use of hashes for both individual dependencies and the contents of the lock file is meant to help guard against changes that haven't been tested. For example, if two pull requests both change the lock file and one gets merged, the other will be in conflict with the target branch due to the lock file's content hash being changed by both pull requests. As part of resolving the conflict, the outstanding pull request's lock file will need to be regenerated to include the changes from the other, which in so doing will (partially) validate the combined changes.

Having developers run commands that modify the lock file as part of the testing procedure leads to more work and more opportunities for accidentally pushing bad changes to the lock file. What this pull request does instead is have the scripts that use the test artifacts repo pull in the latest version of the repo with plain Git at run time. This means no updates to run manually and no files in the code repos to tweak and accidentally break when adding to the artifacts.

## Tests Performed
Ran a test run of Travis on my fork and ran the unit tests manually on my local system.

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
