### PR TITLE
Rewrite of StructuredFile data endpoint to support Euca ingest

### DIFF
--- a/classes/ETL/DataEndpoint/File.php
+++ b/classes/ETL/DataEndpoint/File.php
@@ -52,8 +52,6 @@ class File extends aDataEndpoint implements iDataEndpoint
             $this->path = \xd_utilities\qualify_path($options->path, $options->paths->data_dir);
         }
 
-        // $this->path = $options->applyBasePath("paths->data_dir", $options->path);
-
     }  // __construct()
 
     /* ------------------------------------------------------------------------------------------

--- a/classes/ETL/DataEndpoint/File.php
+++ b/classes/ETL/DataEndpoint/File.php
@@ -7,7 +7,7 @@
 namespace ETL\DataEndpoint;
 
 use ETL\DataEndpoint\DataEndpointOptions;
-use \Log;
+use Log;
 
 class File extends aDataEndpoint implements iDataEndpoint
 {
@@ -16,10 +16,7 @@ class File extends aDataEndpoint implements iDataEndpoint
     protected $path = null;
 
     // File mode. See http://php.net/manual/en/function.fopen.php
-    protected $mode = null;
-
-    // The default directory for files that do not specify a full path
-    protected $data_dir = null;
+    protected $mode = 'r';
 
     /* ------------------------------------------------------------------------------------------
      * @see iDataEndpoint::__construct()
@@ -33,37 +30,34 @@ class File extends aDataEndpoint implements iDataEndpoint
         $requiredKeys = array("path");
         $this->verifyRequiredConfigKeys($requiredKeys, $options);
 
-        // Default to read-only mode
-        $this->mode = ( null === $options->mode || "" == $options->mode ? "r" : $options->mode );
+        $messages = array();
+        $propertyTypes = array(
+            'path' => 'string',
+            'mode' => 'string'
+        );
+
+        if ( ! \xd_utilities\verify_object_property_types($options, $propertyTypes, $messages, true) ) {
+            $this->logAndThrowException("Error verifying options: " . implode(", ", $messages));
+        }
+
+        if ( isset($options->mode) ) {
+            $this->mode = $options->mode;
+        }
+
+        $this->path = $options->path;
 
         $this->key = md5(implode($this->keySeparator, array($this->type, $this->path, $this->mode)));
 
-        $this->path = $options->applyBasePath("paths->data_dir", $options->path);
+        if ( isset($options->paths->data_dir) ) {
+            $this->path = \xd_utilities\qualify_path($options->path, $options->paths->data_dir);
+        }
+
+        // $this->path = $options->applyBasePath("paths->data_dir", $options->path);
 
     }  // __construct()
 
     /* ------------------------------------------------------------------------------------------
-     * Set the value of the path for this endpoint.
-     *
-     * @param $path The path to the file for this endpoint
-     *
-     * @return This object to support method chaining
-     * ------------------------------------------------------------------------------------------
-     */
-
-    public function setPath($path)
-    {
-        if ( ! is_string($path) ) {
-            $msg = "Path must be a string";
-            $this->logAndThrowException($msg);
-        }
-
-        return $this;
-
-    }  // setPath()
-
-    /* ------------------------------------------------------------------------------------------
-     * @return The path to this file
+     * @see iFile::getPath()
      * ------------------------------------------------------------------------------------------
      */
 
@@ -73,7 +67,19 @@ class File extends aDataEndpoint implements iDataEndpoint
     } // getPath()
 
     /* ------------------------------------------------------------------------------------------
-     * @see aDataEndpoint::connect()
+     * @see iFile::getMode()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getMode()
+    {
+
+
+        return $this->mode;
+    } // getMode()
+
+    /* ------------------------------------------------------------------------------------------
+     * @see iDataEndpoint::connect()
      * ------------------------------------------------------------------------------------------
      */
 
@@ -81,11 +87,18 @@ class File extends aDataEndpoint implements iDataEndpoint
     {
         // The first time a connection is made the endpoint handle should be set.
 
-        $this->handle = @fopen($this->path, $this->mode);
-        if ( false === $this->handle ) {
-            $error = error_get_last();
-            $msg = "Error opening file '{$this->path}': " . $error['message'];
-            $this->logAndThrowException($msg);
+        if ( null === $this->handle ) {
+
+            $this->handle = @fopen($this->path, $this->mode);
+
+            if ( false === $this->handle ) {
+                $this->handle = null;
+                $error = error_get_last();
+                $this->logAndThrowException(
+                    sprintf("Error opening file '%s': %s", $this->path, $error['message'])
+                );
+            }
+
         }
 
         return $this->handle;
@@ -93,23 +106,25 @@ class File extends aDataEndpoint implements iDataEndpoint
     }  // connect()
 
     /* ------------------------------------------------------------------------------------------
-     * @see aDataEndpoint::disconnect()
+     * @see iDataEndpoint::disconnect()
      * ------------------------------------------------------------------------------------------
      */
 
     public function disconnect()
     {
-        if ( null === $this->handle ) {
-            return true;
-        }
+        if ( null !== $this->handle ) {
 
-        if ( false === @fclose($this->handle) ) {
-            $error = error_get_last();
-            $msg = "Error closing file '{$this->path}': " . $error['message'];
-            $this->logAndThrowException($msg);
-        }
+            if ( false === @fclose($this->handle) ) {
+                $error = error_get_last();
+                $msg = "Error closing file '{$this->path}': " . $error['message'];
+                $this->logAndThrowException(
+                    sprintf("Error closing file '%s': %s", $this->path, $error['message'])
+                );
+            }
 
-        $this->handle = null;
+            $this->handle = null;
+
+        }
 
         return true;
 
@@ -126,25 +141,37 @@ class File extends aDataEndpoint implements iDataEndpoint
         $writeModes = array("r+", "w", "w+", "a", "a+", "x", "x+", "c", "c+");
 
         if ( ! is_string($this->path) ) {
-            $msg =  "Path '" . $this->path . "' is not a string";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Path '" . $this->path . "' is not a string");
         }
 
         if ( ! in_array($this->mode, array_merge($readModes, $writeModes)) ) {
-            $msg = "Unsupported mode '{$this->mode}'";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Unsupported mode '" . $this->mode . "'");
+        }
+
+        if ( ! is_file($this->path) ) {
+            $this->logAndThrowException("Path '" . $this->path . "' is not a file");
         }
 
         if ( in_array($this->mode, $readModes) && ! is_readable($this->path) ) {
-            $msg = "File '{$this->path}' is not readable";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("Path '" . $this->path . "' is not readable");
         }
 
         $fh = $this->connect();
+
         if ( ! $leaveConnected ) {
             $this->disconnect();
         }
 
         return true;
     }  // verify()
+
+    /* ------------------------------------------------------------------------------------------
+     * @see iDataEndpoint::__toString()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function __toString()
+    {
+        return sprintf('%s (class=%s, path=%s)', $this->name, get_class($this), $this->path);
+    }  // __toString()
 }  // class File

--- a/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
+++ b/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
@@ -241,9 +241,9 @@ class ExternalProcess extends \php_user_filter
             throw new \Exception($errorMessage);
         }
 
+        fclose($this->pipes[0]);
         fclose($this->pipes[1]);
         fclose($this->pipes[2]);
-        fclose($this->pipes[3]);
         proc_close($this->filterResource);
         fclose($this->tmpResource);
 

--- a/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
+++ b/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
@@ -1,0 +1,267 @@
+<?php
+/* ==========================================================================================
+ * PHP stream filter implementation allowing data to be passed through an external process
+ * (e.g., jq, awk, sed) for processing. The external application MUST support reading from
+ * standard input and writing to standard output.
+ *
+ * Stream filters are added to a file handle and intercept data that is read from the file
+ * (using standard file functions such as fread()). Filters process the data and pass it
+ * along to the next filter and eventually to the application that requested the
+ * data. This is transparent to the application that is operating on the file
+ * handle. Stream filters must extend the php_user_filter class.
+ *
+ * @see http://php.net/manual/en/stream.filters.php
+ * @see http://php.net/manual/en/class.php-user-filter.php
+ * ==========================================================================================
+ */
+
+namespace ETL\DataEndpoint\Filter;
+
+use Log;
+
+class ExternalProcess extends \php_user_filter
+{
+    /**
+     * Filter name, used when registering the stream filter.
+     */
+
+    const NAME = 'xdmod.external_process';
+
+    /**
+     * Number of bytes to read and write to the application pipes at once
+     */
+
+    const READ_SIZE = 1024;
+
+    /**
+     * The name of the filter, populated by PHP
+     *
+     * @var string
+     */
+
+    public $filtername = null;
+
+    /**
+     * The parameters passed to this filter by stream_filter_prepend() or
+     * stream_filter_append(), set by PHP. This is expected to be an object with the
+     * following properties:
+     *
+     * path: The path to the external application. If a relative path is given, regular
+     *       shell $PATH rules apply.
+     * arguments: Optional argument string to be passed to the application
+     * logger: Optional logger for displying error messages
+     *
+     * @var stdClass
+     */
+
+    public $params = null;
+
+    /**
+     * An array containing file descriptors connected to the application.
+     * 0: application stdin
+     * 1: application stdout
+     * 2: application stdout
+     *
+     * @var array
+     */
+
+    private $pipes = null;
+
+    /**
+     * File handle returned by proc_open()
+     *
+     * @var resource
+     */
+
+    private $filterResource = null;
+
+    /**
+     * Temporary resource used when creating new buckets
+     *
+     * @var resource
+     */
+
+    private $tmpResource = null;
+
+    /**
+     * The command that was executed, including arguments.
+     *
+     * @var string
+     */
+
+    private $command = null;
+
+    /** ------------------------------------------------------------------------------------------
+     * Called when applying the filter. Move data from the input buckets to the output
+     * buckets, filtering along the way.
+     *
+     * @param $in A resource pointing to a bucket brigade which contains one or more
+     *   bucket objects containing data to be filtered.
+     * @param $out A resource pointing to a second bucket brigade into which your modified
+     *   buckets should be placed.
+     * @param $consumed A reference to a value that should be incremented by the length of
+     *   the data which your filter reads in and alters. In most cases this means you will
+     *   increment consumed by $bucket->datalen for each $bucket.
+     * @param $closing Set to TRUE if the stream is in the process of closing (and
+     *   therefore this is the last pass through the filterchain).
+     *
+     * @return PSFS_PASS_ON If data has been copied to the $out brigade
+     * @return PSFS_FEED_ME If the filter was successful but did not copy data to the $out brigade,
+     * @return PSFS_ERR_FATAL On error.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function filter($in, $out, &$consumed, $closing)
+    {
+        $retval = PSFS_FEED_ME;
+
+        // Process all of the incoming buckets and write their data to the process
+        // input pipe.
+
+        while ( $bucket = stream_bucket_make_writeable($in) ) {
+            $consumed += $bucket->datalen;
+            fwrite($this->pipes[0], $bucket->data);
+        }
+
+        // Process any data that may have came out of the pipe and send it to the out
+        // brigade.
+
+        while ( ! feof($this->pipes[1]) && '' !=  ($data = fread($this->pipes[1], self::READ_SIZE)) ) {
+            stream_bucket_append($out, stream_bucket_new($this->tmpResource, $data));
+            $retval = PSFS_PASS_ON;
+        }
+
+        if ( $closing ) {
+
+            // Close the process's input file so it can finish up
+
+            @fclose($this->pipes[0]);
+
+            // Process all data left on the pipe from the process
+
+            while ( ! feof($this->pipes[1]) ) {
+                $data = fread($this->pipes[1], self::READ_SIZE);
+                if ( 0 != strlen($data) ) {
+                    stream_bucket_append($out, stream_bucket_new($this->tmpResource, $data));
+                }
+            }
+
+            $retval = PSFS_PASS_ON;
+
+        }  // if ($closing)
+
+        return $retval;
+    }  // filter()
+
+    /** -----------------------------------------------------------------------------------------
+     * Perform setup on filter instantiation. This includes setting up the external filter
+     * application and opening read and write pipes to the application.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function onCreate()
+    {
+        // Verify parameters
+
+        if ( ! is_object($this->params) || ! isset($this->params->path) ) {
+            fwrite(STDERR, __CLASS__ . ": Path parameter not set\n");
+            return false;
+        }
+
+        if ( isset($this->params->logger) && ! $this->params->logger instanceof Log ) {
+            fwrite(STDERR, "Invalid logger, expected Log and got " . gettype($this->params->logger) . "\n");
+            return false;
+        }
+
+        $arguments = ( isset($this->params->arguments) ? " " . $this->params->arguments : "" );
+        $this->command = $this->params->path . $arguments;
+
+        // stream_bucket_new() needs somewhere to store temporary data but the
+        // documentation doesn't give any details:
+        // http://php.net/manual/en/function.stream-bucket-new.php
+
+        if ( false === ($this->tmpResource = @fopen('php://temp', 'w+')) ) {
+            $this->logError($errorMessage);
+            return false;
+        }
+
+        // Start the process and open read and write pipes so we can interact with it. If
+        // there is an error running the external process (e.g., bad arguments or syntax)
+        // it may not manifest immediately because the process may take some time to set
+        // up. We will need to check the exit status using proc_get_status().
+
+        $this->filterResource = @proc_open(
+            $this->command,
+            array(
+                0 => array('pipe', 'r'),
+                1 => array('pipe', 'w'),
+                2 => array('pipe', 'w')
+            ),
+            $this->pipes
+        );
+
+        if ( false === $this->filterResource ) {
+            $this->logError($errorMessage);
+            return false;
+        }
+
+        // Set the output from the application to non-blocking mode or the fread() in
+        // filter() may block while waiting for the external process to provide data
+        // resulting in a deadlock.
+
+        stream_set_blocking($this->pipes[1], false);
+        stream_set_blocking($this->pipes[2], false);
+
+        return true;
+
+    }  // onCreate()
+
+    /** -----------------------------------------------------------------------------------------
+     * Cleanup after the filter is closed.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function onClose()
+    {
+        // There is difficulty detecting if there is an error running the external
+        // process. By the time the process executes and fails, it is entirely possible
+        // that all data could be written to the process before we can discover that it
+        // has a non-zero exit status.
+
+        $status = proc_get_status($this->filterResource);
+
+        // While the process is running the exit status is shown as -1
+
+        if ( ! in_array($status['exitcode'], array(-1, 0)) ) {
+            $errorMessage = 'Error executing external filter process: ';
+            while ( ! feof($this->pipes[2]) ) {
+                $errorMessage .= fgets($this->pipes[2]);
+            }
+            $this->logError($errorMessage);
+            throw new \Exception($errorMessage);
+        }
+
+        fclose($this->pipes[1]);
+        fclose($this->pipes[2]);
+        fclose($this->pipes[3]);
+        proc_close($this->filterResource);
+        fclose($this->tmpResource);
+
+    } // onClose()
+
+    /** -----------------------------------------------------------------------------------------
+     * Log error messages to stderr or the logger if it has been provided.
+     *
+     * @param string $message The log message
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private function logError($message)
+    {
+        if ( isset($this->params->logger) ) {
+            $this->params->logger->err($message);
+        } else {
+            fwrite(STDERR, $message . PHP_EOL);
+        }
+    }  // logError()
+}  // class ExternalProcess

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -85,7 +85,7 @@ abstract class aStructuredFile extends File
         $messages = array();
         $propertyTypes = array(
             'record_schema_path' => 'string',
-            'filters'            => 'object',
+            'filters'            => 'array',
             'record_separator'   => 'string',
             'field_separator'    => 'string'
         );
@@ -160,11 +160,11 @@ abstract class aStructuredFile extends File
 
         $fd = $this->connect();
 
-        foreach ( $this->filterDefinitions as $filterKey => $config ) {
+        foreach ( $this->filterDefinitions as $config ) {
 
             if ( ! is_object($config) ) {
                 $this->logger->warning(sprintf(
-                    "Filter config for '%s' must be an object, '%s' given. Skipping.",
+                    "Filter config must be an object, '%s' given. Skipping.",
                     $filterKey,
                     gettype($config)
                 ));
@@ -172,9 +172,9 @@ abstract class aStructuredFile extends File
             }
 
             $messages = array();
-            $properties = array('type' => 'string');
+            $properties = array('name' => 'string', 'type' => 'string');
             if ( ! \xd_utilities\verify_object_property_types($config, $properties, $messages) ) {
-                $this->logAndThrowException("Filters must specify a type: " . implode(', ', $messages));
+                $this->logAndThrowException("Filter missing required properties: " . implode(', ', $messages));
             }
 
             // Include the logger for better error logging
@@ -185,7 +185,7 @@ abstract class aStructuredFile extends File
                     $properties = array('path' => 'string');
                     if ( ! \xd_utilities\verify_object_property_types($config, $properties, $messages) ) {
                         $this->logger->warning(
-                            sprintf("Skipping filter '%s': %s", $filterKey, implode(", ", $messages))
+                            sprintf("Skipping filter '%s': %s", $config->name, implode(", ", $messages))
                         );
                         continue;
                     }
@@ -197,7 +197,7 @@ abstract class aStructuredFile extends File
                         $error = error_get_last();
                         $this->logAndThrowException("Error adding stream filter: " . $error['message']);
                     }
-                    $this->filterList[$filterKey] = $config;
+                    $this->filterList[$config->name] = $config;
                     break;
                 default:
                     $this->logger->warning(

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -1,0 +1,465 @@
+<?php
+/* ==========================================================================================
+ * Abstract class to define properties and implement methods required by all structured
+ * files. Methods supporting the Iterator and Countable interfaces that iStructuredFile
+ * extends are defined here as well.
+ *
+ * @see Iterator
+ * @see Countable
+ * ==========================================================================================
+ */
+
+namespace ETL\DataEndpoint;
+
+use Log;
+
+abstract class aStructuredFile extends File
+{
+    /**
+     * The default number of bytes for file read operations.
+     */
+    const DEFAULT_READ_BYTES = 4096;
+
+    /**
+     * The path to a JSON Schema describing each record the JSON file.
+     *
+     * This is null if no schema was provided.
+     *
+     * @var array|null
+     */
+    protected $recordSchemaPath = null;
+
+    /**
+     * The list of filters that have been attached to the file handle
+     *
+     * @var array|null
+     */
+    protected $filterList = array();
+
+    /**
+     * The list of filters definition objects used to create filters.
+     *
+     * @var array|null
+     */
+    protected $filterDefinitions = null;
+
+    /**
+     * The list of records read from the input file
+     *
+     * @var array
+     */
+    protected $recordList = array();
+
+    /**
+     * The iterator position in the record list.
+     *
+     * @var int
+     */
+    private $recordListPosition = 0;
+
+    /**
+     * Character used to separate records in the input file, defaults to NULL.
+     *
+     * @var string
+     */
+    protected $recordSeparator = null;
+
+    /**
+     * Character used to separate fields in the record, defaults to NULL.
+     *
+     * @var string
+     */
+    protected $fieldSeparator = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iDataEndpoint::__construct()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function __construct(DataEndpointOptions $options, Log $logger = null)
+    {
+        parent::__construct($options, $logger);
+
+        $this->generateUniqueKey();
+
+        $messages = array();
+        $propertyTypes = array(
+            'record_schema_path' => 'string',
+            'filters'            => 'object',
+            'record_separator'   => 'string',
+            'field_separator'    => 'string'
+        );
+
+        if ( ! \xd_utilities\verify_object_property_types($options, $propertyTypes, $messages, true) ) {
+            $this->logAndThrowException("Error verifying options: " . implode(", ", $messages));
+        }
+
+        if ( isset($options->record_schema_path) ) {
+            $this->recordSchemaPath = $options->record_schema_path;
+
+            if ( isset($options->paths->schema_dir) ) {
+                $this->recordSchemaPath = \xd_utilities\resolve_path(\xd_utilities\qualify_path(
+                    $this->recordSchemaPath,
+                    $options->paths->schema_dir
+                ));
+            }
+
+            if ( ! is_readable($this->recordSchemaPath) ) {
+                $this->logAndThrowException(
+                    sprintf("Schema file '%s' is not readable", $this->recordSchemaPath)
+                );
+            }
+        }
+
+        if ( isset($options->record_separator) ) {
+            $this->recordSeparator = $options->record_separator;
+        }
+
+        if ( isset($options->filters) ) {
+            $this->filterDefinitions = $options->filters;
+        }
+
+    }  // __construct()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iStructuredFile::parse()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function parse()
+    {
+        $this->logger->info("Parsing " . $this->path);
+        $this->attachFilters();
+        $numBytesRead = $this->parseFile($this->path);
+        $this->verifyData();
+
+        $this->rewind();
+        return $this->current();
+
+    } // parse()
+
+    /* ------------------------------------------------------------------------------------------
+     * Add any filters that have been configured for this endpoint. PHP's stream filters
+     * will be used to implement filtering and filters will be attached directly to the
+     * file handle. As data is read from the file it is passed through the list of filters
+     * using a bucket-brigade and accessed normally using fread() or other file functions.
+     * See http://php.net/manual/en/ref.stream.php
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function attachFilters()
+    {
+        if ( null === $this->filterDefinitions ) {
+            return;
+        }
+
+        // Register supported filters. Be sure to use the namespace in the class name.
+        $filterName = \ETL\DataEndpoint\Filter\ExternalProcess::NAME;
+        stream_filter_register($filterName, 'ETL\DataEndpoint\Filter\ExternalProcess');
+        $this->logger->debug("Registering filter: $filterName");
+
+        $fd = $this->connect();
+
+        foreach ( $this->filterDefinitions as $filterKey => $config ) {
+
+            if ( ! is_object($config) ) {
+                $this->logger->warning(sprintf(
+                    "Filter config for '%s' must be an object, '%s' given. Skipping.",
+                    $filterKey,
+                    gettype($config)
+                ));
+                continue;
+            }
+
+            $messages = array();
+            $properties = array('type' => 'string');
+            if ( ! \xd_utilities\verify_object_property_types($config, $properties, $messages) ) {
+                $this->logAndThrowException("Filters must specify a type: " . implode(', ', $messages));
+            }
+
+            // Include the logger for better error logging
+            $config->logger = $this->logger;
+
+            switch ($config->type) {
+                case 'external':
+                    $properties = array('path' => 'string');
+                    if ( ! \xd_utilities\verify_object_property_types($config, $properties, $messages) ) {
+                        $this->logger->warning(
+                            sprintf("Skipping filter '%s': %s", $filterKey, implode(", ", $messages))
+                        );
+                        continue;
+                    }
+                    $filterName = 'xdmod.external_process';
+                    $resource = @stream_filter_prepend($fd, $filterName, STREAM_FILTER_READ, $config);
+                    $this->logger->debug(sprintf("Adding filter %s to stream", $filterName));
+
+                    if ( false === $resource ) {
+                        $error = error_get_last();
+                        $this->logAndThrowException("Error adding stream filter: " . $error['message']);
+                    }
+                    $this->filterList[$filterKey] = $config;
+                    break;
+                default:
+                    $this->logger->warning(
+                        sprintf("Unsupported filter type '%s', skipping", $config->type)
+                    );
+                    break;
+            }
+        }
+
+    }  // attachFilters()
+
+    /** -----------------------------------------------------------------------------------------
+     * Parse and decode a data file and return the parsed representation. We parse (and
+     * optionally filter) the entire file at once and place decoded records into the
+     * record list. Reading is not allowed until after parsing is complete. In the future,
+     * we can consider processing the data in a separate thread/process and reading it
+     * back as a stream so we can allow reading before the all data is fully processed.
+     *
+     * @param string $path The path of the file to parse.
+     *
+     * @return The number of bytes read
+     *
+     * @throw Exception If the file could not be read.
+     * @throw Exception If the file could not be parsed.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function parseFile($path)
+    {
+        $buffer = '';
+        $totalBytesRead = 0;
+
+        // Reset the record list and it's iterator pointer
+
+        $this->recordList = array();
+        $this->rewind();
+
+        $fd = $this->connect();
+
+        // If there is no record separator set we can read the file through to the end,
+        // otherwise we need to check for the record separator and handle individual
+        // records appropriately.
+
+        if ( null === $this->recordSeparator ) {
+            while ( ! feof($fd) ) {
+                $data = fread($fd, self::DEFAULT_READ_BYTES);
+                if ( false !== $data ) {
+                    $buffer .= $data;
+                    $totalBytesRead += strlen($data);
+                }
+            }
+        } else {
+            while ( ! feof($fd) ) {
+
+                $data = fread($fd, self::DEFAULT_READ_BYTES);
+
+                // The read operation may not return any data...
+                if ( '' == $data ) {
+                    continue;
+                }
+
+                // If this is a new chunk of data we may need to continue processing a
+                // record from the previous chunk.
+
+                $newDataChunk = true;
+                $numBytesRead = strlen($data);
+                $totalBytesRead += $numBytesRead;
+
+                // Handle the following cases after reading a chunk of data:
+                //
+                // 1. The data does not contain any record separator (RS)
+                // 2. The data starts with the RS
+                // 3. The data ends with the RS
+                // 4. The data contains one or more RS
+
+                // #2 The data begins with a record separator. Decode any data already in
+                // the buffer as strtok() will not explicitly identify this case.
+
+                if ( $this->recordSeparator == $data[0] && '' != $buffer ) {
+                    $this->decodeRecord($buffer);
+                    $buffer = '';
+                }
+
+                // Tokenize the string into records based on the record separator. The
+                // data may contain 0 or more instances of the record separator. strtok()
+                // will not explictly identify a RS at the start or end of the data. If
+                // there is no RS a single record will be returned.
+
+                $record = strtok($data, $this->recordSeparator);
+                while ( false !== $record ) {
+
+                    // Don't flush the buffer if we had a partial record from a previous
+                    // fread() operation.
+
+                    if ( '' != $buffer && ! $newDataChunk ) {
+                        $this->decodeRecord($buffer);
+                        $buffer = '';
+                    }
+
+                    $buffer .= $record;
+                    $record = strtok($this->recordSeparator);
+                    $newDataChunk = false;
+                }
+
+                // #3 We've processed all of the records and the data ends with a record
+                // separator. Decode the current buffer (and continue to read data until
+                // we find a separator or hit EOF). Note that the buffer could be empty if
+                // the data contained only record separators.
+
+                if ( $this->recordSeparator == $data[$numBytesRead - 1] && '' != $buffer ) {
+                    $this->decodeRecord($buffer);
+                    $buffer = '';
+                }
+
+            }
+        }
+
+        // Decode anything remaining in the buffer
+
+        if ( 0 != strlen($buffer) ) {
+            $this->decodeRecord($buffer);
+        }
+        $this->disconnect();
+
+        $this->logger->debug("Parsed " . count($this->recordList) . " records");
+
+        return $totalBytesRead;
+
+    }  // parseFile()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iStructuredFile::getRecordSeparator()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordSeparator()
+    {
+        return $this->recordSeparator;
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iStructuredFile::getFieldSeparator()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getFieldSeparator()
+    {
+        return $this->fieldSeparator;
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iStructuredFile::getRecordFieldNames()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordFieldNames()
+    {
+        return array();
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iStructuredFile::getAttachedFilters()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getAttachedFilters()
+    {
+        return $this->filterList;
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iStructuredFile::getRecordsDefinition()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordsDefinition()
+    {
+        return array();
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::current()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function current()
+    {
+        if ( ! $this->valid() ) {
+            return false;
+        }
+        return $this->recordList[$this->recordListPosition];
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::current()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function key()
+    {
+        return $this->recordListPosition;
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::current()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function next()
+    {
+        $this->recordListPosition++;
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::current()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function rewind()
+    {
+        $this->recordListPosition = 0;
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::current()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function valid()
+    {
+        return isset($this->recordList[$this->recordListPosition]);
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Countable::count()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function count()
+    {
+        return count($this->recordList);
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * Decodes a data string into a PHP object and add it to the record list.
+     *
+     * @param  string $data The data string to decode.
+     *
+     * @return bool TRUE on success
+     * @throws Exception if there was an error decoding the data.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    abstract protected function decodeRecord($data);
+
+    /** -----------------------------------------------------------------------------------------
+     * If a record schema was specified, verify that each record conforms to that schema.
+     *
+     * @return TRUE on success
+     * @throw Exception If there was a validation error
+     * ------------------------------------------------------------------------------------------
+     */
+
+    abstract protected function verifyData();
+}  // abstract class aStructuredFile

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -21,7 +21,7 @@ abstract class aStructuredFile extends File
     const DEFAULT_READ_BYTES = 4096;
 
     /**
-     * The path to a JSON Schema describing each record the JSON file.
+     * Optional path to a schema describing each record the structured file.
      *
      * This is null if no schema was provided.
      *

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -165,7 +165,6 @@ abstract class aStructuredFile extends File
             if ( ! is_object($config) ) {
                 $this->logger->warning(sprintf(
                     "Filter config must be an object, '%s' given. Skipping.",
-                    $filterKey,
                     gettype($config)
                 ));
                 continue;

--- a/classes/ETL/DataEndpoint/iDataEndpoint.php
+++ b/classes/ETL/DataEndpoint/iDataEndpoint.php
@@ -6,9 +6,8 @@
  * well such as a schema for a database or a mode for a file.  In addition to metadata, endpoints
  * provide a handle to the underlying implementation (e.g., a PDO or file handle)
  *
- * The endpoint name may have different meaning in different contexts. E.g., for a mysql endpoint it
- * may be a configuration file section specifying connection parameters and for a file endpoint it
- * may be the path to the file.
+ * Data Endpoint configurations tend to be immutable once they are created, providing only
+ * accessors to properties and not setters.
  *
  * @author Steve Gallo <smgallo@buffalo.edu>
  * @date 2015-10-15
@@ -19,16 +18,21 @@
 
 namespace ETL\DataEndpoint;
 
+// PEAR logger
+use Log;
+
 interface iDataEndpoint
 {
     /* ------------------------------------------------------------------------------------------
      * Create the DataEndpoint object
      *
-     * @param $options A DataEndpointOptions object containing option information
+     * @param DataEndpointOptions $options A DataEndpointOptions object containing option
+     *    information
+     * @param Log $logger Optional PEAR Log object for system logging
      * ------------------------------------------------------------------------------------------
      */
 
-    public function __construct(DataEndpointOptions $options);
+    public function __construct(DataEndpointOptions $options, Log $logger = null);
 
     /* ------------------------------------------------------------------------------------------
      * @return The endpoint type (e.g., mysql, postgres, file)

--- a/classes/ETL/DataEndpoint/iFile.php
+++ b/classes/ETL/DataEndpoint/iFile.php
@@ -1,0 +1,28 @@
+<?php
+/* ==========================================================================================
+ * Interface for file data endpoints. Files add the ability to specify a path and mode.
+ *
+ * @author Steve Gallo  <smgallo@buffalo.edu>
+ * @date 2017-05-10
+ * ==========================================================================================
+ */
+
+namespace ETL\DataEndpoint;
+
+interface iFile extends iDataEndpoint
+{
+
+    /* ------------------------------------------------------------------------------------------
+     * @return The path to the file
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getPath();
+
+    /* ------------------------------------------------------------------------------------------
+     * @return The mode used to access the file specified by the path.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getMode();
+}  // interface iFile

--- a/classes/ETL/DataEndpoint/iStructuredFile.php
+++ b/classes/ETL/DataEndpoint/iStructuredFile.php
@@ -1,0 +1,78 @@
+<?php
+/* ==========================================================================================
+ * Interface for handling structured files. Structured files contain data in a known
+ * (structured) format including CSV, tab-delimited, and JSON. Records are separated by a
+ * Record Separator (RS) and individual fields may be separated by a Field Separator (FS)
+ * if the format allows or requires it (e.g., CSV and TSV). Typically, we will read a
+ * structured file by iterating over the records and operating on the fields within the
+ * record.
+ *
+ * @author Steve Gallo  <smgallo@buffalo.edu>
+ * @date 2017-05-10
+ * ==========================================================================================
+ */
+
+namespace ETL\DataEndpoint;
+
+interface iStructuredFile extends iFile, \Iterator, \Countable
+{
+
+    /** -----------------------------------------------------------------------------------------
+     * @return The record separator, or NULL if none has been set.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordSeparator();
+
+    /** -----------------------------------------------------------------------------------------
+     * @return The field separator, or NULL if none has been set.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getFieldSeparator();
+
+    /** -----------------------------------------------------------------------------------------
+     * @return The list of field names for a record
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordFieldNames();
+
+    /** -----------------------------------------------------------------------------------------
+     * @return An associative array filters attached to be applied to the data in this
+     *   file where the key is the filter key used in the configuration.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getAttachedFilters();
+
+    /** -----------------------------------------------------------------------------------------
+     * The record definition is a mixed list of scalar field names and objects specifying
+     * the field name and type.
+     *
+     * @return An array containing the record definition.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordsDefinition();
+
+    /** -----------------------------------------------------------------------------------------
+     * Parse and possibly decode the (possibly filtered) file data. The resulting data
+     * will be stored in an internal data structure and accessible via the iterator
+     * methods. The first record will be returned, allowing the implementation of file
+     * formats such as a JSON file to return a single object representing simple cases
+     * such as a configuration file without needing to use the iterator methods.
+     *
+     * Note that different types of structured files will represent data differently. For
+     * example, a CSV file will typically contain multiple records, one record per
+     * line. separated by an end-of-line character. A JSON file could containan a single
+     * object (such as a configuration) or an array of objects or scalar data with no
+     * record separator. However, a JSON file could also contain multiple individual
+     * objects separated by a record separator without the enclosing array.
+     *
+     * @return mixed The first parsed record parsed from the file.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function parse();
+}  // interface iStructuredFile

--- a/classes/ETL/DbModel/Column.php
+++ b/classes/ETL/DbModel/Column.php
@@ -175,17 +175,17 @@ class Column extends NamedEntity implements iEntity
             if ( (null !== $srcDefault && null === $srcExtra) ) {
                 if ( null !== $destExtra ) {
                     // Extra has changed (destination has a value)
-                    return -1;
+                    return -2;
                 } elseif ( null === $destDefault ) {
                     // Default has changed from NULL to something
-                    return -1;
+                    return -3;
                 } elseif ( strtolower($srcDefault) != strtolower($destDefault)
                             && ( ("0" == "$srcDefault" && '0000-00-00 00:00:00' != $destDefault)
                                  || ("0" != "$srcDefault" && $srcDefault . ' 00:00:00' != $destDefault) ) )
                 {
                     // Note the casting of 0 to "0" above is necessary because php considers 0 == "0000-01-01" to be true.
                     // Default has changed
-                    return -1;
+                    return -4;
                 }
             }
 
@@ -195,13 +195,13 @@ class Column extends NamedEntity implements iEntity
 
             if ( null !== $srcDefault && null !== $srcExtra ) {
                 if ( strtolower($srcExtra) != strtolower($destExtra) ) {
-                    return -1;
+                    return -5;
                 } elseif ( strtolower($srcDefault) != strtolower($destDefault)
                             && ( ("0" == "$srcDefault" && '0000-00-00 00:00:00' != $destDefault)
                                  || ("0" != "$srcDefault" && $srcDefault . ' 00:00:00' != $destDefault)) )
                 {
                     // Note the casting of 0 to "0" above is necessary because php considers 0 == "0000-01-01" to be true.
-                    return -1;
+                    return -6;
                 }
             }
 
@@ -214,7 +214,7 @@ class Column extends NamedEntity implements iEntity
                      || strtolower($srcExtra) != strtolower($destExtra)
                      || (null !== $destDefault && '0000-00-00 00:00:00' != $destDefault) )
                 {
-                    return -1;
+                    return -7;
                 }
             }
 
@@ -222,11 +222,11 @@ class Column extends NamedEntity implements iEntity
             // The following properties do not have defaults set by the database and should be considered if
             // one of them is set.
             if ( ( null !== $this->default || null !== $cmp->default ) && $this->default != $cmp->default ) {
-                return -1;
+                return -8;
             }
 
-            if ( ( null !== $this->extra || null !== $cmp->extra ) && $this->extra != $cmp->extra ) {
-                return -1;
+            if ( ( null !== $this->extra || null !== $cmp->extra ) && strtolower($this->extra) != strtolower($cmp->extra) ) {
+                return -9;
             }
         } // else ( "timestamp" == $this->type )
 
@@ -241,7 +241,7 @@ class Column extends NamedEntity implements iEntity
             $cmpType = substr($cmp->type, 4);
             $cmpType = implode(',', preg_split('/\s*,\s*/', trim($cmpType, "() \t\n\r\0\x0B")));
             if ( $myType != $cmpType ) {
-                return -1;
+                return -10;
             }
         }
 
@@ -249,14 +249,14 @@ class Column extends NamedEntity implements iEntity
         // a value will be provided when the database information schema is queried.
 
         if ( ( null !== $this->nullable && null !== $cmp->nullable ) && $this->nullable != $cmp->nullable ) {
-            return -1;
+            return -11;
         }
 
         // The following properties do not have defaults set by the database and should be considered if
         // one of them is set.
 
         if ( ( null !== $this->comment || null !== $cmp->comment ) && $this->comment != $cmp->comment ) {
-            return -1;
+            return -12;
         }
 
         return 0;

--- a/classes/ETL/DbModel/Index.php
+++ b/classes/ETL/DbModel/Index.php
@@ -154,7 +154,7 @@ class Index extends NamedEntity implements iEntity
         // a value will be provided when the database information schema is queried.
 
         if ( ( null !== $this->type && null !== $cmp->type ) && $this->type != $cmp->type ) {
-            return -11;
+            return -2;
         }
 
         // The following properties do not have defaults set by the database and should be considered if
@@ -165,7 +165,7 @@ class Index extends NamedEntity implements iEntity
         if ( "PRIMARY" != $this->name && "PRIMARY" != $cmp->name
              && ( null !== $this->is_unique && null !== $cmp->is_unique )
              && $this->is_unique != $cmp->is_unique ) {
-            return -111;
+            return -3;
         }
 
         return 0;

--- a/classes/ETL/DbModel/Join.php
+++ b/classes/ETL/DbModel/Join.php
@@ -86,7 +86,11 @@ class Join extends SchemaEntity implements iEntity
             return 1;
         }
 
-        return ( $this == $cmp );
+        if ( $this == $cmp ) {
+            return 0;
+        } else {
+            return -1;
+        }
 
     }  // compare()
 

--- a/classes/ETL/DbModel/Table.php
+++ b/classes/ETL/DbModel/Table.php
@@ -624,6 +624,7 @@ ORDER BY trigger_name ASC";
             if ( 0 == $destColumn->compare($this->getColumn($name)) ) {
                 continue;
             }
+
             $alterList[] = "CHANGE COLUMN " . $destColumn->getName(true) . " " . $destColumn->getSql($includeSchema);
         }
 

--- a/classes/ETL/DbModel/Trigger.php
+++ b/classes/ETL/DbModel/Trigger.php
@@ -114,14 +114,14 @@ class Trigger extends SchemaEntity implements iEntity
         // a value will be provided when the database information schema is queried.
 
         if ( ( null !== $this->definer && null !== $cmp->definer ) && $this->definer != $cmp->definer ) {
-            return -1;
+            return -2;
         }
 
         // The following properties do not have defaults set by the database and should be considered if
         // one of them is set.
 
         if ( ( null !== $this->schema || null !== $cmp->schema ) && $this->schema != $cmp->schema ) {
-            return -1;
+            return -3;
         }
 
     }  // compare()

--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -17,8 +17,8 @@ use ETL\Configuration\EtlConfiguration;
 use ETL\EtlOverseerOptions;
 use ETL\aRdbmsDestinationAction;
 use ETL\aOptions;
-use ETL\DataEndpoint\StructuredFile;
-use \Log;
+use ETL\DataEndpoint\iStructuredFile;
+use Log;
 
 class StructuredFileIngestor extends aIngestor implements iAction
 {
@@ -52,7 +52,6 @@ class StructuredFileIngestor extends aIngestor implements iAction
     public function __construct(aOptions $options, EtlConfiguration $etlConfig, Log $logger = null)
     {
         parent::__construct($options, $etlConfig, $logger);
-
     }  // __construct()
 
     /* ------------------------------------------------------------------------------------------
@@ -82,8 +81,8 @@ class StructuredFileIngestor extends aIngestor implements iAction
             $this->sourceEndpoint = null;
             $this->sourceHandle = null;
         } elseif ( $this->options->source !== null && ! $this->options->ignore_source ) {
-            if ( ! $this->sourceEndpoint instanceof StructuredFile ) {
-                $msg = "Source is not an instance of ETL\\DataEndpoint\\StructuredFile";
+            if ( ! $this->sourceEndpoint instanceof iStructuredFile ) {
+                $msg = "Source is not an instance of ETL\\DataEndpoint\\iStructuredFile";
                 $this->logAndThrowException($msg);
             }
         }
@@ -143,12 +142,19 @@ class StructuredFileIngestor extends aIngestor implements iAction
     /**
      * @see aIngestor::_execute()
      */
+
+    // @codingStandardsIgnoreLine
     protected function _execute()
     {
         $destColumns = $this->executionData['destColumns'];
         $destColumnsToSourceKeys = $this->executionData['destColumnsToSourceKeys'];
         $sourceValues = $this->executionData['sourceValues'];
         $customInsertValuesComponents = $this->executionData['customInsertValuesComponents'];
+
+        // If no data was provided in the file, use the StructuredFile endpoint
+        if ( null === $sourceValues ) {
+            $sourceValues = $this->sourceEndpoint;
+        }
 
         $numColumns = count($destColumns);
         $numRecords = count($sourceValues);
@@ -230,10 +236,17 @@ class StructuredFileIngestor extends aIngestor implements iAction
             $destColumns = array_keys($destColumnsToSourceKeys);
         }
 
+        // The StructuredFile data endpoint now implements the Iterator interface. Storing
+        // source values directly in the definition file will be deprecated in the future
+        // in favor of maintaing a separate data file with a reference to that file in the
+        // definition.
+
+        $sourceValues = null;
+
         // If a source data endpoint was given, use it. Otherwise, use data
         // values specified in the definition file.
-        if ($this->sourceEndpoint) {
-            $sourceValues = $this->sourceEndpoint->parse();
+        if ( null !== $this->sourceEndpoint) {
+            $this->sourceEndpoint->parse();
         } else {
             $sourceValues = $this->parsedDefinitionFile->source_values;
         }

--- a/composer.lock
+++ b/composer.lock
@@ -2695,12 +2695,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ubccr/xdmod-test-artifacts.git",
-                "reference": "173dcefc611ba7eabd1aa9aa3c400372e7f9aaf7"
+                "reference": "aa431c5969c30511a8dbe56f758a43543406c2a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ubccr/xdmod-test-artifacts/zipball/f4a08a5244cf41d212e7655b4c87276fb04f2494",
-                "reference": "173dcefc611ba7eabd1aa9aa3c400372e7f9aaf7",
+                "url": "https://api.github.com/repos/ubccr/xdmod-test-artifacts/zipball/aa431c5969c30511a8dbe56f758a43543406c2a0",
+                "reference": "aa431c5969c30511a8dbe56f758a43543406c2a0",
                 "shasum": ""
             },
             "type": "library",

--- a/configuration/etl/etl.json
+++ b/configuration/etl/etl.json
@@ -4,7 +4,7 @@
 
     "paths": {
         "definition_file_dir": "etl_tables.d",
-        "specs_dir": "etl_specs.d",
+        "schema_dir": "etl_schemas.d",
         "macro_dir": "etl_macros.d",
         "sql_dir": "etl_sql.d",
         "data_dir": "etl_data.d",

--- a/libraries/utilities.php
+++ b/libraries/utilities.php
@@ -627,6 +627,8 @@ function resolve_path($path)
  * @param array $propertyList The list of required properties
  * @param array $missing Optional reference to an array that will contain a list of the
  *   missing properties.
+ *
+ * @return TRUE if the object contains all of the required properties, FALSE otherwise.
  */
 
 function verify_required_object_properties(\stdClass $obj, array $propertyList, array &$missing = null)
@@ -646,7 +648,7 @@ function verify_required_object_properties(\stdClass $obj, array $propertyList, 
 /**
  * Verify the types of object properties, optionally skipping properties that are not
  * present in the object.  Property types must match the PHP is_*() methods (e.g.,
- * is_int(), is_object(), is_string()) and will silently be skipped if a function
+ * is_int(), is_object(), is_string()) and will generate a warning message a function
  * corresponding to the specified type does not exist.
  *
  * @param stdClass $obj The object to examine
@@ -654,7 +656,7 @@ function verify_required_object_properties(\stdClass $obj, array $propertyList, 
  *   the values are property types.
  * @param array $messages Optional reference to an array that will contain a list of
  *   messages regarding the property types.
- * @param int $skipMissingProperties If set to FALSE, properties that are not present in
+ * @param boolean $skipMissingProperties If set to FALSE, properties that are not present in
  *   the object generate an error. If set to TRUE missing properties are silently skipped,
  *
  * @return TRUE if all properties were present and their type checks passed, FALSE
@@ -677,7 +679,9 @@ function verify_object_property_types(
             continue;
         }
         $func = 'is_' . $type;
-        if ( function_exists($func) && ! $func($obj->$p) ) {
+        if ( ! function_exists($func) ) {
+            $messages[] = sprintf("Unsupported type %s given for property '%s'", $type, $p);
+        } elseif ( ! $func($obj->$p) ) {
             $messages[] = sprintf("'%s' must be a %s, %s given", $p, $type, gettype($obj->$p));
         }
     }

--- a/libraries/utilities.php
+++ b/libraries/utilities.php
@@ -619,3 +619,68 @@ function resolve_path($path)
 
     return implode(DIRECTORY_SEPARATOR, $resolved);
 }  // resolve_path()
+
+/**
+ * Verify that an object contains all of the properties specified in the $propertyList
+ *
+ * @param stdClass $obj The object to examine
+ * @param array $propertyList The list of required properties
+ * @param array $missing Optional reference to an array that will contain a list of the
+ *   missing properties.
+ */
+
+function verify_required_object_properties(\stdClass $obj, array $propertyList, array &$missing = null)
+{
+    $missing = array();
+
+    foreach ( $propertyList as $p ) {
+        if ( ! isset($obj->$p) ) {
+            $missing[] = $p;
+        }
+    }
+
+    return 0 == count($missing);
+
+}  // verify_required_object_properties()
+
+/**
+ * Verify the types of object properties, optionally skipping properties that are not
+ * present in the object.  Property types must match the PHP is_*() methods (e.g.,
+ * is_int(), is_object(), is_string()) and will silently be skipped if a function
+ * corresponding to the specified type does not exist.
+ *
+ * @param stdClass $obj The object to examine
+ * @param array $typeList An associative array where the keys are property names and
+ *   the values are property types.
+ * @param array $messages Optional reference to an array that will contain a list of
+ *   messages regarding the property types.
+ * @param int $skipMissingProperties If set to FALSE, properties that are not present in
+ *   the object generate an error. If set to TRUE missing properties are silently skipped,
+ *
+ * @return TRUE if all properties were present and their type checks passed, FALSE
+ *   otherwise.
+ */
+
+function verify_object_property_types(
+    \stdClass $obj,
+    array $propertyList,
+    array &$messages = null,
+    $skipMissingProperties = false
+) {
+    $messages = array();
+
+    foreach ( $propertyList as $p => $type ) {
+        if ( ! isset($obj->$p) ) {
+            if ( ! $skipMissingProperties ) {
+                $messages[] = sprintf("missing property '%s'", $p);
+            }
+            continue;
+        }
+        $func = 'is_' . $type;
+        if ( function_exists($func) && ! $func($obj->$p) ) {
+            $messages[] = sprintf("'%s' must be a %s, %s given", $p, $type, gettype($obj->$p));
+        }
+    }
+
+    return ( 0 == count($messages) );
+}  // verify_object_property_types()

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/FileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/FileTest.php
@@ -1,0 +1,116 @@
+<?php
+/* ------------------------------------------------------------------------------------------
+ * Component tests for ETL File DataEndpoints.
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ * @date 2017-05-15
+ * ------------------------------------------------------------------------------------------
+ */
+
+namespace UnitTesting\ETL\DataEndpoint;
+
+use Exception;
+use CCR\Log;
+// use ETL\DataEndpoint\File;
+use ETL\DataEndpoint;
+use ETL\DataEndpoint\DataEndpointOptions;
+
+class FileTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
+    private $logger = null;
+
+    public function __construct()
+    {
+        // Set up a logger so we can get warnings and error messages from the ETL
+        // infrastructure
+        $conf = array(
+            'file' => false,
+            'db' => false,
+            'mail' => false,
+            'consoleLogLevel' => Log::WARNING
+        );
+
+        $this->logger = Log::factory('PHPUnit', $conf);
+    }  // __construct()
+
+    /**
+     * Test trying to read a directory instead of a file.
+     *
+     * @expectedException Exception
+     */
+
+    public function testNotFile()
+    {
+        $config = array(
+            'name' => 'Not a file',
+            'path' => sys_get_temp_dir(),
+            'type' => 'file'
+        );
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+    }  // testFileNotReadable()
+
+    /**
+     * Test trying to open a file with an invalid mode.
+     *
+     * @expectedException Exception
+     */
+
+    public function testBadFileMode()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'xdmod_test');
+
+        $config = array(
+            'name' => 'Bad file mode',
+            'path' => $path,
+            'mode' => 'junk-mode',
+            'type' => 'file'
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+
+        try {
+            $file->verify();
+        } catch ( Exception $e ) {
+            unlink($path);
+            throw $e;
+        }
+
+        unlink($path);
+
+    }  // testBadFileMode()
+
+    /**
+     * Test reading a simple string from a file.
+     */
+
+    public function testReadFile()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'xdmod_test');
+        $expected = "Random string to a file";
+        file_put_contents($path, $expected);
+
+        $config = array(
+            'name' => 'Read test',
+            'path' => $path,
+            'type' => 'file'
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $fh = $file->connect();
+
+        $generated = fgets($fh);
+        $file->disconnect();
+
+        $this->assertEquals($expected, $generated);
+
+        @unlink($path);
+
+    }  // testReadFile()
+}  // class FileTest

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
@@ -210,9 +210,9 @@ class StructuredFileTest extends \PHPUnit_Framework_TestCase
             'name' => 'xdmod_va_users.json',
             'path' => $path,
             'type' => 'jsonfile',
-            // Filters should be an object
-            'filters' => array(
-                (object) array(
+            // Filters should be an array
+            'filters' => (object) array(
+                'jq' => (object) array(
                     'path' => 'jq',
                     'arguments' => "'map({ name: .organizations[].name})|unique'"
                 )
@@ -237,9 +237,10 @@ class StructuredFileTest extends \PHPUnit_Framework_TestCase
             'name' => 'xdmod_va_users.json',
             'path' => $path,
             'type' => 'jsonfile',
-            'filters' => (object) array(
-                'jq' => (object) array(
-                    // Need a filter type
+            'filters' => array(
+                (object) array(
+                    // Need a filter type 'type' => 'external'
+                    'name' => 'jq',
                     'path' => 'jq',
                     'arguments' => "'map({ name: .organizations[].name}) | unique'"
                 )
@@ -267,9 +268,10 @@ class StructuredFileTest extends \PHPUnit_Framework_TestCase
             'name' => 'xdmod_va_users.json',
             'path' => $path,
             'type' => 'jsonfile',
-            'filters' => (object) array(
-                'jq' => (object) array(
+            'filters' => array(
+                (object) array(
                     'type' => 'external',
+                    'name' => 'jq',
                     'path' => 'jq',
                     // The single quotes should be included IN the string, an exception will be thrown
                     'arguments' => 'map({ name: .organizations[].name})|unique'
@@ -299,9 +301,10 @@ class StructuredFileTest extends \PHPUnit_Framework_TestCase
             'name' => 'xdmod_va_users.json',
             'path' => $path,
             'type' => 'jsonfile',
-            'filters' => (object) array(
-                'jq' => (object) array(
+            'filters' => array(
+                (object) array(
                     'type' => 'external',
+                    'name' => 'jq',
                     'path' => 'jq',
                     // Retrive the list of unique org names as a list of objects
                     'arguments' => "'map({ name: .organizations[].name})|unique'"
@@ -348,9 +351,10 @@ class StructuredFileTest extends \PHPUnit_Framework_TestCase
             'path' => $path,
             'type' => 'jsonfile',
             'record_separator' => "\n",
-            'filters' => (object) array(
-                'jq' => (object) array(
+            'filters' => array(
+                (object) array(
                     'type' => 'external',
+                    'name' => 'jq',
                     'path' => 'jq',
                     // Retrieve the instance type object from each record. Note the -c to
                     // preserve the newline as record separator

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
@@ -1,0 +1,436 @@
+<?php
+/* ------------------------------------------------------------------------------------------
+ * Component tests for ETL StructuredFile DataEndpoints
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ * @date 2017-05-15
+ * ------------------------------------------------------------------------------------------
+ */
+
+namespace UnitTesting\ETL\DataEndpoint;
+
+use CCR\Log;
+use ETL\DataEndpoint;
+use ETL\DataEndpoint\DataEndpointOptions;
+
+class StructuredFileTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
+    private $logger = null;
+
+    public function __construct()
+    {
+        // Set up a logger so we can get warnings and error messages from the ETL
+        // infrastructure
+        $conf = array(
+            'file' => false,
+            'db' => false,
+            'mail' => false,
+            'consoleLogLevel' => Log::WARNING
+        );
+
+        $this->logger = Log::factory('PHPUnit', $conf);
+    }  // __construct()
+
+    /**
+     * Test parsing a simple JSON file containing an array of objects.
+     */
+
+    public function testParseJsonFileArray()
+    {
+        $expected = array(
+            (object) array(
+                'organizations' => array(
+                    (object) array(
+                        'division' => 'IN-OPTH',
+                        'appointment_type' => 'Faculty',
+                        'name' => 'Indiana University',
+                        'id' => 'helegreen'
+                    )
+                ),
+                'first_name' => 'Helen',
+                'last_name' => 'Green',
+                'groups' => array(
+                    'BUS-KDFACULTY',
+                    'AssociateProfessors-Tenured',
+                    'CHEM-HiringCommitteeOne'
+                )
+            ),
+            (object) array(
+                'organizations' => array(
+                    (object) array(
+                        'division' => 'IN-HEMO',
+                        'appointment_type' => 'Faculty',
+                        'name' => 'Indiana University',
+                        'id' => 'dorogreen'
+                    )
+                ),
+                'first_name' => 'Dorothy',
+                'last_name' => 'Green',
+                'groups' => array(
+                    'MDEP-Gastroenterology',
+                    'Chemlearn-C484'
+                )
+            ),
+             (object) array(
+                 'organizations' => array(
+                     (object) array(
+                         'division' => 'IN-UROL',
+                         'appointment_type' => 'Faculty',
+                         'name' => 'Indiana University',
+                         'id' => 'majohnson'
+                     )
+                 ),
+                'first_name' => 'Mario',
+                'last_name' => 'Johnson',
+                'groups' => array(
+                    'PSYC-CHFAC',
+                    'IUCC-Newsletter',
+                    'ET_STU03'
+                )
+            )
+        );
+
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/xdmod_va_users.json';
+        $config = array(
+            'name' => 'xdmod_va_users.json',
+            'path' => $path,
+            'type' => 'jsonfile'
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $file->parse();
+
+        foreach ($file as $index => $record) {
+            $this->assertEquals($expected[$index], $record);
+        }
+    }  // testParseJsonFileArray()
+
+    /**
+     * Test parsing a simple JSON file containing multiple objects, each on a single line,
+     * separated by a newline.
+     */
+
+    public function testParseJsonFileRecords()
+    {
+        $expected = array(
+            (object) array(
+                'node_controller' => null,
+                'public_ip' => null,
+                'account' => '000048934329',
+                'event_type' => 'STATE_REPORT',
+                'event_time' => '2017-05-16T03:55:04Z',
+                'instance_type' => (object) array(
+                    'name' => 'c1.medium',
+                    'cpu' => '4',
+                    'memory' => '16384',
+                    'disk' => '40',
+                    'networkInterfaces' => '2'
+                ),
+                'image_type' => 'emi-521695e8',
+                'instance_id' => 'i-cb13943e',
+                'record_type' => 'ADMINISTRATIVE',
+                'block_devices' => array(
+                    (object) array(
+                        'account' => 'big',
+                        'attach_time' => '2017-04-19T13:47:38.609Z',
+                        'backing' => 'ebs',
+                        'create_time' => '2017-04-19T13:47:38.550Z',
+                        'user' => 'tyearke',
+                        'id' => 'vol-6a9b5bc2',
+                        'size' => '40'
+                    )
+                ),
+                'private_ip' => null,
+                'root_type' => 'ebs'
+            ),
+            (object) array(
+                'node_controller' => '172.17.0.31',
+                'public_ip' => '199.109.192.61',
+                'account' => '000669660540',
+                'event_type' => 'STATE_REPORT',
+                'event_time' => '2017-05-16T03:55:04Z',
+                'instance_type' => (object) array(
+                    'name' => 'm1.medium',
+                    'cpu' => '2',
+                    'memory' => '4096',
+                    'disk' => '20',
+                    'networkInterfaces' => '2'
+                ),
+                'image_type' => 'emi-3f83abf8',
+                'instance_id' => 'i-dd04e6bf',
+                'record_type' => 'ADMINISTRATIVE',
+                'block_devices' => array(
+                    (object) array(
+                        'account' => 'redfly',
+                        'attach_time' => '2017-03-21T16:57:45.376Z',
+                        'backing' => 'ebs',
+                        'create_time' => '2017-03-21T16:57:45.330Z',
+                        'user' => 'riveraj',
+                        'id' => 'vol-dae393e0',
+                        'size' => '10'
+                    )
+                ),
+                'private_ip' => '172.17.47.126',
+                'root_type' => 'ebs'
+            )
+        );
+
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/euca_acct.json';
+        $config = array(
+            'name' => 'euca_acct.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'record_separator' => "\n"
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $file->parse();
+
+        foreach ($file as $index => $record) {
+            $this->assertEquals($expected[$index], $record);
+        }
+    }
+
+    /**
+     * Test error reporting when config is not valid.
+     *
+     * @expectedException Exception
+     */
+
+    public function testInvalidFilterConfig()
+    {
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/xdmod_va_users.json';
+        $config = array(
+            'name' => 'xdmod_va_users.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            // Filters should be an object
+            'filters' => array(
+                (object) array(
+                    'path' => 'jq',
+                    'arguments' => "'map({ name: .organizations[].name})|unique'"
+                )
+            )
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+
+    }  // testInvalidFilterConfig()
+
+    /**
+     * Test error reporting when a filter type is not provided.
+     *
+     * @expectedException Exception
+     */
+
+    public function testMissingFilterType()
+    {
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/xdmod_va_users.json';
+        $config = array(
+            'name' => 'xdmod_va_users.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'filters' => (object) array(
+                'jq' => (object) array(
+                    // Need a filter type
+                    'path' => 'jq',
+                    'arguments' => "'map({ name: .organizations[].name}) | unique'"
+                )
+            )
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        // Filters are not crearted until parse() is called
+        $file->parse();
+
+    }  // testMissingFilterType()
+
+    /**
+     * Test filter syntax error.
+     *
+     * @expectedException Exception
+     */
+
+    public function testFilterSyntaxError()
+    {
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/xdmod_va_users.json';
+        $config = array(
+            'name' => 'xdmod_va_users.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'filters' => (object) array(
+                'jq' => (object) array(
+                    'type' => 'external',
+                    'path' => 'jq',
+                    // The single quotes should be included IN the string, an exception will be thrown
+                    'arguments' => 'map({ name: .organizations[].name})|unique'
+                )
+            )
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $file->parse();
+    }  // testFilterSyntaxError()
+
+    /**
+     * Test parsing a simple JSON file containing an array of objects filtered through an
+     * external process.
+     */
+
+    public function testParseJsonFileFilteredArray()
+    {
+        $expected = (object) array(
+            'name' => 'Indiana University'
+        );
+
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/xdmod_va_users.json';
+        $config = array(
+            'name' => 'xdmod_va_users.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'filters' => (object) array(
+                'jq' => (object) array(
+                    'type' => 'external',
+                    'path' => 'jq',
+                    // Retrive the list of unique org names as a list of objects
+                    'arguments' => "'map({ name: .organizations[].name})|unique'"
+                )
+            )
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        // We are expecting a single unique name
+        $generated = $file->parse();
+
+        $this->assertEquals($expected, $generated);
+    }  // testParseJsonFileFilteredArray()
+
+    /**
+     * Test parsing a simple JSON file containing multiple records separated by a newline
+     * and filtered through an external process.
+     */
+
+    public function testParseJsonFileFilteredRecords()
+    {
+        $expected = array(
+            (object) array(
+                'name' => 'c1.medium',
+                'cpu' => '4',
+                'memory' => '16384',
+                'disk' => '40',
+                'networkInterfaces' => '2'
+            ),
+            (object) array(
+                'name' => 'm1.medium',
+                'cpu' => '2',
+                'memory' => '4096',
+                'disk' => '20',
+                'networkInterfaces' => '2'
+            )
+        );
+
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/euca_acct.json';
+        $config = array(
+            'name' => 'euca_acct.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'record_separator' => "\n",
+            'filters' => (object) array(
+                'jq' => (object) array(
+                    'type' => 'external',
+                    'path' => 'jq',
+                    // Retrieve the instance type object from each record. Note the -c to
+                    // preserve the newline as record separator
+                    'arguments' => "-c '.instance_type'"
+                )
+            )
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        // We are expecting a single unique name
+        $file->parse();
+
+        foreach ($file as $index => $record) {
+            $this->assertEquals($expected[$index], $record);
+        }
+    }  // testParseJsonFileFilteredRecords()
+
+    /**
+     * Test successful JSON schema validation.
+     */
+
+    public function testSchemaValidationSuccess()
+    {
+        $expected = (object) array(
+            'organizations' => array(
+                (object) array(
+                    'division' => 'IN-OPTH',
+                    'appointment_type' => 'Faculty',
+                    'name' => 'Indiana University',
+                    'id' => 'helegreen'
+                )
+            ),
+            'first_name' => 'Helen',
+            'last_name' => 'Green',
+            'groups' => array(
+                'BUS-KDFACULTY',
+                'AssociateProfessors-Tenured',
+                'CHEM-HiringCommitteeOne'
+            )
+        );
+
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/xdmod_va_users.json';
+        $config = array(
+            'name' => 'xdmod_va_users.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'record_schema_path' => self::TEST_ARTIFACT_INPUT_PATH . '/person.schema.json'
+        );
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $generated = $file->parse();
+
+        $this->assertEquals($expected, $generated);
+
+    }  // testSchemaValidationSuccess()
+
+    /**
+     * Test failed JSON schema validation.
+     *
+     * @expectedException Exception
+     */
+
+    public function testSchemaValidationFailure()
+    {
+
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/xdmod_va_bad_users.json';
+        $config = array(
+            'name' => 'xdmod_va_bad_users.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'record_schema_path' => self::TEST_ARTIFACT_INPUT_PATH . '/person.schema.json'
+        );
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $generated = $file->parse();
+
+    }  // testSchemaValidationFailure()
+
+}  // class StructuredFileTest

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
@@ -432,5 +432,4 @@ class StructuredFileTest extends \PHPUnit_Framework_TestCase
         $generated = $file->parse();
 
     }  // testSchemaValidationFailure()
-
 }  // class StructuredFileTest

--- a/tools/dev/verify_table_data.php
+++ b/tools/dev/verify_table_data.php
@@ -248,7 +248,6 @@ try {
 $success = true;
 
 foreach ($scriptOptions['compare-tables'] as $table ) {
-
     list($srcTable, $destTable) = $table;
     $retval = compareTables($srcTable, $destTable);
     $success = $success && $retval;
@@ -308,6 +307,11 @@ function compareTables($srcTable, $destTable)
 
     $srcTableColumns = getTableColumns($srcTable, $srcSchema, $scriptOptions['exclude-columns']);
     $destTableColumns = getTableColumns($destTable, $destSchema, $scriptOptions['exclude-columns']);
+
+    if ( false === $srcTableColumns || false === $destTableColumns ) {
+        return false;
+    }
+
     $numSrcColumns = count($srcTableColumns);
     $numDestColumns = count($destTableColumns);
 
@@ -427,7 +431,7 @@ ORDER BY ordinal_position ASC";
     $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
     if ( 0 == count($result) ) {
         $logger->err("Table '$tableName' does not exist");
-        exit();
+        return false;
     }
 
     $retval = array();
@@ -529,6 +533,22 @@ function compareTableData(
         }
     }
 
+    // Find the first non-nullable column to use for the comparison. Otherwise, a column
+    // might have a valid value of NULL and give false positives.
+
+    $comparisonColumn = null;
+    foreach ( $destTableColumnInfo as $colName => $colInfo ) {
+        if ( 'NO' == $colInfo['is_nullable'] ) {
+            $comparisonColumn = $colName;
+            break;
+        }
+    }
+
+    if ( null === $comparisonColumn ) {
+        $comparisonColumn = $firstCol;
+        print "WARNING: No non-nlullable columns, potential for false positives." . PHP_EOL;
+    }
+
     // Determine the columns to compute the percent error for, if any.
 
     foreach ( $scriptOptions['pct-error-columns'] as $column ) {
@@ -589,7 +609,7 @@ function compareTableData(
     );
 
     $where = array(
-        "dest.$firstCol IS NULL"
+        "dest.$comparisonColumn IS NULL"
     );
 
     if ( 0 != count($scriptOptions['wheres']) ) {

--- a/tools/dev/verify_table_data.php
+++ b/tools/dev/verify_table_data.php
@@ -546,7 +546,7 @@ function compareTableData(
 
     if ( null === $comparisonColumn ) {
         $comparisonColumn = $firstCol;
-        print "WARNING: No non-nlullable columns, potential for false positives." . PHP_EOL;
+        print "WARNING: No non-nullable columns, potential for false positives." . PHP_EOL;
     }
 
     // Determine the columns to compute the percent error for, if any.


### PR DESCRIPTION
This PR is a rewrite of the StructuredFile data endpoint to support ingesting Eucalyptus accounting records. A number of small debugging enhancements implemented during testing are also included.

This PR is a prerequisite for ubccr/xdmod-value-analytics#14.

## Description

Structured files contain data in a known (structured) format including CSV, tab-delimited, and JSON. Records are separated by an optional Record Separator (RS) and individual fields may be separated by a Field Separator (FS) if the format allows or requires it (e.g., CSV and TSV). Typically, we will read a structured file by iterating over the records and operating on the fields within the record.

This PR implements a `StructuredFile` data endpoint that implements `Iterator`, allowing ETL actions to parse the file and then simply aggregate over the endpoint to access the parsed records. While JSON documents are the only structured file we currently use, CSV/TSV files will be supported in the future and functionality to support them has been included (e.g., field separator and record names). Much of the workflow for handling structured files is contained in `aStructuredFile`, allowing the classes that support particular formats such as JSON to implement only the portions that are required for their particular format such as parsing the file format and decoding the individual records. The StructuredFile ingestor has been updated accordingly.

In addition, a flexible method for filtering input files through one or more external processes has been implemented. `ETL\DataEndpoint\Filter\ExternalProcess` allows us to specify a pipeline of process that data will be sent through before it is seen by the data endpoint itself. This is implemented using PHP stream filters that are attached directly to a file handle on `fopen()` in `aStructuredFile::attachFilters()` and process the input stream before it is accessed by `fread()`. The `ExternalProcess` class opens input and output pipes to the external process and sends data through this process allowing any program that accepts input in `stdin` and produces output on `stdout` to act as a filter. This includes `jq`, `sed`, `awk`, and even `gzip`.  An example of a filter specification on a data endpoint is:
```
"endpoints": {
    "source": {
        "type": "jsonfile",
        "name": "Value Analytics People Input File (Filtered to Organizations)",
        "path": "value_analytics/people.json",
        "filters": {
            "jq": {
                "type": "external",
                "path": "jq",
                "arguments": "'map({name: .organizations[].name}) | unique'"
            }
        }
    }
}
```

### Examples

#### CSV

- RS: `\n` (UNIX), `\r\n` (Windows), `\r` (OSX)
- FS: `,` (CSV), `\t`

```
one, two, "three blind mice"
```

#### JSON

- Optional RS: `\n` (UNIX), `\r\n` (Windows), `\r` (OSX)

JSON documents can represent arrays and objects and therefore do not **require** a RS and do not support a FS. For documents that do not specify a RS it is assumed that the document will be either a single record or an array of records.

A single file containing a 2-dimensional array with no RS. This data is parsed all at once and the individual arrays are available through the iterator.

```
[
    [1, 2, 3, 4],
    [2, 3, 5, 6]
]
```

An single file containing an array of objects with no RS where the record names are the object keys. This data is parsed all at once and the individual objects are available through the iterator.

```
[
    {
        "first": "Steve",
        "last": "Gallo",
        "middle": "M."
    },{
        "first": "Ben",
        "last": "Plessenger"
    }
]
```

A single file containing one object per line (RS = EOL). The data may be streamed or parsed all at once.

```
{ "first": "Steve", "last": "Gallo", "middle": "M." }
{ "first": "Ben", "last": "Plessenger" }
```

## Motivation and Context

Needed a more flexible method for ingesting JSON data in a variety of configurations.

## Tests performed

Unit tests were added to cover the following cases:

- File data endpoint
    - Test trying to read a directory instead of a file
    - Test trying to open a file with an invalid mode
    - Test reading a simple string from a file
- StructuredFile data endpoint (extends File)
    - Test parsing a simple JSON file containing an array of objects (using sample XDMoD-VA data)
    - Test parsing a simple JSON file containing multiple objects, each on a single line, separated by a newline (using sample Euca accounting records)
    - Test error reporting when config is not valid
    - Test error reporting when a filter type is not provided
    - Test filter syntax error
    - Test parsing a simple JSON file containing an array of objects filtered through an external process (`jq`)
    - Test parsing a simple JSON file containing multiple records separated by a newline and filtered through an external process (`jq`)
    - Test successful JSON schema validation
    - Test failed JSON schema validation

Testing of parsing JSON files was performed by running the XDMoD-VA ETL and comparing the data to a dump of the `modw_value_analytics` database on the "VA Demo" site (see PR ubccr/xdmod-value-analytics#14). In addition, **all** JSON configuration files that are parsed go through this data endpoint.

The `CloudAssetTypeIngestor` action uses an in-line JSON document (which will be depricated at a later date) and was used to verify this functionality.

```
$ ./etl_overseer.php -c ../../../etc/etl/etl.json -a CloudAssetTypeIngestor -v info
2017-05-19 15:04:25 [info] Command: './etl_overseer.php' '-c' '../../../etc/etl/etl.json' '-a' 'CloudAssetTypeIngestor' '-v' 'info'
2017-05-19 15:04:25 [notice] dw_extract_transform_load start (process_start_time: 2017-05-19 15:04:25)
2017-05-19 15:04:25 [info] Loading configuration file /home/smgallo/xdmod-structured-file/etc/etl/etl.json
2017-05-19 15:04:26 [info] Parsing /home/smgallo/xdmod-structured-file/etc/etl/etl.json
...
2017-05-19 15:04:26 [info] Verifying endpoint: ('Utility DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-05-19 15:04:26 [info] Verifying endpoint: ('Cloud DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw_cloud, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-05-19 15:04:26 [info] Verifying endpoint: ('Cloud DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw_cloud, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-05-19 15:04:26 [info] Create action CloudAssetTypeIngestor (ETL\Ingestor\StructuredFileIngestor)
2017-05-19 15:04:26 [info] Parse definition file: '/home/smgallo/xdmod-structured-file/etc/etl/etl_tables.d/cloud/asset_type.json'
2017-05-19 15:04:26 [info] Loading configuration file /home/smgallo/xdmod-structured-file/etc/etl/etl_tables.d/cloud/asset_type.json
2017-05-19 15:04:26 [info] Parsing /home/smgallo/xdmod-structured-file/etc/etl/etl_tables.d/cloud/asset_type.json
2017-05-19 15:04:26 [info] Verifying action: CloudAssetTypeIngestor (ETL\Ingestor\StructuredFileIngestor)
2017-05-19 15:04:26 [info] Obtaining lock file '/var/lock/xdmod/etlv2_25727'
2017-05-19 15:04:26 [info] start (action_name: CloudAssetTypeIngestor, action: CloudAssetTypeIngestor (ETL\Ingestor\StructuredFileIngestor), start_date: , end_date: )
2017-05-19 15:04:26 [info] Truncate destination table: `modw_cloud`.`asset_type`
2017-05-19 15:04:26 [info] Table does not exist: '`modw_cloud`.`asset_type`', skipping.
2017-05-19 15:04:26 [notice] Table `modw_cloud`.`asset_type` does not exist, creating.
2017-05-19 15:04:26 [info] Truncate destination table: `modw_cloud`.`asset_type`
2017-05-19 15:04:26 [info] Process date interval (1/1) (start: none, end: none)
2017-05-19 15:04:26 [notice] (action: CloudAssetTypeIngestor (ETL\Ingestor\StructuredFileIngestor), start_time: 1495220666.0755, end_time: 1495220666.0853, elapsed_time: 0.00976, records_loaded: 5)
2017-05-19 15:04:26 [info] ETL\Ingestor\StructuredFileIngestor: Rows Processed: 5 records (Time Taken: 0.01 s)
2017-05-19 15:04:26 [notice] (action: CloudAssetTypeIngestor (ETL\Ingestor\StructuredFileIngestor), start_time: 1495220666.0739, end_time: 1495220666.0858, elapsed_time: 0.01188, records_examined: 5, records_loaded: 5)
2017-05-19 15:04:26 [info] end (action_name: CloudAssetTypeIngestor, action: CloudAssetTypeIngestor (ETL\Ingestor\StructuredFileIngestor))
2017-05-19 15:04:26 [info] Releasing lock '/var/lock/xdmod/etlv2_25727'
2017-05-19 15:04:26 [notice] dw_extract_transform_load end (process_end_time: 2017-05-19 15:04:26)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
