### PR TITLE
Modified PHP linker to use configurable autoloaders and include paths

### DIFF
--- a/configuration/linker.json
+++ b/configuration/linker.json
@@ -1,0 +1,22 @@
+{
+    "autoloaders": [
+        "vendor/autoload.php"
+    ],
+    "include_dirs": [
+        "classes",
+        "classes/DB",
+        "classes/DB/TACCStatsIngestors",
+        "classes/DB/TGcDBIngestors",
+        "classes/DB/POPSIngestors",
+        "classes/DB/XRASIngestors",
+        "classes/DB/Aggregators",
+        "classes/DB/DBModel",
+        "classes/DB/TimePeriodGenerators",
+        "classes/ExtJS",
+        "classes/REST",
+        "classes/User",
+        "classes/ReportTemplates",
+        "classes/AppKernel",
+        "libraries/HighRoller_1.0.5"
+    ]
+}

--- a/configuration/linker.php
+++ b/configuration/linker.php
@@ -7,31 +7,26 @@ require_once($dir . '/constants.php');
 
 // ---------------------------
 
-// Load the autoloader for dependencies managed by Composer.
-require_once($baseDir . '/vendor/autoload.php');
+// Load linker configuration.
+require_once("$baseDir/classes/CCR/Json.php");
+require_once("$baseDir/classes/Xdmod/Config.php");
+$config = Xdmod\Config::factory();
+$linkerConfig = $config['linker'];
 
-// ---------------------------
+// Load configured autoloaders.
+foreach ($linkerConfig['autoloaders'] as $autoloaderPath) {
+    require_once("$baseDir/$autoloaderPath");
+}
 
-// Register a custom autoloader for XDMoD components.
+// Update PHP's include path to include certain XDMoD directories.
 $include_path  = ini_get('include_path');
-$include_path .= ":" . $baseDir . '/classes';
-$include_path .= ":" . $baseDir . '/classes/DB';
-$include_path .= ":" . $baseDir . '/classes/DB/TACCStatsIngestors';
-$include_path .= ":" . $baseDir . '/classes/DB/TGcDBIngestors';
-$include_path .= ":" . $baseDir . '/classes/DB/POPSIngestors';
-$include_path .= ":" . $baseDir . '/classes/DB/XRASIngestors';
-$include_path .= ":" . $baseDir . '/classes/DB/Aggregators';
-$include_path .= ":" . $baseDir . '/classes/DB/DBModel';
-$include_path .= ":" . $baseDir . '/classes/DB/TimePeriodGenerators';
-$include_path .= ":" . $baseDir . '/classes/ExtJS';
-$include_path .= ":" . $baseDir . '/classes/REST';
-$include_path .= ":" . $baseDir . '/classes/User';
-$include_path .= ":" . $baseDir . '/classes/ReportTemplates';
-$include_path .= ":" . $baseDir . '/classes/AppKernel';
-$include_path .= ":" . $baseDir . '/libraries/HighRoller_1.0.5';
+foreach ($linkerConfig['include_dirs'] as $includeDirPath) {
+    $include_path .= ":$baseDir/$includeDirPath";
+}
 
 ini_alter('include_path', $include_path);
 
+// Register a custom autoloader for XDMoD components.
 function xdmodAutoload($className)
 {
     $pathList = explode(":", ini_get('include_path'));
@@ -207,8 +202,6 @@ function global_uncaught_exception_handler($exception)
 set_exception_handler('global_uncaught_exception_handler');
 
 // Configurable constants ---------------------------
-
-$config = Xdmod\Config::factory();
 
 $org = $config['organization'];
 define('ORGANIZATION_NAME', $org['name']);

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -59,6 +59,7 @@
             "configuration/etl",
             "configuration/hierarchy.json",
             "configuration/internal_dashboard.json",
+            "configuration/linker.json",
             "configuration/organization.json",
             "configuration/portal_settings.ini",
             "configuration/processor_buckets.json",


### PR DESCRIPTION
## Description
This pull request allows modules to specify PHP autoloaders and include paths using JSON config files in `etc/linker.d`.

## Motivation and Context
XDMoD requires additional PHP libraries beyond Open XDMoD's requirements. This pull request allows those libraries to be used without having to directly reference them in Open XDMoD.

## Tests Performed
Deployed modified code and verified that the instance worked as expected. Modified deployments with debug code to verify that the final include path stayed identical to the path before this change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
