### PR TITLE
Load Chart drop-down menu: cosmetic improvements

### DIFF
--- a/html/gui/css/MetricExplorer.css
+++ b/html/gui/css/MetricExplorer.css
@@ -1,0 +1,6 @@
+/* MetricExplorer.css */
+
+.metric-explorer-dirty-chart-record {
+    background: url(/gui/images/exclamation.png) no-repeat 2px 1px;
+    padding-left: 16px;
+}

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -4959,15 +4959,31 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                 header: 'Chart Name',
                 id: 'name',
                 dataIndex: 'name',
-                editor: new Ext.form.TextField({}),
+                renderer: function (name, metaData/* record, rowIndex, colIndex, store */) {
+                    // if the name is (~arbitrarily) long, place it in a tooltip. This length is relative
+                    // to the width of the GridPanel.
+                    if (name.length > 73) {
+                        /* eslint-disable no-param-reassign */
+                        metaData.attr += 'ext:qtip="' + name + '"';
+                        /* eslint-enable no-param-reassign */
+                    }
+                    return name;
+                },
                 sortable: true
             }, {
                 header: 'Last Modified',
-                width: 180,
+                width: 140,
                 dataIndex: 'ts',
+                align: 'center',
                 renderer: function(ts, metaData, record /*, rowIndex, colIndex, store*/ ) {
-                    var saveText = record.stack && !record.stack.isMarked() ? " - <b>Unsaved</b>" : "";
-                    return Ext.util.Format.date(new Date(ts * 1000).toString(), 'Y-m-d H:i:s') + saveText;
+                    // if unsaved chart record, display icon and tooltip:
+                    if (record.stack && !record.stack.isMarked()) {
+                        /* eslint-disable no-param-reassign */
+                        metaData.css = 'metric-explorer-dirty-chart-record';
+                        metaData.attr += 'ext:qtip="Unsaved Chart"';
+                        /* eslint-enable no-param-reassign */
+                    }
+                    return Ext.util.Format.date(new Date(ts * 1000).toString(), 'Y-m-d H:i:s');
                 },
                 sortable: true
             }], //columns

--- a/html/index.php
+++ b/html/index.php
@@ -225,6 +225,7 @@
       <script type="text/javascript" src="gui/js/ContainerMask.js"></script>
        <script type="text/javascript" src="gui/js/ContainerBodyMask.js"></script>
 
+      <link rel="stylesheet" type="text/css" href="gui/css/MetricExplorer.css" />
       <link rel="stylesheet" type="text/css" href="gui/css/common.css" />
       <!--[if lte IE 9]>
       <link rel="stylesheet" type="text/css" href="gui/css/common_ie9.css" />


### PR DESCRIPTION
Cosmetic improvements to the Metric Explorer Load Chart dialog.

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
In Load Chart menu:
 - Display the dirty chart icon next to Last Modified Date for unsaved chart records. This replaces the text "Unsaved", matches the appearance of the Save drop-down, and preserves space in the Load Chart menu.
 - For charts with long names (>72 characters), display chart name in tooltip.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes were requested here: https://app.asana.com/0/14787510600562/75162375641137

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These changes are strictly cosmetic. They have been tested by hand to ensure they behave as intended, and to ensure they don't disturb existing functionality. Existing, complete tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
