### PR TITLE
7.0/fix about tab

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1368,6 +1368,9 @@ CCR.getParameter = function (name, source) {
  *   TAB
  */
 CCR.tokenize = function (hash) {
+    if (typeof hash !== 'string') {
+        hash = String(hash)
+    }
     var matches = hash.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
 
     var tokens = {

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1368,13 +1368,14 @@ CCR.getParameter = function (name, source) {
  *   TAB
  */
 CCR.tokenize = function (hash) {
-    if (typeof hash !== 'string') {
-        hash = String(hash)
-    }
-    var matches = hash.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
+    var raw = (typeof hash !== 'string')
+      ? String(hash)
+      : hash;
+
+    var matches = raw.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
 
     var tokens = {
-        raw: hash,
+        raw: raw,
         content: matches[1],
         root: matches[2],
         tab: matches[3],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Discovered a small bug during 7.0 testing. If the 'About' tab is the first tab you visit after loading XDMoD, while using Chrome, the 'activate' listener would error out due to the Ext.History.getToken() function returning: null. On Firefox the function returns "null" and does not error out. 

## Motivation and Context
It's good to have consistent behavior across browser. 

## Tests performed
Manual Testing: (Chrome) 
    - Navigate to XDMoD ( ensure that there is no hash, so just https://<xdmod_address>/
    - Click the 'About' Tab
Expected Outcome:
    - That the first item in the left hand navigation pane is automatically selected. 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
