### PR TITLE
Switch peer click to use the run_search_action mechanism.

### DIFF
--- a/html/gui/js/modules/job_viewer/GanttChart.js
+++ b/html/gui/js/modules/job_viewer/GanttChart.js
@@ -39,14 +39,12 @@ XDMoD.Module.JobViewer.GanttChart = Ext.extend(XDMoD.Module.JobViewer.ChartTab, 
 
             var clickEvent = function (evt) {
                 var info = {
+                    action: 'show',
                     title: 'Peers of ' + record.data.schema.ref.text,
                     realm: evt.point.ref.realm,
-                    text: evt.point.category,
-                    job_id: evt.point.ref.jobid,
-                    local_job_id: evt.point.ref.local_job_id,
-                    resource: evt.point.ref.resource
+                    jobref: evt.point.ref.jobid
                 };
-                Ext.History.add('job_viewer?job=' + window.btoa(JSON.stringify(info)));
+                Ext.History.add('job_viewer?' + Ext.urlEncode(info));
             };
 
             while (this.chart.series.length > 0) {


### PR DESCRIPTION
Job peer clicks now use the job search action that was added in pull
request #156. The benefit of this mechanism is that it gracefully
handles the case where the user does not have access to the underlying
job data.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
