### PR TITLE
Bug fix - removed some Mail code

### DIFF
--- a/html/controllers/mailer/contact.php
+++ b/html/controllers/mailer/contact.php
@@ -106,7 +106,7 @@ try {
 }
 catch (Exception $e) {
     $response['success'] = false;
-    $response['message'] = $e->getMessage() . "\n" . $mail->ErrorInfo;
+    $response['message'] = $e->getMessage();
     echo json_encode($response);
     exit;
 }
@@ -134,7 +134,7 @@ try {
 }
 catch (Exception $e) {
     $response['success'] = false;
-    $response['message'] = $e->getMessage() . "\n" . $mail->ErrorInfo;
+    $response['message'] = $e->getMessage();
     echo json_encode($response);
     exit;
 }

--- a/html/controllers/user_admin/create_user.php
+++ b/html/controllers/user_admin/create_user.php
@@ -140,7 +140,7 @@ try {
     $mail->send();
 }
 catch (Exception $e) {
-    \xd_response\presentError($e->getMessage() . "\n" . $mail->ErrorInfo);
+    \xd_response\presentError($e->getMessage());
 }
 
 // -----------------------------

--- a/html/controllers/user_admin/pass_reset.php
+++ b/html/controllers/user_admin/pass_reset.php
@@ -55,7 +55,7 @@ try {
 }
 catch (Exception $e) {
     $returnData['success'] = false;
-    $returnData['message'] = $e->getMessage() . "\n" . $mail->ErrorInfo;
+    $returnData['message'] = $e->getMessage();
 }
 
 xd_controller\returnJSON($returnData);

--- a/html/controllers/user_auth/pass_reset.php
+++ b/html/controllers/user_auth/pass_reset.php
@@ -59,7 +59,7 @@ try {
 }
 catch (Exception $e) {
     $returnData['success'] = false;
-    $returnData['message'] = $e->getMessage() . "\n" . $mail->ErrorInfo;
+    $returnData['message'] = $e->getMessage();
     $returnData['status']  = 'failure';
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I removed some code pertaining to catching errors with PHPMailer objects.

## Motivation and Context
Since PHPMailer objects can throw phpmailer exceptions, some error handling code is not needed because it is redundant.  Since we catch all exceptions using a generic exception, getMessage() and ErrorInfo will provide the same message, but from different sources.  Another reason to delete ErrorInfo is because if the error occurs in the initMailWrapper, a mail object will not exist, and therefore ErrorInfo will be useless. getMessage() would still be able to provide us with the same error response ErrorInfo would normally provide us, so ErrorInfo is not needed.

## Tests performed
I (purposely) caused a mail-related error with only getMessage printing the error, and then with only ErrorInfo printing the error, and the messages were the same.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
