### PR TITLE
Change ETLv2 file locking to use flock

### DIFF
--- a/classes/ETL/LockFile.php
+++ b/classes/ETL/LockFile.php
@@ -188,7 +188,11 @@ class LockFile extends Loggable
         // always has to be done manually." because the OS releases the lock automatically
         // when the file is closed.
 
-        flock($fp, LOCK_EX);
+        if ( ! flock($fp, LOCK_EX | LOCK_NB) ) {
+            $this->logAndThrowException(
+                sprintf("Unexpected failure to obtain lock for process %d on file %s", $this->pid, $lockFile)
+            );
+        }
         fwrite($fp, $contents);
         fflush($fp);
 


### PR DESCRIPTION
Change ETLv2 file locking to use flock

## Description

The current ETLv2 file locking uses a pid in the lockfile to determine if a process is currently running and using the lockfile. This causes a problem for processes using moderate amounts of memory because PHP hits the script memory limit when attempting to fork/exec to run the `ps` command. This PR changes the behavior to use `flock()` instead.

## Motivation and Context

PHP script out of memory errors.

## Tests performed

Tested running an ETL pipeline
- Single pipeline running at a time
- Two of the same pipelines running at the same time
- Kill a pipeline and observe proper lockfile cleanup
- @ryanrath confirmed that memory errors are no longer present

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
