### PR TITLE
Added npm lock files

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -36,4 +36,9 @@ pear install Log
 source ~/.nvm/nvm.sh
 nvm install "$NODE_VERSION"
 nvm use "$NODE_VERSION"
+
+echo "Updating npm..."
+npm update -g npm
+
+echo "Installing npm dependencies..."
 npm install

--- a/etl/js/package-lock.json
+++ b/etl/js/package-lock.json
@@ -1,0 +1,234 @@
+{
+    "name": "xdmod-etl",
+    "version": "0.0.0",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "async": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "aws-sign": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz",
+            "integrity": "sha1-xVAThWyBlOyFSgy+yQqrWgTOOsU="
+        },
+        "bignumber.js": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.3.0.tgz",
+            "integrity": "sha1-B749FxI1oqt4wO+uUjONZFx2tzU="
+        },
+        "boom": {
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz",
+            "integrity": "sha1-yM2wQUNZEnQWKMBE7Mcy0dF8Ceo="
+        },
+        "bson": {
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+            "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
+        },
+        "cloneextend": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/cloneextend/-/cloneextend-0.0.3.tgz",
+            "integrity": "sha1-3wYpykhFMWr9iEzxthoM30sSn3k="
+        },
+        "colors": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+            "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+        },
+        "combined-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+            "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8="
+        },
+        "cookie-jar": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz",
+            "integrity": "sha1-ZOzAasl423leS1KQy+SLo3gUAPo="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cryptiles": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz",
+            "integrity": "sha1-GlVnNPBtJLo0hirpy55wmjr7/xw="
+        },
+        "cycle": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+        },
+        "delayed-stream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+            "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+        },
+        "es6-promise": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+            "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+        },
+        "eyes": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+        },
+        "forever-agent": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz",
+            "integrity": "sha1-4cJcetROCcOPIzh2x2/MJP+EOx8="
+        },
+        "form-data": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+            "integrity": "sha1-2zRaU3jYau6x7V1VO4aawZLS9e0="
+        },
+        "hawk": {
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+            "integrity": "sha1-mzYd7pWpMWQObVBOBWCaj8OsRdI="
+        },
+        "hoek": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
+            "integrity": "sha1-YPvZBFV1Qc0rh5Wr8wihs3cOFVo="
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ini": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.2.1.tgz",
+            "integrity": "sha1-f3dOLyJ1LNHay/nGMyPfKhZOvKM="
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "json-stringify-safe": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz",
+            "integrity": "sha1-nbew5TDH8onF6MhDKvGRwv91pbM="
+        },
+        "mime": {
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+            "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+        },
+        "mongodb": {
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.21.tgz",
+            "integrity": "sha1-dkcJ28zrWCW06zH5U5X5Zf1EInI="
+        },
+        "mongodb-core": {
+            "version": "1.3.21",
+            "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.21.tgz",
+            "integrity": "sha1-/hKee+4rOybBQJ3gKrYNA/YpHMo="
+        },
+        "mysql": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.2.0.tgz",
+            "integrity": "sha1-d5nNAtdPkyZDTXNReRyUaYFIW5g=",
+            "dependencies": {
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+                }
+            }
+        },
+        "node-uuid": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+            "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "oauth-sign": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz",
+            "integrity": "sha1-oOahcV2u0GLzIrYit/5a/RA1tuI="
+        },
+        "pkginfo": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+            "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+        },
+        "qs": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+            "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q="
+        },
+        "readable-stream": {
+            "version": "1.0.31",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+            "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64="
+        },
+        "request": {
+            "version": "2.16.6",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+            "integrity": "sha1-hy/kRa5y3iZrN4edatfclI+gHK0="
+        },
+        "require_optional": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+            "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8="
+        },
+        "require-all": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.8.tgz",
+            "integrity": "sha1-p9QwfZDkIvy58ErwGMFJkgB05LM="
+        },
+        "resolve-from": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+            "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+        },
+        "semver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        },
+        "sntp": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz",
+            "integrity": "sha1-XvSBuVGnspr/30r9fyaDj8ESD4Q="
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "tunnel-agent": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz",
+            "integrity": "sha1-aFPCr7GyEJ5FYp5JK9419Fnqaeg="
+        },
+        "tv4": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+            "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
+        },
+        "winston": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
+            "integrity": "sha1-euMTunP83C7LSqL5zURugphncmY="
+        },
+        "winston-mysql-transport": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/winston-mysql-transport/-/winston-mysql-transport-0.1.2.tgz",
+            "integrity": "sha1-ZHtpxVW2P5Y0HTER6kWWKxRHyIM="
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1059 @@
+{
+    "name": "xdmod",
+    "version": "7.0.0",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "acorn": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+            "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "dev": true,
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "ajv": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "dev": true
+        },
+        "ajv-keywords": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+            "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+            "dev": true
+        },
+        "ansi-escapes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+            "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "dev": true
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true
+        },
+        "circular-json": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+            "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+            "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+            "dev": true
+        },
+        "cli-width": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+            "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+            "dev": true
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+            "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+            "dev": true
+        },
+        "contains-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.8",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+            "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+            "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "dev": true
+        },
+        "es5-ext": {
+            "version": "0.10.22",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.22.tgz",
+            "integrity": "sha512-YXTXSlZkJsVwMEVljp1Bh5P9+Raa3524OMl9kywGMp1aazKTCnAqORRL/8dkuqNHk+LRYe0LezuS8PlUt3+mOw==",
+            "dev": true
+        },
+        "es6-iterator": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+            "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+            "dev": true
+        },
+        "es6-map": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+            "dev": true
+        },
+        "es6-set": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+            "dev": true
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "dev": true
+        },
+        "es6-weak-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escope": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+            "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+            "dev": true
+        },
+        "eslint-config-airbnb-base": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.2.0.tgz",
+            "integrity": "sha1-GancRIGib3CQRUXsBAEWh2AY+FM=",
+            "dev": true
+        },
+        "eslint-import-resolver-node": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
+            "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+            "dev": true
+        },
+        "eslint-module-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
+            "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-import": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz",
+            "integrity": "sha1-N8gB4K2g4pbL3yDD85OstbUq82s=",
+            "dev": true,
+            "dependencies": {
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true
+                }
+            }
+        },
+        "espree": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+            "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+            "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+            "dev": true
+        },
+        "esrecurse": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+            "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+            "dev": true,
+            "dependencies": {
+                "estraverse": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                    "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+                    "dev": true
+                }
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true
+        },
+        "exit-hook": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "dev": true
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "dev": true
+        },
+        "find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true
+        },
+        "flat-cache": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+            "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "function-bind": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+            "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+            "dev": true
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true
+        },
+        "globals": {
+            "version": "9.17.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+            "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+            "dev": true
+        },
+        "globby": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+            "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+            "dev": true
+        },
+        "ignore": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+            "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+            "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+            "dev": true
+        },
+        "interpret": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+            "dev": true
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true
+        },
+        "is-my-json-valid": {
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+            "dev": true
+        },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+            "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+            "dev": true
+        },
+        "is-path-inside": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+            "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+            "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+            "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+            "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
+        },
+        "lodash.cond": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+            "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+            "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
+            "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true
+        },
+        "onetime": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+            "dev": true
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+            "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+            "dev": true
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true
+        },
+        "pkg-dir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+            "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+            "dev": true
+        },
+        "pluralize": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+            "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "progress": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true
+        },
+        "read-pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.2.10",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+            "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
+            "dev": true
+        },
+        "readline2": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+            "dev": true
+        },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+            "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+            "dev": true
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+            "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+            "dev": true
+        },
+        "run-async": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+            "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+            "dev": true
+        },
+        "rx-lite": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+            "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+            "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "dev": true
+        },
+        "shelljs": {
+            "version": "0.7.7",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+            "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+            "dev": true
+        },
+        "spdx-license-ids": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+            "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "table": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+            "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+            "dev": true,
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+                    "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+                    "dev": true
+                }
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tryit": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+            "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "user-home": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+            "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+            "dev": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        }
+    }
+}


### PR DESCRIPTION
## Description
This pull request adds the lock files generated by npm v5 to this repo. This will lock down the npm dependencies in a manner similar to how Composer locks dependencies.

It also updates a Travis setup script to ensure npm is up to date.

If approved, similar pull requests will be opened for other XDMoD repos.

## Motivation and Context
npm v5 automatically generates `package-lock.json` files similar to how Composer generates `composer.lock` files. Like the latter's lock files, they are designed to ensure that consistent environments are generated across instances and are intended to be checked into source control.

## Tests Performed
I verified that tools pulled in by npm continue to work, and I verified that the changes to the Travis script work as intended.

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
