### PR TITLE
Support references into complex source records such as JSON objects

### DIFF
--- a/classes/ETL/Aggregator/aAggregator.php
+++ b/classes/ETL/Aggregator/aAggregator.php
@@ -135,6 +135,10 @@ abstract class aAggregator extends aRdbmsDestinationAction
 
                     $this->truncateDestination();
 
+                    $this->logger->debug(
+                        sprintf("Available Variables: %s", $this->getVariableMapDebugString())
+                    );
+
                     // Perform the dirty work
 
                     $numAggregationPeriodsProcessed = $this->_execute($aggregationUnit);

--- a/classes/ETL/Configuration/JsonReferenceTransformer.php
+++ b/classes/ETL/Configuration/JsonReferenceTransformer.php
@@ -15,12 +15,11 @@ namespace ETL\Configuration;
 use Log;
 use stdClass;
 use ETL\Loggable;
+use ETL\JsonPointer;
 
 class JsonReferenceTransformer extends Loggable implements iConfigFileKeyTransformer
 {
     const REFERENCE_KEY = '$ref';
-    const LAST_ARRAY_ELEMENT_CHAR = '-';
-    const POINTER_CHAR = '/';
 
     /* ------------------------------------------------------------------------------------------
      * @see iConfigFileKeyTransformer::__construct()
@@ -118,8 +117,16 @@ class JsonReferenceTransformer extends Loggable implements iConfigFileKeyTransfo
 
         $key = null;
 
-        // No fragment means include the entire file
-        $value = ( '' == $fragment ? json_decode($contents) : $this->extractJsonFragment($contents, $fragment) );
+        JsonPointer::setLoggable($this);
+        $value = JsonPointer::extractFragment($contents, $fragment);
+        JsonPointer::setLoggable(null);
+
+        if ( false === $value ) {
+            $this->logAndThrowException(
+                sprintf("Error processing JSON pointer: %s", $fragment)
+            );
+            return false;
+        }
 
         return true;
 
@@ -141,132 +148,4 @@ class JsonReferenceTransformer extends Loggable implements iConfigFileKeyTransfo
         $this->logger->debug(get_class($this));
         return \xd_utilities\qualify_path($path, $config->getBaseDir());
     }
-
-    /* ------------------------------------------------------------------------------------------
-     * Extract an RFC 6901 (https://tools.ietf.org/html/rfc6901) JSON pointer from the document.
-     *
-     * @param string $json The JSON document
-     * @param string $pointer The JSON pointer
-     *
-     * @returns The portion of the JSON document referenced by the pointer
-     *
-     * @throws Exception if the pointer is invalid or if there is an error traversing the document.
-     * ------------------------------------------------------------------------------------------
-     */
-
-    private function extractJsonFragment($json, $pointer)
-    {
-        // Based in part on https://github.com/raphaelstolt/php-jsonpointer
-        // Replace with this package once we support PHP 5.4
-
-        // Validate the JSON pointer
-
-        if ( "" !== $pointer && ! is_string($pointer) ) {
-            $this->logAndThrowException("Invalid JSON pointer: '$pointer'");
-        }
-
-        if ( 0 !== strpos($pointer, self::POINTER_CHAR) ) {
-            $this->logAndThrowException(
-                sprintf("JSON pointer must start with '%s'", self::POINTER_CHAR)
-            );
-        }
-
-        // Validate the json
-
-        $jsonObj = json_decode($json);
-
-        if ( json_last_error() !== JSON_ERROR_NONE ) {
-            $this->logAndThrowException('Invalid JSON');
-        }
-
-        // An empty pointer references the entire document
-
-        if ( '' == $pointer ) {
-            return $jsonObj;
-        }
-
-        // Urldecode and extract the pointer after the '/'
-
-        $pointerParts = array_slice(
-            array_map('urldecode', explode('/', $pointer)),
-            1
-        );
-
-        // Convert encoded characters (see https://tools.ietf.org/html/rfc6901#section-3)
-
-        $parts = array();
-        array_filter(
-            $pointerParts,
-            function ($p) use (&$parts) {
-                return $parts[] = str_replace(array('~1', '~0'), array('/', '~'), $p);
-            }
-        );
-
-        return $this->traverseJson($jsonObj, $pointer, $parts);
-
-    }  // extractJsonFragment()
-
-    /* ------------------------------------------------------------------------------------------
-     * Recursively traverse the JSON document, looking for the portion that is referenced by
-     * the pointer.
-     *
-     * @param mixed $json The JSON document or a portion of the document
-     * @param string $pointer The full JSON pointer
-     * @param array $pointerParts An array containing the portions of the pointer that have
-     *   yet to be traversed.
-     *
-     * @returns The portion of the JSON document referenced by the pointer
-     *
-     * @throws Exception if the value referenced by the pointer does not exist in the document.
-     * ------------------------------------------------------------------------------------------
-     */
-
-    private function traverseJson(&$json, $pointer, array $pointerParts)
-    {
-        $pointerPart = array_shift($pointerParts);
-
-        if ( is_array($json) && isset($json[$pointerPart]) ) {
-
-            if ( count($pointerParts) === 0 ) {
-                return $json[$pointerPart];
-            }
-
-            if ( (is_array($json[$pointerPart]) || is_object($json[$pointerPart])) && is_array($pointerParts) ) {
-                return $this->traverseJson($json[$pointerPart], $pointer, $pointerParts);
-            }
-
-        } elseif ( is_object($json) && in_array($pointerPart, array_keys(get_object_vars($json))) ) {
-
-            if ( count($pointerParts) === 0 ) {
-                return $json->{$pointerPart};
-            }
-
-            if ( (is_object($json->{$pointerPart}) || is_array($json->{$pointerPart})) && is_array($pointerParts) ) {
-                return $this->traverseJson($json->{$pointerPart}, $pointer, $pointerParts);
-            }
-
-        } elseif ( is_object($json) && empty($pointerPart) && array_key_exists('_empty_', get_object_vars($json)) ) {
-
-            $pointerPart = '_empty_';
-
-            if ( count($pointerParts) === 0 ) {
-                return $json->{$pointerPart};
-            }
-
-            if ( (is_object($json->{$pointerPart}) || is_array($json->{$pointerPart})) && is_array($pointerParts) ) {
-                return $this->traverseJson($json->{$pointerPart}, $pointer, $pointerParts);
-            }
-
-        } elseif ( $pointerPart === self::LAST_ARRAY_ELEMENT_CHAR && is_array($json) ) {
-            return end($json);
-        } elseif ( is_array($json) && count($json) < $pointerPart ) {
-            // Do nothing, let Exception bubble up
-        } elseif ( is_array($json) && array_key_exists($pointerPart, $json) && $json[$pointerPart] === null ) {
-            return $json[$pointerPart];
-        }
-
-        $this->logAndThrowException(
-            sprintf("JSON pointer '%s' references a nonexistent value", $pointer)
-        );
-    } // traverseJson()
 }  // class JsonReferenceTransformer

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -211,10 +211,12 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
                         $this->logger->info(
                             sprintf("%s: Relative path provided, absolute path recommended", $this)
                         );
-                        $this->logger->info(
-                            sprintf("Qualifying relative path %s with %s", $this->path, $options->paths->data_dir)
-                        );
-                        $this->path = \xd_utilities\qualify_path($this->path, $options->paths->data_dir);
+                        if ( isset($options->paths->data_dir) ) {
+                            $this->logger->info(
+                                sprintf("Qualifying relative path %s with %s", $this->path, $options->paths->data_dir)
+                            );
+                            $this->path = \xd_utilities\qualify_path($this->path, $options->paths->data_dir);
+                        }
                     }
                     break;
 

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -32,16 +32,6 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
     const ENDPOINT_NAME = 'directoryscanner';
 
     /** -----------------------------------------------------------------------------------------
-     * Numeric key to use for the default file extension handler. This should be the only
-     * numeric key used.
-     *
-     * @var integer
-     * ------------------------------------------------------------------------------------------
-     */
-
-    const DEFAULT_HANDLER_KEY = 0;
-
-    /** -----------------------------------------------------------------------------------------
      * The directory path that we will be scanning. This should be a fully qualified path.
      *
      * @var string

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -4,7 +4,7 @@
  * File endpoints that recursively scans a directory for files and instantiates Structured
  * File endpoint each file in a directory (or subdirectory) matching a set of optionally
  * specified criteria. It supports file name pattern matching and last modified dates. The
- * Directory Scanner implements the Iterator interface and iteration spans the union of
+ * Directory Scanner implements the Iterator interface adepnd iteration spans the union of
  * the records in each of the files. For example, if 2 files are found in a directory then
  * the Directory Scanner iterator will span all of the records in both files.
  *
@@ -20,7 +20,7 @@ use ETL\DataEndpoint\StructuredFile;
 use Exception;
 use Log;
 
-class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
+class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComplexDataRecords
 {
     /** -----------------------------------------------------------------------------------------
      * The ENDPOINT_NAME constant defines the name for this endpoint that should be used
@@ -51,7 +51,7 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
     protected $path = null;
 
     /** -----------------------------------------------------------------------------------------
-     * An optional regex that files must match to be identified by the scanner. This
+     * An optional PCRE that files must match to be identified by the scanner. This
      * applies to the file portion of the path only.
      *
      * @var string | null
@@ -61,7 +61,7 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
     protected $filePattern = null;
 
     /** -----------------------------------------------------------------------------------------
-     * An optional regex that directories must match to be identified by the scanner.
+     * An optional PCRE that directories must match to be identified by the scanner.
      *
      * @var string | null
      * ------------------------------------------------------------------------------------------
@@ -71,7 +71,9 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
     /** -----------------------------------------------------------------------------------------
      * The maximum depth that we will recurse into the directory hierarchy. -1 indicates
-     * no limit.
+     * no limit. The depth is calculated relative to the original path. For example, if the path
+     * is /data/lives/here then all files in /data/lives/here are considered a depth of 1, files
+     * in /data/lives/here/raw are a depth of 2, etc.
      *
      * @var integer | null
      * ------------------------------------------------------------------------------------------
@@ -100,19 +102,14 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
     protected $lastModifiedEndTimestamp = null;
 
     /** -----------------------------------------------------------------------------------------
-     * An array containing handler templates for various file types, which will be
-     * augmented with the file name and path when the handler is instantiated. If a single
-     * handler with no extension specified then it will be used for all files. If multiple
-     * handlers are specified it is required that they also specify a file extension
-     * (string) to determine which hanbdler gets applied to apply to a particular
-     * file. When multiple handlers are specified, an extension of NULL indicates a
-     * catch-all handler.
+     * A handler template that will be used to instantiate the handler for each file matched
+     * by the directory scanner. The file name will be injected into the template.
      *
-     * @var array
+     * @var object | null
      * ------------------------------------------------------------------------------------------
      */
 
-    protected $handlerTemplateList = array();
+    protected $handlerTemplate = null;
 
     /** -----------------------------------------------------------------------------------------
      * The name of the current file that we are parsing.
@@ -131,6 +128,34 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
      */
 
     private $currentFileIterator = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * The name of the first file that was parsed. This allows us to reset the iterator witout
+     * re-parsing the first file.
+     *
+     * @var string
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private $firstFilename = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * The iterator for the first file that was parsed. This allows us to reset the iterator witout
+     * re-parsing the first file.
+     *
+     * @var Iterator
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private $firstFileIterator = null;
+
+    /**
+     * The first record parsed from the first file.
+     *
+     * @var mixed
+     */
+
+    private $firstRecord = null;
 
     /** -----------------------------------------------------------------------------------------
      * The number of files that have been scanned so far. Note that an empty file
@@ -161,13 +186,13 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
     {
         parent::__construct($options, $logger);
 
-        $requiredKeys = array('path', 'handlers');
+        $requiredKeys = array('path', 'handler');
         $this->verifyRequiredConfigKeys($requiredKeys, $options);
 
         $messages = array();
         $propertyTypes = array(
             'path'                => 'string',
-            'handlers'            => 'array',
+            'handler'             => 'object',
             'file_pattern'        => 'string',
             'directory_pattern'   => 'string',
             'recursion_depth'     => 'int',
@@ -231,44 +256,33 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
                     }
                     break;
 
+                case 'handler':
+                    $validEndpoints = \ETL\DataEndpoint::getDataEndpointNames();
+                    if ( ! isset($value->type) ) {
+                        $this->logAndThrowException("Handler does not specify endpoint type");
+                    } elseif ( ! in_array($value->type, $validEndpoints) ) {
+                        $this->logAndThrowException(
+                            sprintf(
+                                "Unknown handler type '%s'. Valid types are: %s",
+                                $value->type,
+                                implode(', ', $validEndpoints)
+                            )
+                        );
+                    } else {
+                        $this->handlerTemplate = $value;
+
+                        // If the paths block has been set in the options, add it to the handler template
+                        // so it can take advantage of the paths passed down from the configuration.
+
+                        if ( isset($options->paths) ) {
+                            $this->handlerTemplate->paths = $options->paths;
+                        }
+                    }
+                    break;
+
                 default:
                     break;
             }
-        }
-
-        $numHandlers = count($options->handlers);
-
-        if ( 0 == $numHandlers ) {
-            $this->logAndThrowException("At least 1 handler must be specified");
-        }
-
-        $numDefaultHandlers = 0;
-
-        foreach ( $options->handlers as $handler ) {
-            if ( isset($handler->extension) ) {
-                // Normalize the extension to not contain a period
-                $ext = $handler->extension;
-                if ( 0 === strrpos($ext, '.') ) {
-                    $ext = substr($ext, 1);
-                }
-                $this->logger->debug(
-                    sprintf("%s: Adding handler for file extension '%s'", $this, $ext)
-                );
-                $this->handlerTemplateList[$ext] = $handler;
-            } else {
-                // Assign a default handler.
-                $this->logger->debug(
-                    sprintf("%s: Adding default file handler", $this)
-                );
-                $this->handlerTemplateList[self::DEFAULT_HANDLER_KEY] = $handler;
-                $numDefaultHandlers++;
-            }
-        }
-
-        if ( $numDefaultHandlers > 1 ) {
-            $this->logAndThrowException(
-                sprintf("%d default handlers specified, only 1 is allowed", $numDefaultHandlers)
-            );
         }
 
         $this->key = md5(implode($this->keySeparator, array($this->type, $this->path, $this->name)));
@@ -339,16 +353,15 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
     }  // getLastModifiedEndTime()
 
     /** -----------------------------------------------------------------------------------------
-     * @return array The list of handler templates. If more than one items is in the list
-     * the keys will be strings represneting the file extensions matching the template
-     * with an index of 0 for the catch-all handler.
+     * @return object The handler template that will be used to create a configuration for the
+     * file handlers.
      * ------------------------------------------------------------------------------------------
      */
 
-    public function getHandlerTemplateList()
+    public function getHandlerTemplate()
     {
-        return $this->handlerTemplateList;
-    }  // getHandlerTemplateList()
+        return $this->handlerTemplate;
+    }  // getHandlerTemplate()
 
     /** -----------------------------------------------------------------------------------------
      * @return integer The number of files scanned so far.
@@ -509,18 +522,37 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
                 $patternCallbackIterator = new \CallbackFilterIterator(
                     $iterator,
                     function ($current, $key, $iterator) use ($dirPattern, $filePattern) {
-                        if (
-                            null !== $dirPattern
-                            && ! preg_match($dirPattern, $current->getPath())
-                        ) {
-                            return false;
+
+                        // Return TRUE only if both directory and file patterns match
+
+                        if ( null !== $dirPattern ) {
+                            if ( false === ($match = @preg_match($dirPattern, $current->getPath())) ) {
+                                $err = error_get_last();
+                                $this->logAndThrowException(
+                                    sprintf(
+                                        "Error matching directory pattern '%s': %s",
+                                        $dirPattern,
+                                        $err['message']
+                                    )
+                                );
+                            } elseif ( ! $match ) {
+                                return false;
+                            }
                         }
 
-                        if (
-                            null !== $filePattern
-                            && ! preg_match($filePattern, $current->getFilename())
-                        ) {
-                            return false;
+                        if ( null !== $filePattern ) {
+                            if ( false === ($match = @preg_match($filePattern, $current->getFilename())) ) {
+                                $err = error_get_last();
+                                $this->logAndThrowException(
+                                    sprintf(
+                                        "Error matching file pattern '%s': %s",
+                                        $filePattern,
+                                        $err['message']
+                                    )
+                                );
+                            } elseif ( ! $match ) {
+                                return false;
+                            }
                         }
 
                         return true;
@@ -638,12 +670,17 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
      * be a valid value for the iterator, This is why valid() MUST be called before current().
      *
      * @see Iterator::current()
+     * @see current()
      * ------------------------------------------------------------------------------------------
      */
 
     public function current()
     {
-        return $this->currentFileIterator->current();
+        if ( null === $this->currentFileIterator ) {
+            return false;
+        } else {
+            return $this->currentFileIterator->current();
+        }
     }  // current()
 
     /** -----------------------------------------------------------------------------------------
@@ -651,12 +688,17 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
      * are processing in that file.
      *
      * @see Iterator::key()
+     * @see key()
      * ------------------------------------------------------------------------------------------
      */
 
     public function key()
     {
-        return sprintf("%s[%s]", $this->currentFilename, $this->currentFileIterator->key());
+        if ( null === $this->currentFileIterator ) {
+            return null;
+        } else {
+            return sprintf("%s[%s]", $this->currentFilename, $this->currentFileIterator->key());
+        }
     }  // key()
 
     /** -----------------------------------------------------------------------------------------
@@ -669,13 +711,16 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
     public function next()
     {
-        $this->currentFileIterator->next();
+        if ( null !== $this->currentFileIterator ) {
+            $this->currentFileIterator->next();
+        }
     }  // next()
 
     /** -----------------------------------------------------------------------------------------
      * Note that calling rewind() rewinds the entire directory scan, not the current file. After
      * rewinding the directory scan, reset any pointers and call valid() to ensure that we are
-     * pointing at the first record in the first non-empty file.
+     * pointing at the first record in the first non-empty file. The side effect of this is that we
+     * must re-parse the first non-empty file.
      *
      * @see Iterator::rewind()
      * ------------------------------------------------------------------------------------------
@@ -685,8 +730,20 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
     {
         $this->handle->rewind();
         $this->numFilesScanned = 0;
-        $this->currentFileIterator = null;
-        $this->valid();
+        $this->numRecordsParsed = 0;
+
+        // If we have already parsed the first file, reset the current file to the first file so
+        // we don't need to re-parse the file.
+
+        if ( null !== $this->firstFileIterator ) {
+            $this->currentFileIterator = $this->firstFileIterator;
+            $this->currentFilename = $this->firstFilename;
+            $this->currentFileIterator->rewind();
+        } else {
+            $this->currentFileIterator = null;
+            $this->valid();
+        }
+
     }  // rewind()
 
     /** -----------------------------------------------------------------------------------------
@@ -728,31 +785,57 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
             // By default the key is the path and the value is an SplFileInfo object.
             // http://php.net/manual/en/class.splfileinfo.php
 
-            return $this->initializeCurrentFileIterator($this->handle->key());
+            $this->logger->debug("Initializing first file iterator");
 
-        } else {
+            $this->initializeCurrentFileIterator($this->handle->key());
 
-            // If there are records available in the current file, return TRUE. If not, we will need
-            // to move on to the next file.
+            // Save the first file iterator so we don't need to re-parse the first file on rewind
 
-            if ( $this->currentFileIterator->valid() ) {
-                return true;
-            } else {
+            $this->firstFileIterator = $this->currentFileIterator;
+            $this->firstFilename = $this->currentFilename;
 
-                // Since a file could be empty, move on to the next file if we initialize a file
-                // that contains no valid records.
+        } elseif ( ! $this->currentFileIterator->valid() ) {
 
+            // If there are no records available in the current file we will need to move on to the
+            // next file. Since a file could be empty, move on to the next file if we initialize a
+            // file that contains no valid records.
+
+            $this->logger->debug("Current file iterator no longer valid, checking next iterator.");
+            $this->handle->next();
+
+            while ($this->handle->valid() && ! $this->initializeCurrentFileIterator($this->handle->key()) ) {
                 $this->handle->next();
-
-                while ($this->handle->valid() && ! $this->initializeCurrentFileIterator($this->handle->key()) ) {
-                    $this->handle->next();
-                }
-
-                return $this->currentFileIterator->valid();
             }
+
         }
 
+        return $this->currentFileIterator->valid();
+
     }  // valid()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see Countable::count()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function count()
+    {
+        return $this->numRecordsParsed;
+    }  // count()
+
+    /* ------------------------------------------------------------------------------------------
+     * @see iFile::getMode()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getMode()
+    {
+        if ( null === $this->currentFileIterator ) {
+            return null;
+        } else {
+            return $this->currentFileIterator->getMode();
+        }
+    } // getMode()
 
     /** -----------------------------------------------------------------------------------------
      * Set up the internal file iterator for the specified file. This will create a handler based on
@@ -761,32 +844,18 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
      *
      * @param string $filename The filename that we are initializing
      *
-     * @returns boolean The value of valid() for the current file handler.
+     * @return boolean The value of valid() for the current file handler.
      * ------------------------------------------------------------------------------------------
      */
 
     private function initializeCurrentFileIterator($filename)
     {
-        // SplFileInfo::getExtension() is not defined until PHP 5.3.6
+        $this->logger->info(sprintf('Scanning file: %s', $filename));
 
-        $extension = '';
-        if ( false !== ($pos = strrpos($filename, '.')) ) {
-            $extension = substr($filename, $pos + 1);
-        }
+        // NOTE: We are cloning the handler template because it is an object and will be passed
+        // by reference otherwise and we do not want to modify the template itself.
 
-        $this->logger->debug(
-            sprintf('Scanning file: %s (%s)', $filename, $extension)
-        );
-
-        // Use the file extension and use it to look up a handler. If no extension was found, use
-        // the default handler. NOTE: We are cloning the handler template because it is an object
-        // and will be passed by reference otherwise.
-
-        if ( array_key_exists($extension, $this->handlerTemplateList) ) {
-            $handlerConfig = clone $this->handlerTemplateList[$extension];
-        } else {
-            $handlerConfig = clone $this->handlerTemplateList[self::DEFAULT_HANDLER_KEY];
-        }
+        $handlerConfig = clone $this->handlerTemplate;
 
         // Inject the current file data into the handler config and parse the file
 
@@ -802,12 +871,20 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
         }
 
         $fileHandler->verify();
-        $fileHandler->parse();
+        $record = $fileHandler->parse();
+
+        // Save the first record parsed from the first file so we can return it from parse()
+
+        if ( null === $this->firstRecord ) {
+            $this->firstRecord = $record;
+        }
 
         $this->currentFileIterator = $fileHandler;
         $this->currentFilename = $filename;
         $this->numFilesScanned++;
         $this->numRecordsParsed += $fileHandler->count();
+
+        $this->logger->info(sprintf('Found %d records', $fileHandler->count()));
 
         return $this->currentFileIterator->valid();
 
@@ -820,6 +897,243 @@ class DirectoryScanner extends aDataEndpoint implements iDataEndpoint, \Iterator
 
     public function __toString()
     {
-        return sprintf('%s (name=%s, path=%s)', get_class($this), $this->name, $this->path);
+        $handlerString = (
+            null !== $this->handlerTemplate
+            ? sprintf(', handler=%s', $this->handlerTemplate->type)
+            : ""
+        );
+
+        return sprintf('%s (name=%s, path=%s%s)', get_class($this), $this->name, $this->path, $handlerString);
     }  // __toString()
+
+    /** -----------------------------------------------------------------------------------------
+     * If parse() has been called we can pull the value of record separator from the file handler,
+     * otherwise check the handler template.
+     *
+     * @see iStructuredFile::getRecordSeparator()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordSeparator()
+    {
+        if ( null !== $this->currentFileIterator ) {
+            return $this->currentFileIterator->getRecordSeparator();
+        } else {
+            return (
+                isset($this->handlerTemplate->record_separator)
+                ? $this->handlerTemplate->record_separator
+                : null
+            );
+        }
+    }  // getRecordSeparator()
+
+    /** -----------------------------------------------------------------------------------------
+     * If parse() has been called we can pull the value of field separatp from the file handler,
+     * otherwise check the handler template.
+     *
+     * @see iStructuredFile::getFieldSeparator()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getFieldSeparator()
+    {
+        if ( null !== $this->currentFileIterator ) {
+            return $this->currentFileIterator->getFieldSeparator();
+        } else {
+            return (
+                isset($this->handlerTemplate->field_separator)
+                ? $this->handlerTemplate->field_separator
+                : null
+            );
+        }
+    }  // getFieldSeparator()
+
+    /** -----------------------------------------------------------------------------------------
+     * If parse() has been called we can pull the value of header record from the file handler,
+     * otherwise check the handler template.
+     *
+     * @see iStructuredFile::hasHeaderRecord()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function hasHeaderRecord()
+    {
+        if ( null !== $this->currentFileIterator ) {
+            return $this->currentFileIterator->getRecordFieldNames();
+        } else {
+            return (
+                isset($this->handlerTemplate->header_record)
+                ? $this->handlerTemplate->header_record
+                : true
+            );
+        }
+    }  // hasHeaderRecord()
+
+    /** -----------------------------------------------------------------------------------------
+     * If parse() has been called we can pull the field names from the file handler, otherwise
+     * check the handler template.
+     *
+     * @see iStructuredFile::getRecordFieldNames()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getRecordFieldNames()
+    {
+        if ( null !== $this->currentFileIterator ) {
+            return $this->currentFileIterator->getRecordFieldNames();
+        } else {
+            return (
+                isset($this->handlerTemplate->field_names)
+                ? $this->handlerTemplate->field_names
+                : null
+            );
+        }
+    }  //getRecordFieldNames()
+
+    /** -----------------------------------------------------------------------------------------
+     * If parse() has been called we can pull the discovered field names from the file handler,
+     * otherwise return NULL.
+     *
+     * @see iStructuredFile::getDiscoveredRecordFieldNames()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getDiscoveredRecordFieldNames()
+    {
+        if ( null !== $this->currentFileIterator ) {
+            return $this->currentFileIterator->getDiscoveredRecordFieldNames();
+        } else {
+            return null;
+        }
+    } // getDiscoveredRecordFieldNames()
+
+    /** -----------------------------------------------------------------------------------------
+     * If parse() has been called we can pull the attached filter list from the file handler,
+     * otherwise return an empty array().
+     *
+     * @see iStructuredFile::getAttachedFilters()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getAttachedFilters()
+    {
+        if ( null !== $this->currentFileIterator ) {
+            return $this->currentFileIterator->getAttachedFilters();
+        } else {
+            return array();
+        }
+    }  // getAttachedFilters()
+
+    /** -----------------------------------------------------------------------------------------
+     * For a structured file endpoint, parse() must be called prior to iterating over the
+     * data, but the DirectoryScanner endpoint will automatically handle this when it
+     * initializes each file handler. This method is for compatibility with
+     * iStructuredFile behavior.
+     *
+     * @see iStructuredFile::parse()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function parse()
+    {
+        // If current file iterator is NULL then initialize it
+
+        if ( null === $this->currentFileIterator ) {
+            $this->valid();
+        }
+
+        return $this->firstRecord;
+
+    }  // parse()
+
+    /** -----------------------------------------------------------------------------------------
+     * This class does not support complex data records directly, but relies on the handler.
+     *
+     * @see iStructuredFile::supportsComplexDataRecords()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function supportsComplexDataRecords()
+    {
+        // If current file iterator is NULL then initialize it
+
+        if ( null === $this->currentFileIterator ) {
+            $this->valid();
+        }
+
+        return $this->currentFileIterator->supportsComplexDataRecords();
+
+    }  // supportsComplexDataRecords()
+
+    /** -----------------------------------------------------------------------------------------
+     * This class does not support complex data records directly, but relies on the handler so
+     * pass all iComplexDataRecords methods through to the handler if it supports them.
+     *
+     * @see iComplexDataRecords::validateDestinationMapSourceFields()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function validateDestinationMapSourceFields(array $destinationTableMap)
+    {
+        if ( $this->supportsComplexDataRecords() ) {
+            return $this->currentFileIterator->validateDestinationMapSourceFields(
+                $destinationTableMap
+            );
+        } else {
+            $this->logAndThrowException(
+                sprintf(
+                    "Handler endpoint '%s' does not support complex data records",
+                    $this->currentFileIterator
+                )
+            );
+        }
+    }  // validateDestinationMapSourceFields()
+
+    /** -----------------------------------------------------------------------------------------
+     * This class does not support complex data records directly, but relies on the handler so
+     * pass all iComplexDataRecords methods through to the handler if it supports them.
+     *
+     * @see iComplexDataRecords::isComplexSourceField()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function isComplexSourceField($sourceField)
+    {
+        if ( $this->supportsComplexDataRecords() ) {
+            return $this->currentFileIterator->isComplexSourceField($sourceField);
+        } else {
+            $this->logAndThrowException(
+                sprintf(
+                    "Handler endpoint '%s' does not support complex data records",
+                    $this->currentFileIterator
+                )
+            );
+        }
+    }  // isComplexSourceField()
+
+    /** -----------------------------------------------------------------------------------------
+     * This class does not support complex data records directly, but relies on the handler so
+     * pass all iComplexDataRecords methods through to the handler if it supports them.
+     *
+     * @see iComplexDataRecords::evaluateComplexSourceField()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function evaluateComplexSourceField($sourceField, $record, $invalidRefValue = null)
+    {
+        if ( $this->supportsComplexDataRecords() ) {
+            return $this->currentFileIterator->evaluateComplexSourceField(
+                $sourceField,
+                $record,
+                $invalidRefValue
+            );
+        } else {
+            $this->logAndThrowException(
+                sprintf(
+                    "Handler endpoint '%s' does not support complex data records",
+                    $this->currentFileIterator
+                )
+            );
+        }
+    }  // evaluateComplexSourceField()
 }  // class DirectoryScanner

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -221,6 +221,10 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
                         $this->logger->info(
                             sprintf("%s: Relative path provided, absolute path recommended", $this)
                         );
+                        $this->logger->info(
+                            sprintf("Qualifying relative path %s with %s", $this->path, $options->paths->data_dir)
+                        );
+                        $this->path = \xd_utilities\qualify_path($this->path, $options->paths->data_dir);
                     }
                     break;
 
@@ -449,7 +453,7 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
         );
 
         try {
-            $directoryIterator = new \RecursiveDirectoryIterator($this->path);
+            $directoryIterator = new \RecursiveDirectoryIterator($this->path, \FilesystemIterator::FOLLOW_SYMLINKS);
             $iterator = $directoryIterator;
         } catch ( Exception $e ) {
             $this->logAndThrowException(
@@ -523,7 +527,7 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
                     $iterator,
                     function ($current, $key, $iterator) use ($dirPattern, $filePattern) {
 
-                        // Return TRUE only if both directory and file patterns match
+                        // Return TRUE only if both directory and file patterns match.
 
                         if ( null !== $dirPattern ) {
                             if ( false === ($match = @preg_match($dirPattern, $current->getPath())) ) {
@@ -1061,7 +1065,11 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
             $this->valid();
         }
 
-        return $this->currentFileIterator->supportsComplexDataRecords();
+        return (
+            null === $this->currentFileIterator
+            ? false
+            : $this->currentFileIterator->supportsComplexDataRecords()
+        );
 
     }  // supportsComplexDataRecords()
 

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -446,7 +446,7 @@ abstract class aStructuredFile extends File
      * downstream that relies on it.  For example, when parsing a JSON configuration file
      * we must maintain the stdClass type and not blindly convert it to an associative
      * array.  The child class can re-implement this method as needed.
-     *
+
      * @return array A record that includes all of the data for the requested fields
      * ------------------------------------------------------------------------------------------
      */
@@ -473,10 +473,21 @@ abstract class aStructuredFile extends File
         // the template are overwritten with the record values where the fields
         // match.
 
+        // This should be created once when we determine the requested field names...
         $dataTemplate = array_fill_keys($this->requestedRecordFieldNames, null);
 
         return array_merge($dataTemplate, array_intersect_key($arrayRecord, $dataTemplate));
     }  // createReturnRecord()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iStructuredFile::supportsComplexDataRecords()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function supportsComplexDataRecords()
+    {
+        return ( $this instanceof iComplexDataRecords );
+    }  // supportsComplexDataRecords()
 
      /** -----------------------------------------------------------------------------------------
      * Return the current record as a Traversable entity such as an associative array or

--- a/classes/ETL/DataEndpoint/iComplexDataRecords.php
+++ b/classes/ETL/DataEndpoint/iComplexDataRecords.php
@@ -1,0 +1,97 @@
+<?php
+/** =========================================================================================
+ * The ETL process supports populating multiple destinations from a single source. For example,
+ * a single database query or data file can be used to populate multiple destination tables.
+ * The destination field map is used to map individual fields in the source record fields to fields
+ * in the destination (tables).  By default, the destination map supports simple scalar values for
+ * the source record field names (i.e., values in the source fields are mapped directly to
+ * destination fields).
+ *
+ * By implementing this interface a data endpoint indicates that it supports complex data records
+ * and implements the methods necessary to handle complex source fields in addition to scalar fields
+ * in the destination field map. For example, a JSON data endpoint supports complex nested objects
+ * and may allow JSON pointers in the map's source fields to reference data inside the complex
+ * object.
+ *
+ * NOTE: Some classes, such as DirectoryScanner, may delegate their support for complex source
+ *   records to underlying classes or handlers. To support this we use
+ *   iStructuredFile::supportsComplexDataRecords().
+ *
+ * For example, the following destination map contains JSON pointers to access the nested object in
+ * the JSON record below. Without JSON pointers, there would be no way to programmatically access
+ * data other than the top level keys.
+ *
+ * "destination_field_map": {
+ *     "instance_types": {
+ *         "id": "instance_id",
+ *         "name": "/instance_type/name",
+ *         "num_cores": "/instace_type/cpu"
+ *     }
+ * }
+ *
+ * {
+ *     "id": "887233-bya",
+ *     "instance_type": {
+ *         "name": "m1.medium",
+ *         "num_cores": 8,
+ *         "memory": 4096
+ *     }
+ * }
+ *
+ * @see iStructuredFile::supportsComplexDataRecords()
+ *
+ * @author Steve Gallo  <smgallo@buffalo.edu>
+ * @datetime 2017-07-19
+ * ==========================================================================================
+ */
+
+namespace ETL\DataEndpoint;
+
+interface iComplexDataRecords
+{
+    /** -----------------------------------------------------------------------------------------
+     * Perorm validation of the destination map for an INDIVIDUAL table to ensure that the source
+     * fields specified in the map are in a supported format and the fields that they evaluate to
+     * are present in the fields provided by the source endpoint.
+     *
+     * @param array $destinationTableMap The mapping between source fields and destination fields
+     *   for an INDIVIDUAL table. Keys are destination table fields and values are source record
+     *   fields. Note that a source record field may be specified multiple times.
+     *
+     * @return array An associative array of destination map entries that did NOT pass validation.
+     *   The keys are destination fields and the values are source record fields.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function validateDestinationMapSourceFields(array $destinationTableMap);
+
+    /** -----------------------------------------------------------------------------------------
+     * Determine if the given field is a complex file as supported by the implementing class.
+     *
+     * @param string $sourceField The source field to examine.
+     *
+     * @return boolean TRUE if the field is a complex field, FALSE otherwise.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function isComplexSourceField($sourceField);
+
+    /** -----------------------------------------------------------------------------------------
+     * Evaluate a complex source field against a record and return the data in the record referenced
+     * by the field. For example, if the field is a JSON pointer return the data in the record
+     * referenced by the pointer.
+     *
+     * @param string $sourceField The complex source field that will be evaluated
+     * @param mixed $record The data record that we will reference
+     * @param mixed $invalidRefValue The value to return if there was an arror evaluating the source
+     *   field. This includes an improperly formatted reference as well as a reference to a field
+     *   that does not exist.
+     *
+     * @return mixed The data in the record referenced by the source field.
+     *
+     * @throws Exception If the source field was invalid
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function evaluateComplexSourceField($sourceField, $record, $invalidReferenceValue = null);
+} // interface iComplexDataRecords

--- a/classes/ETL/DataEndpoint/iStructuredFile.php
+++ b/classes/ETL/DataEndpoint/iStructuredFile.php
@@ -86,4 +86,14 @@ interface iStructuredFile extends iFile, \Iterator, \Countable
      */
 
     public function parse();
+
+    /** -----------------------------------------------------------------------------------------
+     * Check to see if the endpoint supports complex data records (e.g. JSON objects). This may
+     * check to see if the endpoint implements iComplexDataRecords or perform other checks.
+     *
+     * @return boolean TRUE if the endpoint supports complex data records, FALSE if it does not.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function supportsComplexDataRecords();
 }  // interface iStructuredFile

--- a/classes/ETL/DbModel/Column.php
+++ b/classes/ETL/DbModel/Column.php
@@ -162,7 +162,7 @@ class Column extends NamedEntity implements iEntity
             //
             // **WARNING**
             //
-            // Having multime TIMESTAMP columns in the same table may result in unexpected behavior
+            // Having multiple TIMESTAMP columns in the same table may result in unexpected behavior
             // for the 2nd or following columns.
             //
             // See:

--- a/classes/ETL/DbModel/Column.php
+++ b/classes/ETL/DbModel/Column.php
@@ -154,11 +154,27 @@ class Column extends NamedEntity implements iEntity
                 $srcExtra = str_ireplace($search, "CURRENT_TIMESTAMP", $srcExtra);
             }  // if ( null !== $srcExtra)
 
-            // If no DEFAULT and no EXTRA is provided, MySQL will use:
+            // If no DEFAULT and no EXTRA is provided MySQL will use:
             // DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
             //
             // If no DEFAULT is provided but an EXTRA is provided the default will be 0 unless
             // the collumn is nullable, then it will be NULL.
+            //
+            // **WARNING**
+            //
+            // Having multime TIMESTAMP columns in the same table may result in unexpected behavior
+            // for the 2nd or following columns.
+            //
+            // See:
+            // https://dev.mysql.com/doc/refman/5.5/en/timestamp-initialization.html
+            // http://jasonbos.co/two-timestamp-columns-in-mysql
+            //
+            // One TIMESTAMP column in a table can have the current timestamp as the default value
+            // for initializing the column, as the auto-update value, or both. It is not possible to
+            // have the current timestamp be the default value for one column and the auto-update
+            // value for another column.   to specify automatic initialization or updating for a
+            // different TIMESTAMP column, you must suppress the automatic properties for the first
+            // one.
 
             if ( ( (null === $srcDefault && null === $srcExtra)
                    || ('current_timestamp' === strtolower($srcDefault) && 'on update current_timestamp' === strtolower($srcExtra)) )

--- a/classes/ETL/DbModel/Table.php
+++ b/classes/ETL/DbModel/Table.php
@@ -621,8 +621,12 @@ ORDER BY trigger_name ASC";
         foreach ( $changeColNames as $name ) {
             $destColumn = $destination->getColumn($name);
             // Not all properties are required so a simple object comparison isn't possible
-            if ( 0 == $destColumn->compare($this->getColumn($name)) ) {
+            if ( 0 == ($compareCode = $destColumn->compare($this->getColumn($name))) ) {
                 continue;
+            } else {
+                $this->logger->debug(
+                    sprintf("Column comparison for '%s' returned %d", $name, $compareCode)
+                );
             }
 
             $alterList[] = "CHANGE COLUMN " . $destColumn->getName(true) . " " . $destColumn->getSql($includeSchema);
@@ -632,8 +636,12 @@ ORDER BY trigger_name ASC";
             $destColumn = $destination->getColumn($toColumnName);
             $currentColumn = $this->getColumn($fromColumnName);
             // Not all properties are required so a simple object comparison isn't possible
-            if ( 0 == $destColumn->compare($currentColumn) ) {
+            if ( 0 == ($compareCode = $destColumn->compare($currentColumn)) ) {
                 continue;
+            } else {
+                $this->logger->debug(
+                    sprintf("Column comparison for '%s' returned %d", $fromColumnName, $compareCode)
+                );
             }
             $alterList[] = "CHANGE COLUMN " . $currentColumn->getName(true) . " " . $destColumn->getSql($includeSchema);
         }

--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -257,8 +257,8 @@ class StructuredFileIngestor extends aIngestor implements iAction
             // Verify the parameters are scalars
 
             foreach ( $parameters as $index => $value ) {
-                if ( ! is_scalar($value) ) {
-                    $sourcefield = $destinationFieldIdToSourceFieldMap[$etlTableKey][$index];
+                if ( null !== $value && ! is_scalar($value) ) {
+                    $sourceField = $destinationFieldIdToSourceFieldMap[$etlTableKey][$index];
                     $invalidSourceValues[$etlTableKey][$sourceField] = $value;
                 }
             }

--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -11,23 +11,27 @@
 namespace ETL\Ingestor;
 
 use stdClass;
+use Exception;
+use PDOException;
+use Log;
 
 use ETL\iAction;
+use ETL\aOptions;
 use ETL\Configuration\EtlConfiguration;
 use ETL\EtlOverseerOptions;
+use ETL\Utilities;
 use ETL\aRdbmsDestinationAction;
-use ETL\aOptions;
 use ETL\DataEndpoint\iStructuredFile;
-use Log;
 
 class StructuredFileIngestor extends aIngestor implements iAction
 {
-    /**
+    /** -----------------------------------------------------------------------------------------
      * The custom insert values component is an object that allows us to specify a
      * subquery to use when inserting data rather than the raw source value. If the
      * destination column is present as a key in the object, the key's value will be used.
      *
      * @var array|null
+     * ------------------------------------------------------------------------------------------
      */
 
     protected $customInsertValuesComponents = null;
@@ -86,11 +90,23 @@ class StructuredFileIngestor extends aIngestor implements iAction
         $numRecords = 0;
         $insertStatements = array();
 
-        // We will need to get the record fields from the source data. This happens after
-        // the first record is parsed.
+        // We will need to get the record fields from the source data. This happens after the first
+        // record is parsed.
 
-        $this->sourceEndpoint->parse();
+        $firstRecord = $this->sourceEndpoint->parse();
+
+        // If there are no records we can bail out. Otherwise we may not even be able to infer the
+        // source field names.
+
+        if ( 0 == $this->sourceEndpoint->count() ) {
+            $this->logger->info(
+                sprintf("Source endpoint %s returned 0 records, skipping.", $this->sourceEndpoint)
+            );
+            return $numRecords;
+        }
+
         $recordFieldNames = $this->sourceEndpoint->getRecordFieldNames();
+
         $this->logger->debug(
             sprintf("Requested %d record fields: %s", count($recordFieldNames), implode(', ', $recordFieldNames))
         );
@@ -99,32 +115,72 @@ class StructuredFileIngestor extends aIngestor implements iAction
             return $numRecords;
         }
 
-        $this->parseDestinationFieldMap($recordFieldNames);
+        $this->parseDestinationFieldMap($recordFieldNames, $this->sourceEndpoint);
 
-        // The custom_insert_values_components option is an object that allows us to
-        // specify a subquery to use when inserting data rather than the raw source
-        // value. If the destination column is present as a key in the object, use the
-        // subquery, otherwise use "?" as a placeholder. Note that the raw value will be
-        // provided to the subquery and it should contain a single "?" placeholder.
+        // The custom_insert_values_components option is an object that allows us to specify a
+        // subquery to use when inserting data rather than the raw source value. If the destination
+        // column is present as a key in the object, use the subquery, otherwise use "?" as a
+        // placeholder. Note that the raw value will be provided to the subquery and it should
+        // contain a single "?" placeholder.
         //
-        // NOTE: Null values will not overwrite non-null values in the database.
-        // This is done to handle destinations that can be populated by
-        // multiple sources with varying levels of detail.
+        // NOTE: Null values will not overwrite non-null values in the database. This is done to
+        // handle destinations that can be populated by multiple sources with varying levels of
+        // detail.
 
         $customInsertValuesComponents = $this->customInsertValuesComponents;
 
-        // The destination field map may specify that the same source field is mapped to
-        // multiple destination fields and the order that the source record fields is
-        // returned may be different from the order the fields were specified in the
-        // map. Maintain a mapping between source fields and the position (index) that
-        // they were specified in the map so we cam properly build the SQL parameter list.
+        // The destination field map may specify that the same source field is mapped to multiple
+        // destination fields and the order that the source record fields are returned may be
+        // different from the order the fields were specified in the map. For each destination
+        // table, maintain a mapping between the field position in the map (index) and the source
+        // fields so we cam properly build the SQL parameter list in the proper order. At the same
+        // time generate other data structures that will be needed later.
 
-        $sourceFieldIndexes = array();
+        $destinationFieldIdToSourceFieldMap = array();
 
-        foreach ( $this->etlDestinationTableList as $etlTableKey => $etlTable ) {
-            $destFieldToSourceFieldMap = $this->destinationFieldMappings[$etlTableKey];
+        // Templates for source field values containing pre-determined values such as variables or
+        // macros
+        $sourceFieldToValueMapTemplate = array();
+
+        // Scalar source fields that map to source fields
+        $simpleSourceFields = array();
+
+        // Complex source fields that must be evaluated by the source endpoint
+        $complexSourceFields = array();
+
+        // Variables or macros that will be substituted
+        $variableSourceFields = array();
+
+        // Iterate over the destination field mappings rather than the destination table list because it
+        // is possible that a table definition is provided but no data is mapped to it.
+
+        $this->logger->debug("Processing destination field map");
+
+        foreach ( $this->destinationFieldMappings as $etlTableKey => $destFieldToSourceFieldMap ) {
             $destinationFields = array_keys($destFieldToSourceFieldMap);
-            $sourceFieldIndexes[$etlTableKey] = array_values($destFieldToSourceFieldMap);
+
+            // Create a mapping from the source fields to the all of the destination field indexes
+            // they correspond to. At the same time, split the source fileds into lists of simple
+            // and complex fields.
+
+            $simpleSourceFields[$etlTableKey] = array();
+            $complexSourceFields[$etlTableKey] = array();
+            $variableSourceFields[$etlTableKey] = array();
+            $destinationFieldIdToSourceFieldMap[$etlTableKey] = array();
+
+            foreach ( array_values($destFieldToSourceFieldMap) as $index => $sourceField ){
+                $destinationFieldIdToSourceFieldMap[$etlTableKey][$index] = $sourceField;
+                if (
+                    $this->sourceEndpoint->supportsComplexDataRecords()
+                    && $this->sourceEndpoint->isComplexSourceField($sourceField)
+                ) {
+                    $complexSourceFields[$etlTableKey][] = $sourceField;
+                } elseif ( Utilities::containsVariable($sourceField) ) {
+                    $variableSourceFields[$etlTableKey][] = $sourceField;
+                } else {
+                    $simpleSourceFields[$etlTableKey][] = $sourceField;
+                }
+            }
 
             $valuesComponents = array_map(
                 function ($destField) use ($customInsertValuesComponents) {
@@ -135,11 +191,11 @@ class StructuredFileIngestor extends aIngestor implements iAction
                 $destinationFields
             );
 
-            // Generate one statement per destination table
+            // Generate one SQL statement per destination table
 
             $sql = sprintf(
                 'INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s',
-                $etlTable->getFullName(),
+                $this->etlDestinationTableList[$etlTableKey]->getFullName(),
                 implode(', ', $destinationFields),
                 implode(', ', $valuesComponents),
                 implode(', ', array_map(
@@ -151,7 +207,9 @@ class StructuredFileIngestor extends aIngestor implements iAction
             );
 
             try {
-                $this->logger->debug("Insert SQL: $sql");
+                $this->logger->debug(
+                    sprintf("Insert SQL for table key '%s':\n%s", $etlTableKey, $sql)
+                );
                 if ( ! $this->getEtlOverseerOptions()->isDryrun() ) {
                     $insertStatements[$etlTableKey] = $this->destinationHandle->prepare($sql);
                 }
@@ -161,41 +219,106 @@ class StructuredFileIngestor extends aIngestor implements iAction
                     array('exception' => $e, 'endpoint' => $this)
                 );
             }
+
+            // If there are source fields that are variables or macros, evaluate them once here and
+            // save them to a reusable template.
+
+            $sourceFieldToValueMapTemplate[$etlTableKey] = array();
+
+            if ( 0 != count($variableSourceFields[$etlTableKey]) ) {
+                foreach ( $variableSourceFields[$etlTableKey] as $variable ) {
+                    $sourceFieldToValueMapTemplate[$etlTableKey][$variable] =
+                        Utilities::substituteVariables($variable, $this->variableMap, $this);
+                }
+            }
         }
 
         if ( $this->getEtlOverseerOptions()->isDryrun() ) {
             return $numRecords;
         }
 
+        // When the destination field map is auto-generated, only scalar source fields are used. If
+        // the source data is complex (e.g., JSON) we may end up with some complex fields in the
+        // source record (e.g., JSON objects as stdClass). Obviously, these cannot be used in the
+        // SQL parameter list but checking each field of each source record will reduce ingest
+        // performance.  Perform a on the first record to provide some sanity checking.
+
+        $invalidSourceValues = array();
+
+        foreach ( $this->destinationFieldMappings as $etlTableKey => $destFieldToSourceFieldMap ) {
+            $parameters = $this->generateParametersFromSourceRecord(
+                $firstRecord,
+                $destinationFieldIdToSourceFieldMap[$etlTableKey],
+                $sourceFieldToValueMapTemplate[$etlTableKey],
+                $simpleSourceFields[$etlTableKey],
+                $complexSourceFields[$etlTableKey]
+            );
+
+            // Verify the parameters are scalars
+
+            foreach ( $parameters as $index => $value ) {
+                if ( ! is_scalar($value) ) {
+                    $sourcefield = $destinationFieldIdToSourceFieldMap[$etlTableKey][$index];
+                    $invalidSourceValues[$etlTableKey][$sourceField] = $value;
+                }
+            }
+        }
+
+        if ( 0 != count($invalidSourceValues) ) {
+            $this->logger->err(sprintf("First record:%s%s", PHP_EOL, print_r($firstRecord, true)));
+            $this->logAndThrowException(
+                sprintf(
+                    "Source record contains non-scalar values that cannot be used as SQL params. %s",
+                    implode('; ', array_map(
+                        function ($table, $invalidValues) {
+                            return sprintf(
+                                "Table '%s': %s",
+                                $table,
+                                implode(', ', array_map(
+                                    function ($k, $v) {
+                                        return sprintf("field '%s' = %s", $k, gettype($v));
+                                    },
+                                    array_keys($invalidValues),
+                                    $invalidValues
+                                ))
+                            );
+                        },
+                        array_keys($invalidSourceValues),
+                        $invalidSourceValues
+                    ))
+                )
+            );
+        }
+
         // Insert each source record. Note that the source record may be an array or an
         // object and must be Traversable.
 
         foreach ( $this->sourceEndpoint as $sourceRecord ) {
+
+            // The same source record may be used in multiple tables.
+
             foreach ( $this->destinationFieldMappings as $etlTableKey => $destFieldToSourceFieldMap ) {
 
-                $parameters = array();
-
-                // Build up the parameter list for the query. Note that the same source
-                // value may be used multiple times. The records returned from a
-                // StructuredFile endpoint will be Traversable as ($key, $value) pairs,
-                // however this does not mean that we can assume they can be treated as
-                // arrays (e.g., $sourceRecord[$sourceField]) because they may be objects
-                // or store data in private members that are exposed by the Iterator
-                // interface.
-
-                foreach ($sourceRecord as $sourceField => $sourceValue) {
-                    // Find all indexes that match the current source field
-                    $indexes = array_keys(array_intersect($sourceFieldIndexes[$etlTableKey], array($sourceField)));
-                    foreach ( $indexes as $i ) {
-                        $parameters[$i] = $sourceValue;
-                    }
-                }
+                $parameters = $this->generateParametersFromSourceRecord(
+                    $sourceRecord,
+                    $destinationFieldIdToSourceFieldMap[$etlTableKey],
+                    $sourceFieldToValueMapTemplate[$etlTableKey],
+                    $simpleSourceFields[$etlTableKey],
+                    $complexSourceFields[$etlTableKey]
+                );
 
                 try {
+                    // Some values of parameters are complex objects and cannot be! This is due to
+                    // the auto-generated field map.
                     $insertStatements[$etlTableKey]->execute($parameters);
                 } catch (PDOException $e) {
+                    $this->logger->debug(print_r($sourceRecord, true));
                     $this->logAndThrowException(
-                        "Error inserting data into table key '$etlTableKey' for record " . ( $numRecords + 1),
+                        sprintf(
+                            "Error inserting data into table key '%s' for record %s.",
+                            $etlTableKey,
+                            $this->sourceEndpoint->key()
+                        ),
                         array('exception' => $e, 'endpoint' => $this)
                     );
                 }
@@ -206,6 +329,64 @@ class StructuredFileIngestor extends aIngestor implements iAction
         return $numRecords;
 
     }  // _execute()
+
+    /**
+     * Build up a parameter list suitable for an SQL query. The parameters must be in the proper
+     * order as expected by the field list of the query (this mapping information is stored in
+     * $destinationFieldIdToSourceFieldMap). Note that the same source value may be used multiple
+     * times in the query.
+     *
+     * @param $sourceRecord The current record from the source endpoint (must be Traversable but
+     *   may not explicitly implement Traversable such as an array or stdClass)
+     * @param array $destinationFieldIdToSourceFieldMap A mapping between the parameter position
+     *   (index) in the SQL statement and the source fields so we cam properly build the SQL
+     *   parameter list in the correct order.
+     * @param array $sourceTemplate Templates for source field values containing pre-determined
+     *   values such as variables or macros.
+     * @param array $simpleSourceFields Scalar source fields that map to source fields.
+     * @param array $complexSourceFields Complex source fields that must be evaluated by the source
+     *   endpoint
+     *
+     * @return array A list of values to use as SQL parameters in the proper order corresponding
+     *   to the SQL query parameters.
+     */
+
+    private function generateParametersFromSourceRecord(
+        $sourceRecord,
+        array $destinationFieldIdToSourceFieldMap,
+        array $sourceTemplate,
+        array $simpleSourceFields,
+        array $complexSourceFields
+    ) {
+        $sourceFieldToValueMap = $sourceTemplate;
+
+        // Build up the parameter list for the query. Note that the same source value may be
+        // used multiple times.
+
+        foreach ($sourceRecord as $sourceField => $sourceValue) {
+            if ( in_array($sourceField, $simpleSourceFields) ) {
+                $sourceFieldToValueMap[$sourceField] = $sourceValue;
+            }
+        }
+
+        // If this source endpoint does not support complex fields this loop won't be
+        // processed because no fields will have been identified as complex.
+
+        foreach ( $complexSourceFields as $sourceField ) {
+            $sourceFieldToValueMap[$sourceField] =
+                $this->sourceEndpoint->evaluateComplexSourceField($sourceField, $sourceRecord);
+        }
+
+        // Map the values from the source record to the correct order in the parameter list
+
+        $parameters = array();
+        foreach ( $destinationFieldIdToSourceFieldMap as $index => $sourceField ) {
+            $parameters[$index] = $sourceFieldToValueMap[$sourceField];
+        }
+
+        return $parameters;
+
+    }  // generateParametersFromSourceRecord()
 
     /** -----------------------------------------------------------------------------------------
      * @see aIngestor::performPreExecuteTasks

--- a/classes/ETL/Ingestor/aIngestor.php
+++ b/classes/ETL/Ingestor/aIngestor.php
@@ -119,6 +119,10 @@ abstract class aIngestor extends aRdbmsDestinationAction
                 );
                 $this->variableMap = array_merge($this->variableMap, $localVariableMap);
 
+                $this->logger->debug(
+                    sprintf("Available Variables: %s", $this->getVariableMapDebugString())
+                );
+
                 $numRecordsProcessed = $this->_execute();
                 $totalRecordsProcessed += $numRecordsProcessed;
                 $intervalNum++;
@@ -158,5 +162,6 @@ abstract class aIngestor extends aRdbmsDestinationAction
      * ------------------------------------------------------------------------------------------
      */
 
+    // @codingStandardsIgnoreLine
     abstract protected function _execute();
 }  // abstract class aIngestor

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -801,6 +801,7 @@ class pdoIngestor extends aIngestor
 
                             ftruncate($outFdList[$etlTableKey], 0);
                             rewind($outFdList[$etlTableKey]);
+                            $numFilesLoaded++;
                         }
                         catch (Exception $e) {
                             $msg = array('message'    => $e->getMessage(),
@@ -850,6 +851,7 @@ class pdoIngestor extends aIngestor
 
                 fclose($outFdList[$etlTableKey]);
                 @unlink($infileList[$etlTableKey]);
+                $numFilesLoaded++;
 
             }  // foreach ( $loadStatementList as $etlTableKey => $loadStatement )
 

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -540,14 +540,13 @@ class pdoIngestor extends aIngestor
         // is possible that a table definition is provided but no data is mapped to it.
 
         foreach ( $this->destinationFieldMappings as $etlTableKey => $destFieldToSourceFieldMap ) {
+
+            // The destination map is parsed in aRdbmsDestinationAction::parseDestinationFieldMap()
+            // and any table with no mapping is not included. Keys are also verified to match a
+            // destionation table name.
+
             $etlTable = $this->etlDestinationTableList[$etlTableKey];
             $qualifiedDestTableName = $etlTable->getFullName();
-
-            // If there are no source query columns mapped to this table, skip it.
-
-            if ( 0 == count($destFieldToSourceFieldMap) ) {
-                continue;
-            }
 
             $infileName = tempnam(
                 sys_get_temp_dir(),

--- a/classes/ETL/JsonPointer.php
+++ b/classes/ETL/JsonPointer.php
@@ -1,0 +1,248 @@
+<?php
+/** -----------------------------------------------------------------------------------------
+ * Singleton class for implementing RFC 6901 JSON Pointers. Pointers allow us to extract individual
+ * fragments from a JSON document.
+ *
+ * @see https://tools.ietf.org/html/rfc6901
+ * @author Steve Gallo 2017-07-18
+ * ------------------------------------------------------------------------------------------
+ */
+
+namespace ETL;
+
+use Log;
+use Exception;
+
+class JsonPointer
+{
+    /**
+     * Character representing the last element of an array.
+     *
+     * @var string
+     */
+
+    const LAST_ARRAY_ELEMENT_CHAR = '-';
+
+    /**
+     * A JSON pointer must start with this character or be be an empty string.
+     *
+     * @var string
+     */
+
+    const POINTER_CHAR = '/';
+
+    /**
+     * An object extending Loggable that can be used to log error messages.
+     *
+     * @var Loggable
+     */
+
+    private static $loggable = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * This is a singleton class.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private function __construct()
+    {
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * Set the loggable object to use when logging.
+     *
+     * @param Loggable $loggable An object that has access to the logger, or NULL to unset the
+     *   logger.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function setLoggable(Loggable $loggable = null)
+    {
+        self::$loggable = $loggable;
+    }  // loggable()
+
+    /** -----------------------------------------------------------------------------------------
+     * Check to see if a string is a valid JSON pointer. Optionally verify that the first token is
+     * an expected value.
+     *
+     * @param string $pointer The pointer to validate.
+     * @param string $expectedFirstToken Optional first token for verification
+     *
+     * @return TRUE if the string is a valid JSON pointer (and optionally that the first token is
+     *   the expected token), FALSE otherwise.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function isValidPointer($pointer, $expectedFirstToken = null)
+    {
+        if ( '' !== $pointer && ! is_string($pointer) ) {
+            return false;
+        }
+
+        if ( '' !== $pointer && 0 !== strpos($pointer, self::POINTER_CHAR) ) {
+            return false;
+        }
+
+        if ( null !== $expectedFirstToken ) {
+            $firstToken = array_shift(
+                array_slice(array_map('urldecode', explode('/', $pointer)), 1)
+            );
+            return ( $firstToken == $expectedFirstToken );
+        }
+        return true;
+    }  // isValidPointer()
+
+    /** -----------------------------------------------------------------------------------------
+     * Return the first token (e.g., top level object property) of a valid JSON pointer.
+     *
+     * @param string $pointer The pointer to process.
+     *
+     * @return string The first token in the pointer or FALSE if the pointer was not valid.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function getFirstToken($pointer)
+    {
+        if ( ! static::isValidPointer($pointer) ) {
+            return false;
+        }
+
+        return array_shift(
+            array_slice(array_map('urldecode', explode('/', $pointer)), 1)
+        );
+
+    }  // getFirstToken()
+
+    /** -----------------------------------------------------------------------------------------
+     * Extract a JSON fragment from a document referenced by an RFC 6901 JSON pointer (see
+     * https://tools.ietf.org/html/rfc6901).
+     *
+     * @param mixed $json The JSON document string or a decoded JSON object
+     * @param string $pointer The JSON pointer
+     *
+     * @returns The portion of the JSON document referenced by the pointer
+     *
+     * @throws Exception if the pointer is invalid or if there is an error traversing the document.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function extractFragment($json, $pointer)
+    {
+        // Based in part on https://github.com/raphaelstolt/php-jsonpointer
+        // Replace with this package once we support PHP 5.4
+
+        if ( ! static::isValidPointer($pointer) ) {
+            return false;
+        }
+
+        $jsonObj = null;
+
+        if ( is_string($json) ) {
+            $jsonObj = json_decode($json);
+
+            if ( json_last_error() !== JSON_ERROR_NONE ) {
+                if ( null !== self::$loggable ) {
+                    self::$loggable->getLogger()->err('Invalid JSON');
+                }
+                return false;
+            }
+        } else {
+            $jsonObj = $json;
+        }
+
+        // An empty pointer references the entire document
+
+        if ( '' == $pointer ) {
+            return $jsonObj;
+        }
+
+        // Urldecode and extract the pointer after the '/'
+
+        $pointerParts = array_slice(array_map('urldecode', explode('/', $pointer)), 1);
+
+        // Convert encoded characters (see https://tools.ietf.org/html/rfc6901#section-3)
+
+        $parts = array();
+        array_filter(
+            $pointerParts,
+            function ($p) use (&$parts) {
+                return $parts[] = str_replace(array('~1', '~0'), array('/', '~'), $p);
+            }
+        );
+
+        return static::traverseJson($jsonObj, $pointer, $parts);
+
+    }  // extractFragment()
+
+    /* ------------------------------------------------------------------------------------------
+     * Recursively traverse the JSON document, looking for the portion that is referenced by
+     * the pointer.
+     *
+     * @param mixed $json The JSON document or a portion of the document
+     * @param string $pointer The full JSON pointer
+     * @param array $pointerParts An array containing the portions of the pointer that have
+     *   yet to be traversed.
+     *
+     * @returns The portion of the JSON document referenced by the pointer
+     *
+     * @throws Exception if the value referenced by the pointer does not exist in the document.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private static function traverseJson(&$json, $pointer, array $pointerParts)
+    {
+        $pointerPart = array_shift($pointerParts);
+
+        if ( is_array($json) && isset($json[$pointerPart]) ) {
+
+            if ( count($pointerParts) === 0 ) {
+                return $json[$pointerPart];
+            }
+
+            if ( (is_array($json[$pointerPart]) || is_object($json[$pointerPart])) && is_array($pointerParts) ) {
+                return static::traverseJson($json[$pointerPart], $pointer, $pointerParts);
+            }
+
+        } elseif ( is_object($json) && in_array($pointerPart, array_keys(get_object_vars($json))) ) {
+
+            if ( count($pointerParts) === 0 ) {
+                return $json->{$pointerPart};
+            }
+
+            if ( (is_object($json->{$pointerPart}) || is_array($json->{$pointerPart})) && is_array($pointerParts) ) {
+                return static::traverseJson($json->{$pointerPart}, $pointer, $pointerParts);
+            }
+
+        } elseif ( is_object($json) && empty($pointerPart) && array_key_exists('_empty_', get_object_vars($json)) ) {
+
+            $pointerPart = '_empty_';
+
+            if ( count($pointerParts) === 0 ) {
+                return $json->{$pointerPart};
+            }
+
+            if ( (is_object($json->{$pointerPart}) || is_array($json->{$pointerPart})) && is_array($pointerParts) ) {
+                return static::traverseJson($json->{$pointerPart}, $pointer, $pointerParts);
+            }
+
+        } elseif ( $pointerPart === self::LAST_ARRAY_ELEMENT_CHAR && is_array($json) ) {
+            return end($json);
+        } elseif ( is_array($json) && count($json) < $pointerPart ) {
+            // Do nothing, let Exception bubble up
+        } elseif ( is_array($json) && array_key_exists($pointerPart, $json) && $json[$pointerPart] === null ) {
+            return $json[$pointerPart];
+        }
+
+        if ( null !== self::$loggable ) {
+            self::$loggable->getLogger()->warning(
+                sprintf("JSON pointer '%s' references a nonexistent value", $pointer)
+            );
+        }
+
+        // Throw an exception rather than returning NULL or FALSE because both of those are valid
+        // JSON values.
+
+        throw new Exception(sprintf("JSON pointer '%s' references a nonexistent value", $pointer));
+
+    } // traverseJson()
+}  // class JsonPointer

--- a/classes/ETL/Loggable.php
+++ b/classes/ETL/Loggable.php
@@ -50,6 +50,20 @@ class Loggable
     }  // setLogger()
 
     /* ------------------------------------------------------------------------------------------
+     * Set the logger for this object.
+     *
+     * @param Log $logger A logger class
+     *
+     * @return This object for method chaining.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getLogger()
+    {
+        return $this->logger;
+    }  // getLogger()
+
+    /* ------------------------------------------------------------------------------------------
      * Helper function to log errors in a consistent format and provide a mechanism to
      * supply additional, optional, parameters for greater detail.
      *
@@ -70,7 +84,7 @@ class Loggable
     public function logAndThrowException($message, array $options = null)
     {
         $logMessage = array();
-        $message = "{$this}: " . ( is_string($message) ? "'$message'" : "''" );
+        $message = "{$this}: " . ( is_string($message) ? $message : "" );
         $logLevel = PEAR_LOG_ERR;
 
         if ( null !== $options ) {

--- a/classes/ETL/Maintenance/ExecuteSql.php
+++ b/classes/ETL/Maintenance/ExecuteSql.php
@@ -244,7 +244,7 @@ class ExecuteSql extends aAction implements iAction
                 } catch ( PDOException $e ) {
                     $this->logAndThrowException(
                         "Error executing SQL",
-                        array('exception' => $e, 'sql' => $this->sqlQueryString, 'endpoint' => $this->sourceEndpoint)
+                        array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->sourceEndpoint)
                     );
                 }
 

--- a/classes/ETL/Utilities.php
+++ b/classes/ETL/Utilities.php
@@ -31,6 +31,21 @@ class Utilities
         self::$etlConfig = $config;
     }  // setEtlConfig
 
+    /**
+     * Determine if a string contains a variable or macro.  A variable or macro is a string wrapped
+     * in ${}. For example, ${RESOURCE}.
+     *
+     * *
+     * @param string $string The string to check
+     *
+     * @return boolean TRUE if $string contains a variable or macro.
+     */
+
+    public static function containsVariable($string)
+    {
+        return 1 === preg_match('/\$\{.+\}/', $string);
+    }  // containsVariable()
+
     /* ------------------------------------------------------------------------------------------
      * Perform variable/macro substitution on a string using a variable map. The map keys
      * are the names of the variables WITHOUT the ${} wrapper (e.g., a key of 'SCHEMA'

--- a/classes/ETL/aOptions.php
+++ b/classes/ETL/aOptions.php
@@ -55,7 +55,7 @@ abstract class aOptions extends \stdClass implements \Iterator
         "description" => null,
 
         // TRUE if this aggregator is enabled
-        "enabled" => false,
+        "enabled" => true,
 
         // Object containing path information for the various directories used by the ETL process (table
         // configs, data, etc.)

--- a/classes/ETL/aRdbmsDestinationAction.php
+++ b/classes/ETL/aRdbmsDestinationAction.php
@@ -24,8 +24,8 @@ use ETL\Configuration\EtlConfiguration;
 use ETL\DataEndpoint\iDataEndpoint;
 use ETL\DataEndpoint\iRdbmsEndpoint;
 use ETL\aOptions;
-use ETL\DbModel\Table;
 
+use ETL\DbModel\Table;
 use PHPSQLParser\PHPSQLParser;
 
 use Exception;
@@ -199,41 +199,45 @@ abstract class aRdbmsDestinationAction extends aAction
     }  // createDestinationTableObjects()
 
     /** -----------------------------------------------------------------------------------------
-     * Parse and verify the mapping between source record fields and destination table
-     * fields. If a mapping has not been provided, generate one automatically. The
-     * destination field map specifies a mapping from source record fields to destination
-     * table fields for one or more destination tables.
+     * Parse and verify the mapping between source record fields and destination table fields. If a
+     * mapping has not been provided, generate one automatically. The destination field map
+     * specifies a mapping from source record fields to destination table fields for one or more
+     * destination tables.
      *
      * Use Cases:
      *
      * 1. There are >= 1 destination tables and no destination field map
      *
-     * Automatically create the destination field map by mapping source fields to
-     * destination table fields **where the fields match, excluding non-matching fields.**
-     * Log a warning for any fields that do not match.
+     * Automatically create the destination field map by mapping source fields to destination table
+     * fields **where the fields match, excluding non-matching fields.** Log a warning for any
+     * fields that do not match.
      *
      * 2. There are >= 1 destination tables and a destination field map is specified.
      *
-     * Verify that the destination fields specified in the mapping are valid fields for
-     * the destination table that they references. Also verify that the source fields are
-     * valid. It is not required that all source fields are mapped to destination fields
-     * but care should be exercised that resonable defaults are specified in the table
-     * definitions.
+     * Verify that the destination fields specified in the mapping are valid fields for the
+     * destination table that they reference. Also verify that the source fields are valid (and at
+     * least 1 source field exists). It is not required that all source fields are mapped to
+     * destination fields but care should be exercised that resonable defaults are specified in the
+     * table definitions.
      *
      * @param array An array containing the fields available from the source record
+     * @param iDataEndpoint $sourceEndpoint Optional source endpoint used to validate values
      *
-     * @return array | null A 2-dimensional array where the keys match etl table
-     *   definitions and values map table columns (destination) to query result columns
-     *   (source), or null if no destination record map was specified.
+     * @return array | null A 2-dimensional array where the keys match etl table definitions and
+     *   values map table columns (destination) to query result columns (source), or null if no
+     *   destination record map was specified.
      * ------------------------------------------------------------------------------------------
      */
 
-    protected function parseDestinationFieldMap(array $sourceFields)
-    {
+    protected function parseDestinationFieldMap(
+        array $sourceFields,
+        iDataEndpoint $sourceEndpoint = null
+    ) {
         $this->destinationFieldMappings = array();
 
         if ( ! isset($this->parsedDefinitionFile->destination_record_map) ) {
 
+            $this->logger->debug("No destination_field_map specified");
             $this->destinationFieldMappings = $this->generateDestinationFieldMap($sourceFields);
 
         } elseif ( ! is_object($this->parsedDefinitionFile->destination_record_map) ) {
@@ -246,12 +250,17 @@ abstract class aRdbmsDestinationAction extends aAction
 
                 if ( ! is_object($fieldMap) ) {
                     $this->logAndThrowException(
-                        sprintf("destination_record_map for table '%s' must be an object", $etlTableKey)
+                        sprintf("destination_record_map for table key '%s' must be an object", $etlTableKey)
                     );
                 } elseif ( 0 == count(array_keys((array) $fieldMap)) ) {
                     $this->logger->warning(
-                        sprintf("%s: destination_record_map for table '%s' is empty", $this, $etlTableKey)
+                        sprintf(
+                            "%s: destination_record_map for table key '%s' is empty, skipping.",
+                            $this,
+                            $etlTableKey
+                        )
                     );
+                    continue;
                 }
 
                 // Convert the field map from an object to an associative array where keys
@@ -263,7 +272,7 @@ abstract class aRdbmsDestinationAction extends aAction
 
         $success = true;
         $success &= $this->verifyDestinationMapKeys();
-        $success &= $this->verifyDestinationMapValues($sourceFields);
+        $success &= $this->verifyDestinationMapSourceFields($sourceFields, $sourceEndpoint);
 
         return $success;
 
@@ -285,16 +294,23 @@ abstract class aRdbmsDestinationAction extends aAction
     protected function generateDestinationFieldMap(array $sourceFields)
     {
         $destinationFieldMap = array();
-        $fieldMapDebugOutput = '';
+        $fieldMapDebugOutput = array();
         $numSourceFields = count($sourceFields);
 
         $this->logger->debug(
             sprintf(
-                "Auto-generating destination_field_map from %d source fields: %s",
+                "Auto-generating destination_field_map using %d source fields: %s",
                 $numSourceFields,
                 implode(', ', $sourceFields)
             )
         );
+
+        // If there are no source fields then we have no data to map.
+
+        if ( 0 == $numSourceFields ) {
+            $this->logger->debug("No source record fields, creating empty destination field map");
+            return $destinationFieldMap;
+        }
 
         foreach ( $this->etlDestinationTableList as $etlTableKey => $etlTable ) {
 
@@ -304,21 +320,26 @@ abstract class aRdbmsDestinationAction extends aAction
                 sprintf("Available fields for table key '%s': %s", $etlTableKey, implode(', ', $availableTableFields))
             );
 
-            if ( 0 == $numSourceFields ) {
-                $destinationFieldMap[$etlTableKey] = array();
-                continue;
-            }
-
             // Map common fields and log warnings for fields that are not mapped
 
             $commonFields = array_intersect($availableTableFields, $sourceFields);
             $unmappedSourceFields = array_diff($sourceFields, $availableTableFields);
 
+            // If there were no common fields between the source record and destination table,
+            // don't bother creating a map for this table.
+
+            if ( 0 == count($commonFields) ) {
+                $this->logger->warning(
+                    sprintf("No source fields match available fields for table key '%s', skipping.", $etlTableKey)
+                );
+                continue;
+            }
+
             $destinationFieldMap[$etlTableKey] = array_combine($commonFields, $commonFields);
 
             // Generate a more succinct representation of the field map
 
-            $fieldMapDebugOutput .= sprintf(
+            $fieldMapDebugOutput[] = sprintf(
                 "Table: %s%s",
                 $etlTableKey,
                 array_reduce(
@@ -334,8 +355,9 @@ abstract class aRdbmsDestinationAction extends aAction
             if ( 0 != count($unmappedSourceFields) ) {
                 $this->logger->warning(
                     sprintf(
-                        "%s: The following source record fields were not mapped for table '%s': (%s)",
+                        "%s: The following %d source record fields were not mapped for table '%s': (%s)",
                         $this,
+                        count($unmappedSourceFields),
                         $etlTableKey,
                         implode(', ', $unmappedSourceFields)
                     )
@@ -343,19 +365,9 @@ abstract class aRdbmsDestinationAction extends aAction
             }
         }
 
-        if ( 0 == count($sourceFields) ) {
-            $this->logger->debug(
-                sprintf(
-                    "Generated empty destination_field_map for table keys: %s",
-                    implode(', ', array_keys($destinationFieldMap))
-                )
-            );
-
-        } else {
-            $this->logger->debug(
-                sprintf("Generated destination_field_map:\n%s", $fieldMapDebugOutput)
-            );
-        }
+        $this->logger->debug(
+            sprintf("Generated destination_field_map:\n%s", implode(PHP_EOL, $fieldMapDebugOutput))
+        );
 
         return $destinationFieldMap;
 
@@ -384,11 +396,13 @@ abstract class aRdbmsDestinationAction extends aAction
         $undefinedFields = array();
 
         foreach ( $this->destinationFieldMappings as $etlTableKey => $destinationTableMap ) {
+
             if ( ! array_key_exists($etlTableKey, $this->etlDestinationTableList) ) {
                 $this->logAndThrowException(
-                    sprintf("Unknown table '%s' referenced in destination_record_map", $etlTableKey)
+                    sprintf("Unknown table key '%s' referenced in destination_record_map", $etlTableKey)
                 );
             }
+
             $availableTableFields = $this->etlDestinationTableList[$etlTableKey]->getColumnNames();
             // Remember that the keys in the field map are table field names
             $destinationTableFields = array_keys($destinationTableMap);
@@ -422,6 +436,7 @@ abstract class aRdbmsDestinationAction extends aAction
      * destination table fields. The values in the map must be valid source record fields.
      *
      * @param array An array containing the fields available from the source record
+     * @param iDataEndpoint $sourceEndpoint Optional source endpoint used to validate values
      *
      * @return bool TRUE on success
      *
@@ -429,8 +444,10 @@ abstract class aRdbmsDestinationAction extends aAction
      * ------------------------------------------------------------------------------------------
      */
 
-    protected function verifyDestinationMapValues(array $sourceFields)
-    {
+    protected function verifyDestinationMapSourceFields(
+        array $sourceFields,
+        iDataEndpoint $sourceEndpoint = null
+    ) {
         $undefinedFields = array();
 
         foreach ( $this->destinationFieldMappings as $etlTableKey => $destinationTableMap ) {
@@ -438,9 +455,28 @@ abstract class aRdbmsDestinationAction extends aAction
                 $this->logAndThrowException(
                     sprintf("Unknown table '%s' referenced in destination_record_map", $etlTableKey)
                 );
+
             }
 
-            $missing = array_diff($destinationTableMap, $sourceFields);
+            // By default, we verify that the source fields specified in the destination map are
+            // present in the fields provided by the source records (this is not automated for RDBMS
+            // endpoints yet). Endpoints that support complex data records perform their own
+            // validation of the source fields in the destination field map.
+
+            if ( null !== $sourceEndpoint && $sourceEndpoint->supportsComplexDataRecords() ) {
+                $missing = $sourceEndpoint->validateDestinationMapSourceFields($destinationTableMap);
+            } else {
+                $missing = array_diff($destinationTableMap, $sourceFields);
+            }
+
+            // Allow the destination map values (source fields) to contain variables.
+
+            $missing = array_filter(
+                $missing,
+                function ($item) {
+                    return ! Utilities::containsVariable($item);
+                }
+            );
 
             if ( 0  != count($missing) ) {
                 $missing = array_map(
@@ -453,7 +489,7 @@ abstract class aRdbmsDestinationAction extends aAction
                 $undefinedFields[] = sprintf(
                     "Table '%s' has undefined source query fields for keys (%s)",
                     $etlTableKey,
-                    implode(",", $missing)
+                    implode(', ', $missing)
                 );
             }
 
@@ -470,7 +506,7 @@ abstract class aRdbmsDestinationAction extends aAction
 
         return true;
 
-    }  // verifyDestinationMapValues()
+    }  // verifyDestinationMapSourceFields()
 
     /** -----------------------------------------------------------------------------------------
      * Truncate records from the destination table. Note that
@@ -696,7 +732,8 @@ abstract class aRdbmsDestinationAction extends aAction
     } // parseSql()
 
     /** -----------------------------------------------------------------------------------------
-     * Parse an SQL SELECT statement and return the fields (columns) that are being queried.
+     * Parse an SQL SELECT statement and return the fields (columns) that are being queried. It is
+     * expected that the order of the column names is the same as they appear in the query.
      * @see https://code.google.com/p/php-sql-parser/
      *
      * @param string $sql The SQL statement to parse

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/DirectoryScannerTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/DirectoryScannerTest.php
@@ -51,7 +51,7 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
             'recursion_depth' => '2',
             'last_modified_start' => 10,
             'last_modified_end' => 10,
-            'handlers' => (object) array (
+            'handler' => (object) array(
                 'type' => 'jsonfile',
                 'record_separator' => "\n"
             )
@@ -73,11 +73,9 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
             'name' => 'Not a directory',
             'type' => 'directoryscanner',
             'path' => '/dev/null',
-            'handlers' => array(
-                (object) array (
-                    'type' => 'jsonfile',
-                    'record_separator' => "\n"
-                )
+            'handler' => (object) array(
+                'type' => 'jsonfile',
+                'record_separator' => "\n"
             )
         );
         $options = new DataEndpointOptions($config);
@@ -97,11 +95,9 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
             'name' => 'Euca files',
             'type' => 'directoryscanner',
             'path' => self::TEST_ARTIFACT_INPUT_PATH . '/directory_scanner',
-            'handlers' => array(
-                (object) array (
-                    'type' => 'jsonfile',
-                    'record_separator' => "\n"
-                )
+            'handler' => (object) array(
+                'type' => 'jsonfile',
+                'record_separator' => "\n"
             )
         );
         $options = new DataEndpointOptions($config);
@@ -109,9 +105,11 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
         $scanner->verify();
         $scanner->connect();
 
-        // The directory isn't scanned until we iterate over it.
+        // The directory is scanned when connect() is called but each file isn't processed
+        // until we iterate over it.
 
         foreach ( $scanner as $key => $val ) {
+            $this->logger->info($key);
         }
 
         // One file in the directory contains no data.
@@ -135,12 +133,10 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
             'path' => self::TEST_ARTIFACT_INPUT_PATH,
             'directory_pattern' => '/_scanner/',
             'file_pattern' => '/euca.*\.json/',
-            'handlers' => array(
-                (object) array (
-                    'extension' => '.json',
-                    'type' => 'jsonfile',
-                    'record_separator' => "\n"
-                )
+            'handler' => (object) array(
+                'extension' => '.json',
+                'type' => 'jsonfile',
+                'record_separator' => "\n"
             )
         );
         $options = new DataEndpointOptions($config);
@@ -148,7 +144,9 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
         $scanner->verify();
         $scanner->connect();
 
-        // The directory isn't scanned until we iterate over it.
+        // The directory is scanned when connect() is called but each file isn't processed
+        // until we iterate over it.
+
         foreach ( $scanner as $key => $val ) {
         }
 
@@ -181,12 +179,10 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
             'file_pattern' => '/euca.*\.json/',
             'last_modified_start' => $startDate,
             'last_modified_end' => $endDate,
-            'handlers' => array(
-                (object) array (
-                    'extension' => '.json',
-                    'type' => 'jsonfile',
-                    'record_separator' => "\n"
-                )
+            'handler' => (object) array(
+                'extension' => '.json',
+                'type' => 'jsonfile',
+                'record_separator' => "\n"
             )
         );
         $options = new DataEndpointOptions($config);
@@ -194,7 +190,9 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
         $scanner->verify();
         $scanner->connect();
 
-        // The directory isn't scanned until we iterate over it.
+        // The directory is scanned when connect() is called but each file isn't processed
+        // until we iterate over it.
+
         foreach ( $scanner as $key => $val ) {
         }
 

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/JsonPointer/JsonPointerTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/JsonPointer/JsonPointerTest.php
@@ -1,0 +1,78 @@
+<?php
+/* ------------------------------------------------------------------------------------------
+ * Component tests for ETL JSON configuration files
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ * @date 2017-04-21
+ * ------------------------------------------------------------------------------------------
+ */
+
+namespace UnitTesting\ETL\Configuration;
+
+use CCR\Log;
+use ETL\JsonPointer;
+use ETL\Loggable;
+
+class JsonPointerTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_INPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/etlv2/dbmodel/output";
+    private $logger = null;
+
+    public function __construct()
+    {
+        // Set up a logger so we can get warnings and error messages from the ETL
+        // infrastructure
+        $conf = array(
+            'file' => false,
+            'db' => false,
+            'mail' => false,
+            'consoleLogLevel' => Log::WARNING
+        );
+        $this->logger = Log::factory('PHPUnit', $conf);
+    }
+
+    /**
+     * Test various JSON pointers.
+     */
+
+    public function testJsonPointer()
+    {
+        $file = self::TEST_ARTIFACT_INPUT_PATH . DIRECTORY_SEPARATOR . 'sample_config.json';
+        $fileContents = file_get_contents($file);
+        $json = json_decode($fileContents);
+
+        $jsonPointer = new JsonPointer($this->logger);
+
+        // Whole document
+        $pointer = '';
+        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $this->assertEquals($json, $generated);
+
+        // Scalar value
+        $pointer = '/key_one/name';
+        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $this->assertEquals($json->key_one->name, $generated);
+
+        // Object value
+        $pointer = '/key_one';
+        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $this->assertEquals($json->key_one, $generated);
+
+        // Array value
+        $pointer = '/key_two';
+        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $this->assertEquals($json->key_two, $generated);
+
+        // First element of an array
+        $pointer = '/key_two/0';
+        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $this->assertEquals($json->key_two[0], $generated);
+
+        // Last element of an array
+        $pointer = '/key_two/-';
+        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $this->assertEquals(end($json->key_two), $generated);
+
+    }  // testJsonPointer()
+} // class JsonPointerTest

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/JsonPointer/JsonPointerTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/JsonPointer/JsonPointerTest.php
@@ -42,36 +42,34 @@ class JsonPointerTest extends \PHPUnit_Framework_TestCase
         $fileContents = file_get_contents($file);
         $json = json_decode($fileContents);
 
-        $jsonPointer = new JsonPointer($this->logger);
-
         // Whole document
         $pointer = '';
-        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $generated = JsonPointer::extractFragment($fileContents, $pointer);
         $this->assertEquals($json, $generated);
 
         // Scalar value
         $pointer = '/key_one/name';
-        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $generated = JsonPointer::extractFragment($fileContents, $pointer);
         $this->assertEquals($json->key_one->name, $generated);
 
         // Object value
         $pointer = '/key_one';
-        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $generated = JsonPointer::extractFragment($fileContents, $pointer);
         $this->assertEquals($json->key_one, $generated);
 
         // Array value
         $pointer = '/key_two';
-        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $generated = JsonPointer::extractFragment($fileContents, $pointer);
         $this->assertEquals($json->key_two, $generated);
 
         // First element of an array
         $pointer = '/key_two/0';
-        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $generated = JsonPointer::extractFragment($fileContents, $pointer);
         $this->assertEquals($json->key_two[0], $generated);
 
         // Last element of an array
         $pointer = '/key_two/-';
-        $generated = $jsonPointer->extractFragment($fileContents, $pointer);
+        $generated = JsonPointer::extractFragment($fileContents, $pointer);
         $this->assertEquals(end($json->key_two), $generated);
 
     }  // testJsonPointer()


### PR DESCRIPTION
Support references into complex source records such as JSON objects, improve verification of ETLv2 configuration files, add support for ETL variables in source fields.

## Description

### Complex Source Records

Structured file endpoints may support complex data records where the value of a field is not a
scalar but an array or an object (e.g., a JSON object). These require a method for handling complex
records and addressing individual fields within those records during the ingest process. Source
field names specified in an action's destination field map may be simple scalars (e.g., simply the
name of the source field) or references to data with a complex record with a format that is specific
to the particular endpoint (e.g., JSON pointers for referencing data in a JSON object). The `DirectoryScanner` endpoint is configurable and can use **any** StructuredFile endpoint as a
handler to process files that it discovers.  Therefore, it must be able to proxy support for complex source records to the handler.

While the implementation will be specific to the endpoint, one use case is a JSON object as a source
record. In this case, we support using a JSON pointer to reference data fields inside of an object.
For example, given the source record

```
{
    "id": "887233-bya",
    "instance_type": {
        "name": "m1.medium",
        "num_cores": 8
    }
}
```

we can specify scalar fields in the object root and use JSON pointers to reference data within nested
objects

```
"destination_field_map": {
    "instance_types": {
        "id": "instance_id",
        "name": "/instance_type/name",
        "num_cores": "/instace_type/cpu"
    }
}
```
### Improve verification of ETLv2 configuration files

The field list for the INSERT must be in the same order as the fields returned by the query or we will get field mismatches. Use the source record fields (generated from the source query in initialize()) as the correct order. Since the destination field map may have been user-specified we cannot guarantee the order.

### ETL variables in source fields

We now support ETL variables as source data. For example, to set the resource_id to the value of the ${RESOURCE_ID} variable:

```
"destination_field_map": {
    "instance_types": {
        "id": "instance_id",
        "resource_id": "${RESOURCE_ID}",
        "name": "/instance_type/name",
        "num_cores": "/instace_type/cpu"
    }
}
```
## Motivation and Context

Need a clean way for data endpoints to allow support for accessing data in complex data records.

## Tests performed

Ran unit tests and ingestion for XDMoD-VA, Resource Allocations, common job tables, and XSEDE jobs data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
