### PR TITLE
Regenerate source query string prior to execute

### DIFF
--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -688,11 +688,14 @@ class EtlConfiguration extends Configuration
         // Set up the options with whatever was included in the config. The factory and implementation
         // classes will check for required parameters.
 
-        // Register the endpoints. Endpoints are global and only one endpoint will be created for each
-        // unique key. We need to register the endpoints first because the actions will need the keys
-        // when they are executed.
+        // Actions are enabled by default and do not require the "enabled" key, but it may still be
+        // specified in the config.
 
-        if ( $config->enabled ) {
+        if ( ! isset($config->enabled) || $config->enabled ) {
+
+            // Register the endpoints. Endpoints are global and only one endpoint will be created
+            // for each unique key. We need to register the endpoints first because the actions will
+            // need the keys when they are executed.
 
             $endpointKey = self::DATA_ENDPOINT_KEY;
             foreach ($config->$endpointKey as $endpointName => $endpointConfig) {
@@ -722,7 +725,7 @@ class EtlConfiguration extends Configuration
                 }
             }
         } else {
-            // For actions that are not configured, set minimal information needed for listing actions
+            // For actions that are not enabled, set minimal information needed for listing actions
             $options->enabled = false;
             $options->name = $config->name;
             if ( isset($config->description) ) {


### PR DESCRIPTION
Always regenerate source query string prior to execute to ensure modified ETL variables are properly applied.

## Description

The Google SQL parser does not handle complex queries well so we need the ability to specify the source record fields in a child class that overrides `pdoIngestor::getSourceQueryString()` to set the query string. In addition, if the query defined in `getSourceQueryString()` makes use of ETL variables/macros, those variables must be re-applied prior to each execution. For example, if we are chunking a ingestion long period into year chunks.

Also ensure that the data endpoints are registered for actions that are not explicitly marked as enabled (now that actions are enabled by default).

## Motivation and Context

Required to support Science Gateways data ingestion.

## Tests performed

Ingested Science Gateway data:

```
./etl_overseer.php -c ../../../etc/etl/etl.json -p science-gateway -s '2009-10-15' -e now -k year  -v debug
```

Verified resource allocations data

```
./etl_overseer.php -c ../../../etc/etl/etl.json -v debug -p resource-allocations -o "truncate_destination=true" -o "experimental_enable_batch_aggregation=true"
../dev/verify_table_data.php -s modw_ra -d modw_ra_etltest -n 1 -v info -t resource_allocations
2017-09-07 11:42:25 [notice] Compare tables src=modw_ra.resource_allocations, dest=modw_ra_etltest.resource_allocations
2017-09-07 11:42:25 [info] 10 columns
2017-09-07 11:42:25 [info] Row counts: modw_ra.resource_allocations = 480; modw_ra_etltest.resource_allocations = 480
2017-09-07 11:42:25 [notice] Identical
../dev/verify_table_data.php -s modw_aggregates -d modw_ra_etltest -n 1 -v info -t resourceallocationfact_by_quarter -t resourceallocationfact_by_year
2017-09-07 11:43:25 [notice] Compare tables src=modw_aggregates.resourceallocationfact_by_quarter, dest=modw_ra_etltest.resourceallocationfact_by_quarter
2017-09-07 11:43:25 [info] 11 columns
2017-09-07 11:43:25 [info] Row counts: modw_aggregates.resourceallocationfact_by_quarter = 478; modw_ra_etltest.resourceallocationfact_by_quarter = 478
2017-09-07 11:43:25 [notice] Identical
2017-09-07 11:43:25 [notice] Compare tables src=modw_aggregates.resourceallocationfact_by_year, dest=modw_ra_etltest.resourceallocationfact_by_year
2017-09-07 11:43:25 [info] 10 columns
2017-09-07 11:43:25 [info] Row counts: modw_aggregates.resourceallocationfact_by_year = 478; modw_ra_etltest.resourceallocationfact_by_year = 478
2017-09-07 11:43:25 [notice] Identical
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
