### PR TITLE
Fix ETL overseer exit status

### DIFF
--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -254,27 +254,21 @@ class EtlOverseer extends Loggable implements iEtlOverseer
         // initialization may need to connect to a data endpoint to obtain the handle so these need
         // to be done first.
 
-        try {
-            if ( ! $this->verifiedDataEndpoints ) {
-                $leaveConnected = ( $this->etlOverseerOptions->isDryrun() ? false : true );
-                $this->verifyDataEndpoints($etlConfig, $leaveConnected);
-            }
+        if ( ! $this->verifiedDataEndpoints ) {
+            $leaveConnected = ( $this->etlOverseerOptions->isDryrun() ? false : true );
+            $this->verifyDataEndpoints($etlConfig, $leaveConnected);
+        }
 
-            // Verify actions that were specified directly on the command line
-            $actionNames = $this->etlOverseerOptions->getActionNames();
-            if ( count($actionNames) > 0 ) {
-                $this->standaloneActions = $this->verifyActions($etlConfig, $actionNames);
-            }
+        // Verify actions that were specified directly on the command line
+        $actionNames = $this->etlOverseerOptions->getActionNames();
+        if ( count($actionNames) > 0 ) {
+            $this->standaloneActions = $this->verifyActions($etlConfig, $actionNames);
+        }
 
-            // Verify sections that were specified as part of a pipeline
-            $sectionNames = $this->etlOverseerOptions->getSectionNames();
-            if ( count($sectionNames) > 0 ) {
-                $this->sectionActions = $this->verifySections($etlConfig, $sectionNames);
-            }
-        } catch ( Exception $e ) {
-            $msg = get_class($this) . ": Verification error: " . $e->getMessage();
-            $this->logger->err($msg);
-            return;
+        // Verify sections that were specified as part of a pipeline
+        $sectionNames = $this->etlOverseerOptions->getSectionNames();
+        if ( count($sectionNames) > 0 ) {
+            $this->sectionActions = $this->verifySections($etlConfig, $sectionNames);
         }
 
         // Generate a list of individual actions that will be executed so we can store them in the

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -398,7 +398,10 @@ try {
     $etlConfig->setLogger($logger);
     $etlConfig->initialize();
 } catch ( Exception $e ) {
-    exit($e->getMessage() . "\n". $e->getTraceAsString() . "\n");
+    $msg = sprintf("%s%s%s", $e->getMessage(), PHP_EOL, $e->getTraceAsString());
+    $logger->err($msg);
+    fwrite(STDERR, $msg . PHP_EOL);
+    exit(1);
 }
 
 Utilities::setEtlConfig($etlConfig);
@@ -421,8 +424,10 @@ if ( count($scriptOptions['process-sections']) > 0 ) {
     }
 
     if ( count($missing) > 0 ) {
-        fwrite(STDERR, "Unknown sections: " . implode(", ", $missing) . "\n");
-        exit();
+        $msg = sprintf("Unknown sections: %s", implode(", ", $missing));
+        $logger->err($msg);
+        fwrite(STDERR, $msg . PHP_EOL);
+        exit(1);
     }
 }  // if ( count($scriptOptions['process-sections'] > 0) )
 
@@ -430,9 +435,15 @@ if ( count($scriptOptions['process-sections']) > 0 ) {
 // List any requested resources. After listing, exit.
 
 if ( false === ($utilityEndpoint = $etlConfig->getGlobalEndpoint('utility')) ) {
-    $msg = "Global utility endpoint not defined, cannot query database for resource code mapping";
-    exit("$msg\n". $e->getTraceAsString() . "\n");
-    throw new Exception($msg);
+    $msg = sprintf(
+        "%s%s%s",
+        "Global utility endpoint not defined, cannot query database for resource code mapping",
+        PHP_EOL,
+        $e->getTraceAsString()
+    );
+    $logger->err($msg);
+    fwrite(STDERR, $msg . PHP_EOL);
+    exit(1);
 }
 $utilitySchema = $utilityEndpoint->getSchema();
 
@@ -455,7 +466,10 @@ if ( $showList ) {
                 try {
                     $result = $utilityEndpoint->getHandle()->query($sql);
                 } catch (Exception $e) {
-                    exit($e->getMessage() . "\n". $e->getTraceAsString() . "\n");
+                    $msg = sprintf("%s%s%s", $e->getMessage(), PHP_EOL, $e->getTraceAsString());
+                    $logger->err($msg);
+                    fwrite(STDERR, $msg . PHP_EOL);
+                    exit(1);
                 }
                 $headings = array("Resource Code","Start Date","End Date");
                 print implode(LIST_SEPARATOR, $headings) . "\n";
@@ -550,7 +564,7 @@ if ( $showList ) {
                 break;
         }
     }
-    exit();
+    exit(0);
 }  // if ( $showList )
 
 // ------------------------------------------------------------------------------------------
@@ -560,7 +574,10 @@ if ( $showList ) {
 try {
     $result = $utilityEndpoint->getHandle()->query("SELECT id, code from {$utilitySchema}.resourcefact");
 } catch (Exception $e) {
-    exit($e->getMessage() . "\n". $e->getTraceAsString() . "\n");
+    $msg = sprintf("%s%s%s", $e->getMessage(), PHP_EOL, $e->getTraceAsString());
+    $logger->err($msg);
+    fwrite(STDERR, $msg . PHP_EOL);
+    exit(1);
 }
 $scriptOptions['resource-code-map'] = array();
 
@@ -571,7 +588,10 @@ foreach ( $result as $row ) {
 try {
     $overseerOptions = new EtlOverseerOptions($scriptOptions, $logger);
 } catch ( Exception $e ) {
-    exit($e->getMessage() . "\n". $e->getTraceAsString() . "\n");
+    $msg = sprintf("%s%s%s", $e->getMessage(), PHP_EOL, $e->getTraceAsString());
+    $logger->err($msg);
+    fwrite(STDERR, $msg . PHP_EOL);
+    exit(1);
 }
 
 // If nothing was requested, exit.
@@ -590,14 +610,19 @@ if ( count($scriptOptions['process-sections']) == 0 &&
 $overseer = new EtlOverseer($overseerOptions, $logger);
 if ( ! ($overseer instanceof iEtlOverseer ) )
 {
-    $msg = "EtlOverseer is not an instance of iEtlOverseer";
-    exit($msg);
+    $msg = sprintf("EtlOverseer (%s) is not an instance of iEtlOverseer", get_class($overseer));
+    $logger->err($msg);
+    fwrite(STDERR, $msg . PHP_EOL);
+    exit(1);
 }
 
 try {
     $overseer->execute($etlConfig);
 } catch ( Exception $e ) {
-    exit($e->getMessage() . "\n" . $e->getTraceAsString() . "\n");
+    $msg = sprintf("%s%s%s", $e->getMessage(), PHP_EOL, $e->getTraceAsString());
+    $logger->err($msg);
+    fwrite(STDERR, $msg . PHP_EOL);
+    exit(1);
 }
 
 // NOTE: "process_end_time" is needed for log summary."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When calling `exit()` with a string you cannot also return an exit status of 1. Log and write errors to `STDERR` and call `exit(1)` to indicate a failure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
Tested with and without JSON syntax errors during action verification.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
