### PR TITLE
Remove 5.3.3 from travis builds

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -1,36 +1,17 @@
 #!/usr/bin/env bash
 
-# If PHP 5.3.3 is installed, SSL/TLS isn't available to PHP.
-# Use a newer version of PHP for installing Composer dependencies.
-using_php_533="false"; [[ "$(php --version)" == PHP\ 5.3.3\ * ]] && using_php_533="true"
-if "$using_php_533"; then
-    echo "Using newer version of PHP for installing dependencies"
-    phpenv global 5.3
-    php --version
-
-    # Update Composer since the attempt made by the Travis setup script
-    # using PHP 5.3.3 would have failed.
-    #
-    # First, we update to the latest developer version since the version
-    # of Composer pre-installed on Travis systems (1.0.0) doesn't support
-    # selecting an update channel. Then, we use this version to rollback to
-    # the latest stable version.
-    composer self-update
-    composer self-update --stable
-fi
-
 # Install Composer dependencies.
+
+composer self-update --stable
+
 composer install
 
-# If using PHP 5.3.3 for testing purposes, stop using the newer PHP version.
-if "$using_php_533"; then
-    echo "Reverting back to PHP 5.3.3 for testing"
-    phpenv global 5.3.3
-    php --version
-fi
-
 # Install PEAR dependencies.
-pear install Log
+#fix for https://github.com/travis-ci/travis-ci/issues/8365
+pear config-set php_dir $(php -r 'echo substr(get_include_path(),2);')
+
+pear channel-update pear.php.net
+pear install --alldeps Log
 
 # Install npm dependencies.
 source ~/.nvm/nvm.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 # Use container-based environment for quicker initialization
 sudo: false
 
-# Since we still support CentOS 6 we need to be able to test 5.3.3
-dist: precise
-
 # Specify the build matrix
 language: php
 php:
-    - '5.3.3'
     - '5.4'
     - '7.0'
     - '7.1.6'
@@ -22,8 +18,6 @@ env:
         - TEST_SUITE=build
 matrix:
     exclude:
-        - php: '5.4'
-          env: TEST_SUITE=style
         - php: '7.0'
           env: TEST_SUITE=style
         - php: '7.1.6'


### PR DESCRIPTION
Travis has issues with php 5.3.3 since this is no longer going to be supported after 7.0, remove it from the 7.0 branch testing automatically, any bug fixes need to be verified separately to make sure the build still works.