### PR TITLE
Make Error bars tick box hidden when not applicable.

### DIFF
--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -483,10 +483,9 @@ class Usage extends Common
                 'show_aggregate_labels' =>  \xd_utilities\array_get($this->request, 'show_aggregate_labels', $usageGroupByObject->getDefaultShowAggregateLabels()),
                 'show_error_labels' =>      \xd_utilities\array_get($this->request, 'show_error_labels', $usageGroupByObject->getDefaultShowErrorLabels()),
                 'hide_tooltip' =>           \xd_utilities\array_get($this->request, 'hide_tooltip', false),
-                'enable_errors' =>          \xd_utilities\array_get($this->request, 'enable_errors', $usageGroupByObject->getDefaultEnableErrors()),
+                'enable_errors' =>          'n',
                 'enable_trend_line' =>      \xd_utilities\array_get($this->request, 'enable_trend_line', $usageGroupByObject->getDefaultEnableTrendLine()),
             );
-            $usageChartSettingsJson = json_encode($usageChartSettings);
 
             $usageSubnotes = array();
             if ($usageGroupBy === 'resource' || array_key_exists('resource', $this->request)) {
@@ -521,6 +520,11 @@ class Usage extends Common
 
                 // Get the statistic object used by this chart request.
                 $meRequestMetric = $usageRealmAggregateClass::getStatistic($meRequest['data_series_unencoded'][0]['metric']);
+
+                $errorstat = 'sem_' . $meRequest['data_series_unencoded'][0]['metric'];
+                if (in_array($errorstat, array_keys($usageRealmAggregateClass::getRegisteredStatistics())) ) {
+                    $usageChartSettings['enable_errors'] = 'y';
+                }
 
                 // Get the chart object from the response.
                 $meChart = &$meResponseContent['data'][0];
@@ -816,6 +820,10 @@ class Usage extends Common
                     }
                 });
 
+                if ('n' == $usageGroupByObject->getDefaultEnableErrors()) {
+                    $usageChartSettings['enable_errors'] = 'n';
+                }
+
                 // Create a Usage-style chart.
                 $usageChart = array(
                     'hc_jsonstore' => $meChart,
@@ -838,7 +846,7 @@ class Usage extends Common
                     'realm' => $usageRealm,
                     'start_date' => $this->request['start_date'],
                     'end_date' => $this->request['end_date'],
-                    'chart_settings' => $usageChartSettingsJson,
+                    'chart_settings' => json_encode($usageChartSettings),
                     'show_gradient' => $usageShowGradient,
                     'final_width' => $usageWidth,
                     'final_height' => $usageHeight - 4,

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
@@ -164,4 +164,79 @@ EOF;
 
         $this->assertEquals(1.79457892, $dataseries[0]['data'][0]['y'], '', 1.0e-6);
     }
+
+    /**
+     * @dataProvider errorBarDataProvider
+     */
+    public function testErrorBars($input, $expected)
+    {
+        $response = $this->helper->post('/controllers/user_interface.php', null, $input);
+
+        $this->assertEquals($response[1]['content_type'], 'text/plain; charset=UTF-8');
+        $this->assertEquals($response[1]['http_code'], 200);
+
+        $plotdata = json_decode(\TestHarness\UsageExplorerHelper::demanglePlotData($response[0]), true);
+
+        $this->assertArrayHasKey('chart_settings', $plotdata['data'][0]);
+
+        $settings = json_decode($plotdata['data'][0]['chart_settings'], true);
+
+        $this->assertArrayHasKey('enable_errors', $settings);
+        $this->assertEquals($expected, $settings['enable_errors']);
+    }
+
+    public function errorBarDataProvider()
+    {
+        $baseJson = <<<EOF
+{
+    "public_user": "true",
+    "realm": "Jobs",
+    "group_by": "none",
+    "statistic": "avg_wallduration_hours",
+    "start_date": "2016-12-25",
+    "end_date": "2017-01-02",
+    "operation": "get_charts",
+    "timeframe_label": "User Defined",
+    "scale": "1",
+    "aggregation_unit": "Auto",
+    "dataset_type": "timeseries",
+    "thumbnail": "n",
+    "query_group": "tg_usage",
+    "display_type": "line",
+    "combine_type": "side",
+    "limit": "10",
+    "offset": "0",
+    "log_scale": "n",
+    "show_guide_lines": "y",
+    "show_trend_line": "n",
+    "show_error_bars": "n",
+    "show_aggregate_labels": "n",
+    "show_error_labels": "y",
+    "hide_tooltip": "false",
+    "show_title": "y",
+    "width": "1377",
+    "height": "590",
+    "legend_type": "bottom_center",
+    "font_size": "3",
+    "interactive_elements": "y",
+    "controller_module": "user_interface"
+}
+EOF;
+        $baseSettings = json_decode($baseJson, true);
+
+        $ret = array(
+            array($baseSettings, 'y')
+        );
+
+        $baseSettings['statistic'] = 'job_count';
+        $ret[] = array($baseSettings, 'n');
+
+        $baseSettings['statistic'] = 'avg_node_hours';
+        $ret[] = array($baseSettings, 'y');
+
+        $baseSettings['group_by'] = 'nsfdirectorate';
+        $ret[] = array($baseSettings, 'n');
+
+        return $ret;
+    }
 }


### PR DESCRIPTION
## Description
There was code in the usage explorer that controls whether the error bar tick boxes were displayed, but inexplicably it was not being sent the correct information. Perhaps this was a bug introduced when the code was change to use the metric explorer backend? 

## Motivation and Context
Fix annoying bug where the error bards tick boxes could be ticked even when plotting data that has no error bars.

Asana issue:

https://app.asana.com/0/search/389297140308050/71363948851100

## Tests performed
Naturally.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)