### PR TITLE
Update Config.php

### DIFF
--- a/classes/Xdmod/Config.php
+++ b/classes/Xdmod/Config.php
@@ -296,7 +296,12 @@ class Config implements ArrayAccess
                 // If the key starts with a "+", merge the values.
 
                 $mainKey   = substr($key, 1);
-                $mainValue = $data[$mainKey];
+                if (array_key_exists($mainKey, $data)){
+                    $mainValue = $data[$mainKey];
+                }
+                else {
+                    $mainValue = null;
+                }
 
                 if (!is_array($mainValue)) {
                     $msg


### PR DESCRIPTION
add check for `Undefined index` and keep mainValue as null allowing exception to be thrown.
This resolves only the issue of notices being thrown when the array key does not exist, this will still throw an error as expected.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Turning notices on on dev caused an undefined index.
This allows the proper response to be sent back.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
added check verified that notice went away

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)