### PR TITLE
Resolving issue with tests not running on *nix/Firefox

### DIFF
--- a/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/loginPage.page.js
+++ b/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/loginPage.page.js
@@ -1,3 +1,4 @@
+/* eslint-env node, es6 */
 class LoginPage {
     login(title, theUrl, loginName, loginPassword, displayName) {
         describe('General', function () {

--- a/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/loginPage.page.js
+++ b/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/loginPage.page.js
@@ -23,6 +23,12 @@ class LoginPage {
                 $('#txt_login_username input').setValue(loginName);
                 $('#txt_login_password input').setValue(loginPassword);
                 $('#btn_sign_in .x-btn-mc').click();
+
+                // Per: http://webdriver.io/api/protocol/frame.html#Usage
+                // Resetting the server to the page's default content
+                // This was causing issues with running the tests under
+                // Ubuntu 16.04:Firefox
+                browser.frame();
             });
             it('Display Logged in Users Name', function () {
                 $('#welcome_message').waitForExist(60000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- There was an issue running the tests under *nix / Firefox that occurred due to
  Firefox not switching back to the default frame context which lead any further
  tests to fail ( as it would not be able to locate anything ).

## Motivation and Context
Because tests would not run on *nix / Firefox

## Tests performed
Ran full test suite under Firefox / Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
