### PR TITLE
Fix newlines for ORDER BY and GROUP BY in ETL DbModel

### DIFF
--- a/classes/ETL/DbModel/Query.php
+++ b/classes/ETL/DbModel/Query.php
@@ -424,7 +424,7 @@ class Query extends Entity implements iEntity
             implode("\n", $joinList) .
             ( count($whereConditions) > 0 ? "\nWHERE " . implode("\nAND ", $whereConditions) : "" ) .
             ( count($this->groupby) > 0 ? "\nGROUP BY " . implode(", ", $this->groupby) : "" ) .
-            ( count($this->orderby) > 0 ? "\nORDER BY " . implode(", ", $this->orderby) : "" ) . "\n";
+            ( count($this->orderby) > 0 ? "\nORDER BY " . implode(", ", $this->orderby) : "" );
 
         // If any macros have been defined, process those macros now. Since macros can contain variables
         // themselves, we will process the variables later.

--- a/classes/ETL/DbModel/Query.php
+++ b/classes/ETL/DbModel/Query.php
@@ -421,10 +421,10 @@ class Query extends Entity implements iEntity
 
         $sql = "SELECT" .( null !== $this->query_hint ? " " . $this->query_hint : "" ) . "\n" .
             implode(",\n", $columnList) . "\n" .
-            implode("\n", $joinList) . "\n" .
-            ( count($whereConditions) > 0 ? "WHERE " . implode("\nAND ", $whereConditions) . "\n" : "" ) .
-            ( count($this->groupby) > 0 ? "GROUP BY " . implode(", ", $this->groupby) : "" ) .
-            ( count($this->orderby) > 0 ? "ORDER BY " . implode(", ", $this->orderby) : "" );
+            implode("\n", $joinList) .
+            ( count($whereConditions) > 0 ? "\nWHERE " . implode("\nAND ", $whereConditions) : "" ) .
+            ( count($this->groupby) > 0 ? "\nGROUP BY " . implode(", ", $this->groupby) : "" ) .
+            ( count($this->orderby) > 0 ? "\nORDER BY " . implode(", ", $this->orderby) : "" ) . "\n";
 
         // If any macros have been defined, process those macros now. Since macros can contain variables
         // themselves, we will process the variables later.


### PR DESCRIPTION
Fix newlines for ORDER BY and GROUP BY in ETL DbModel

## Description

A new line was missing when both an ORDER BY and GROUP BY was specified in a constructed ETLv2 query.

## Motivation and Context

Bugfix

## Tests performed

Tested query generation with only GROUP BY, only ORDER BY, and both by modifying the OSG job reporting verification action.

```
php etl_overseer.php -c ../../../etc/etl/etl.json -a VerifyOsgJobReporting -t -v debug -n 5
```
Generated queries:

```
SELECT
r.id AS id,
r.name AS name,
r.code AS code,
max(maxts.max_ts) AS last_entry_date,
5 AS number_of_days
FROM `federated_osg`.`resourcefact` AS r
JOIN `federated_osg`.`raw_jobs_test` AS j ON r.code = 'OSG'
JOIN ( SELECT 2799 as resource_id, max(j.ts) as max_ts FROM federated_osg.raw_jobs_test j ) AS maxts ON maxts.resource_id = r.id
WHERE maxts.max_ts < (NOW() - INTERVAL 5 DAY)
AND r.id IN (2799)
GROUP BY r.id

SELECT
r.id AS id,
r.name AS name,
r.code AS code,
max(maxts.max_ts) AS last_entry_date,
5 AS number_of_days
FROM `federated_osg`.`resourcefact` AS r
JOIN `federated_osg`.`raw_jobs_test` AS j ON r.code = 'OSG'
JOIN ( SELECT 2799 as resource_id, max(j.ts) as max_ts FROM federated_osg.raw_jobs_test j ) AS maxts ON maxts.resource_id = r.id
WHERE maxts.max_ts < (NOW() - INTERVAL 5 DAY)
AND r.id IN (2799)
ORDER BY name asc

SELECT
r.id AS id,
r.name AS name,
r.code AS code,
max(maxts.max_ts) AS last_entry_date,
5 AS number_of_days
FROM `federated_osg`.`resourcefact` AS r
JOIN `federated_osg`.`raw_jobs_test` AS j ON r.code = 'OSG'
JOIN ( SELECT 2799 as resource_id, max(j.ts) as max_ts FROM federated_osg.raw_jobs_test j ) AS maxts ON maxts.resource_id = r.id
WHERE maxts.max_ts < (NOW() - INTERVAL 5 DAY)
AND r.id IN (2799)
GROUP BY r.id
ORDER BY name asc
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
