### PR TITLE
Use the Ext.ajax API call correctly.

### DIFF
--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -16,7 +16,6 @@
          "_makeRequest",
          "_panelActivation",
          "_performLoad",
-         "_retrieveSearchInfo",
          "_truncatePath",
          "_updateHistoryFromPanel",
          "_upsertSearch"
@@ -1884,7 +1883,17 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             local_job_id: jobLocalId
         };
 
-        var searchPromise = this._retrieveSearchInfo(realm, searchTitle);
+        var searchPromise = this._makeRequest(
+            'GET',
+            XDMoD.REST.url + '/' + this.rest.warehouse + '/search/history',
+            null,
+            {
+                realm: realm,
+                title: searchTitle,
+                token: XDMoD.REST.token
+            }
+        );
+
         searchPromise.then(function (results) {
             var data = results.data;
             var recordId = data.recordid;
@@ -1940,35 +1949,6 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             CCR.error('Error', 'Unable to complete the requested operation: ' + message);*/
         });
     }, // _createHistoryEntry
-
-    /**
-     * A helper function that, given a realm and search title, will handle
-     * making the correct REST call to retrieve the information ( if any ) about
-     * the uniquely identified search. This will be provided via a Promise so
-     * the caller will need to call:
-     *
-     * _retrieveSearchInfo(realm, title).then( function(results) {
-     *   ... processing logic goes here ...
-     * }).catch( function(errorResponse) {
-     *   ... error logic goes here ...
-     * });
-     *
-     *
-     * @param realm used to help uniquely identify the search to return.
-     * @param title used to help uniquely identify the search to return.
-     * @returns {Promise}
-     * @private
-     */
-    _retrieveSearchInfo: function (realm, title) {
-        /*'/rest/datawarehouse/search/info'*/
-        var url = XDMoD.REST.url + '/' + this.rest.warehouse + '/search/history';
-        var encoded = CCR.encode({
-            realm: realm,
-            title: title
-        });
-        url += ('?' + encoded + '&token=' + XDMoD.REST.token);
-        return this._makeRequest('GET', url);
-    }, // _retrieveSearchInfo
 
     /**
      * Attempts to execute an 'upsert' ( either an update or an insert depending


### PR DESCRIPTION
## Description
The existing code used the half-baked CCR.encode function to try to
encode data for a rest call. This change uses the ExtJS library function
that encodes the parameters correctly.

## Motivation and Context
Bug fix

## Tests performed
Steps to reproduce / verify:
1) Create metric explorer chart with a '#' symbol in the chart title; Add some supremm data
2) Click show raw data in the chart; Click on a job in the "raw data" window and confirm that job viewer loads and has a search node with the aforementioned chart title.
3) Go back to the metric explorer and click on another job. 
4) Confirm that the job viewer loads again and the second job appears under the same tree node as the first one (the buggy code would incorrectly create a duplicate search node).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
