### PR TITLE
DirectoryScanner data endpoint

### DIFF
--- a/classes/ETL/DataEndpoint.php
+++ b/classes/ETL/DataEndpoint.php
@@ -29,15 +29,18 @@ class DataEndpoint
     const TYPE_ORACLE = "oracle";
     const TYPE_FILE = "file";
     const TYPE_JSONFILE = "jsonfile";
+    const TYPE_DIRECTORY_SCANNER = "directoryscanner";
     const TYPE_REST = "rest";
 
-    private static $supportedTypes =
-        array(self::TYPE_MYSQL,
-              self::TYPE_ORACLE,
-              self::TYPE_POSTGRES,
-              self::TYPE_FILE,
-              self::TYPE_JSONFILE,
-              self::TYPE_REST);
+    private static $supportedTypes = array(
+        self::TYPE_MYSQL,
+        self::TYPE_ORACLE,
+        self::TYPE_POSTGRES,
+        self::TYPE_FILE,
+        self::TYPE_JSONFILE,
+        self::TYPE_DIRECTORY_SCANNER,
+        self::TYPE_REST
+    );
 
     private static $classmap = array(
         self::TYPE_MYSQL => 'ETL\DataEndpoint\Mysql',
@@ -45,8 +48,9 @@ class DataEndpoint
         self::TYPE_ORACLE => 'ETL\DataEndpoint\Oracle',
         self::TYPE_FILE => 'ETL\DataEndpoint\File',
         self::TYPE_JSONFILE => 'ETL\DataEndpoint\JsonFile',
+        self::TYPE_DIRECTORY_SCANNER => 'ETL\DataEndpoint\DirectoryScanner',
         self::TYPE_REST => 'ETL\DataEndpoint\Rest'
-        );
+    );
 
     /* ------------------------------------------------------------------------------------------
      * Private constructor ensures the singleton can't be instantiated.

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -1,0 +1,818 @@
+<?php
+/** =========================================================================================
+ * Directory Scanner Data Endpoint. The Directory Scanner is a wrapper around Structured
+ * File endpoints that recursively scans a directory for files and instantiates Structured
+ * File endpoint each file in a directory (or subdirectory) matching a set of optionally
+ * specified criteria. It supports file name pattern matching and last modified dates. The
+ * Directory Scanner implements the Iterator interface and iteration spans the union of
+ * the records in each of the files. For example, if 2 files are found in a directory then
+ * the Directory Scanner iterator will span all of the records in both files.
+ *
+ * @author Steven M. Gallo <smgallo@buffalo.edu>
+ * @date 2017-05-31
+ * ==========================================================================================
+ */
+
+namespace ETL\DataEndpoint;
+
+use ETL\DataEndpoint\DataEndpointOptions;
+use ETL\DataEndpoint\StructuredFile;
+use Exception;
+use Log;
+
+class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
+{
+
+    /** -----------------------------------------------------------------------------------------
+     * Numeric key to use for the default file extension handler. This should be the only
+     * numeric key used.
+     *
+     * @var integer
+     * ------------------------------------------------------------------------------------------
+     */
+
+    const DEFAULT_HANDLER_KEY = 0;
+
+    /** -----------------------------------------------------------------------------------------
+     * The directory path that we will be scanning. This should be a fully qualified path.
+     *
+     * @var string
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $path = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * An optional regex that files must match to be identified by the scanner. This
+     * applies to the file portion of the path only.
+     *
+     * @var string | null
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $filePattern = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * An optional regex that directories must match to be identified by the scanner.
+     *
+     * @var string | null
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $directoryPattern = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * The maximum depth that we will recurse into the directory hierarchy. -1 indicates
+     * no limit.
+     *
+     * @var integer | null
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $maxRecursionDepth = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * Only files modified on or after this time will be examined. Stored as a unix
+     * timestamp, NULL indicates no restriction.
+     *
+     * @var int | null
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $lastModifiedStartTimestamp = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * Only files modified on or before this time will be examined. Stored as a unix
+     * timestamp, NULL indicates to restriction.
+     *
+     * @var int | null
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $lastModifiedEndTimestamp = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * An array containing handler templates for various file types, which will be
+     * augmented with the file name and path when the handler is instantiated. If a single
+     * handler with no extension specified then it will be used for all files. If multiple
+     * handlers are specified it is required that they also specify a file extension
+     * (string) to determine which hanbdler gets applied to apply to a particular
+     * file. When multiple handlers are specified, an extension of NULL indicates a
+     * catch-all handler.
+     *
+     * @var array
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $handlerTemplateList = array();
+
+    /** -----------------------------------------------------------------------------------------
+     * The name of the current file that we are parsing.
+     *
+     * @var string
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private $currentFilename = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * The iterator for the current file that we are parsing.
+     *
+     * @var Iterator
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private $currentFileIterator = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * The number of files that have been scanned so far. Note that an empty file
+     * containing no records is considered scanned.
+     *
+     * @var integer
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private $numFilesScanned = 0;
+
+    /** -----------------------------------------------------------------------------------------
+     * The number of records parsed in all of the files scanned so far. This does not mean
+     * that the records were traversed.
+     *
+     * @var integer
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private $numRecordsParsed = 0;
+
+    /* ------------------------------------------------------------------------------------------
+     * @see iDataEndpoint::__construct()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function __construct(DataEndpointOptions $options, Log $logger = null)
+    {
+        parent::__construct($options, $logger);
+
+        $requiredKeys = array('path', 'handlers');
+        $this->verifyRequiredConfigKeys($requiredKeys, $options);
+
+        $messages = array();
+        $propertyTypes = array(
+            'path'                => 'string',
+            'handlers'            => 'array',
+            'file_pattern'        => 'string',
+            'directory_pattern'   => 'string',
+            'recursion_depth'     => 'int',
+            'last_modified_start' => 'string',
+            'last_modified_end'   => 'string'
+        );
+
+        if ( ! \xd_utilities\verify_object_property_types($options, $propertyTypes, $messages, true) ) {
+            $this->logAndThrowException("Error verifying options: " . implode(", ", $messages));
+        }
+
+        // Save values from the options to local properties
+
+        foreach ( $options as $property => $value ) {
+
+            // $this->logger->debug("OPT: $property => " . print_r($value, true));
+
+            // Skip null values and use property defaults
+
+            if ( null === $value ) {
+                continue;
+            }
+
+            switch($property) {
+                case 'path':
+                    $this->path = $value;
+                    if ( 0 !== strpos($value, '/') ) {
+                        $this->logger->info(
+                            sprintf("%s: Relative path provided, absolute path recommended", $this)
+                        );
+                    }
+                    break;
+
+                case 'file_pattern':
+                    $this->filePattern = $value;
+                    break;
+
+                case 'directory_pattern':
+                    $this->directoryPattern = $value;
+                    break;
+
+                case 'recursion_depth':
+                    $this->maxRecursionDepth = $value;
+                    break;
+
+                case 'last_modified_start':
+                    if ( false === ( $ts = strtotime($value) ) ) {
+                        $this->logAndThrowException(
+                            sprintf("Error setting %s: Invalid date value '%s'", $property, $value)
+                        );
+                    } else {
+                        $this->lastModifiedStartTimestamp = $ts;
+                    }
+                    break;
+
+                case 'last_modified_end':
+                    if ( false === ( $ts = strtotime($value) ) ) {
+                        $this->logAndThrowException(
+                            sprintf("Error setting %s: Invalid date value '%s'", $property, $value)
+                        );
+                    } else {
+                        $this->lastModifiedEndTimestamp = $ts;
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        $numHandlers = count($options->handlers);
+
+        if ( 0 == $numHandlers ) {
+            $this->logAndThrowException("At least 1 handler must be specified");
+        }
+
+        $numDefaultHandlers = 0;
+
+        foreach ( $options->handlers as $handler ) {
+            if ( isset($handler->extension) ) {
+                // Normalize the extension to not contain a period
+                $ext = $handler->extension;
+                if ( 0 === strrpos($ext, '.') ) {
+                    $ext = substr($ext, 1);
+                }
+                $this->logger->debug(
+                    sprintf("%s: Adding handler for file extension '%s'", $this, $ext)
+                );
+                $this->handlerTemplateList[$ext] = $handler;
+            } else {
+                // Assign a default handler.
+                $this->logger->debug(
+                    sprintf("%s: Adding default file handler", $this)
+                );
+                $this->handlerTemplateList[self::DEFAULT_HANDLER_KEY] = $handler;
+                $numDefaultHandlers++;
+            }
+        }
+
+        if ( $numDefaultHandlers > 1 ) {
+            $this->logAndThrowException(
+                sprintf("%d default handlers specified, only 1 is allowed", $numDefaultHandlers)
+            );
+        }
+
+        $this->key = md5(implode($this->keySeparator, array($this->type, $this->path, $this->name)));
+
+    }  // __construct()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return string The directory path that we will be scanning.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getPath()
+    {
+        return $this->path;
+    } // getPath()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return string|null An optional regex that files must match to be identified by the
+     * scanner.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getFilePattern()
+    {
+        return $this->filePattern;
+    } // getFilePattern()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return string|null An optional regex that directories must match to be identified
+     * by the scanner.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getDirectoryPattern()
+    {
+        return $this->directoryPattern;
+    }  // getDirectoryPattern()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return integer The maximum depth that we will recurse into the directory
+     * hierarchy. -1 indicates no limit.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getMaxRecursionDepth()
+    {
+        return $this->maxRecursionDepth;
+    }  // getMaxRecursionDepth()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return string|null The minumum last modified time for a file.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getLastModifiedStartTime()
+    {
+        return $this->lastModifiedStartTimestamp;
+    }  // getLastModifiedStartTime()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return string|null The maximum last modified time for a file.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getLastModifiedEndTime()
+    {
+        return $this->lastModifiedEndTimestamp;
+    }  // getLastModifiedEndTime()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return array The list of handler templates. If more than one items is in the list
+     * the keys will be strings represneting the file extensions matching the template
+     * with an index of 0 for the catch-all handler.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getHandlerTemplateList()
+    {
+        return $this->handlerTemplateList;
+    }  // getHandlerTemplateList()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return integer The number of files scanned so far.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getNumFilesScanned()
+    {
+        return $this->numFilesScanned;
+    }  // getNumFilesScanned()
+
+    /** -----------------------------------------------------------------------------------------
+     * @return integer The total number of records parsed in all files scanned so far.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getNumRecordsParsed()
+    {
+        return $this->numRecordsParsed;
+    }  // getNumRecordsParsed()
+
+    /** -----------------------------------------------------------------------------------------
+     * Connecting for the DirectoryScanner includes applying any filters specified in the
+     * configuration.
+     *
+     * @see iDataEndpoint::connect()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function connect()
+    {
+        // The first time a connection is made the endpoint handle should be set.
+
+        if ( null === $this->handle ) {
+
+            // The PHP docs on SPL iterators at http://php.net/manual/en/spl.iterators.php
+            // are sparse so these are some notes on usage of RecursiveDirectoryIterator,
+            // RecursiveIteratorIterator, and filtering.
+            //
+            // A note on recursive iterators: If a directory doesn't match the filter
+            // (i.e., it returns FALSE) then the directory will not be recursed
+            // into. Rather than using RecursiveCallbackFilterIterator it may be better to
+            // use CallbackFilterIterator after RecursiveIteratorIterator depending on the
+            // situation.
+            //
+            // We want to be able to filter on the path and file separately so we are
+            // using an instance of RecursiveCallbackFilterIterator to do this instead of
+            // RecursiveRegexIterator (directories) and RegexIterator.
+            //
+            // RecursiveDirectoryIterator provides a mechanism to recursively iterate over
+            // directories and the files that they contain. It does not iterate beyond the
+            // *root* directory automatically. For this we need to roll our own or use
+            // RecursiveIteratorIterator.
+            //
+            // RecursiveRegexIterator can be attached to the RecursiveDirectoryIterator to
+            // filter paths. Note that if a directory doesn't match the regex it will not
+            // be recursed into so this is not well suited for regexes that should be
+            // applied to files.
+            //
+            // RecursiveCallbackFilterIterator needs to operate on a RecursiveIterator so
+            // it cannot be applied to a RecursiveIteratorIterator, use
+            // CallbackFilterIterator on a RecursiveIteratorIterator.
+            //
+            // RecursiveIteratorIterator operates on classes implementing
+            // RecursiveIterator and will handle the recursion into the children.  The
+            // mode can be specified as LEAVES_ONLY (default), SELF_FIRST, CHILD_FIRST.
+            // Note that LEAVES_ONLY will include "." and ".." directories so these will
+            // need to be filtered out AFTER applying this iterator.
+            //
+            // RegexIterator can be attached to RecursiveIteratorIterator to filter the
+            // paths that it returns, but note that the regex applies to the full path,
+            // not just the name of the file itself.
+            //
+            // Note that we want to be able to filter on the path and file separately and
+            // are using the RecursiveCallbackFilterIterator to do this instead of
+            // RecursiveRegexIterator and RegexIterator.
+
+            // We are conditionally creating multiple iterators that will consume earlier
+            // iterators. Keep track of the current iterator.
+
+            $iterator = null;
+
+            $this->logger->debug(
+                sprintf("Connecting directory scanner to %s", $this->path)
+            );
+
+            try {
+                $directoryIterator = new \RecursiveDirectoryIterator($this->path);
+                $iterator = $directoryIterator;
+            } catch ( Exception $e ) {
+                $this->logAndThrowException(
+                    sprintf("Error opening directory '%s': %s", $this->path, $e->getMessage())
+                );
+            }
+
+            // Apply the recursion iterator that will traverse the directory iterator
+
+            try {
+                $flattenedIterator = new \RecursiveIteratorIterator($iterator);
+            }  catch ( Exception $e ) {
+                $this->logAndThrowException(
+                    sprintf("Error creating RecursiveIteratorIterator: %s", $e->getMessage())
+                );
+            }
+
+            if ( null !== $this->maxRecursionDepth ) {
+                $this->logger->debug(
+                    sprintf("Set max recursion depth: %d", $this->maxRecursionDepth)
+                );
+                $flattenedIterator->setMaxDepth($this->maxRecursionDepth);
+            }
+
+            $iterator = $flattenedIterator;
+
+            // Filter out directories "." and "..". This and other filters could be
+            // included in a single CallbackFilterIterator bit I've decided to keep them
+            // split out for readability, debugging, and error reporting.
+
+            // For the CallbackFilter classes, the types of the callback parameters depend
+            // on the flags passed to RecursiveDirectoryIterator::__construct(). In our
+            // case, $current is a SplFileInfo object and the key is the fill path to the
+            // file.
+
+            try {
+                $dotDirFilterIterator = new \CallbackFilterIterator(
+                    $iterator,
+                    function ($current, $key, $iterator) {
+                        if ( $iterator->isDot() ) {
+                            return false;
+                        }
+                        return true;
+                    }
+                );
+                $iterator = $dotDirFilterIterator;
+            }  catch ( Exception $e ) {
+                $this->logAndThrowException(
+                    sprintf("Error applying dot directory filters: %s", $e->getMessage())
+                );
+            }
+
+            // We do not want to return directories as part of the traversal so we need to
+            // apply directory/file patterns and other checks AFTER traversing the
+            // directory tree. Otherwise, directories may be inadvertantly filtered and
+            // the files missed.
+
+            if ( null !== $this->directoryPattern || null !== $this->filePattern ) {
+
+                $this->logger->info(
+                    sprintf(
+                        "Applying pattern filters: (directory: %s, file: %s)",
+                        ( null === $this->directoryPattern ? "null" : $this->directoryPattern ),
+                        ( null === $this->filePattern ? "null" : $this->filePattern )
+                    )
+                );
+
+                try {
+                    $patternCallbackIterator = new \CallbackFilterIterator(
+                        $iterator,
+                        function ($current, $key, $iterator) {
+                            if (
+                                null !== $this->directoryPattern
+                                && ! preg_match($this->directoryPattern, $current->getPath())
+                            ) {
+                                return false;
+                            }
+
+                            if (
+                                null !== $this->filePattern
+                                 && ! preg_match($this->filePattern, $current->getFilename())
+                            ) {
+                                return false;
+                            }
+
+                            return true;
+                        }
+                    );
+                    $iterator = $patternCallbackIterator;
+                }  catch ( Exception $e ) {
+                    $this->logAndThrowException(
+                        sprintf(
+                            "Error applying pattern filters (directory: %s, file: %s): %s",
+                            ( null === $this->directoryPattern ? "null" : $this->directoryPattern ),
+                            ( null === $this->filePattern ? "null" : $this->filePattern ),
+                            $e->getMessage()
+                        )
+                    );
+                }
+            }
+
+            if ( null !== $this->lastModifiedStartTimestamp || null !== $this->lastModifiedEndTimestamp ) {
+
+                $lmStartTs = $this->lastModifiedStartTimestamp;
+                $lmEndTs = $this->lastModifiedEndTimestamp;
+
+                $this->logger->info(
+                    sprintf(
+                        "Applying mtime filter: (start: %s, end: %s)",
+                        ( null === $lmStartTs ? "null" : $lmStartTs ),
+                        ( null === $lmEndTs ? "null" : $lmEndTs )
+                    )
+                );
+
+                try {
+                    $callbackIterator = new \CallbackFilterIterator(
+                        $iterator,
+                        function ($current, $key, $iterator) use ($lmStartTs, $lmEndTs) {
+                            if ( null !== $lmStartTs && null !== $lmEndTs ) {
+                                return $current->getMTime() >= $lmStartTs && $current->getMTime() <= $lmEndTs;
+                            } elseif ( null !== $lmStartTs ) {
+                                return $current->getMTime() >= $lmStartTs;
+                            } elseif ( null !== $lmEndTs ) {
+                                return $current->getMTime() <= $lmEndTs;
+                            } else {
+                                return false;
+                            }
+                        }
+                    );
+                    $iterator = $callbackIterator;
+                }  catch ( Exception $e ) {
+                    $this->logAndThrowException(
+                        sprintf(
+                            "Error applying last modified filter (start: %s, end: %s): %s",
+                            ( null === $this->lastModifiedStartTimestamp ? "null" : $this->lastModifiedStartTimestamp ),
+                            ( null === $this->lastModifiedEndTimestamp ? "null" : $this->lastModifiedEndTimestamp ),
+                            $e->getMessage()
+                        )
+                    );
+                }
+            }
+
+            $this->handle = $iterator;
+        }
+
+        // Rewind the handle so it is ready to use.
+        $this->handle->rewind();
+
+        return $this->handle;
+
+    }  // connect()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iDataEndpoint::disconnect()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function disconnect()
+    {
+        $this->handle = null;
+        return true;
+    }  // disconnect()
+
+    /** -----------------------------------------------------------------------------------------
+     * Note that this class is essentially an iterator over a set of other iterators. The
+     * $leaveConnected parameter does not apply in this context and is ignored.
+     *
+     * @see iDataEndpoint::verify()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function verify($dryrun = false, $leaveConnected = false)
+    {
+        if ( ! is_dir($this->path) ) {
+            $this->logAndThrowException("Path '" . $this->path . "' is not a directory");
+        }
+
+        if ( ! is_readable($this->path) ) {
+            $this->logAndThrowException("Path '" . $this->path . "' is not readable");
+        }
+
+        $dir = @opendir($this->path);
+
+        if ( false === $dir ) {
+            $error = error_get_last();
+            $this->logAndThrowException(
+                sprintf("Error opening directory '%s': %s", $this->path, $error['message'])
+            );
+        } else {
+            closedir($dir);
+        }
+
+        return true;
+    }  // verify()
+
+    /** -----------------------------------------------------------------------------------------
+     * Note that current() can't return FALSE if the internal pointer is not valid because FALSE may
+     * be a valid value for the iterator, This is why valid() MUST be called before current().
+     *
+     * @see Iterator::current()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function current()
+    {
+        return $this->currentFileIterator->current();
+    }  // current()
+
+    /** -----------------------------------------------------------------------------------------
+     * Return a composite key made up of the current file and the record number that we
+     * are processing in that file.
+     *
+     * @see Iterator::key()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function key()
+    {
+        return sprintf("%s[%s]", $this->currentFilename, $this->currentFileIterator->key());
+    }  // key()
+
+    /** -----------------------------------------------------------------------------------------
+     * Move to the next record in the current file iterator. Only move on to the next file in the
+     * directory scan once we iterate over all records in the file.
+     *
+     * @see Iterator::next()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function next()
+    {
+        $this->currentFileIterator->next();
+    }  // next()
+
+    /** -----------------------------------------------------------------------------------------
+     * Note that calling rewind() rewinds the entire directory scan, not the current file. After
+     * rewinding the directory scan, reset any pointers and call valid() to ensure that we are
+     * pointing at the first record in the first non-empty file.
+     *
+     * @see Iterator::rewind()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function rewind()
+    {
+        $this->handle->rewind();
+        $this->numFilesScanned = 0;
+        $this->currentFileIterator = null;
+        $this->valid();
+    }  // rewind()
+
+    /** -----------------------------------------------------------------------------------------
+     * This function, along with initializeCurrentFileIterator(), is the meat of the scanner. The
+     * pseudocode for a foreach loop is:
+     *
+     * $iterator->rewind();
+     * while ( $iterator->valid() ) {
+     *     $iteraor->current(), $iterator->key();
+     *     $iterator->next();
+     * }
+     *
+     * Since we are using 2 iterators (the list of files and the list of records in each of those
+     * files), a valid position means that we have a valid file and a valid record in that file. If
+     * we have reached the end of the record list for a particular file (and a file could be empty
+     * and contain no records) then we need to move on to the next file in the list. Only after we
+     * have processed all files and all records in the final file should valid() return FALSE.
+     *
+     * @return boolen TRUE if the current position is valid, FALSE otherwise.
+     *
+     * @see Iterator::valid()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function valid()
+    {
+        // Ensure the handle is valid since there may be no files matching the specified criteria or
+        // we could be at the end of the file list.
+
+        if ( ! $this->handle->valid() ) {
+            return false;
+        }
+
+        // If this is the first time we are traversing the directory tree, be sure to initialize the
+        // referene to the current file iterator.
+
+        if ( null === $this->currentFileIterator ) {
+
+            // By default the key is the path and the value is an SplFileInfo object.
+            // http://php.net/manual/en/class.splfileinfo.php
+
+            return $this->initializeCurrentFileIterator(
+                $this->handle->key(),
+                $this->handle->current()->getExtension()
+            );
+
+        } else {
+
+            // If there are records available in the current file, return TRUE. If not, we will need
+            // to move on to the next file.
+
+            if ( $this->currentFileIterator->valid() ) {
+                return true;
+            } else {
+
+                // Since a file could be empty, move on to the next file if we initialize a file
+                // that contains no valid records.
+
+                $this->handle->next();
+
+                while (
+                    $this->handle->valid() &&
+                    ! $this->initializeCurrentFileIterator($this->handle->key(), $this->handle->current()->getExtension())
+                ) {
+                    $this->handle->next();
+                }
+
+                return $this->currentFileIterator->valid();
+            }
+        }
+
+    }  // valid()
+
+    /** -----------------------------------------------------------------------------------------
+     * Set up the internal file iterator for the specified file. This will create a handler based on
+     * the configuration and parse the file using that handler. If the file is empty, then the file
+     * handler's valid() metbod will return FALSE.
+     *
+     * @param string $filename The filename that we are initializing
+     * @param string $extension The extension of the filename
+     *
+     * @returns boolean The value of valid() for the current file handler.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private function initializeCurrentFileIterator($filename, $extension)
+    {
+        $this->logger->debug(
+            sprintf('Scanning file: %s (%s)', $filename, $extension)
+        );
+
+        // Use the file extension and use it to look up a handler. If no extension was found, use
+        // the default handler. NOTE: We are cloning the handler template because it is an object
+        // and will be passed by reference otherwise.
+
+        if ( array_key_exists($extension, $this->handlerTemplateList) ) {
+            $handlerConfig = clone $this->handlerTemplateList[$extension];
+        } else {
+            $handlerConfig = clone $this->handlerTemplateList[self::DEFAULT_HANDLER_KEY];
+        }
+
+        // Inject the current file data into the handler config and parse the file
+
+        $handlerConfig->name = basename($filename);
+        $handlerConfig->path = $filename;
+        $options = new DataEndpointOptions((array) $handlerConfig);
+        $fileHandler = \ETL\DataEndpoint::factory($options, $this->logger);
+
+        if ( ! $fileHandler instanceof iStructuredFile ) {
+            $this->logAndThrowException(
+                sprintf("%s does not implement iStructuredFile", $fileHandler)
+            );
+        }
+
+        $fileHandler->verify();
+        $fileHandler->parse();
+
+        $this->currentFileIterator = $fileHandler;
+        $this->currentFilename = $filename;
+        $this->numFilesScanned++;
+        $this->numRecordsParsed += $fileHandler->count();
+
+        return $this->currentFileIterator->valid();
+
+    }  // initializeCurrentFileIterator()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iDataEndpoint::__toString()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function __toString()
+    {
+        return sprintf('%s (name=%s, path=%s)', get_class($this), $this->name, $this->path);
+    }  // __toString()
+}  // class DirectoryScanner

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -488,28 +488,32 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
             if ( null !== $this->directoryPattern || null !== $this->filePattern ) {
 
+                // PHP 5.3 does not allow us to reference the object in the callback
+                $dirPattern = $this->directoryPattern;
+                $filePattern = $this->filePattern;
+
                 $this->logger->info(
                     sprintf(
                         "Applying pattern filters: (directory: %s, file: %s)",
-                        ( null === $this->directoryPattern ? "null" : $this->directoryPattern ),
-                        ( null === $this->filePattern ? "null" : $this->filePattern )
+                        ( null === $dirPattern ? "null" : $dirPattern ),
+                        ( null === $filePattern ? "null" : $filePattern )
                     )
                 );
 
                 try {
                     $patternCallbackIterator = new \CallbackFilterIterator(
                         $iterator,
-                        function ($current, $key, $iterator) {
+                        function ($current, $key, $iterator) use ($dirPattern, $filePattern) {
                             if (
-                                null !== $this->directoryPattern
-                                && ! preg_match($this->directoryPattern, $current->getPath())
+                                null !== $dirPattern
+                                && ! preg_match($dirPattern, $current->getPath())
                             ) {
                                 return false;
                             }
 
                             if (
-                                null !== $this->filePattern
-                                 && ! preg_match($this->filePattern, $current->getFilename())
+                                null !== $filePattern
+                                 && ! preg_match($filePattern, $current->getFilename())
                             ) {
                                 return false;
                             }
@@ -532,6 +536,7 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
             if ( null !== $this->lastModifiedStartTimestamp || null !== $this->lastModifiedEndTimestamp ) {
 
+                // PHP 5.3 does not allow us to reference the object in the callback
                 $lmStartTs = $this->lastModifiedStartTimestamp;
                 $lmEndTs = $this->lastModifiedEndTimestamp;
 

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -388,9 +388,8 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
             // use CallbackFilterIterator after RecursiveIteratorIterator depending on the
             // situation.
             //
-            // We want to be able to filter on the path and file separately so we are
-            // using an instance of RecursiveCallbackFilterIterator to do this instead of
-            // RecursiveRegexIterator (directories) and RegexIterator.
+            // We want to be able to filter on the path and file separately so we are using an
+            // instance of CallbackFilterIterator to do this instead of RegexIterator.
             //
             // RecursiveDirectoryIterator provides a mechanism to recursively iterate over
             // directories and the files that they contain. It does not iterate beyond the
@@ -416,9 +415,8 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
             // paths that it returns, but note that the regex applies to the full path,
             // not just the name of the file itself.
             //
-            // Note that we want to be able to filter on the path and file separately and
-            // are using the RecursiveCallbackFilterIterator to do this instead of
-            // RecursiveRegexIterator and RegexIterator.
+            // Note that we want to be able to filter on the path and file separately and are using
+            // the CallbackFilterIterator to do this instead of RegexIterator.
 
             // We are conditionally creating multiple iterators that will consume earlier
             // iterators. Keep track of the current iterator.
@@ -721,10 +719,7 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
             // By default the key is the path and the value is an SplFileInfo object.
             // http://php.net/manual/en/class.splfileinfo.php
 
-            return $this->initializeCurrentFileIterator(
-                $this->handle->key(),
-                $this->handle->current()->getExtension()
-            );
+            return $this->initializeCurrentFileIterator($this->handle->key());
 
         } else {
 
@@ -740,10 +735,7 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
                 $this->handle->next();
 
-                while (
-                    $this->handle->valid() &&
-                    ! $this->initializeCurrentFileIterator($this->handle->key(), $this->handle->current()->getExtension())
-                ) {
+                while ($this->handle->valid() && ! $this->initializeCurrentFileIterator($this->handle->key()) ) {
                     $this->handle->next();
                 }
 
@@ -759,14 +751,20 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
      * handler's valid() metbod will return FALSE.
      *
      * @param string $filename The filename that we are initializing
-     * @param string $extension The extension of the filename
      *
      * @returns boolean The value of valid() for the current file handler.
      * ------------------------------------------------------------------------------------------
      */
 
-    private function initializeCurrentFileIterator($filename, $extension)
+    private function initializeCurrentFileIterator($filename)
     {
+        // SplFileInfo::getExtension() is not defined until PHP 5.3.6
+
+        $extension = '';
+        if ( false !== ($pos = strrpos($filename, '.')) ) {
+            $extension = substr($filename, $pos + 1);
+        }
+
         $this->logger->debug(
             sprintf('Scanning file: %s (%s)', $filename, $extension)
         );

--- a/classes/ETL/DataEndpoint/File.php
+++ b/classes/ETL/DataEndpoint/File.php
@@ -138,10 +138,6 @@ class File extends aDataEndpoint implements iDataEndpoint
         $readModes = array("r", "r+", "w+", "a+", "x+", "c+");
         $writeModes = array("r+", "w", "w+", "a", "a+", "x", "x+", "c", "c+");
 
-        if ( ! is_string($this->path) ) {
-            $this->logAndThrowException("Path '" . $this->path . "' is not a string");
-        }
-
         if ( ! in_array($this->mode, array_merge($readModes, $writeModes)) ) {
             $this->logAndThrowException("Unsupported mode '" . $this->mode . "'");
         }
@@ -170,6 +166,6 @@ class File extends aDataEndpoint implements iDataEndpoint
 
     public function __toString()
     {
-        return sprintf('%s (class=%s, path=%s)', $this->name, get_class($this), $this->path);
+        return sprintf('%s (name=%s, path=%s)', get_class($this), $this->name, $this->path);
     }  // __toString()
 }  // class File

--- a/classes/ETL/DataEndpoint/aDataEndpoint.php
+++ b/classes/ETL/DataEndpoint/aDataEndpoint.php
@@ -48,8 +48,19 @@ abstract class aDataEndpoint extends aEtlObject
         $requiredKeys = array("name", "type");
         $this->verifyRequiredConfigKeys($requiredKeys, $options);
 
+        $messages = array();
+        $propertyTypes = array(
+            'name' => 'string',
+            'type' => 'string'
+        );
+
+        if ( ! \xd_utilities\verify_object_property_types($options, $propertyTypes, $messages, true) ) {
+            $this->logAndThrowException("Error verifying options: " . implode(", ", $messages));
+        }
+
         $this->type = $options->type;
         $this->setName($options->name);
+
     }  // __construct()
 
     // ------------------------------------------------------------------------------------------

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -51,13 +51,6 @@ abstract class aStructuredFile extends File
     protected $recordList = array();
 
     /**
-     * The iterator position in the record list.
-     *
-     * @var int
-     */
-    private $recordListPosition = 0;
-
-    /**
      * Character used to separate records in the input file, defaults to NULL.
      *
      * @var string
@@ -387,48 +380,51 @@ abstract class aStructuredFile extends File
         if ( ! $this->valid() ) {
             return false;
         }
-        return $this->recordList[$this->recordListPosition];
-    }
+        return current($this->recordList);
+    }  // current()
 
     /** -----------------------------------------------------------------------------------------
-     * @see Iterator::current()
+     * @see Iterator::key()
      * ------------------------------------------------------------------------------------------
      */
 
     public function key()
     {
-        return $this->recordListPosition;
-    }
+        return key($this->recordList);
+    }  // key()
 
     /** -----------------------------------------------------------------------------------------
-     * @see Iterator::current()
+     * @see Iterator::next()
      * ------------------------------------------------------------------------------------------
      */
 
     public function next()
     {
-        $this->recordListPosition++;
-    }
+        next($this->recordList);
+    }  // next()
 
     /** -----------------------------------------------------------------------------------------
-     * @see Iterator::current()
+     * @see Iterator::rewind()
      * ------------------------------------------------------------------------------------------
      */
 
     public function rewind()
     {
-        $this->recordListPosition = 0;
-    }
+        reset($this->recordList);
+    }  // rewind()
 
     /** -----------------------------------------------------------------------------------------
-     * @see Iterator::current()
+     * @see Iterator::valid()
      * ------------------------------------------------------------------------------------------
      */
 
     public function valid()
     {
-        return isset($this->recordList[$this->recordListPosition]);
-    }
+        // return isset($this->recordList[$this->recordListPosition]);
+        // Note that we can't check for values that are FALSE because that is a valid
+        // data value.
+        return null !== key($this->recordList);
+    }  // valid()
 
     /** -----------------------------------------------------------------------------------------
      * @see Countable::count()
@@ -438,7 +434,7 @@ abstract class aStructuredFile extends File
     public function count()
     {
         return count($this->recordList);
-    }
+    }  // count()
 
     /** -----------------------------------------------------------------------------------------
      * Decodes a data string into a PHP object and add it to the record list.

--- a/classes/ETL/aOptions.php
+++ b/classes/ETL/aOptions.php
@@ -1,10 +1,11 @@
 <?php
 
-/* ==========================================================================================
- * Abstract class for defining general option sets to the ETL process. All option sets have an
- * optional list of required options and the list of options themselves. Options may have any name
- * and value and options that are listed as required may not have a value that is NULL or an empty
- * string.
+/** =========================================================================================
+ * Abstract class for defining general option sets to the ETL process. All option sets
+ * have an optional list of required options and the list of options themselves. Options
+ * may have any name and value and options that are listed as required may not have a
+ * value that is NULL or an empty string. Implementing the Iterator interface allows us to
+ * treat the $options array of this class as public propertes and iterate over them.
  *
  * A verification method checks for the existnace of all required options and a generic getter
  * method returns a requested option, or NULL if it does not exist. It is expected that extending
@@ -23,7 +24,7 @@ use \Exception;
 // Extending stdClass allows us to use aOptions with when a general class is used, such as verifying
 // required keys in an aOptions class or a standard parsed JSON object.
 
-abstract class aOptions extends \stdClass
+abstract class aOptions extends \stdClass implements \Iterator
 {
     // The list of required options. These options cannot be set to NULL or an empty string.
     protected $requiredOptions = array(
@@ -308,4 +309,59 @@ abstract class aOptions extends \stdClass
         } // else ( 1 == count($parts) )
 
     }  // applyBasePath()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::current()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function current()
+    {
+        if ( ! $this->valid() ) {
+            return false;
+        }
+        return current($this->options);
+    }  // current()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::key()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function key()
+    {
+        return key($this->options);
+    }  // key()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::next()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function next()
+    {
+        next($this->options);
+    }  // next()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::rewind()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function rewind()
+    {
+        reset($this->options);
+    }  // rewind()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Iterator::valid()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function valid()
+    {
+        // Note that we can't check for values that are FALSE because that is a valid
+        // data value.
+        return null !== key($this->options);
+    }  // valid()
 }  // class aOptions

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/DirectoryScannerTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/DirectoryScannerTest.php
@@ -1,0 +1,206 @@
+<?php
+/* ------------------------------------------------------------------------------------------
+ * Component tests for ETL Directory Scanner Data Endpoints.
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ * @date 2017-05-31
+ * ------------------------------------------------------------------------------------------
+ */
+
+namespace UnitTesting\ETL\DataEndpoint;
+
+use Exception;
+use CCR\Log;
+use ETL\DataEndpoint;
+use ETL\DataEndpoint\DataEndpointOptions;
+
+class DirectoryScanner extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
+    private $logger = null;
+
+    public function __construct()
+    {
+        // Set up a logger so we can get warnings and error messages from the ETL
+        // infrastructure
+        $conf = array(
+            'file' => false,
+            'db' => false,
+            'mail' => false,
+            'consoleLogLevel' => Log::INFO
+        );
+
+        $this->logger = Log::factory('PHPUnit', $conf);
+    }  // __construct()
+
+    /**
+     * Test passing options with the wrong types.
+     *
+     * @expectedException Exception
+     */
+
+    public function testInvalidOptions()
+    {
+        $config = array(
+            'name' => 'Invalid Options',
+            'type' => 'directoryscanner',
+            'path' => '/dev/null',
+            'file_pattern' => 1,
+            'directory_pattern' => false,
+            'recursion_depth' => '2',
+            'last_modified_start' => 10,
+            'last_modified_end' => 10,
+            'handlers' => (object) array (
+                'type' => 'jsonfile',
+                'record_separator' => "\n"
+            )
+        );
+        $options = new DataEndpointOptions($config);
+        $scanner = DataEndpoint::factory($options, $this->logger);
+        $scanner->verify();
+    }  // testInvalidOptions()
+
+    /**
+     * Test trying to read a file instead of a directory.
+     *
+     * @expectedException Exception
+     */
+
+    public function testNotDirectory()
+    {
+        $config = array(
+            'name' => 'Not a directory',
+            'type' => 'directoryscanner',
+            'path' => '/dev/null',
+            'handlers' => array(
+                (object) array (
+                    'type' => 'jsonfile',
+                    'record_separator' => "\n"
+                )
+            )
+        );
+        $options = new DataEndpointOptions($config);
+        $scanner = DataEndpoint::factory($options, $this->logger);
+        $scanner->verify();
+
+    }  // testNotDirectory()
+
+    /**
+     * Test basic scanner with no filters and default handler for all file types. This
+     * directory includes a file that is empty (has no records).
+     */
+
+    public function testBasicOptions()
+    {
+        $config = array(
+            'name' => 'Euca files',
+            'type' => 'directoryscanner',
+            'path' => self::TEST_ARTIFACT_INPUT_PATH . '/directory_scanner',
+            'handlers' => array(
+                (object) array (
+                    'type' => 'jsonfile',
+                    'record_separator' => "\n"
+                )
+            )
+        );
+        $options = new DataEndpointOptions($config);
+        $scanner = DataEndpoint::factory($options, $this->logger);
+        $scanner->verify();
+        $scanner->connect();
+
+        // The directory isn't scanned until we iterate over it.
+
+        foreach ( $scanner as $key => $val ) {
+        }
+
+        // One file in the directory contains no data.
+
+        $this->assertEquals(3, $scanner->getNumFilesScanned());
+        $this->assertEquals(6, $scanner->getNumRecordsParsed());
+
+    }  // testBasicOptions()
+
+    /**
+     * Test trying to read a file filtered using the file_fileter regex.
+     */
+
+    public function testPatternFilters()
+    {
+        // Restrict to directories containing "_scanner" and files matching "euca*.json"
+
+        $config = array(
+            'name' => 'Euca files',
+            'type' => 'directoryscanner',
+            'path' => self::TEST_ARTIFACT_INPUT_PATH,
+            'directory_pattern' => '/_scanner/',
+            'file_pattern' => '/euca.*\.json/',
+            'handlers' => array(
+                (object) array (
+                    'extension' => '.json',
+                    'type' => 'jsonfile',
+                    'record_separator' => "\n"
+                )
+            )
+        );
+        $options = new DataEndpointOptions($config);
+        $scanner = DataEndpoint::factory($options, $this->logger);
+        $scanner->verify();
+        $scanner->connect();
+
+        // The directory isn't scanned until we iterate over it.
+        foreach ( $scanner as $key => $val ) {
+        }
+
+        $this->assertEquals(3, $scanner->getNumFilesScanned());
+        $this->assertEquals(6, $scanner->getNumRecordsParsed());
+
+    }  // testPatternFilters()
+
+    /**
+     * Test trying to read a file modified between a particular start and end date.
+     */
+
+    public function testLastModifiedFilters()
+    {
+        // Restrict to files matching "euca*.json", and modified recently.
+
+        self::TEST_ARTIFACT_INPUT_PATH;
+
+        $origFile = self::TEST_ARTIFACT_INPUT_PATH . '/euca_acct.json';
+        $newFile = self::TEST_ARTIFACT_INPUT_PATH . '/directory_scanner/euca_my_new_file.json';
+        $startDate = date('c');
+        @copy($origFile, $newFile);
+        sleep(1);
+        $endDate = date('c');
+
+        $config = array(
+            'name' => 'Euca files',
+            'type' => 'directoryscanner',
+            'path' => self::TEST_ARTIFACT_INPUT_PATH,
+            'file_pattern' => '/euca.*\.json/',
+            'last_modified_start' => $startDate,
+            'last_modified_end' => $endDate,
+            'handlers' => array(
+                (object) array (
+                    'extension' => '.json',
+                    'type' => 'jsonfile',
+                    'record_separator' => "\n"
+                )
+            )
+        );
+        $options = new DataEndpointOptions($config);
+        $scanner = DataEndpoint::factory($options, $this->logger);
+        $scanner->verify();
+        $scanner->connect();
+
+        // The directory isn't scanned until we iterate over it.
+        foreach ( $scanner as $key => $val ) {
+        }
+
+        @unlink($newFile);
+        $this->assertEquals(1, $scanner->getNumFilesScanned());
+        $this->assertEquals(2, $scanner->getNumRecordsParsed());
+
+    }  // testLastModifiedFilter()
+}  // class DirectoryScannerTest

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
@@ -286,6 +286,63 @@ class StructuredFileTest extends \PHPUnit_Framework_TestCase
     }  // testFilterSyntaxError()
 
     /**
+     * Test unknown filter executable.
+     *
+     * @expectedException Exception
+     */
+
+    public function testInvalidFilter()
+    {
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/empty.json';
+        $config = array(
+            'name' => 'empty.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'filters' => array(
+                (object) array(
+                    'type' => 'external',
+                    'name' => 'unknown',
+                    'path' => 'gobbledygook'
+                )
+            )
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $file->parse();
+
+    }  // testInvalidFilter()
+
+    /**
+     * Test parsing of an empty file.
+     */
+
+    public function testEmptyFile()
+    {
+        $path = self::TEST_ARTIFACT_INPUT_PATH . '/empty.json';
+        $config = array(
+            'name' => 'empty.json',
+            'path' => $path,
+            'type' => 'jsonfile',
+            'filters' => array(
+                (object) array(
+                    'type' => 'external',
+                    'name' => 'jq',
+                    'path' => 'jq',
+                    'arguments' => "'.'"
+                )
+            )
+        );
+
+        $options = new DataEndpointOptions($config);
+        $file = DataEndpoint::factory($options, $this->logger);
+        $file->verify();
+        $this->assertFalse($file->parse());
+
+    }  // testEmptyFile()
+
+    /**
      * Test parsing a simple JSON file containing an array of objects filtered through an
      * external process.
      */

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/StructuredFileTest.php
@@ -15,8 +15,8 @@ use ETL\DataEndpoint\DataEndpointOptions;
 
 class StructuredFileTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_INPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
-    const TEST_ARTIFACT_OUTPUT_PATH = "../../../../vendor/ubccr/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dataendpoint/output";
     private $logger = null;
 
     public function __construct()


### PR DESCRIPTION
This is the initial implementation of the DirectoryScanner data endpoint to support ingestion of cloud data.

## Description

The Directory Scanner Data Endpoint is designed to be a drop-in replacement for a Structured File
endpoint. It is designed as a wrapper around the Structured File endpoint that allows a Structured
File endpoint to be instantiated for each file in a directory (or subdirectory) matching a specified
criteria. It supports directory and file name pattern filtering as well as filtering on last
modified dates. The Directory Scanner implements the `Iterator` interface and the iteration spans
the union of the records in each of the files matching the criteria. For example, if 2 files are found in a
directory then the Directory Scanner iterator will span all of the records in both files.

This is designed so that an action can simply iterate over the Directory Scanner to access all
records in all matching files contained in the directory, independent of their format. For example:

```php
$config = array(
    'name' => 'Euca files',
    'type' => 'directoryscanner',
    'path' => '/some/directory',
    'handlers' => array(
        (object) array (
            'extension' => '.json',
            'type' => 'jsonfile',
            'record_separator' => "\n"
        )
    )
);
$options = new DataEndpointOptions($config);
$scanner = DataEndpoint::factory($options, $this->logger);
$scanner->verify();
$scanner->connect();

foreach ( $scanner as $key => $record ) {
    // Do something
}
```

Note that the handler object is used as a template for the StructuredFile configuration. The
required name and path will be injected on instantiation.  Multiple handlers may be specified for
different file extensions but records in each file must contain the same set of data field in order
to be ingested properly. Support for the ETL Overseer macros `${LAST_MODIFIED_START_DATE}` and
`${LAST_MODIFIED_END_DATE}` will be added along with StructuredFile action enhancements.

```javascript
"endpoints": {
    "source": {
        "name": "My Name",
        "path": "/path/to/directory",
        "file_pattern": "/regex/",
        "directory_pattern": "/regex/",
        "recursion_depth": 1,
        "last_modified_start": "${LAST_MODIFIED_START_DATE}",
        "last_modified_end": "${LAST_MODIFIED_END_DATE}",
        "type": "directoryscanner",
        "handlers": [
            {
                "extension": ".json",
                "type": "jsonfile",
                "record_schema_path": "value_analytics/user.json",
                "record_separator": "\n"
            },
            {
                "extension": ".csv",
                "type": "csvfile",
                "record_separator": "\n",
                "field_separator": ","
            }
        ]
    }
}
```

### Filtering

Filtering is available using the following criteria. Files will only be examined if the meet all
specified criteria. Note that these criteria are only used by the Directory Scanner endpoint for
selecting files to examine, and not for the actual parsing of those files or the ingestion of the data.

1. `directory_pattern` Only directories matching the regex specified will be examined. If the
   directory portion of a file does not match this criteria it will be skipped.
2. `file_pattern` Only files matching the regex specified will be processed.
3. `recursion_depth` Only descend this deep into the directory hierarchy when searching for files.
4. `last_modified_start` and `last_modified_end`. Only files modified on or before/after this time
   will be processed. If the variables `${LAST_MODIFIED_START_DATE}` or `${LAST_MODIFIED_END_DATE}`
   are specified as the value then last modified value passed on the ETL Overseer command line will
   be used. In the future, a value of "auto" may be available that will evaluate to time of the last
   execution of the directory scanner or the `max(last_modified)` of the table. Note that this only
   applies to the data endpoint processing the files, the action that processes the data may use the
   `last_modified` value in a different way. **Note that the ETL Overseer will need to be able to
   specify a last modified time of "none" so all files could be examined during a full ingestion.**

### Filtering Use Cases

1. `directory_pattern` Directory names may be in a specific format and we will want to only process
   files in directories conforming to this format. For example, the Euca accounting directories are
   named using the date (e.g., `2017-05-10`) that contains an accounting file and may contain a
   subdirectory called `raw`. We do not want to descend into this subdirectory so we would restrict
   the search using `"directory_pattern": "/(?!.*raw)/"`.

2. `file_pattern` File names may be in a specific format or we may want to only find files with a
   particular extension. For example, only process resource manager log files of the form `20120101`
   using `"file_pattern": "/^\d{4}\d{2}\d{2}$/"`. Another example is finding only files with a
   ".json" extension using `"file_pattern": "/.json$/"`.
  
3. `last_modified_start` When shredding or ingesting resource manager or cloud log files, it is
   possible that hundreds or even thousands of files may exist in the log directory. Rather than
   process all files, only new files or those that contain updated data should be
   examined. Specifying a value for `last_modified_start` we can examine only files that were
   modified on or after the specified time. For example, `"last_modified_start":
   "${LAST_MODIFIED_START_DATE}"` will use the value of the last modified start date as passed to
   the ETL Overseer allowing us to specify values such as `--last-modified-start-date "now - 5
   days"`.

## Motivation and Context

Scanning a directory and parsing/ingesting all or a subset of files in that directory will be needed for the cloud as well as migrating ETLv1 to ETLv2 (e.g., resource manager log files).

## Tests performed

Component tests have been created for the following cases:

- StructuredFile
    - Unknown/invalid filter executable
    - Parsing of an empty file (i.e., no records)
- DirectoryScanner
    - Invalid endpoint options
    - Path is not a directory
    - Scan all files in a directory including an empty file (verify number of files and total number of records found)
    - Apply directory and file regex patterns (verify number of files and total number of records found)
    - Apply last modified start and end filters

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
