### PR TITLE
Update Error.js.php

### DIFF
--- a/html/gui/js/Error.js.php
+++ b/html/gui/js/Error.js.php
@@ -1,3 +1,7 @@
+<?php
+  require_once('../../../configuration/linker.php');
+  \xd_response\useDynamicJavascriptHeaders();
+?>
 /**
  * Error.js.php
  *
@@ -8,13 +12,7 @@
 Ext.namespace('XDMoD.Error');
 
 <?php
-
-	require_once('../../../configuration/linker.php');
-
-    \xd_response\useDynamicJavascriptHeaders();
-
-	foreach (XDError::getErrorCodes() as $errorName => $errorCode) {
-		echo "XDMoD.Error.$errorName = $errorCode;\n";
-	}
-
+  foreach (XDError::getErrorCodes() as $errorName => $errorCode) {
+    echo "XDMoD.Error.$errorName = $errorCode;\n";
+  }
 ?>

--- a/html/gui/js/Error.js.php
+++ b/html/gui/js/Error.js.php
@@ -1,6 +1,8 @@
 <?php
-  require_once('../../../configuration/linker.php');
-  \xd_response\useDynamicJavascriptHeaders();
+
+require_once('../../../configuration/linker.php');
+\xd_response\useDynamicJavascriptHeaders();
+
 ?>
 /**
  * Error.js.php
@@ -12,7 +14,7 @@
 Ext.namespace('XDMoD.Error');
 
 <?php
-  foreach (XDError::getErrorCodes() as $errorName => $errorCode) {
+
+foreach (XDError::getErrorCodes() as $errorName => $errorCode) {
     echo "XDMoD.Error.$errorName = $errorCode;\n";
-  }
-?>
+}


### PR DESCRIPTION
Update to prevent warnings.
This allows the headers to be set before content is output.

<!--- Provide a general summary of your changes in the Title above -->

## Description
While testing on development system with warning enabled, this file ends up outputting warning preventing some functionality from happening correctly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To prevent warnings and make life better all around

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
went to 
https://metrics-dev.ccr.buffalo.edu/gui/js/Error.js.php
utter sadness:
```html
/** * Error.js.php * * Defines the error codes used by XDMoD. This file is generated from * server-side error code definitions in the PHP XDError class. */ Ext.namespace('XDMoD.Error');
( ! ) Warning: Cannot modify header information - headers already sent by (output started at /usr/share/xdmod/html/gui/js/Error.js.php:10) in /usr/share/xdmod/libraries/response.php on line 72
Call Stack
#	Time	Memory	Function	Location
1	0.0003	239672	{main}( )	../Error.js.php:0
2	0.0444	3803776	xd_response\useDynamicJavascriptHeaders( )	../Error.js.php:14
3	0.0444	3803984	header ( )	../response.php:72

( ! ) Warning: Cannot modify header information - headers already sent by (output started at /usr/share/xdmod/html/gui/js/Error.js.php:10) in /usr/share/xdmod/libraries/response.php on line 78
Call Stack
#	Time	Memory	Function	Location
1	0.0003	239672	{main}( )	../Error.js.php:0
2	0.0444	3803776	xd_response\useDynamicJavascriptHeaders( )	../Error.js.php:14
3	0.0445	3803984	header ( )	../response.php:78

( ! ) Warning: Cannot modify header information - headers already sent by (output started at /usr/share/xdmod/html/gui/js/Error.js.php:10) in /usr/share/xdmod/libraries/response.php on line 79
Call Stack
#	Time	Memory	Function	Location
1	0.0003	239672	{main}( )	../Error.js.php:0
2	0.0444	3803776	xd_response\useDynamicJavascriptHeaders( )	../Error.js.php:14
3	0.0446	3804032	header ( )	../response.php:79

( ! ) Warning: Cannot modify header information - headers already sent by (output started at /usr/share/xdmod/html/gui/js/Error.js.php:10) in /usr/share/xdmod/libraries/response.php on line 80
Call Stack
#	Time	Memory	Function	Location
1	0.0003	239672	{main}( )	../Error.js.php:0
2	0.0444	3803776	xd_response\useDynamicJavascriptHeaders( )	../Error.js.php:14
3	0.0446	3803984	header ( )	../response.php:80

( ! ) Warning: Cannot modify header information - headers already sent by (output started at /usr/share/xdmod/html/gui/js/Error.js.php:10) in /usr/share/xdmod/libraries/response.php on line 81
Call Stack
#	Time	Memory	Function	Location
1	0.0003	239672	{main}( )	../Error.js.php:0
2	0.0444	3803776	xd_response\useDynamicJavascriptHeaders( )	../Error.js.php:14
3	0.0447	3803984	header ( )	../response.php:81
XDMoD.Error.UnknownXdmodException = -1; XDMoD.Error.NotAuthenticated = 1; XDMoD.Error.SessionExpired = 2; XDMoD.Error.QueryException = 100; XDMoD.Error.QueryUnknownGroupBy = 101; XDMoD.Error.QueryUnavailableTimeAggregationUnit = 102; XDMoD.Error.QueryAccessDenied = 103; XDMoD.Error.QueryBadRequest = 104; XDMoD.Error.QueryNotFound = 105; XDMoD.Error.QueryMissingFilterListTable = 106; 
```

replaced file
YEAH!!!
```javascript
/**
 * Error.js.php
 *
 * Defines the error codes used by XDMoD. This file is generated from
 * server-side error code definitions in the PHP XDError class.
 */

Ext.namespace('XDMoD.Error');

XDMoD.Error.UnknownXdmodException = -1;
XDMoD.Error.NotAuthenticated = 1;
XDMoD.Error.SessionExpired = 2;
XDMoD.Error.QueryException = 100;
XDMoD.Error.QueryUnknownGroupBy = 101;
XDMoD.Error.QueryUnavailableTimeAggregationUnit = 102;
XDMoD.Error.QueryAccessDenied = 103;
XDMoD.Error.QueryBadRequest = 104;
XDMoD.Error.QueryNotFound = 105;
XDMoD.Error.QueryMissingFilterListTable = 106;
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
