### PR TITLE
Add gantt chart view of job peers

### DIFF
--- a/classes/NewRest/Controllers/WarehouseControllerProvider.php
+++ b/classes/NewRest/Controllers/WarehouseControllerProvider.php
@@ -116,13 +116,6 @@ class WarehouseControllerProvider extends BaseControllerProvider
                 "type" => "utf8-text",
                 "leaf" => true
             ),
-        \DataWarehouse\Query\RawQueryTypes::PEERS =>
-            array(
-                "infoid" => \DataWarehouse\Query\RawQueryTypes::PEERS,
-                "dtype" => "infoid",
-                "text" => "Peers",
-                "leaf" => false
-            ),
         \DataWarehouse\Query\RawQueryTypes::EXECUTABLE =>
             array(
                 "infoid" => \DataWarehouse\Query\RawQueryTypes::EXECUTABLE,
@@ -135,6 +128,16 @@ class WarehouseControllerProvider extends BaseControllerProvider
                                     environment.",
                 "type" => "nested",
                 "leaf" => true),
+        \DataWarehouse\Query\RawQueryTypes::PEERS =>
+            array(
+                "infoid" => \DataWarehouse\Query\RawQueryTypes::PEERS,
+                "dtype" => "infoid",
+                "text" => "Peers",
+                'url' => '/rest/v1.0/warehouse/search/jobs/peers',
+                'documentation' => 'Shows the list of other HPC jobs that ran concurrently using the same shared hardware resources.',
+                'type' => 'ganttchart',
+                "leaf" => true
+            ),
         \DataWarehouse\Query\RawQueryTypes::NORMALIZED_METRICS =>
             array(
                 "infoid" => \DataWarehouse\Query\RawQueryTypes::NORMALIZED_METRICS,
@@ -1324,6 +1327,11 @@ class WarehouseControllerProvider extends BaseControllerProvider
             case 'analytics':
                 $results = $this->_getJobData($app, $user, $realm, $jobId, $action, $actionName);
                 break;
+            case 'peers':
+                $start = $this->getIntParam($request, 'start', true);
+                $limit = $this->getIntParam($request, 'limit', true);
+                $results = $this->getJobPeers($app, $user, $realm, $jobId, $start, $limit);
+                break;
             case 'executable':
                 $results = $this->_getJobExecutable($app, $user, $realm, $jobId, $action, $actionName);
                 break;
@@ -1350,6 +1358,72 @@ class WarehouseControllerProvider extends BaseControllerProvider
         }
 
         return $results;
+    }
+
+    protected function getJobPeers(Application $app, XDUser $user, $realm, $jobId, $start, $limit)
+    {
+        $jobdata = $this->_getJobDataSet($user, $realm, $jobId, 'internal');
+        if (!$jobdata->hasResults()) {
+            throw new NotFoundException();
+        }
+        $jobresults = $jobdata->getResults();
+        $thisjob = $jobresults[0];
+
+        $i = 0;
+
+        $result = array(
+            'series' => array(
+                array(
+                    'name' => 'Walltime',
+                    'data' => array(
+                        array(
+                            'x' => $i++,
+                            'low' => $thisjob['start_time_ts'] * 1000.0,
+                            'high' => $thisjob['end_time_ts'] * 1000.0
+                        )
+                    )
+                ),
+                array(
+                    'name' => 'Walltime',
+                    'data' => array()
+                )
+            ),
+            'categories' => array(
+                'Current'
+            ),
+            'schema' => array(
+                'timezone' => $thisjob['timezone'],
+                'ref' => array(
+                    'realm' => $realm,
+                    'jobid' => $jobId,
+                    "text" => $thisjob['resource'] . '-' . $thisjob['local_job_id']
+                )
+            )
+        );
+
+        $dataset = $this->_getJobDataSet($user, $realm, $jobId, 'peers');
+        foreach ($dataset->getResults() as $index => $jobpeer) {
+            if ( ($index >= $start) && ($index < ($start + $limit))) {
+                $result['series'][1]['data'][] = array(
+                    'x' => $i++,
+                    'low' => $jobpeer['start_time_ts'] * 1000.0,
+                    'high' => $jobpeer['end_time_ts'] * 1000.0,
+                    'ref' => array(
+                        'realm' => $realm,
+                        'jobid' => $jobpeer['jobid'],
+                        'local_job_id' => $jobpeer['local_job_id'],
+                        'resource' => $jobpeer['resource']
+                    )
+                );
+                $result['categories'][] = $jobpeer['resource'] . '-' . $jobpeer['local_job_id'];
+            }
+        }
+
+        return  $app->json(array(
+            'success' => true,
+            'data' => array($result),
+            'total' => count($dataset->getResults())
+        ));
     }
 
     /**
@@ -1570,19 +1644,6 @@ class WarehouseControllerProvider extends BaseControllerProvider
                     $tsid['type'] = "timeseries";
                     $tsid['dtype'] = "tsid";
                     $result[] = $tsid;
-                }
-                return $app->json(array('success' => true, "results" => $result));
-                break;
-            case "" . \DataWarehouse\Query\RawQueryTypes::PEERS:
-                $dataset = $this->_getJobDataSet($user, $realm, $jobId, "peers");
-                $result = array();
-                foreach ($dataset->getResults() as $jobpeer) {
-                    $result[] = array(
-                        "text" => $jobpeer['resource'] . '-' . $jobpeer['local_job_id'],
-                        "dtype" => "peerid",
-                        "peerid" => $jobpeer['jobid'],
-                        "qtip" => "Job Owner: " . $jobpeer['name'],
-                        "leaf" => true);
                 }
                 return $app->json(array('success' => true, "results" => $result));
                 break;

--- a/classes/NewRest/Controllers/WarehouseControllerProvider.php
+++ b/classes/NewRest/Controllers/WarehouseControllerProvider.php
@@ -1360,6 +1360,17 @@ class WarehouseControllerProvider extends BaseControllerProvider
         return $results;
     }
 
+    /**
+     * Return data about a job's peers.
+     *
+     * @param Application $app The router application.
+     * @param XDUser $user the logged in user.
+     * @param $realm data realm.
+     * @param $jobId the unique identifier for the job.
+     * @param $start the start offset (for store paging).
+     * @param $limit the number of records to return (for store paging).
+     * @return json in Extjs.store parsable format.
+     */
     protected function getJobPeers(Application $app, XDUser $user, $realm, $jobId, $start, $limit)
     {
         $jobdata = $this->_getJobDataSet($user, $realm, $jobId, 'internal');

--- a/html/gui/js/modules/job_viewer/ChartTab.js
+++ b/html/gui/js/modules/job_viewer/ChartTab.js
@@ -1,0 +1,204 @@
+Ext.namespace('XDMoD', 'XDMoD.Module', 'XDMoD.Module.JobViewer');
+
+/**
+ * @class XDMoD.Module.JobViewer.ChartTab
+ * @extends Ext.Panel
+ * <p>A specialized panel intended for the display of timeseries data from an Ext.store into
+ * a Highcharts chart in the job viewer.</p>
+ * <p> The derived class should implement the updateChart event listener that is fired when
+ * ever data is loaded from the store.
+ * @constructor
+ * @param {Object} config The config object
+ */
+XDMoD.Module.JobViewer.ChartTab = Ext.extend(Ext.Panel, {
+    /**
+     * @cfg {Object} chartSettings
+     * The Highcharts chart settings. This settings object overrides the default values.
+     *
+     * @cfg {string} panelSettings.url
+     * The url to connect to
+     *
+     * @cfg {string} panelSettings.baseParams
+     * The baseParams for the store
+     *
+     * @cfg {Object} panelSettings.store
+     * Overrides for any store settings.
+     *
+     * @cfg {number} panelSettings.pageSize
+     * If defined then the paging toolbar is enabled and the number of records to request from the store
+     * is set the the pageSize. If undefined then no paging is done (default undefined).
+     */
+
+    chart: null,
+    store: null,
+    displayTimezone: 'UTC',
+
+    initComponent: function () {
+        var self = this;
+
+        var createChart = function () {
+            var defaultChartSettings = {
+                chart: {
+                    renderTo: self.id + '_hc'
+                },
+                colors: ['#2f7ed8', '#0d233a', '#8bbc21', '#910000', '#1aadce', '#492970', '#f28f43', '#77a1e5', '#c42525', '#a6c96a'],
+                title: {
+                    style: {
+                        color: '#444b6e',
+                        fontSize: '16px'
+                    },
+                    text: ''
+                },
+                loading: {
+                    style: {
+                        opacity: 0.7
+                    }
+                },
+                yAxis: {
+                    title: {
+                        style: {
+                            fontWeight: 'bold',
+                            color: '#5078a0'
+                        }
+                    }
+                },
+                legend: {
+                    enabled: false
+                },
+                exporting: {
+                    enabled: false
+                },
+                tooltip: {
+                    pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.low:%A, %b %e, %H:%M:%S}</b> - <b>{point.high:%A, %b %e, %H:%M:%S}</b><br/>',
+                    dateTimeLabelFormats: {
+                        millisecond: '%A, %b %e, %H:%M:%S.%L %T',
+                        second: '%A, %b %e, %H:%M:%S %T',
+                        minute: '%A, %b %e, %H:%M:%S %T',
+                        hour: '%A, %b %e, %H:%M:%S %T'
+                    }
+                },
+                plotOptions: {
+                    line: {
+                        marker: {
+                            enabled: false
+                        }
+                    },
+                    columnrange: {
+                        minPointLength: 3,
+                        animation: false,
+                        dataLabels: {
+                            enabled: false
+                        }
+                    },
+                    series: {
+                        allowPointSelect: false,
+                        animation: false
+                    }
+                }
+            };
+
+            var chartOptions = jQuery.extend(true, {}, defaultChartSettings, self.chartSettings);
+
+            self.chart = new Highcharts.Chart(chartOptions);
+            self.chart.showLoading();
+
+            var storeParams;
+            if (self.panelSettings.pageSize) {
+                storeParams = {
+                    params: {
+                        start: 0,
+                        limit: self.panelSettings.pageSize
+                    }
+                };
+            }
+            self.store.load(storeParams);
+        };
+
+        var defaultStoreSettings = {
+            proxy: new Ext.data.HttpProxy({
+                method: 'GET',
+                url: this.panelSettings.url,
+                listeners: {
+                    exception: function (proxy, type, action, options, response) {
+                        while (self.chart.series.length > 0) {
+                            self.chart.series[0].remove(true);
+                        }
+                        var text = self.chart.renderer.text('ERROR ' + response.status + ' ' + response.statusText, self.chart.plotLeft + 23, self.chart.plotTop + 10).add();
+                        var box = text.getBBox();
+                        self.chart.renderer.image('/gui/images/about_16.png', box.x - 23, box.y - 1, 16, 16).add();
+                        self.chart.hideLoading();
+                        self.chart.redraw();
+                    }
+                }
+            }),
+            baseParams: this.panelSettings.baseParams,
+            autoLoad: false,
+            root: 'data',
+            fields: ['series', 'schema'],
+            listeners: {
+                load: function (inst, record, options) {
+                    self.fireEvent('updateChart', inst, record, options);
+                }
+            }
+        };
+
+        var storeSettings = jQuery.extend(true, {}, defaultStoreSettings, this.panelSettings.store);
+
+        this.store = new Ext.data.JsonStore(storeSettings);
+
+        this.layout = 'fit';
+        this.items = [{
+            xtype: 'container',
+            id: this.id + '_hc',
+            listeners: {
+                resize: function () {
+                    if (self.chart) {
+                        self.chart.reflow();
+                    }
+                },
+                render: createChart
+            }
+        }];
+
+        if (this.panelSettings.pageSize) {
+            this.bbar = new Ext.PagingToolbar({
+                pageSize: this.panelSettings.pageSize,
+                buttonAlign: 'right',
+                store: this.store,
+                listeners: {
+                    load: function (store, records, options) {
+                        this.onLoad(store, records, options);
+                    }
+                }
+            });
+        }
+
+        XDMoD.Module.JobViewer.ChartTab.superclass.initComponent.call(this, arguments);
+    },
+
+    updateTimezone: function (timezone) {
+        this.displayTimezone = timezone;
+        this.setHighchartTimezone();
+    },
+
+    setHighchartTimezone: function () {
+        Highcharts.setOptions({
+            global: {
+                timezone: this.displayTimezone
+            }
+        });
+    },
+
+    listeners: {
+        activate: function () {
+            this.setHighchartTimezone();
+            Ext.History.add(this.historyToken);
+        },
+        destroy: function () {
+            if (this.chart) {
+                this.chart.destroy();
+                this.chart = null;
+            }
+        }
+    }
+});

--- a/html/gui/js/modules/job_viewer/GanttChart.js
+++ b/html/gui/js/modules/job_viewer/GanttChart.js
@@ -1,0 +1,79 @@
+Ext.namespace('XDMoD', 'XDMoD.Module', 'XDMoD.Module.JobViewer');
+
+XDMoD.Module.JobViewer.GanttChart = Ext.extend(XDMoD.Module.JobViewer.ChartTab, {
+
+    initComponent: function () {
+        this.chartSettings = {
+            chart: {
+                type: 'columnrange',
+                grouping: false,
+                inverted: true
+            },
+            yAxis: {
+                type: 'datetime',
+                minTickInterval: 1000,
+                title: {
+                    text: 'Time (' + self.displayTimezone + ')'
+                }
+            }
+        };
+
+        this.panelSettings = {
+            pageSize: 11,
+            url: this.url,
+            baseParams: this.baseParams,
+            store: {
+                fields: ['series', 'schema', 'categories']
+            }
+        };
+
+        XDMoD.Module.JobViewer.GanttChart.superclass.initComponent.call(this, arguments);
+
+        this.addListener('updateChart', function (store) {
+            if (store.getCount() < 1) {
+                return;
+            }
+            var record = store.getAt(0);
+
+            this.updateTimezone(record.data.schema.timezone);
+
+            var clickEvent = function (evt) {
+                var info = {
+                    title: 'Peers of ' + record.data.schema.ref.text,
+                    realm: evt.point.ref.realm,
+                    text: evt.point.category,
+                    job_id: evt.point.ref.jobid,
+                    local_job_id: evt.point.ref.local_job_id,
+                    resource: evt.point.ref.resource
+                };
+                Ext.History.add('job_viewer?job=' + window.btoa(JSON.stringify(info)));
+            };
+
+            while (this.chart.series.length > 0) {
+                this.chart.series[0].remove(false);
+            }
+
+            this.chart.colorCounter = 0;
+            this.chart.symbolCounter = 0;
+            this.chart.xAxis[0].setCategories(record.data.categories, false);
+            this.chart.yAxis[0].update({
+                title: {
+                    text: 'Time (' + record.data.schema.timezone + ')'
+                },
+                min: record.data.series[0].data[0].low,
+                max: record.data.series[0].data[0].high
+            }, false);
+
+            var i;
+            for (i = 0; i < record.data.series.length; i++) {
+                record.data.series[i].events = {
+                    click: clickEvent
+                };
+                this.chart.addSeries(record.data.series[i], false);
+            }
+
+            this.chart.hideLoading();
+            this.chart.redraw();
+        });
+    }
+});

--- a/html/gui/js/modules/job_viewer/GanttChart.js
+++ b/html/gui/js/modules/job_viewer/GanttChart.js
@@ -66,9 +66,13 @@ XDMoD.Module.JobViewer.GanttChart = Ext.extend(XDMoD.Module.JobViewer.ChartTab, 
 
             var i;
             for (i = 0; i < record.data.series.length; i++) {
-                record.data.series[i].events = {
-                    click: clickEvent
-                };
+                if (i > 0) {
+                    // Only add clicks for the other peer jobs not this job.
+                    record.data.series[i].cursor = 'pointer';
+                    record.data.series[i].events = {
+                        click: clickEvent
+                    };
+                }
                 this.chart.addSeries(record.data.series[i], false);
             }
 

--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -834,6 +834,19 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                     dataUrl: url
                 });
                 break;
+            case 'ganttchart':
+                tab = new XDMoD.Module.JobViewer.GanttChart({
+                    id: chartId,
+                    title: title,
+                    url: base,
+                    baseParams: this._getParams(path),
+                    historyToken: '#' + this.module_id + '?' + this._createHistoryTokenFromArray(path),
+                    path: path,
+                    dtypes: [],
+                    dtype: dtype,
+                    dtypeValue: id
+                });
+                break;
             case 'timeline':
             case 'timeseries':
                 var tsid = this._find('tsid', 'tsid', path);

--- a/html/index.php
+++ b/html/index.php
@@ -458,6 +458,8 @@
       <?php if (xd_utilities\getConfiguration('features', 'singlejobviewer') == 'on'): ?>
       <script type="text/javascript" src="gui/js/modules/job_viewer/JobViewer.js"></script>
       <script type="text/javascript" src="gui/js/modules/job_viewer/ChartPanel.js"></script>
+      <script type="text/javascript" src="gui/js/modules/job_viewer/ChartTab.js"></script>
+      <script type="text/javascript" src="gui/js/modules/job_viewer/GanttChart.js"></script>
       <script type="text/javascript" src="gui/js/modules/job_viewer/AnalyticChartPanel.js"></script>
       <script type="text/javascript" src="gui/js/modules/job_viewer/TimeSeriesStore.js"></script>
       <script type="text/javascript" src="gui/js/modules/job_viewer/SearchPanel.js"></script>


### PR DESCRIPTION
## Description
Change the Peers node in the search history so that it opens a new tab with an interactive graphical display of the job's peer jobs (i.e. the jobs that ran on the same shared hardware). The individual job peers no longer show as leaf nodes because this display was not useful and did not scale when there were lots of job peers. Jobs with many peers are now handled using the paging toolbar in the graphical display.

These code changes:
- Add new REST endpoint to retrieve the peer data
- Change the peer tree node type and metadata
- Add new Gantt chart class
- Add new base class for job viewer chart tabs.

Note that the new ChartTab base class is intended to be used as the base class for all job viewer timeseries plots. This should significantly reduce the amount of cut-and-paste boilerplate code. A future pull request is planned to switch all charts over to this code.

The job peers click uses the existing mechanism that supports the click through from the metric explorer.

![peers](https://user-images.githubusercontent.com/5342179/26978431-86c67216-4cf9-11e7-9ed3-caa03dbefa18.png)


## Motivation and Context
Improve ability to analyse shared jobs.

## Tests performed
Installed on metrics-dev manually tested. Tests included:
- confirm that the chart clicks work
- confirm that paging works
- run through multiple combinations of opening and closing job tabs confirm that the UI behaves as expected. Confirm that the tree nodes get updated as expected. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My code follows the code style of this project as found in the **CONTRIBUTING** document.
- All new and existing tests passed.
