### PR TITLE
Removing "impossible" code

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -1079,8 +1079,6 @@ class XDUser {
          ':id' => $this->_id,
       ));
 
-      unset($this);
-
    }//removeUser
 
    // ---------------------------


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- per http://php.net/manual/en/function.unset.php
  "It is not possible to unset $this inside an object method since PHP 5."
- that and the Travis tests were failing on php7.1 ( but not 5.3, 5.4, 7.0 )
  #justphpthings


## Motivation and Context
Getting the Travis tests to pass for php7.1

## Tests performed
pushed these changes to a branch w/ Travis enabled, watched all the tests pass this time as opposed to all of the tests except for the ones run under php7.1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
