### PR TITLE
Prevent ingestion of jobs with 0 start or end time

### DIFF
--- a/classes/OpenXdmod/Ingestor/Shredded/Jobs.php
+++ b/classes/OpenXdmod/Ingestor/Shredded/Jobs.php
@@ -39,12 +39,14 @@ class Jobs extends PDODBMultiIngestor
                 timelimit,
                 node_list
             FROM shredded_job
+            WHERE start_time > 0
+              AND end_time > 0
         ';
 
         $sql = 'SELECT MAX(id) AS max_id FROM staging_job';
         list($row) = $dest_db->query($sql);
         if ($row['max_id'] != null) {
-            $src_query .= 'WHERE shredded_job_id > ' . $row['max_id'];
+            $src_query .= 'AND shredded_job_id > ' . $row['max_id'];
         }
 
         parent::__construct(

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -107,3 +107,23 @@ will create the databases.  You may also use the less safe
 [mysql-binary-log]:                https://dev.mysql.com/doc/refman/5.5/en/replication-options-binary-log.html
 [mysql-grant]:                     https://dev.mysql.com/doc/refman/5.5/en/grant.html
 [log_bin_trust_function_creators]: https://dev.mysql.com/doc/refman/5.5/en/replication-options-binary-log.html#option_mysqld_log-bin-trust-function-creators
+
+### Why do I see the error message "Failed to correct job times" during the shredding process?
+
+Resource manager account log records may be missing some job data under certain
+circumstances.  It is expected that a job record will have a start time, end
+time and wall time.  If one of these is missing it will be calculated using the
+other two.  If two or more are missing the error message in question will be
+displayed along with the values that were present in the job record.  In
+addition to this error message a file will be produced at the end of the
+shredding process containing the job record that produced the error along with
+additional details.  Look for the log message "Job errors written to ...".
+
+One example of a situation that will produce this error is that some resource
+managers record a 0 start time in their accounting logs when a job is canceled
+before the job started.  It is also possible that other errors occurred to
+produce these values so they are not ignored and this error message is produced.
+As of Open XDMoD 7.0 any job with a start or end time equal to 0 will not be
+ingested into the data warehouse and will not contribute to the job count or
+any other metrics.  Previous versions of Open XDMoD did include these jobs
+which resulted in inaccurate results.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes ingestor SQL query to exclude jobs with a start or end time that is 0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jobs with zero start time should not be included in the data warehouse.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Shredded and ingested data containing jobs with zero start time.  Observed that before the change there were rows in `modw.jobfact` with `start_time_ts` zero before the change, but none after.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
