### PR TITLE
Add load mask for the internal search events.

### DIFF
--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -916,6 +916,9 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
          * @param panel
          **/
         activate: function () {
+            if (!this.loadMask) {
+                this.loadMask = new Ext.LoadMask(this.id);
+            }
             Highcharts.setOptions({ global: { timezone: this.cachedHighChartTimezone } });
 
             if (this.clearing) {
@@ -926,6 +929,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             var params = Ext.urlDecode(token.params);
 
             if (params.job) {
+                this.loadMask.show();
                 this.fireEvent('create_history_entry', Ext.decode(window.atob(params.job)));
                 return;
             }
@@ -935,9 +939,12 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             }
 
             if (params.action) {
+                this.loadMask.show();
                 this.fireEvent('run_search_action', params);
                 return;
             }
+
+            this.loadMask.hide();
 
             var selectionModel = this.searchHistoryPanel.getSelectionModel();
 
@@ -1379,6 +1386,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                             title: 'No results',
                             msg: 'No jobs were found that meet the requested search parameters.',
                             buttons: Ext.Msg.OK,
+                            fn: Ext.History.add(self.module_id + '?realm=' + searchparams.realm),
                             icon: Ext.MessageBox.INFO
                         });
                         return;
@@ -1407,6 +1415,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                         title: 'Error ' + response.status + ' ' + response.statusText,
                         msg: message,
                         buttons: Ext.Msg.OK,
+                        fn: Ext.History.add(self.module_id + '?realm=' + searchparams.realm),
                         icon: Ext.MessageBox.ERROR
                     });
                 }


### PR DESCRIPTION
## Description
When the user clicked through from the metric explorer or via a peer
click or from a shared link there was no visual indication that the
borwser was loading data. This adds a load mask whenever these clicks happen.

The reviewer with a keen eye will notice that new Ext.History.add() callbacks have been added to the error dialog box OK button. The reason for this is that this guarantees that, after an error, the panel is reloaded in a safe state and the load mask will be cleared.

## Motivation and Context
Improve UI

## Tests performed
- check mask works with metric explorer click through
- checked mask works with peers click through
- checked mask is cleared when processing an access denied external link
- check mask is cleared when processing a no jobs found external link.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- My code follows the code style of this project as found in the **CONTRIBUTING** document.
- All new and existing tests passed.
