### PR TITLE
Allow DataEndpoint singleton to auto-discover available data endpoints

### DIFF
--- a/classes/ETL/DataEndpoint.php
+++ b/classes/ETL/DataEndpoint.php
@@ -18,31 +18,31 @@ use Log;
 class DataEndpoint
 {
     /**
-     * Namesapce, relative to the current namespace, where data endpoint classes are
+     * Namespace, relative to the current namespace, where data endpoint classes are
      * defined. This is used to automatically search for defined endpoints.
      *
-     * @var string
+     * @const string
      */
 
-    private static $dataEndpointRelativeNs = 'DataEndpoint';
+    const DATA_ENDPOINT_RELATIVE_NS = 'DataEndpoint';
 
     /**
      * Fully namespaced interface that all data endpoints must implement
      *
-     * @var string
+     * @const string
      */
 
-    private static $dataEndpointRequiredInterface = 'ETL\\DataEndpoint\\iDataEndpoint';
+    const DATA_ENDPOINT_REQUIRED_INTERFACE = 'ETL\\DataEndpoint\\iDataEndpoint';
 
     /**
      * The name of the constant expected to be defined in all data endpoint classes. This
      * is used to identify the name that will be used to refer to the endpoint in
      * configuration files.
      *
-     * @var string
+     * @const string
      */
 
-    private static $endpointNameConstant = 'ENDPOINT_NAME';
+    const ENDPOINT_NAME_CONSTANT = 'ENDPOINT_NAME';
 
     /**
      * Associative array where the keys are data endpoint names and the values are fully
@@ -90,11 +90,13 @@ class DataEndpoint
     }  // getDataEndpointInfo()
 
     /** -----------------------------------------------------------------------------------------
-     * Discover the list of currently supported data endpoints and constuct a list mapping
-     * their names to the classes that implement them.  All data endpoints must implement
-     * the interface specified in self::$dataEndpointRequiredInterface.  By automatically
-     * discovering the data endpoints we do not need to modify this file when new
-     * endpoints are created.
+     * Discover the list of currently supported data endpoints and construct a list
+     * mapping their names to the classes that implement them.  All data endpoints must
+     * implement the interface specified in self::DATA_ENDPOINT_REQUIRED_INTERFACE and
+     * also define a constant referenced by self::ENDPOINT_NAME_CONSTANT that is set to
+     * the name of the endpoint (e.g., const ENDPOINT_NAME = 'file.json'.  By
+     * automatically discovering the data endpoints we do not need to modify this file
+     * when new endpoints are created.
      *
      * @param boolean $force Set to TRUE to force re-discovery of endpoints
      * @param Log $logger A PEAR Log object or null to use the null logger.
@@ -114,7 +116,9 @@ class DataEndpoint
         // file resides represent sub-namespaces.
 
         // The endpoint directory is relative to the directory where this file is found
-        $endpointDir =  dirname(__FILE__) . '/' . strtr(self::$dataEndpointRelativeNs, '\\', '/');
+        $endpointDir =  dirname(__FILE__)
+            . DIRECTORY_SEPARATOR
+            . strtr(self::DATA_ENDPOINT_RELATIVE_NS, '\\', DIRECTORY_SEPARATOR);
         $endpointDirLength = strlen($endpointDir);
 
         // Recursively traverse the directory where the endpoints live and discover any
@@ -136,13 +140,13 @@ class DataEndpoint
             // Set up an array so we can programmatically construct the namespace based on
             // the path to the class file
 
-            $constructedNamespace = array(__NAMESPACE__, self::$dataEndpointRelativeNs);
+            $constructedNamespace = array(__NAMESPACE__, self::DATA_ENDPOINT_RELATIVE_NS);
 
             // Construct any additional sub-namespaces for subdirectories discovered under
             // the endpoint namespace (e.g. the subdirectory DataEndpoint/Filters
             // translates to the namespace DataEndpoint\Filters.
 
-            $subDirNs = strtr(substr($fileInfo->getPath(), $endpointDirLength + 1), '/', '\\');
+            $subDirNs = strtr(substr($fileInfo->getPath(), $endpointDirLength + 1), DIRECTORY_SEPARATOR, '\\');
             if ( "" !== $subDirNs) {
                 $constructedNamespace[] = $subDirNs;
             }
@@ -171,11 +175,11 @@ class DataEndpoint
                 // Ensure that the class is not abstract and implements the required
                 // interface
 
-                if ( ! $r->isAbstract() && $r->implementsInterface(self::$dataEndpointRequiredInterface) ) {
+                if ( ! $r->isAbstract() && $r->implementsInterface(self::DATA_ENDPOINT_REQUIRED_INTERFACE) ) {
 
-                    if ( $r->hasConstant(self::$endpointNameConstant) ) {
+                    if ( $r->hasConstant(self::ENDPOINT_NAME_CONSTANT) ) {
 
-                        $name = $r->getConstant(self::$endpointNameConstant);
+                        $name = $r->getConstant(self::ENDPOINT_NAME_CONSTANT);
                         if ( ! array_key_exists($name, self::$endpointClassMap) ) {
                             self::$endpointClassMap[$name] = $r->getName();
                         } elseif ( null !== $logger ) {
@@ -195,7 +199,7 @@ class DataEndpoint
                                 "%s Class '%s' does not define %s, skipping",
                                 __CLASS__,
                                 $r->getName(),
-                                self::$endpointNameConstant
+                                self::ENDPOINT_NAME_CONSTANT
                             )
                         );
 
@@ -215,7 +219,7 @@ class DataEndpoint
      *   parsed from the ETL config.
      * @param Log $logger A PEAR Log object or null to use the null logger.
      *
-     * @return A data endpoint object implementing the iDataEndpoint interface.
+     * @return iDataEndpoint A data endpoint object implementing the iDataEndpoint interface.
      *
      * @throws Exception If required options were not provided
      * @throws Exception If the requested class could not be found

--- a/classes/ETL/DataEndpoint.php
+++ b/classes/ETL/DataEndpoint.php
@@ -176,18 +176,18 @@ class DataEndpoint
                             $logger->warning(
                                 sprintf(
                                     "%s Endpoint with name '%s' already exists, skipping",
-                                    static::class,
+                                    __CLASS__,
                                     $name
                                 )
                             );
                         }
 
-                    } else if ( null !== $logger ) {
+                    } elseif ( null !== $logger ) {
 
                         $logger->warning(
                             sprintf(
                                 "%s Class '%s' does not define %s, skipping",
-                                static::class,
+                                __CLASS__,
                                 $r->getName(),
                                 self::$endpointNameConstant
                             )
@@ -225,7 +225,7 @@ class DataEndpoint
         // If the type is defined and has a mapping to an implementation, create a class for the type.
 
         if ( ! array_key_exists($options->type, self::$endpointClassMap) ) {
-            $msg = sprintf("%s: Undefined data endpoint type: '%s'", static::class, $options->type);
+            $msg = sprintf("%s: Undefined data endpoint type: '%s'", __CLASS__, $options->type);
             if ( null !== $logger ) {
                 $logger->err($msg);
             }
@@ -238,7 +238,7 @@ class DataEndpoint
         $endpoint = new $className($options, $logger);
 
         if ( ! $endpoint instanceof iDataEndpoint ) {
-            $msg = sprintf("%s: %s does not implement iDataEndpoint", static::class, $className);
+            $msg = sprintf("%s: %s does not implement iDataEndpoint", __CLASS__, $className);
             if ( null !== $logger ) {
                 $logger->err($msg);
             }

--- a/classes/ETL/DataEndpoint.php
+++ b/classes/ETL/DataEndpoint.php
@@ -1,7 +1,7 @@
 <?php
 /* ==========================================================================================
- * Singleton factory method for instantiating DataEndpoint objects. All endpoints must implement the
- * iDataEndpoint interface.
+ * Singleton factory method for instantiating DataEndpoint objects. All endpoints must
+ * implement the iDataEndpoint interface.
  *
  * @author Steve Gallo <smgallo@buffalo.edu>
  * @date 2015-09-25
@@ -12,47 +12,49 @@ namespace ETL;
 
 use ETL\DataEndpoint\DataEndpointOptions;
 use ETL\DataEndpoint\iDataEndpoint;
-use \Exception;
-use \Log;
+use Exception;
+use Log;
 
 class DataEndpoint
 {
+    /**
+     * Namesapce, relative to the current namespace, where data endpoint classes are
+     * defined. This is used to automatically search for defined endpoints.
+     *
+     * @var string
+     */
 
-    // Default namespace for ingestors, can be overriden in the ETL configuration file
-    private static $defaultNs = "ETL\\DataEndpoint\\";
+    private static $dataEndpointRelativeNs = 'DataEndpoint';
 
-    // List of defined data endpoint types. These are defined as constants so they can be used in the
-    // ETL configuration file.
+    /**
+     * Fully namespaced interface that all data endpoints must implement
+     *
+     * @var string
+     */
 
-    const TYPE_MYSQL = "mysql";
-    const TYPE_POSTGRES = "postgres";
-    const TYPE_ORACLE = "oracle";
-    const TYPE_FILE = "file";
-    const TYPE_JSONFILE = "jsonfile";
-    const TYPE_DIRECTORY_SCANNER = "directoryscanner";
-    const TYPE_REST = "rest";
+    private static $dataEndpointRequiredInterface = 'ETL\\DataEndpoint\\iDataEndpoint';
 
-    private static $supportedTypes = array(
-        self::TYPE_MYSQL,
-        self::TYPE_ORACLE,
-        self::TYPE_POSTGRES,
-        self::TYPE_FILE,
-        self::TYPE_JSONFILE,
-        self::TYPE_DIRECTORY_SCANNER,
-        self::TYPE_REST
-    );
+    /**
+     * The name of the constant expected to be defined in all data endpoint classes. This
+     * is used to identify the name that will be used to refer to the endpoint in
+     * configuration files.
+     *
+     * @var string
+     */
 
-    private static $classmap = array(
-        self::TYPE_MYSQL => 'ETL\DataEndpoint\Mysql',
-        self::TYPE_POSTGRES => 'ETL\DataEndpoint\Postgres',
-        self::TYPE_ORACLE => 'ETL\DataEndpoint\Oracle',
-        self::TYPE_FILE => 'ETL\DataEndpoint\File',
-        self::TYPE_JSONFILE => 'ETL\DataEndpoint\JsonFile',
-        self::TYPE_DIRECTORY_SCANNER => 'ETL\DataEndpoint\DirectoryScanner',
-        self::TYPE_REST => 'ETL\DataEndpoint\Rest'
-    );
+    private static $endpointNameConstant = 'ENDPOINT_NAME';
 
-    /* ------------------------------------------------------------------------------------------
+    /**
+     * Associative array where the keys are data endpoint names and the values are fully
+     * namespaced class names that implement those endpoints. This will be null until it
+     * is initialized.
+     *
+     * @var array | null
+     */
+
+    private static $endpointClassMap = null;
+
+    /** -----------------------------------------------------------------------------------------
      * Private constructor ensures the singleton can't be instantiated.
      * ------------------------------------------------------------------------------------------
      */
@@ -61,10 +63,151 @@ class DataEndpoint
     {
     }
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
+     * Return the list of data endpoint names that are currently configured/supported.
+     *
+     * @return array A list of data endpoint names
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function getDataEndpointNames()
+    {
+        return array_keys(self::getDataEndpointInfo());
+    }  // getDataEndpointNames()
+
+    /** -----------------------------------------------------------------------------------------
+     * Return an associative array where the keys are data endpoint names and the values
+     * are fully namespaced class names that implement those endpoints.
+     *
+     * @return array A list of data endpoint names
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function getDataEndpointInfo()
+    {
+        self::discover();
+        return self::$endpointClassMap;
+    }  // getDataEndpointInfo()
+
+    /** -----------------------------------------------------------------------------------------
+     * Discover the list of currently supported data endpoints and constuct a list mapping
+     * their names to the classes that implement them.  All data endpoints must implement
+     * the interface specified in self::$dataEndpointRequiredInterface.  By automatically
+     * discovering the data endpoints we do not need to modify this file when new
+     * endpoints are created.
+     *
+     * @param boolean $force Set to TRUE to force re-discovery of endpoints
+     * @param Log $logger A PEAR Log object or null to use the null logger.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function discover($force = false, Log $logger = null)
+    {
+        if ( null !== self::$endpointClassMap && ! $force ) {
+            return;
+        }
+
+        // As per PSR-4 (http://www.php-fig.org/psr/psr-4/) the contiguous sub-namespace
+        // names after the "namespace prefix" correspond to a subdirectory within a "base
+        // directory", in which the namespace separators represent directory separators.
+        // This means that we can assume subdirectories under the directory where this
+        // file resides represent sub-namespaces.
+
+        // The endpoint directory is relative to the directory where this file is found
+        $endpointDir =  dirname(__FILE__) . '/' . strtr(self::$dataEndpointRelativeNs, '\\', '/');
+        $endpointDirLength = strlen($endpointDir);
+
+        // Recursively traverse the directory where the endpoints live and discover any
+        // defined endpoints.
+
+        $dirIterator = new \RecursiveDirectoryIterator($endpointDir);
+        $flattenedIterator = new \RecursiveIteratorIterator($dirIterator);
+        self::$endpointClassMap = array();
+
+        // The iterator returns SplFileInfo objects where the keys are the path to the
+        // file.
+
+        foreach ( $flattenedIterator as $path => $fileInfo ) {
+
+            if ( $flattenedIterator->isDot() ) {
+                continue;
+            }
+
+            // Set up an array so we can programmatically construct the namespace based on
+            // the path to the class file
+
+            $constructedNamespace = array(__NAMESPACE__, self::$dataEndpointRelativeNs);
+
+            // Construct any additional sub-namespaces for subdirectories discovered under
+            // the endpoint namespace (e.g. the subdirectory DataEndpoint/Filters
+            // translates to the namespace DataEndpoint\Filters.
+
+            $subDirNs = strtr(substr($fileInfo->getPath(), $endpointDirLength + 1), '/', '\\');
+            if ( "" !== $subDirNs) {
+                $constructedNamespace[] = $subDirNs;
+            }
+
+            // Discover the class name based on the file name. The file name is expected
+            // to be named <class>.<extension>
+
+            $extension = $fileInfo->getExtension();
+            $filename = $fileInfo->getFilename();
+            // Handle the case where there is no extension
+            $length =  ( strlen($extension) > 0 ? -1 * (strlen($extension) + 1) : strlen($filename) );
+            $className = substr($filename, 0, $length);
+            $constructedNamespace[] = $className;
+
+            $nsClass = implode('\\', $constructedNamespace);
+
+            try {
+                $r = new \ReflectionClass($nsClass);
+
+                // Ensure that the class is not abstract and implements the required
+                // interface
+
+                if ( ! $r->isAbstract() && $r->implementsInterface(self::$dataEndpointRequiredInterface) ) {
+
+                    if ( $r->hasConstant(self::$endpointNameConstant) ) {
+
+                        $name = $r->getConstant(self::$endpointNameConstant);
+                        if ( ! array_key_exists($name, self::$endpointClassMap) ) {
+                            self::$endpointClassMap[$name] = $r->getName();
+                        } elseif ( null !== $logger ) {
+                            $logger->warning(
+                                sprintf(
+                                    "%s Endpoint with name '%s' already exists, skipping",
+                                    static::class,
+                                    $name
+                                )
+                            );
+                        }
+
+                    } else if ( null !== $logger ) {
+
+                        $logger->warning(
+                            sprintf(
+                                "%s Class '%s' does not define %s, skipping",
+                                static::class,
+                                $r->getName(),
+                                self::$endpointNameConstant
+                            )
+                        );
+
+                    }
+                }
+            } catch ( \ReflectionException $e ) {
+                // The class does not exist
+                continue;
+            }
+        }
+    }  // discover()
+
+    /** -----------------------------------------------------------------------------------------
      * Factory pattern to instantiate a DataEndpoint based on the options.
      *
-     * @param $options A DataEndpointOptions object containing options parsed from the ETL config.
+     * @param DataEndpointOptions $options A DataEndpointOptions object containing options
+     *   parsed from the ETL config.
+     * @param Log $logger A PEAR Log object or null to use the null logger.
      *
      * @return A data endpoint object implementing the iDataEndpoint interface.
      *
@@ -76,12 +219,13 @@ class DataEndpoint
 
     public static function factory(DataEndpointOptions $options, Log $logger = null)
     {
+        self::discover(false, $logger);
         $options->verify();
 
         // If the type is defined and has a mapping to an implementation, create a class for the type.
 
-        if ( ! array_key_exists($options->type, self::$classmap) ) {
-            $msg = __CLASS__ . ": Undefined data endpoint type: '{$options->type}'";
+        if ( ! array_key_exists($options->type, self::$endpointClassMap) ) {
+            $msg = sprintf("%s: Undefined data endpoint type: '%s'", static::class, $options->type);
             if ( null !== $logger ) {
                 $logger->err($msg);
             }
@@ -89,12 +233,12 @@ class DataEndpoint
         }
 
         // Ensure that the class implements the interface
-        $className = self::$classmap[$options->type];
+        $className = self::$endpointClassMap[$options->type];
 
         $endpoint = new $className($options, $logger);
 
         if ( ! $endpoint instanceof iDataEndpoint ) {
-            $msg = __CLASS__ . ": $className does not implement iDataEndpoint";
+            $msg = sprintf("%s: %s does not implement iDataEndpoint", static::class, $className);
             if ( null !== $logger ) {
                 $logger->err($msg);
             }

--- a/classes/ETL/DataEndpoint.php
+++ b/classes/ETL/DataEndpoint.php
@@ -150,8 +150,14 @@ class DataEndpoint
             // Discover the class name based on the file name. The file name is expected
             // to be named <class>.<extension>
 
-            $extension = $fileInfo->getExtension();
+            // SplFileInfo::getExtension() is not defined until PHP 5.3.6
+
             $filename = $fileInfo->getFilename();
+            $extension = '';
+            if ( false !== ($pos = strrpos($filename, '.')) ) {
+                $extension = substr($filename, $pos + 1);
+            }
+
             // Handle the case where there is no extension
             $length =  ( strlen($extension) > 0 ? -1 * (strlen($extension) + 1) : strlen($filename) );
             $className = substr($filename, 0, $length);

--- a/classes/ETL/DataEndpoint.php
+++ b/classes/ETL/DataEndpoint.php
@@ -94,7 +94,7 @@ class DataEndpoint
      * mapping their names to the classes that implement them.  All data endpoints must
      * implement the interface specified in self::DATA_ENDPOINT_REQUIRED_INTERFACE and
      * also define a constant referenced by self::ENDPOINT_NAME_CONSTANT that is set to
-     * the name of the endpoint (e.g., const ENDPOINT_NAME = 'file.json'.  By
+     * the name of the endpoint (e.g., const ENDPOINT_NAME = 'file.json').  By
      * automatically discovering the data endpoints we do not need to modify this file
      * when new endpoints are created.
      *

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -448,20 +448,20 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
         try {
             $flattenedIterator = new \RecursiveIteratorIterator($iterator);
+
+            if ( null !== $this->maxRecursionDepth ) {
+                $this->logger->debug(
+                    sprintf("Set max recursion depth: %d", $this->maxRecursionDepth)
+                );
+                $flattenedIterator->setMaxDepth($this->maxRecursionDepth);
+            }
+
+            $iterator = $flattenedIterator;
         }  catch ( Exception $e ) {
             $this->logAndThrowException(
                 sprintf("Error creating RecursiveIteratorIterator: %s", $e->getMessage())
             );
         }
-
-        if ( null !== $this->maxRecursionDepth ) {
-            $this->logger->debug(
-                sprintf("Set max recursion depth: %d", $this->maxRecursionDepth)
-            );
-            $flattenedIterator->setMaxDepth($this->maxRecursionDepth);
-        }
-
-        $iterator = $flattenedIterator;
 
         // Filter out directories "." and "..". This and other filters could be
         // included in a single CallbackFilterIterator bit I've decided to keep them
@@ -476,10 +476,7 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
             $dotDirFilterIterator = new \CallbackFilterIterator(
                 $iterator,
                 function ($current, $key, $iterator) {
-                    if ( $iterator->isDot() ) {
-                        return false;
-                    }
-                    return true;
+                    return ( ! $iterator->isDot() );
                 }
             );
             $iterator = $dotDirFilterIterator;

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -175,8 +175,6 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
         foreach ( $options as $property => $value ) {
 
-            // $this->logger->debug("OPT: $property => " . print_r($value, true));
-
             // Skip null values and use property defaults
 
             if ( null === $value ) {
@@ -376,208 +374,209 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
     {
         // The first time a connection is made the endpoint handle should be set.
 
-        if ( null === $this->handle ) {
+        if ( null !== $this->handle ) {
+            return $this->handle;
+        }
 
-            // The PHP docs on SPL iterators at http://php.net/manual/en/spl.iterators.php
-            // are sparse so these are some notes on usage of RecursiveDirectoryIterator,
-            // RecursiveIteratorIterator, and filtering.
-            //
-            // A note on recursive iterators: If a directory doesn't match the filter
-            // (i.e., it returns FALSE) then the directory will not be recursed
-            // into. Rather than using RecursiveCallbackFilterIterator it may be better to
-            // use CallbackFilterIterator after RecursiveIteratorIterator depending on the
-            // situation.
-            //
-            // We want to be able to filter on the path and file separately so we are using an
-            // instance of CallbackFilterIterator to do this instead of RegexIterator.
-            //
-            // RecursiveDirectoryIterator provides a mechanism to recursively iterate over
-            // directories and the files that they contain. It does not iterate beyond the
-            // *root* directory automatically. For this we need to roll our own or use
-            // RecursiveIteratorIterator.
-            //
-            // RecursiveRegexIterator can be attached to the RecursiveDirectoryIterator to
-            // filter paths. Note that if a directory doesn't match the regex it will not
-            // be recursed into so this is not well suited for regexes that should be
-            // applied to files.
-            //
-            // RecursiveCallbackFilterIterator needs to operate on a RecursiveIterator so
-            // it cannot be applied to a RecursiveIteratorIterator, use
-            // CallbackFilterIterator on a RecursiveIteratorIterator.
-            //
-            // RecursiveIteratorIterator operates on classes implementing
-            // RecursiveIterator and will handle the recursion into the children.  The
-            // mode can be specified as LEAVES_ONLY (default), SELF_FIRST, CHILD_FIRST.
-            // Note that LEAVES_ONLY will include "." and ".." directories so these will
-            // need to be filtered out AFTER applying this iterator.
-            //
-            // RegexIterator can be attached to RecursiveIteratorIterator to filter the
-            // paths that it returns, but note that the regex applies to the full path,
-            // not just the name of the file itself.
-            //
-            // Note that we want to be able to filter on the path and file separately and are using
-            // the CallbackFilterIterator to do this instead of RegexIterator.
+        // The PHP docs on SPL iterators at http://php.net/manual/en/spl.iterators.php
+        // are sparse so these are some notes on usage of RecursiveDirectoryIterator,
+        // RecursiveIteratorIterator, and filtering.
+        //
+        // A note on recursive iterators: If a directory doesn't match the filter
+        // (i.e., it returns FALSE) then the directory will not be recursed
+        // into. Rather than using RecursiveCallbackFilterIterator it may be better to
+        // use CallbackFilterIterator after RecursiveIteratorIterator depending on the
+        // situation.
+        //
+        // We want to be able to filter on the path and file separately so we are using an
+        // instance of CallbackFilterIterator to do this instead of RegexIterator.
+        //
+        // RecursiveDirectoryIterator provides a mechanism to recursively iterate over
+        // directories and the files that they contain. It does not iterate beyond the
+        // *root* directory automatically. For this we need to roll our own or use
+        // RecursiveIteratorIterator.
+        //
+        // RecursiveRegexIterator can be attached to the RecursiveDirectoryIterator to
+        // filter paths. Note that if a directory doesn't match the regex it will not
+        // be recursed into so this is not well suited for regexes that should be
+        // applied to files.
+        //
+        // RecursiveCallbackFilterIterator needs to operate on a RecursiveIterator so
+        // it cannot be applied to a RecursiveIteratorIterator, use
+        // CallbackFilterIterator on a RecursiveIteratorIterator.
+        //
+        // RecursiveIteratorIterator operates on classes implementing
+        // RecursiveIterator and will handle the recursion into the children.  The
+        // mode can be specified as LEAVES_ONLY (default), SELF_FIRST, CHILD_FIRST.
+        // Note that LEAVES_ONLY will include "." and ".." directories so these will
+        // need to be filtered out AFTER applying this iterator.
+        //
+        // RegexIterator can be attached to RecursiveIteratorIterator to filter the
+        // paths that it returns, but note that the regex applies to the full path,
+        // not just the name of the file itself.
+        //
+        // Note that we want to be able to filter on the path and file separately and are using
+        // the CallbackFilterIterator to do this instead of RegexIterator.
 
-            // We are conditionally creating multiple iterators that will consume earlier
-            // iterators. Keep track of the current iterator.
+        // We are conditionally creating multiple iterators that will consume earlier
+        // iterators. Keep track of the current iterator.
 
-            $iterator = null;
+        $iterator = null;
 
+        $this->logger->debug(
+            sprintf("Connecting directory scanner to %s", $this->path)
+        );
+
+        try {
+            $directoryIterator = new \RecursiveDirectoryIterator($this->path);
+            $iterator = $directoryIterator;
+        } catch ( Exception $e ) {
+            $this->logAndThrowException(
+                sprintf("Error opening directory '%s': %s", $this->path, $e->getMessage())
+            );
+        }
+
+        // Apply the recursion iterator that will traverse the directory iterator
+
+        try {
+            $flattenedIterator = new \RecursiveIteratorIterator($iterator);
+        }  catch ( Exception $e ) {
+            $this->logAndThrowException(
+                sprintf("Error creating RecursiveIteratorIterator: %s", $e->getMessage())
+            );
+        }
+
+        if ( null !== $this->maxRecursionDepth ) {
             $this->logger->debug(
-                sprintf("Connecting directory scanner to %s", $this->path)
+                sprintf("Set max recursion depth: %d", $this->maxRecursionDepth)
+            );
+            $flattenedIterator->setMaxDepth($this->maxRecursionDepth);
+        }
+
+        $iterator = $flattenedIterator;
+
+        // Filter out directories "." and "..". This and other filters could be
+        // included in a single CallbackFilterIterator bit I've decided to keep them
+        // split out for readability, debugging, and error reporting.
+
+        // For the CallbackFilter classes, the types of the callback parameters depend
+        // on the flags passed to RecursiveDirectoryIterator::__construct(). In our
+        // case, $current is a SplFileInfo object and the key is the fill path to the
+        // file.
+
+        try {
+            $dotDirFilterIterator = new \CallbackFilterIterator(
+                $iterator,
+                function ($current, $key, $iterator) {
+                    if ( $iterator->isDot() ) {
+                        return false;
+                    }
+                    return true;
+                }
+            );
+            $iterator = $dotDirFilterIterator;
+        }  catch ( Exception $e ) {
+            $this->logAndThrowException(
+                sprintf("Error applying dot directory filters: %s", $e->getMessage())
+            );
+        }
+
+        // We do not want to return directories as part of the traversal so we need to
+        // apply directory/file patterns and other checks AFTER traversing the
+        // directory tree. Otherwise, directories may be inadvertantly filtered and
+        // the files missed.
+
+        if ( null !== $this->directoryPattern || null !== $this->filePattern ) {
+
+            // PHP 5.3 does not allow us to reference the object in the callback
+            $dirPattern = $this->directoryPattern;
+            $filePattern = $this->filePattern;
+
+            $this->logger->info(
+                sprintf(
+                    "Applying pattern filters: (directory: %s, file: %s)",
+                    ( null === $dirPattern ? "null" : $dirPattern ),
+                    ( null === $filePattern ? "null" : $filePattern )
+                )
             );
 
             try {
-                $directoryIterator = new \RecursiveDirectoryIterator($this->path);
-                $iterator = $directoryIterator;
-            } catch ( Exception $e ) {
-                $this->logAndThrowException(
-                    sprintf("Error opening directory '%s': %s", $this->path, $e->getMessage())
-                );
-            }
-
-            // Apply the recursion iterator that will traverse the directory iterator
-
-            try {
-                $flattenedIterator = new \RecursiveIteratorIterator($iterator);
-            }  catch ( Exception $e ) {
-                $this->logAndThrowException(
-                    sprintf("Error creating RecursiveIteratorIterator: %s", $e->getMessage())
-                );
-            }
-
-            if ( null !== $this->maxRecursionDepth ) {
-                $this->logger->debug(
-                    sprintf("Set max recursion depth: %d", $this->maxRecursionDepth)
-                );
-                $flattenedIterator->setMaxDepth($this->maxRecursionDepth);
-            }
-
-            $iterator = $flattenedIterator;
-
-            // Filter out directories "." and "..". This and other filters could be
-            // included in a single CallbackFilterIterator bit I've decided to keep them
-            // split out for readability, debugging, and error reporting.
-
-            // For the CallbackFilter classes, the types of the callback parameters depend
-            // on the flags passed to RecursiveDirectoryIterator::__construct(). In our
-            // case, $current is a SplFileInfo object and the key is the fill path to the
-            // file.
-
-            try {
-                $dotDirFilterIterator = new \CallbackFilterIterator(
+                $patternCallbackIterator = new \CallbackFilterIterator(
                     $iterator,
-                    function ($current, $key, $iterator) {
-                        if ( $iterator->isDot() ) {
+                    function ($current, $key, $iterator) use ($dirPattern, $filePattern) {
+                        if (
+                            null !== $dirPattern
+                            && ! preg_match($dirPattern, $current->getPath())
+                        ) {
                             return false;
                         }
+
+                        if (
+                            null !== $filePattern
+                            && ! preg_match($filePattern, $current->getFilename())
+                        ) {
+                            return false;
+                        }
+
                         return true;
                     }
                 );
-                $iterator = $dotDirFilterIterator;
+                $iterator = $patternCallbackIterator;
             }  catch ( Exception $e ) {
                 $this->logAndThrowException(
-                    sprintf("Error applying dot directory filters: %s", $e->getMessage())
-                );
-            }
-
-            // We do not want to return directories as part of the traversal so we need to
-            // apply directory/file patterns and other checks AFTER traversing the
-            // directory tree. Otherwise, directories may be inadvertantly filtered and
-            // the files missed.
-
-            if ( null !== $this->directoryPattern || null !== $this->filePattern ) {
-
-                // PHP 5.3 does not allow us to reference the object in the callback
-                $dirPattern = $this->directoryPattern;
-                $filePattern = $this->filePattern;
-
-                $this->logger->info(
                     sprintf(
-                        "Applying pattern filters: (directory: %s, file: %s)",
-                        ( null === $dirPattern ? "null" : $dirPattern ),
-                        ( null === $filePattern ? "null" : $filePattern )
+                        "Error applying pattern filters (directory: %s, file: %s): %s",
+                        ( null === $this->directoryPattern ? "null" : $this->directoryPattern ),
+                        ( null === $this->filePattern ? "null" : $this->filePattern ),
+                        $e->getMessage()
                     )
                 );
-
-                try {
-                    $patternCallbackIterator = new \CallbackFilterIterator(
-                        $iterator,
-                        function ($current, $key, $iterator) use ($dirPattern, $filePattern) {
-                            if (
-                                null !== $dirPattern
-                                && ! preg_match($dirPattern, $current->getPath())
-                            ) {
-                                return false;
-                            }
-
-                            if (
-                                null !== $filePattern
-                                 && ! preg_match($filePattern, $current->getFilename())
-                            ) {
-                                return false;
-                            }
-
-                            return true;
-                        }
-                    );
-                    $iterator = $patternCallbackIterator;
-                }  catch ( Exception $e ) {
-                    $this->logAndThrowException(
-                        sprintf(
-                            "Error applying pattern filters (directory: %s, file: %s): %s",
-                            ( null === $this->directoryPattern ? "null" : $this->directoryPattern ),
-                            ( null === $this->filePattern ? "null" : $this->filePattern ),
-                            $e->getMessage()
-                        )
-                    );
-                }
             }
-
-            if ( null !== $this->lastModifiedStartTimestamp || null !== $this->lastModifiedEndTimestamp ) {
-
-                // PHP 5.3 does not allow us to reference the object in the callback
-                $lmStartTs = $this->lastModifiedStartTimestamp;
-                $lmEndTs = $this->lastModifiedEndTimestamp;
-
-                $this->logger->info(
-                    sprintf(
-                        "Applying mtime filter: (start: %s, end: %s)",
-                        ( null === $lmStartTs ? "null" : $lmStartTs ),
-                        ( null === $lmEndTs ? "null" : $lmEndTs )
-                    )
-                );
-
-                try {
-                    $callbackIterator = new \CallbackFilterIterator(
-                        $iterator,
-                        function ($current, $key, $iterator) use ($lmStartTs, $lmEndTs) {
-                            if ( null !== $lmStartTs && null !== $lmEndTs ) {
-                                return $current->getMTime() >= $lmStartTs && $current->getMTime() <= $lmEndTs;
-                            } elseif ( null !== $lmStartTs ) {
-                                return $current->getMTime() >= $lmStartTs;
-                            } elseif ( null !== $lmEndTs ) {
-                                return $current->getMTime() <= $lmEndTs;
-                            } else {
-                                return false;
-                            }
-                        }
-                    );
-                    $iterator = $callbackIterator;
-                }  catch ( Exception $e ) {
-                    $this->logAndThrowException(
-                        sprintf(
-                            "Error applying last modified filter (start: %s, end: %s): %s",
-                            ( null === $this->lastModifiedStartTimestamp ? "null" : $this->lastModifiedStartTimestamp ),
-                            ( null === $this->lastModifiedEndTimestamp ? "null" : $this->lastModifiedEndTimestamp ),
-                            $e->getMessage()
-                        )
-                    );
-                }
-            }
-
-            $this->handle = $iterator;
         }
+
+        if ( null !== $this->lastModifiedStartTimestamp || null !== $this->lastModifiedEndTimestamp ) {
+
+            // PHP 5.3 does not allow us to reference the object in the callback
+            $lmStartTs = $this->lastModifiedStartTimestamp;
+            $lmEndTs = $this->lastModifiedEndTimestamp;
+
+            $this->logger->info(
+                sprintf(
+                    "Applying mtime filter: (start: %s, end: %s)",
+                    ( null === $lmStartTs ? "null" : $lmStartTs ),
+                    ( null === $lmEndTs ? "null" : $lmEndTs )
+                )
+            );
+
+            try {
+                $callbackIterator = new \CallbackFilterIterator(
+                    $iterator,
+                    function ($current, $key, $iterator) use ($lmStartTs, $lmEndTs) {
+                        if ( null !== $lmStartTs && null !== $lmEndTs ) {
+                            return $current->getMTime() >= $lmStartTs && $current->getMTime() <= $lmEndTs;
+                        } elseif ( null !== $lmStartTs ) {
+                            return $current->getMTime() >= $lmStartTs;
+                        } elseif ( null !== $lmEndTs ) {
+                            return $current->getMTime() <= $lmEndTs;
+                        } else {
+                            return false;
+                        }
+                    }
+                );
+                $iterator = $callbackIterator;
+            }  catch ( Exception $e ) {
+                $this->logAndThrowException(
+                    sprintf(
+                        "Error applying last modified filter (start: %s, end: %s): %s",
+                        ( null === $this->lastModifiedStartTimestamp ? "null" : $this->lastModifiedStartTimestamp ),
+                        ( null === $this->lastModifiedEndTimestamp ? "null" : $this->lastModifiedEndTimestamp ),
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+
+        $this->handle = $iterator;
 
         // Rewind the handle so it is ready to use.
         $this->handle->rewind();

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -22,6 +22,14 @@ use Log;
 
 class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 {
+    /** -----------------------------------------------------------------------------------------
+     * The ENDPOINT_NAME constant defines the name for this endpoint that should be used
+     * in configuration files. It also allows us to implement auto-discovery.
+     *
+     * @const string
+     */
+
+    const ENDPOINT_NAME = 'directoryscanner';
 
     /** -----------------------------------------------------------------------------------------
      * Numeric key to use for the default file extension handler. This should be the only

--- a/classes/ETL/DataEndpoint/File.php
+++ b/classes/ETL/DataEndpoint/File.php
@@ -12,6 +12,10 @@ use Log;
 class File extends aDataEndpoint implements iDataEndpoint
 {
 
+    // The ENDPOINT_NAME constant defines the name for this endpoint that should be used
+    // in configuration files. It also allows us to implement auto-discovery.
+    const ENDPOINT_NAME = 'file';
+
     // The path to the file.
     protected $path = null;
 

--- a/classes/ETL/DataEndpoint/JsonFile.php
+++ b/classes/ETL/DataEndpoint/JsonFile.php
@@ -19,6 +19,15 @@ use JsonSchema\Constraints\Factory;
 class JsonFile extends aStructuredFile implements iStructuredFile
 {
     /** -----------------------------------------------------------------------------------------
+     * The ENDPOINT_NAME constant defines the name for this endpoint that should be used
+     * in configuration files. It also allows us to implement auto-discovery.
+     *
+     * @const string
+     */
+
+    const ENDPOINT_NAME = 'jsonfile';
+
+    /** -----------------------------------------------------------------------------------------
      * @see iDataEndpoint::__construct()
      * ------------------------------------------------------------------------------------------
      */

--- a/classes/ETL/DataEndpoint/Mysql.php
+++ b/classes/ETL/DataEndpoint/Mysql.php
@@ -10,10 +10,18 @@
 namespace ETL\DataEndpoint;
 
 use ETL\DataEndpoint\DataEndpointOptions;
-use \Log;
+use Log;
 
 class Mysql extends aRdbmsEndpoint implements iRdbmsEndpoint
 {
+    /** -----------------------------------------------------------------------------------------
+     * The ENDPOINT_NAME constant defines the name for this endpoint that should be used
+     * in configuration files. It also allows us to implement auto-discovery.
+     *
+     * @const string
+     */
+
+    const ENDPOINT_NAME = 'mysql';
 
     /* ------------------------------------------------------------------------------------------
      * @see iDataEndpoint::__construct()

--- a/classes/ETL/DataEndpoint/Oracle.php
+++ b/classes/ETL/DataEndpoint/Oracle.php
@@ -10,10 +10,14 @@
 namespace ETL\DataEndpoint;
 
 use ETL\DataEndpoint\DataEndpointOptions;
-use \Log;
+use Log;
 
 class Oracle extends aRdbmsEndpoint implements iRdbmsEndpoint
 {
+
+    // The ENDPOINT_NAME constant defines the name for this endpoint that should be used
+    // in configuration files. It also allows us to implement auto-discovery.
+    const ENDPOINT_NAME = 'oracle';
 
     public function __construct(DataEndpointOptions $options, Log $logger = null)
     {

--- a/classes/ETL/DataEndpoint/Postgres.php
+++ b/classes/ETL/DataEndpoint/Postgres.php
@@ -10,10 +10,18 @@
 namespace ETL\DataEndpoint;
 
 use ETL\DataEndpoint\DataEndpointOptions;
-use \Log;
+use Log;
 
 class Postgres extends aRdbmsEndpoint implements iRdbmsEndpoint
 {
+    /** -----------------------------------------------------------------------------------------
+     * The ENDPOINT_NAME constant defines the name for this endpoint that should be used
+     * in configuration files. It also allows us to implement auto-discovery.
+     *
+     * @const string
+     */
+
+    const ENDPOINT_NAME = 'postgres';
 
     public function __construct(DataEndpointOptions $options, Log $logger = null)
     {

--- a/classes/ETL/DataEndpoint/Rest.php
+++ b/classes/ETL/DataEndpoint/Rest.php
@@ -12,10 +12,15 @@
 namespace ETL\DataEndpoint;
 
 use ETL\DataEndpoint\DataEndpointOptions;
-use \Log;
+use Log;
 
 class Rest extends aDataEndpoint implements iDataEndpoint
 {
+    // The ENDPOINT_NAME constant defines the name for this endpoint that should be used
+    // in configuration files. It also allows us to implement auto-discovery.
+
+    const ENDPOINT_NAME = 'rest';
+
     // The base url for this endpoint
     protected $baseUrl = null;
 

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -52,8 +52,10 @@ $scriptOptions = array(
     'list-actions'      => false,
     // List available aggregators
     'list-aggregators'  => false,
-    // List available data endpoints
-    'list-endpoints'    => false,
+    // List the available data endpoint types (e.g., classes)
+    'list-endpoint-types'    => false,
+    // List endpoints that have been configured
+    'list-configured-endpoints'    => false,
     // List available ETL groups
     'list-groups'       => false,
     // List available Ingestors
@@ -489,7 +491,18 @@ if ( $showList ) {
                 }
                 break;
 
-            case 'list-endpoints':
+            case 'list-endpoint-types':
+                \ETL\DataEndpoint::discover(false, $logger);
+                $endpointInfo = \ETL\DataEndpoint::getDataEndpointInfo(false, $logger);
+                $headings = array("Name", "Class");
+                print implode(LIST_SEPARATOR, $headings) . "\n";
+                ksort($endpointInfo);
+                foreach ( $endpointInfo as $name => $class) {
+                    print "$name\t$class\n";
+                }
+                break;
+
+            case 'list-configured-endpoints':
                 $endpoints = $etlConfig->getDataEndpoints();
 
                 $endpointSummary = array();
@@ -643,7 +656,7 @@ Usage: {$argv[0]}
     -k, --chunk-size {none, day, week, month, year}
     Break up ingestion into chunks of this size. Helps to make more recent data available faster. [default year]
 
-    -l, --list {resources, sections, actions, endpoints} | <etl_section_name>
+    -l, --list {resources, sections, actions, endpoint-types, configured-endpoints} | <etl_section_name>
     List available actions in the specified section, resources, data endpoints, or sections. If a section name is provided list all actions in that section.
 
     -m, --last-modified-start-date


### PR DESCRIPTION
Allow DataEndpoint singleton to auto-discover available data endpoints

## Description

Rather than require a developer to modify `ETL\DataEndpoint.php` and explicitly list each available data endpoint and it's configuration code, we now allow the `DataEndpoint` singleton to automatically discover what data endpoints are available. As per PSR-4 the contiguous sub-namespace names after the "namespace prefix" (`ETL` in our case) correspond to a subdirectory within a "base directory", in which the namespace separators represent directory separators. From this, we can assume the `ETL\DataEndpoint` sub-namespace is in the `DataEndpoint` subdirectory relative to where the `DataEndpoint` singleton class is defined. Using this knowledge we use reflection to recursively examine each file in the `DataEndpoint` subdirectory and any class implementing `iDataEndpoint` and also defining an `ENDPOINT_NAME` constant will be a valid endpoint definition. The  `ENDPOINT_NAME` constant defines the endpoint name to be used in configuration files. Conflicts in endpoint names are logged.

The `etl_overseer` script has been modified to list the available endpoints:
```
$ php etl_overseer.php -c ../../../etc/etl/etl.json -l endpoint-types                       
Name    Class
directoryscanner        ETL\DataEndpoint\DirectoryScanner
file    ETL\DataEndpoint\File
jsonfile        ETL\DataEndpoint\JsonFile
mysql   ETL\DataEndpoint\Mysql
oracle  ETL\DataEndpoint\Oracle
postgres        ETL\DataEndpoint\Postgres
rest    ETL\DataEndpoint\Rest
```
## Motivation and Context

Make it easier to define data endpoints.

## Tests performed

Ran existing tests, several of which use the File and Json endpoints.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
