### PR TITLE
Added ability to link directly to jobs.

### DIFF
--- a/classes/NewRest/Controllers/WarehouseControllerProvider.php
+++ b/classes/NewRest/Controllers/WarehouseControllerProvider.php
@@ -634,8 +634,8 @@ class WarehouseControllerProvider extends BaseControllerProvider
             throw new BadRequestException('params parameter must be valid JSON');
         }
 
-        if (isset($params['resource_id']) && isset($params['local_job_id'])) {
-            return $this->_getJobByLocalJobId($app, $user, $realm, $params['resource_id'], $params['local_job_id']);
+        if ( (isset($params['resource_id']) && isset($params['local_job_id'])) || isset($params['jobref']) ) {
+            return $this->getJobByPrimaryKey($app, $user, $realm, $params);
         } else {
             $startDate = $this->getStringParam($request, 'start_date', true);
             $endDate = $this->getStringParam($request, 'end_date', true);
@@ -1910,23 +1910,31 @@ class WarehouseControllerProvider extends BaseControllerProvider
     }
 
     /**
-     * Attempts to retrieve job information given the provided resource / localjob id's.
+     * Attempts to retrieve job information given the provided resource &
+     * localjob id or by the db primary key (called jobref here to avoid end user
+     * confusion between this internal identifier and the job id provided
+     * by the resource-manager).
      *
      * @param Application $app
      * @param \XDUser $user
      * @param string $realm
-     * @param int $resourceId
-     * @param int $localJobId
+     * @param array $searchparams
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      * @throws \DataWarehouse\Query\Exceptions\AccessDeniedException
      * @throws BadRequestException
      */
-    private function _getJobByLocalJobId(Application $app, \XDUser $user, $realm, $resourceId, $localJobId)
+    private function getJobByPrimaryKey(Application $app, \XDUser $user, $realm, $searchparams)
     {
-        $params = array(
-            new \DataWarehouse\Query\Model\Parameter("resource_id", "=", $resourceId),
-            new \DataWarehouse\Query\Model\Parameter("local_job_id", "=", $localJobId)
-        );
+        if (isset($searchparams['jobref'])) {
+            $params = array(
+                new \DataWarehouse\Query\Model\Parameter('_id', '=', $searchparams['jobref'])
+            );
+        } else {
+            $params = array(
+                new \DataWarehouse\Query\Model\Parameter("resource_id", "=", $searchparams['resource_id']),
+                new \DataWarehouse\Query\Model\Parameter("local_job_id", "=", $searchparams['local_job_id'])
+            );
+        }
 
         $QueryClass = "\\DataWarehouse\\Query\\$realm\\JobDataset";
         $query = new $QueryClass($params, "brief");

--- a/html/gui/js/modules/job_viewer/SearchHistoryPanel.js
+++ b/html/gui/js/modules/job_viewer/SearchHistoryPanel.js
@@ -232,6 +232,23 @@ XDMoD.Module.JobViewer.SearchHistoryPanel = Ext.extend(XDMoD.Module.JobViewer.Se
                         );
                         break;
                     case 'jobid':
+                        title = 'Job Actions';
+                        items.push({
+                            text: 'Get shareable link',
+                            iconCls: 'save_as',
+                            id: 'job-viewer-search-history-context-get-url',
+                            handler: function () {
+                                var params = self.getParams(node);
+                                Ext.Msg.show({
+                                    title: 'URL for ' + node.attributes.text,
+                                    msg: '<p>' + window.location.protocol + '//' + window.location.host + '/#job_viewer?action=show&realm=' + params.realm + '&jobref=' + params.jobid + '<br /><br /></p>' +
+                                         '<p>Note that this link does not change the access permissions on the job data. XDMoD users must already have permission to be able to view the job via this link.</p>',
+                                    buttons: Ext.Msg.OK,
+                                    minWidth: 650,
+                                    icon: Ext.MessageBox.INFO
+                                });
+                            }
+                        });
                         break;
                     case 'infoid':
                         break;
@@ -261,7 +278,7 @@ XDMoD.Module.JobViewer.SearchHistoryPanel = Ext.extend(XDMoD.Module.JobViewer.Se
                         target: 'job-viewer-search-history-context-edit-search',
                         text: hasSearchTerms ?
                             'Edit the selected searches parameters and or selected jobs.' :
-                            'Edit Search is not currently supported for Metric Explorer Searches.'
+                            'Edit Search is not currently supported for searches created from the Metric Explorer or via a sharable link.'
                     });
                 }
 


### PR DESCRIPTION
## Description

Right clicking on a job in the search history tree now gives a context
menu with the option to get a sharable link. This URL can be used to
directly link to a given job for all users of the system (although the
job permissions are not changed, so only those users that have
permission will be able to actually view the job data.

Job search based on the local job id is also possible, but requires the
knowledge of the primary key for the resource that ran the job. This
feature is intended for developer use (e.g. to link to the job viewer
from an external system).

## Motivation and Context
Commonly requested feature

## Tests performed
Manually tested loading the links in firefox Linux and chrome Linux. Tested following combinations:
- Not logged in, then login w/ CD account (confirm that job loads)
- Not logged in, then login w/ unpriv user account (and confirm that access denied message is seen)
- Already logged in as CD
- Alread logged in as unpriv user
- Load url multiple times and confirm that it reuses the same tree node.
- manually edit the url to change to a non-existent job and confirm that you get an error dialog then can continued using the job viewer.
- manually edit the url to add typo to selection criteria and confirm that you get an error dialog then can continued using the job viewer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My code follows the code style of this project as found in the **CONTRIBUTING** document.
- All new and existing tests passed.
