### PR TITLE
Fix syntax error and define abstract methods in subclasses

### DIFF
--- a/classes/ETL/Aggregator/DummyAggregator.php
+++ b/classes/ETL/Aggregator/DummyAggregator.php
@@ -37,9 +37,11 @@ class DummyAggregator extends aAction implements iAction
 
     protected function performPreExecuteTasks()
     {
+        return true;
     }
 
     protected function performPostExecuteTasks($numRecordsProcessed = null)
     {
+        return true;
     }
 }  // class DummyAggregator

--- a/classes/ETL/Aggregator/DummyAggregator.php
+++ b/classes/ETL/Aggregator/DummyAggregator.php
@@ -34,4 +34,12 @@ class DummyAggregator extends aAction implements iAction
         parent::initialize($etlOverseerOptions);
         return true;
     }
+
+    protected function performPreExecuteTasks()
+    {
+    }
+
+    protected function performPostExecuteTasks($numRecordsProcessed = null)
+    {
+    }
 }  // class DummyAggregator

--- a/classes/ETL/Ingestor/DummyIngestor.php
+++ b/classes/ETL/Ingestor/DummyIngestor.php
@@ -34,4 +34,12 @@ class DummyIngestor extends aAction implements iAction
         parent::initialize($etlOverseerOptions);
         return true;
     }
+
+    protected function performPreExecuteTasks()
+    {
+    }
+
+    protected function performPostExecuteTasks($numRecordsProcessed = null)
+    {
+    }
 }  // class DummyIngestor

--- a/classes/ETL/Ingestor/DummyIngestor.php
+++ b/classes/ETL/Ingestor/DummyIngestor.php
@@ -37,9 +37,11 @@ class DummyIngestor extends aAction implements iAction
 
     protected function performPreExecuteTasks()
     {
+        return true;
     }
 
     protected function performPostExecuteTasks($numRecordsProcessed = null)
     {
+        return true;
     }
 }  // class DummyIngestor

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -403,6 +403,7 @@ class pdoIngestor extends aIngestor
      * ------------------------------------------------------------------------------------------
      */
 
+    // @codingStandardsIgnoreLine
     protected function _execute()
     {
         // Since the overseer may split the ingestion period up into chunks. Apply the current
@@ -840,7 +841,7 @@ class pdoIngestor extends aIngestor
 
         if ( ! $this->options->buffered_query && $this->sourceEndpoint instanceof Mysql ) {
             $this->logger->info(
-                sprintf("Returning buffered query mode to: %s". ($originalBufferedQueryAttribute ? "true" : "false"))
+                sprintf("Returning buffered query mode to: %s", ($originalBufferedQueryAttribute ? "true" : "false"))
             );
             $pdo = $this->sourceHandle->handle();
             $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, $originalBufferedQueryAttribute);

--- a/classes/ETL/Maintenance/TestAction.php
+++ b/classes/ETL/Maintenance/TestAction.php
@@ -93,9 +93,11 @@ class TestAction extends aAction implements iAction
 
     protected function performPreExecuteTasks()
     {
+        return true;
     }
 
     protected function performPostExecuteTasks($numRecordsProcessed = null)
     {
+        return true;
     }
 }  // class TestAction

--- a/classes/ETL/Maintenance/TestAction.php
+++ b/classes/ETL/Maintenance/TestAction.php
@@ -90,4 +90,12 @@ class TestAction extends aAction implements iAction
     {
         return true;
     }
+
+    protected function performPreExecuteTasks()
+    {
+    }
+
+    protected function performPostExecuteTasks($numRecordsProcessed = null)
+    {
+    }
 }  // class TestAction

--- a/classes/ETL/Maintenance/VerifyDatabase.php
+++ b/classes/ETL/Maintenance/VerifyDatabase.php
@@ -221,6 +221,26 @@ class VerifyDatabase extends aAction implements iAction
 
     }  // initialize()
 
+    /** -----------------------------------------------------------------------------------------
+     * @see aAction::performPreExecuteTasks()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function performPreExecuteTasks()
+    {
+        return true;
+    } // performPreExecuteTasks()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see aAction::performPostExecuteTasks()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function performPostExecuteTasks($numRecordsProcessed = null)
+    {
+        return true;
+    }  // performPostExecuteTasks()
+
     /* ------------------------------------------------------------------------------------------
      * @see iAction::execute()
      * ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fix syntax error and define abstract methods in subclasses

## Description

When the abstract methods `performPreExecuteTasks()` and `performPostExecuteTasks` were moved up into `aAction` `aRdbmsDestinationAction` some classes that directly extended `aAction` were not properly updated. Also fix syntax error in `pdoIngestor` logging.

## Motivation and Context

Bugfix

## Tests performed

Ran tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
