### PR TITLE
remove php 533 from travis testing

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -1,36 +1,16 @@
 #!/usr/bin/env bash
 
-# If PHP 5.3.3 is installed, SSL/TLS isn't available to PHP.
-# Use a newer version of PHP for installing Composer dependencies.
-using_php_533="false"; [[ "$(php --version)" == PHP\ 5.3.3\ * ]] && using_php_533="true"
-if "$using_php_533"; then
-    echo "Using newer version of PHP for installing dependencies"
-    phpenv global 5.3
-    php --version
-
-    # Update Composer since the attempt made by the Travis setup script
-    # using PHP 5.3.3 would have failed.
-    #
-    # First, we update to the latest developer version since the version
-    # of Composer pre-installed on Travis systems (1.0.0) doesn't support
-    # selecting an update channel. Then, we use this version to rollback to
-    # the latest stable version.
-    composer self-update
-    composer self-update --stable
-fi
+composer self-update --stable
 
 # Install Composer dependencies.
 composer install
 
-# If using PHP 5.3.3 for testing purposes, stop using the newer PHP version.
-if "$using_php_533"; then
-    echo "Reverting back to PHP 5.3.3 for testing"
-    phpenv global 5.3.3
-    php --version
-fi
+#fix for https://github.com/travis-ci/travis-ci/issues/8365
+pear config-set php_dir $(php -r 'echo substr(get_include_path(),2);')
 
+pear channel-update pear.php.net
 # Install PEAR dependencies.
-pear install Log
+pear install --alldeps Log
 
 # Install npm dependencies.
 source ~/.nvm/nvm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 # Use container-based environment for quicker initialization
 sudo: false
 
-# Since we still support CentOS 6 we need to be able to test 5.3.3
-dist: precise
-
 # Specify the build matrix
 language: php
 php:
-    - '5.3.3'
     - '5.4'
     - '7.0'
     - '7.1.6'
@@ -22,8 +18,6 @@ env:
         - TEST_SUITE=build
 matrix:
     exclude:
-        - php: '5.4'
-          env: TEST_SUITE=style
         - php: '7.0'
           env: TEST_SUITE=style
         - php: '7.1.6'


### PR DESCRIPTION
php 5.3.3 is old, we are not going to be supporting it and travis was having issues.  It still is, but this mitigates it to some degree.

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
Remove the tests for 5.3.3, remove the distribution being forced to precise, update to allow pear to install packages properly on php 7.0.7

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make things better
## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Lots of builds to get travis to not yell

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
