### PR TITLE
Enabled checkbox selection feature in Report Generator

### DIFF
--- a/html/gui/js/report_builder/ReportManager.js
+++ b/html/gui/js/report_builder/ReportManager.js
@@ -15,7 +15,8 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
         target_child,
         build_only,
         format,
-        arrLength
+        arrLength,
+        arrNames
     ) {
         if (format == undefined) { format = 'pdf'; }
 
@@ -39,8 +40,6 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
             Ext.encode({name: report_name, action: action, format: format})
         );
 
-        console.log(arrLength);
-
         var activity = '';
         if (arrLength == 1) {
             activity = build_only ?
@@ -50,9 +49,14 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                 'Preparing report for download' : 'Generating and sending reports';
         }
 
+        var listNames = '';
+        for (i = 0; i < arrNames.length; i++) {
+            listNames = listNames + '<br />' + arrNames[i];
+        }
+
         target_child.showMask(
-            '<center>' + activity +
-            '<br /><img src="gui/images/progbar_2.gif">' +
+            '<center>' + activity + '<b>' + listNames +
+            '<br /></b><img src="gui/images/progbar_2.gif">' +
             '<br />Please Wait</center>'
         );
 

--- a/html/gui/js/report_builder/ReportManager.js
+++ b/html/gui/js/report_builder/ReportManager.js
@@ -50,7 +50,7 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
         }
 
         var listNames = '';
-        for (i = 0; i < arrNames.length; i++) {
+        for (var i = 0; i < arrNames.length; i++) {
             listNames = listNames + '<br />' + arrNames[i];
         }
 

--- a/html/gui/js/report_builder/ReportManager.js
+++ b/html/gui/js/report_builder/ReportManager.js
@@ -11,16 +11,16 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
 
     buildReport: function (
         reportName,
-        reportId,
-        targetChild,
-        buildOnly,
+        report_id,
+        target_child,
+        build_only,
         format,
         arrLength,
         arrNames
     ) {
         if (format == undefined) { format = 'pdf'; }
 
-        if (buildOnly) {
+        if (build_only) {
             XDMoD.TrackEvent(
                 'Report Generator',
                 'Attempting to build and download report'
@@ -31,8 +31,8 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                 'Attempting to build and send report'
             );
         }
-        // eslint-disable-next-line camelcase
-        var action = buildOnly ? 'downloading' : 'sending';
+
+        var action = build_only ? 'downloading' : 'sending';
 
         XDMoD.TrackEvent(
             'Report Generator',
@@ -42,19 +42,19 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
 
         var activity = '';
         if (arrLength === 1) {
-            activity = buildOnly ?
+            activity = build_only ?
                 'Preparing report for download' : 'Generating and sending report';
         } else {
-            activity = buildOnly ?
-                'Preparing report for download' : 'Generating and sending reports';
+            activity = build_only ?
+                'Preparing reports for download' : 'Generating and sending reports';
         }
 
         var listNames = '';
-        for (var i = 0; i < arrNames.length; i++) {
+        for (i = 0; i < arrNames.length; i++) {
             listNames = listNames + '<br />' + arrNames[i];
         }
 
-        targetChild.showMask(
+        target_child.showMask(
             '<center>' + activity + '<b>' + listNames +
             '<br /></b><img src="gui/images/progbar_2.gif">' +
             '<br />Please Wait</center>'
@@ -71,8 +71,8 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
 
             params: {
                 operation: 'send_report',
-                report_id: reportId,
-                build_only: buildOnly,
+                report_id: report_id,
+                build_only: build_only,
                 export_format: format
             },
 
@@ -105,7 +105,7 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                         '</div>' +
                         '</center>';
 
-                    if (responseData.buildOnly) {
+                    if (responseData.build_only) {
                         var w = new Ext.Window({
                             title: 'Report Built',
                             width: 220,
@@ -144,7 +144,7 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                                         }),
                                         new Ext.Button({
                                             region: 'south',
-                                            text: 'View Report',
+                                            text: 'View Report: ' + reportName,
                                             handler: function () {
                                                 XDMoD.TrackEvent(
                                                     'Report Generator',
@@ -161,17 +161,17 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                         w.show();
                     }
 
-                    targetChild.showMask(activeTemplate);
+                    target_child.showMask(activeTemplate);
 
                     // Hide / dismiss the mask after 3 seconds ...
-                    (function () { targetChild.hideMask(); }).defer(3000);
+                    (function () { target_child.hideMask(); }).defer(3000);
                 } else {
                     CCR.xdmod.ui.presentFailureResponse(response, {
                         title: 'Report Manager',
                         wrapperMessage: 'There was a problem trying to prepare the report.'
                     });
 
-                    targetChild.hideMask();
+                    target_child.hideMask();
                 }
             }
         });

--- a/html/gui/js/report_builder/ReportManager.js
+++ b/html/gui/js/report_builder/ReportManager.js
@@ -14,7 +14,8 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
         report_id,
         target_child,
         build_only,
-        format
+        format,
+        arrLength
     ) {
         if (format == undefined) { format = 'pdf'; }
 
@@ -38,12 +39,20 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
             Ext.encode({name: report_name, action: action, format: format})
         );
 
-        var activity = build_only ?
-            'Preparing report for download' : 'Generating and sending report';
+        console.log(arrLength);
+
+        var activity = '';
+        if (arrLength == 1) {
+            activity = build_only ?
+                'Preparing report for download' : 'Generating and sending report';
+        } else {
+            activity = build_only ?
+                'Preparing report for download' : 'Generating and sending reports';
+        }
 
         target_child.showMask(
-            '<center>' + activity + '<br /><b>' + report_name +
-            '</b><br /><img src="gui/images/progbar_2.gif">' +
+            '<center>' + activity +
+            '<br /><img src="gui/images/progbar_2.gif">' +
             '<br />Please Wait</center>'
         );
 

--- a/html/gui/js/report_builder/ReportManager.js
+++ b/html/gui/js/report_builder/ReportManager.js
@@ -10,17 +10,17 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
     },
 
     buildReport: function (
-        report_name,
-        report_id,
-        target_child,
-        build_only,
+        reportName,
+        reportId,
+        targetChild,
+        buildOnly,
         format,
         arrLength,
         arrNames
     ) {
         if (format == undefined) { format = 'pdf'; }
 
-        if (build_only) {
+        if (buildOnly) {
             XDMoD.TrackEvent(
                 'Report Generator',
                 'Attempting to build and download report'
@@ -31,30 +31,30 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                 'Attempting to build and send report'
             );
         }
-
-        var action = build_only ? 'downloading' : 'sending';
+        // eslint-disable-next-line camelcase
+        var action = buildOnly ? 'downloading' : 'sending';
 
         XDMoD.TrackEvent(
             'Report Generator',
             'Building report',
-            Ext.encode({name: report_name, action: action, format: format})
+            Ext.encode({name: reportName, action: action, format: format})
         );
 
         var activity = '';
-        if (arrLength == 1) {
-            activity = build_only ?
+        if (arrLength === 1) {
+            activity = buildOnly ?
                 'Preparing report for download' : 'Generating and sending report';
         } else {
-            activity = build_only ?
+            activity = buildOnly ?
                 'Preparing report for download' : 'Generating and sending reports';
         }
 
         var listNames = '';
-        for (i = 0; i < arrNames.length; i++) {
+        for (var i = 0; i < arrNames.length; i++) {
             listNames = listNames + '<br />' + arrNames[i];
         }
 
-        target_child.showMask(
+        targetChild.showMask(
             '<center>' + activity + '<b>' + listNames +
             '<br /></b><img src="gui/images/progbar_2.gif">' +
             '<br />Please Wait</center>'
@@ -71,8 +71,8 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
 
             params: {
                 operation: 'send_report',
-                report_id: report_id,
-                build_only: build_only,
+                report_id: reportId,
+                build_only: buildOnly,
                 export_format: format
             },
 
@@ -89,11 +89,11 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                     XDMoD.TrackEvent(
                         'Report Generator',
                         'Building of report complete',
-                        Ext.encode({name: report_name, format: format})
+                        Ext.encode({name: reportName, format: format})
                     );
 
                     var location = 'controllers/report_builder.php/' +
-                        responseData.report_name +
+                        responseData.reportName +
                         '?operation=download_report&report_loc=' +
                         responseData.report_loc + '&format=' + format;
 
@@ -105,7 +105,7 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                         '</div>' +
                         '</center>';
 
-                    if (responseData.build_only) {
+                    if (responseData.buildOnly) {
                         var w = new Ext.Window({
                             title: 'Report Built',
                             width: 220,
@@ -161,17 +161,17 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                         w.show();
                     }
 
-                    target_child.showMask(activeTemplate);
+                    targetChild.showMask(activeTemplate);
 
                     // Hide / dismiss the mask after 3 seconds ...
-                    (function () { target_child.hideMask(); }).defer(3000);
+                    (function () { targetChild.hideMask(); }).defer(3000);
                 } else {
                     CCR.xdmod.ui.presentFailureResponse(response, {
                         title: 'Report Manager',
                         wrapperMessage: 'There was a problem trying to prepare the report.'
                     });
 
-                    target_child.hideMask();
+                    targetChild.hideMask();
                 }
             }
         });

--- a/html/gui/js/report_builder/ReportManager.js
+++ b/html/gui/js/report_builder/ReportManager.js
@@ -37,7 +37,7 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
         XDMoD.TrackEvent(
             'Report Generator',
             'Building report',
-            Ext.encode({name: reportName, action: action, format: format})
+            Ext.encode({ name: reportName, action: action, format: format })
         );
 
         var activity = '';
@@ -89,7 +89,7 @@ XDMoD.ReportManager = Ext.extend(Ext.Panel, {
                     XDMoD.TrackEvent(
                         'Report Generator',
                         'Building of report complete',
-                        Ext.encode({name: reportName, format: format})
+                        Ext.encode({ name: reportName, format: format })
                     );
 
                     var location = 'controllers/report_builder.php/' +

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -132,22 +132,22 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
               mnuNewBasedOn.setSelectedReport(record.data.report_name);
           }
 
-          mnuNewBasedOn.toggleReportSelection(selectedRows.length !== 0);
+         mnuNewBasedOn.toggleReportSelection(selectedRows.length !== 0);
 
-          btnNewBasedOn.setDisabled(selectedRows.length !== 1);
-          btnEditReport.setDisabled(selectedRows.length !== 1);
-          btnPreviewReport.setDisabled(selectedRows.length !== 1);
+         btnNewBasedOn.setDisabled(selectedRows.length !== 1);
+         btnEditReport.setDisabled(selectedRows.length !== 1);
+         btnPreviewReport.setDisabled(selectedRows.length != 1);
 
-          mnuSendReport.setDisabled(selectedRows.length === 0);
-          mnuDownloadReport.setDisabled(selectedRows.length === 0);
+         mnuSendReport.setDisabled(selectedRows.length === 0);
+         mnuDownloadReport.setDisabled(selectedRows.length === 0);
 
-          btnSendReport.setVisible(false);
-          mnuSendReport.setVisible(true);
+         btnSendReport.setVisible(false);
+         mnuSendReport.setVisible(true);
 
-          btnDownloadReport.setVisible(false);
-          mnuDownloadReport.setVisible(true);
+         btnDownloadReport.setVisible(false);
+         mnuDownloadReport.setVisible(true);
 
-          btnDeleteReport.setDisabled(selectedRows.length === 0);
+         btnDeleteReport.setDisabled(selectedRows.length === 0);
 
          var exceptionDetails = eReport.isExceptionReport(record.data.creation_method);
 

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -151,21 +151,21 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
          var exceptionDetails = eReport.isExceptionReport(record.data.creation_method);
 
-          if (selectedRows.length === 1 && exceptionDetails !== false) {
-            mnuNewBasedOn.toggleReportSelection(exceptionDetails.canDeriveFrom);
-            btnEditReport.setDisabled(!exceptionDetails.canEdit);
-            btnPreviewReport.setDisabled(!exceptionDetails.canPreview);
+           if (selectedRows.length === 1 && exceptionDetails !== false) {
+              mnuNewBasedOn.toggleReportSelection(exceptionDetails.canDeriveFrom);
+              btnEditReport.setDisabled(!exceptionDetails.canEdit);
+              btnPreviewReport.setDisabled(!exceptionDetails.canPreview);
 
-            if (!exceptionDetails.multiFormat) {
+              if (!exceptionDetails.multiFormat) {
 
                btnSendReport.setVisible(true);
                mnuSendReport.setVisible(false);
 
                btnDownloadReport.setVisible(true);
                mnuDownloadReport.setVisible(false);
-            }
+             }
 
-         }
+          }
 
       };//adjustButtonAccessibilty
 
@@ -227,19 +227,19 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
        var queueGrid = new Ext.grid.EditorGridPanel({
 
-         store: this.reportStore,
+           store: this.reportStore,
          //id: 'reportPool_queueGrid' + Ext.id(),
 
-         viewConfig: {
-            emptyText: reportsEmptyText,
-            forceFit: true
+           viewConfig: {
+             emptyText: reportsEmptyText,
+             forceFit: true
          },
 
-         autoScroll: true,
+           autoScroll: true,
 
-          enableHdMenu: false,
-          selModel: checkBoxSelMod,
-          loadMask: true,
+           enableHdMenu: false,
+           selModel: checkBoxSelMod,
+           loadMask: true,
 
            columns: [
             { header: 'ID', width: 10, dataIndex: 'report_id', sortable: false, hidden: true },
@@ -249,9 +249,9 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
             { header: 'Delivery Format', width: 70, dataIndex: 'report_format', sortable: true, renderer: reportFormatColumnRenderer },
             { header: '# Charts', width: 70, dataIndex: 'chart_count', sortable: true, renderer: numChartsColumnRenderer }
            // checkBoxSelMod
-         ]
+           ]
 
-      });//queueGrid
+       });//queueGrid
 
       queueGrid.getSelectionModel().on('rowselect', function(sm, row_index, rec) {
          XDMoD.TrackEvent('Report Generator (My Reports)', 'Selected Report', Ext.encode({report_name: rec.data.report_name}));
@@ -631,9 +631,9 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
            });
 
            Ext.each(selected, function (selection) {
-              self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength, arrNames);
-          });
-       }; //sendReport
+               self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength, arrNames);
+           });
+       };// sendReport
 
        // ----------------------------------------------------
 
@@ -838,8 +838,8 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
          items:[ queueGrid ],
 
          plugins: [
-            new Ext.ux.plugins.ContainerMask({ masked:false }),
-            new XDMoD.Plugins.ContextSensitiveHelper('report+generator')
+             new Ext.ux.plugins.ContainerMask({ masked: false }),
+             new XDMoD.Plugins.ContextSensitiveHelper('report+generator')
          ],
 
          tbar: {

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -127,20 +127,20 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
       var adjustButtonAccessibilty = function(selectionModel, rowIndex, record) {
 
          var selectedRows = selectionModel.getSelections();
-
-         if (selectedRows.length == 1) {
+         console.log(selectedRows);
+         if (selectedRows.length != 0) {
 
             mnuNewBasedOn.setSelectedReport(record.data.report_name);
 
          }
 
-         mnuNewBasedOn.toggleReportSelection(selectedRows.length == 1);
+         mnuNewBasedOn.toggleReportSelection(selectedRows.length != 0);
 
          btnNewBasedOn.setDisabled(selectedRows.length != 1);
          btnEditReport.setDisabled(selectedRows.length != 1);
          btnPreviewReport.setDisabled(selectedRows.length != 1);
 
-         mnuSendReport.setDisabled(selectedRows.length != 1);
+         mnuSendReport.setDisabled(selectedRows.length == 0);
          mnuDownloadReport.setDisabled(selectedRows.length != 1);
 
          btnSendReport.setVisible(false);
@@ -229,7 +229,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
       // ----------------------------------------------------
 
-      var queueGrid = new Ext.grid.GridPanel({
+      var queueGrid = new Ext.grid.EditorGridPanel({
 
          store: this.reportStore,
          //id: 'reportPool_queueGrid' + Ext.id(),
@@ -246,13 +246,13 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
          loadMask: true,
 
          columns: [
-            //checkBoxSelMod,
             {header: 'ID', width: 10, dataIndex: 'report_id', sortable: false, hidden: true},
             {header: 'Name', width: 200, dataIndex: 'report_name', sortable: true},
             {header: 'Derived From', width: 100, dataIndex: 'creation_method', sortable: true},
             {header: 'Schedule', width: 70, dataIndex: 'report_schedule', sortable: true},
             {header: 'Delivery Format', width: 70, dataIndex: 'report_format', sortable: true, renderer: reportFormatColumnRenderer},
-            {header: '# Charts', width: 70, dataIndex: 'chart_count', sortable: true, renderer: numChartsColumnRenderer}
+            {header: '# Charts', width: 70, dataIndex: 'chart_count', sortable: true, renderer: numChartsColumnRenderer},
+            checkBoxSelMod
          ]
 
       });//queueGrid
@@ -627,9 +627,10 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
       var sendReport = function(build_only, format) {
 
-         var rowData = queueGrid.getSelectionModel().getSelected().data;
-
-         self.parent.buildReport(rowData.report_name, rowData.report_id, self, build_only, format);
+         var selected = queueGrid.getSelectionModel().getSelections();
+         Ext.each(selected, function(selection) {
+             self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format);
+         });
 
       };//sendReport
 

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -128,32 +128,30 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
          var selectedRows = selectionModel.getSelections();
 
-         if (selectedRows.length != 0) {
+          if (selectedRows.length !== 0) {
+             mnuNewBasedOn.setSelectedReport(record.data.report_name);
+          }
 
-            mnuNewBasedOn.setSelectedReport(record.data.report_name);
+          mnuNewBasedOn.toggleReportSelection(selectedRows.length !== 0);
 
-         }
+          btnNewBasedOn.setDisabled(selectedRows.length !== 1);
+          btnEditReport.setDisabled(selectedRows.length !== 1);
+          btnPreviewReport.setDisabled(selectedRows.length !== 1);
 
-         mnuNewBasedOn.toggleReportSelection(selectedRows.length != 0);
+          mnuSendReport.setDisabled(selectedRows.length === 0);
+          mnuDownloadReport.setDisabled(selectedRows.length !== 1);
 
-         btnNewBasedOn.setDisabled(selectedRows.length != 1);
-         btnEditReport.setDisabled(selectedRows.length != 1);
-         btnPreviewReport.setDisabled(selectedRows.length != 1);
+          btnSendReport.setVisible(false);
+          mnuSendReport.setVisible(true);
 
-         mnuSendReport.setDisabled(selectedRows.length == 0);
-         mnuDownloadReport.setDisabled(selectedRows.length != 1);
+          btnDownloadReport.setVisible(false);
+          mnuDownloadReport.setVisible(true);
 
-         btnSendReport.setVisible(false);
-         mnuSendReport.setVisible(true);
-
-         btnDownloadReport.setVisible(false);
-         mnuDownloadReport.setVisible(true);
-
-         btnDeleteReport.setDisabled(selectedRows.length == 0);
+          btnDeleteReport.setDisabled(selectedRows.length === 0);
 
          var exceptionDetails = eReport.isExceptionReport(record.data.creation_method);
 
-         if (selectedRows.length == 1 && exceptionDetails !== false) {
+         if (selectedRows.length === 1 && exceptionDetails !== false) {
 
             mnuNewBasedOn.toggleReportSelection(exceptionDetails.canDeriveFrom);
             btnEditReport.setDisabled(!exceptionDetails.canEdit);
@@ -229,7 +227,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
       // ----------------------------------------------------
 
-      var queueGrid = new Ext.grid.EditorGridPanel({
+       var queueGrid = new Ext.grid.EditorGridPanel({
 
          store: this.reportStore,
          //id: 'reportPool_queueGrid' + Ext.id(),
@@ -252,7 +250,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
             {header: 'Schedule', width: 70, dataIndex: 'report_schedule', sortable: true},
             {header: 'Delivery Format', width: 70, dataIndex: 'report_format', sortable: true, renderer: reportFormatColumnRenderer},
             {header: '# Charts', width: 70, dataIndex: 'chart_count', sortable: true, renderer: numChartsColumnRenderer},
-            checkBoxSelMod
+           // checkBoxSelMod
          ]
 
       });//queueGrid
@@ -625,18 +623,17 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
       // ----------------------------------------------------
 
-      var sendReport = function(build_only, format) {
+       var sendReport = function(build_only, format) {
 
-         var selected = queueGrid.getSelectionModel().getSelections();
-         var arrLength = selected.length;
-         var arrNames = new Array();
+          var selected = queueGrid.getSelectionModel().getSelections();
+          var arrLength = selected.length;
+          var arrNames = new Array();
 
-         Ext.each(selected, function(selection) {
-             arrNames.push(selection.data.report_name);
-         })
+          Ext.each(selected, function (selection) {
+              arrNames.push(selection.data.report_name);
+          });
 
-         Ext.each(selected, function(selection) {
-
+          Ext.each(selected, function (selection) {
              self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength, arrNames);
          });
 

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -127,7 +127,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
       var adjustButtonAccessibilty = function(selectionModel, rowIndex, record) {
 
          var selectedRows = selectionModel.getSelections();
-         console.log(selectedRows);
+
          if (selectedRows.length != 0) {
 
             mnuNewBasedOn.setSelectedReport(record.data.report_name);
@@ -628,8 +628,10 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
       var sendReport = function(build_only, format) {
 
          var selected = queueGrid.getSelectionModel().getSelections();
+         var arrLength = selected.length;
+
          Ext.each(selected, function(selection) {
-             self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format);
+             self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength);
          });
 
       };//sendReport

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -629,9 +629,15 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
          var selected = queueGrid.getSelectionModel().getSelections();
          var arrLength = selected.length;
+         var arrNames = new Array();
 
          Ext.each(selected, function(selection) {
-             self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength);
+             arrNames.push(selection.data.report_name);
+         })
+
+         Ext.each(selected, function(selection) {
+
+             self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength, arrNames);
          });
 
       };//sendReport

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -134,8 +134,8 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
          mnuNewBasedOn.toggleReportSelection(selectedRows.length !== 0);
 
-         btnNewBasedOn.setDisabled(selectedRows.length !== 1);
-         btnEditReport.setDisabled(selectedRows.length !== 1);
+         btnNewBasedOn.setDisabled(selectedRows.length != 1);
+         btnEditReport.setDisabled(selectedRows.length != 1);
          btnPreviewReport.setDisabled(selectedRows.length != 1);
 
          mnuSendReport.setDisabled(selectedRows.length === 0);
@@ -147,7 +147,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
          btnDownloadReport.setVisible(false);
          mnuDownloadReport.setVisible(true);
 
-         btnDeleteReport.setDisabled(selectedRows.length === 0);
+         btnDeleteReport.setDisabled(selectedRows.length == 0);
 
          var exceptionDetails = eReport.isExceptionReport(record.data.creation_method);
 
@@ -231,9 +231,9 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
          //id: 'reportPool_queueGrid' + Ext.id(),
 
            viewConfig: {
-             emptyText: reportsEmptyText,
-             forceFit: true
-         },
+               emptyText: reportsEmptyText,
+               forceFit: true
+           },
 
            autoScroll: true,
 
@@ -251,7 +251,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
            // checkBoxSelMod
            ]
 
-       });//queueGrid
+       });// queueGrid
 
       queueGrid.getSelectionModel().on('rowselect', function(sm, row_index, rec) {
          XDMoD.TrackEvent('Report Generator (My Reports)', 'Selected Report', Ext.encode({report_name: rec.data.report_name}));

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -139,7 +139,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
           btnPreviewReport.setDisabled(selectedRows.length !== 1);
 
           mnuSendReport.setDisabled(selectedRows.length === 0);
-          mnuDownloadReport.setDisabled(selectedRows.length !== 1);
+          mnuDownloadReport.setDisabled(selectedRows.length === 0);
 
           btnSendReport.setVisible(false);
           mnuSendReport.setVisible(true);

--- a/html/gui/js/report_builder/ReportsOverview.js
+++ b/html/gui/js/report_builder/ReportsOverview.js
@@ -129,7 +129,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
          var selectedRows = selectionModel.getSelections();
 
           if (selectedRows.length !== 0) {
-             mnuNewBasedOn.setSelectedReport(record.data.report_name);
+              mnuNewBasedOn.setSelectedReport(record.data.report_name);
           }
 
           mnuNewBasedOn.toggleReportSelection(selectedRows.length !== 0);
@@ -151,8 +151,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
          var exceptionDetails = eReport.isExceptionReport(record.data.creation_method);
 
-         if (selectedRows.length === 1 && exceptionDetails !== false) {
-
+          if (selectedRows.length === 1 && exceptionDetails !== false) {
             mnuNewBasedOn.toggleReportSelection(exceptionDetails.canDeriveFrom);
             btnEditReport.setDisabled(!exceptionDetails.canEdit);
             btnPreviewReport.setDisabled(!exceptionDetails.canPreview);
@@ -164,7 +163,6 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
                btnDownloadReport.setVisible(true);
                mnuDownloadReport.setVisible(false);
-
             }
 
          }
@@ -239,17 +237,17 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
          autoScroll: true,
 
-         enableHdMenu: false,
-         selModel : checkBoxSelMod,
-         loadMask: true,
+          enableHdMenu: false,
+          selModel: checkBoxSelMod,
+          loadMask: true,
 
-         columns: [
-            {header: 'ID', width: 10, dataIndex: 'report_id', sortable: false, hidden: true},
-            {header: 'Name', width: 200, dataIndex: 'report_name', sortable: true},
-            {header: 'Derived From', width: 100, dataIndex: 'creation_method', sortable: true},
-            {header: 'Schedule', width: 70, dataIndex: 'report_schedule', sortable: true},
-            {header: 'Delivery Format', width: 70, dataIndex: 'report_format', sortable: true, renderer: reportFormatColumnRenderer},
-            {header: '# Charts', width: 70, dataIndex: 'chart_count', sortable: true, renderer: numChartsColumnRenderer},
+           columns: [
+            { header: 'ID', width: 10, dataIndex: 'report_id', sortable: false, hidden: true },
+            { header: 'Name', width: 200, dataIndex: 'report_name', sortable: true },
+            { header: 'Derived From', width: 100, dataIndex: 'creation_method', sortable: true },
+            { header: 'Schedule', width: 70, dataIndex: 'report_schedule', sortable: true },
+            { header: 'Delivery Format', width: 70, dataIndex: 'report_format', sortable: true, renderer: reportFormatColumnRenderer },
+            { header: '# Charts', width: 70, dataIndex: 'chart_count', sortable: true, renderer: numChartsColumnRenderer }
            // checkBoxSelMod
          ]
 
@@ -623,21 +621,19 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
 
       // ----------------------------------------------------
 
-       var sendReport = function(build_only, format) {
+       var sendReport = function (build_only, format) {
+           var selected = queueGrid.getSelectionModel().getSelections();
+           var arrLength = selected.length;
+           var arrNames = [];
 
-          var selected = queueGrid.getSelectionModel().getSelections();
-          var arrLength = selected.length;
-          var arrNames = new Array();
+           Ext.each(selected, function (selection) {
+               arrNames.push(selection.data.report_name);
+           });
 
-          Ext.each(selected, function (selection) {
-              arrNames.push(selection.data.report_name);
+           Ext.each(selected, function (selection) {
+              self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength, arrNames);
           });
-
-          Ext.each(selected, function (selection) {
-             self.parent.buildReport(selection.data.report_name, selection.data.report_id, self, build_only, format, arrLength, arrNames);
-         });
-
-      };//sendReport
+       }; //sendReport
 
        // ----------------------------------------------------
 
@@ -842,7 +838,7 @@ XDMoD.ReportsOverview = Ext.extend(Ext.Panel,  {
          items:[ queueGrid ],
 
          plugins: [
-            new Ext.ux.plugins.ContainerMask ({ masked:false }),
+            new Ext.ux.plugins.ContainerMask({ masked:false }),
             new XDMoD.Plugins.ContextSensitiveHelper('report+generator')
          ],
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added a check box selection feature to the Report Generator tab so that a user can send multiple reports at once.  Also, the pop up window that states the reports are being generated and sent has been modified to change grammatically based on the number of reports being sent, as well as list out all reports being sent.
![checkbox](https://user-images.githubusercontent.com/20168776/28921710-0642dca4-7825-11e7-923b-43c5283d3a91.png)

## Motivation and Context
This feature allows users to send multiple reports at once, rather than sending them one at a time.

## Tests performed
I have created several example reports, with which I sent one by itself, and then sent a set of two and set of three reports.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
