### PR TITLE
Ensure assist panel shows when there are no job tabs.

### DIFF
--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -1017,9 +1017,9 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                                     // Set the tab panel to be active since a new tab is to be added.
                                     Ext.getCmp('info_display_container').getLayout().setActiveItem(1);
                                 },
-                                close: function(p) {
-                                    if(Ext.getCmp('info_display').items.length == 1) {
-                                        // The only tab left is about to close. Set the assist image to be active
+                                destroy: function () {
+                                    if (Ext.getCmp('info_display').items.length < 1) {
+                                        // All tabs have been destroyed. Set the assist image to be active
                                         Ext.getCmp('info_display_container').getLayout().setActiveItem(0);
                                     }
                                 }


### PR DESCRIPTION
## Description
The assist panel did not show when the job tabs were removed due to a
right-click delete search in the search history tree. This was because
the tab.removeAll() function did not fire the close event. Changed the
code to listen to the destroy event which is always fired.

## Motivation and Context
Bug fix

## Tests performed
Steps to test:

- Open one or more jobs in the job viewer
- in the searhc history tree right click on a search node and select
  'Delete Search'
- Click 'yes' when prompted

With the original code the main tab panel is blank. This change results
in the assist panel being displayed again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)