### PR TITLE
Fix memory leak in Job Viewer.

### DIFF
--- a/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
+++ b/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
@@ -129,6 +129,9 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
                 this.chartOptions.chart.options.colors = [seriesColor];
             }
 
+            if (this.chart) {
+                this.chart.destroy();
+            }
             this.chart = new Highcharts.Chart(this.chartOptions);
             if (CCR.exists(this.chart.series)
                 && CCR.exists(this.chart.series[0])
@@ -203,6 +206,13 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
                 this.chart.redraw();
             }
         }, // reset
+
+        destroy: function () {
+            if (this.chart) {
+                this.chart.destroy();
+                this.chart = null;
+            }
+        },
 
         /**
          * Attempt to resize this components HighCharts instance such that it

--- a/html/gui/js/modules/job_viewer/ChartPanel.js
+++ b/html/gui/js/modules/job_viewer/ChartPanel.js
@@ -214,6 +214,13 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
             this.options.chart.height = adjHeight;
         }, // resize
 
+        destroy: function () {
+            if (this.chart) {
+                this.chart.destroy();
+                this.chart = null;
+            }
+        },
+
         /**
          *
          * @param panel
@@ -319,6 +326,10 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
                     this.jobTab.fireEvent("display_help", panel.helptext);
                 }
             }
+
+            if (panel.chart) {
+                panel.chart.destroy();
+            }
             panel.chart = new Highcharts.Chart(chartOptions);
             if (!record) {
                 panel.chart.showLoading();
@@ -368,11 +379,7 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
                     return;
                 }
                 var record = tor.getAt(0);
-                if (CCR.exists(record) &&
-                   CCR.exists(self.chart)) {
-                    self.chart = null;
-                    self.fireEvent('load_record', self, record);
-                } else if (CCR.exists(record)) {
+                if (CCR.exists(record)) {
                     self.fireEvent('load_record', self, record);
                 }
             });


### PR DESCRIPTION
## Description
Ensure the Highcharts charts are destroyed properly when the container
panel is removed or the chart is replaced.

## Motivation and Context
memory leaks === bad

## Tests performed
Manually opened loads of charts in the job viewer then closed them again. Then ran the following in the firefox console to list the current chart objects.
```
for(var i=0; i < Highcharts.charts.length; i++) { if (Highcharts.charts[i]) { console.log(Highcharts.charts[i].renderTo);}}
```

## Types of changes
* Bug fix (non-breaking change which fixes an issue)
