### PR TITLE
Regenerate source query string prior to execute

### DIFF
--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -688,11 +688,14 @@ class EtlConfiguration extends Configuration
         // Set up the options with whatever was included in the config. The factory and implementation
         // classes will check for required parameters.
 
-        // Register the endpoints. Endpoints are global and only one endpoint will be created for each
-        // unique key. We need to register the endpoints first because the actions will need the keys
-        // when they are executed.
+        // Actions are enabled by default and do not require the "enabled" key, but it may still be
+        // specified in the config.
 
-        if ( $config->enabled ) {
+        if ( ! isset($config->enabled) || $config->enabled ) {
+
+            // Register the endpoints. Endpoints are global and only one endpoint will be created
+            // for each unique key. We need to register the endpoints first because the actions will
+            // need the keys when they are executed.
 
             $endpointKey = self::DATA_ENDPOINT_KEY;
             foreach ($config->$endpointKey as $endpointName => $endpointConfig) {
@@ -722,7 +725,7 @@ class EtlConfiguration extends Configuration
                 }
             }
         } else {
-            // For actions that are not configured, set minimal information needed for listing actions
+            // For actions that are not enabled, set minimal information needed for listing actions
             $options->enabled = false;
             $options->name = $config->name;
             if ( isset($config->description) ) {

--- a/html/about/publications.html
+++ b/html/about/publications.html
@@ -4,68 +4,152 @@
 <div>When referencing XDMoD, please cite the following publication:</div>
 
 <p>
-<b>Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert L. DeLeon, Joseph P. White, Nikolay Simakov, Abani K. Patra, Jeanette Sperhac, Thomas Yearke, Ryan Rathsam, Martins Innus, Cynthia D. Cornelius, James C. Browne, William L. Barth, Richard T. Evans, "Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources", <i>Computing in Science & Engineering</i> 17.4 (2015):52-62, 2015
-<a href="http://dx.doi.org/10.1109/MCSE.2015.68" target="_blank">10.1109/MCSE.2015.68</a></b>
+<b>
+    Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert L. DeLeon, Joseph P. White, Nikolay Simakov, Abani K. Patra, Jeanette Sperhac, Thomas Yearke, Ryan Rathsam, Martins Innus, Cynthia D. Cornelius, James C. Browne, William L. Barth, Richard T. Evans,
+    "Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources",
+    <i>Computing in Science &amp; Engineering</i>, Vol 17, Issue 4, 2015, pp. 52-62.
+    <a href="http://dx.doi.org/10.1109/MCSE.2015.68" target="_blank">10.1109/MCSE.2015.68</a>
+</b>
 </p>
 
 <div><b>2017:</b></div>
+
 <ol>
-<li> Joseph White, Martins Innus, Matthew Jones, Robert DeLeon, Nikolay A. Simakov, Jeffery Palmer, Steven Gallo, Thomas Furlani, Michael Showerman, Robert Brunner, Andriy Kot, Gregory Bauer, Brett Bode, Jeremy Enos and William Kramer, "Challenges of workload analysis on large HPC systems; a case study on NCSA Blue Waters".  Accepted for PEARC 17. </li>
+<li>
+    Joseph White, Martins Innus, Matthew Jones, Robert DeLeon, Nikolay A. Simakov, Jeffery Palmer, Steven Gallo, Thomas Furlani, Michael Showerman, Robert Brunner, Andriy Kot, Gregory Bauer, Brett Bode, Jeremy Enos and William Kramer,
+    "Challenges of workload analysis on large HPC systems; a case study on NCSA Blue Waters",
+    <i>PEARC17 Proceedings of the Practice and Experience in Advanced Research Computing 2017 on Sustainability, Success and Impact (Article No. 6).  9-13 July 2017 New Orleans, LA.</i>
+    <a href="http://dx.doi.org/10.1145/3093338.3093348" target="_blank">10.1145/3093338.3093348</a>
+</li>
 <br>
-<li> Ben Fulton, Steven Gallo, Matt Link, Robert Henschel, Tom Yearke, Katy Borner, Robert L. DeLeon, Thomas Furlani and Craig A. Stewart, "Value Analytics: A Financial Module for the Open XDMoD Project".  Accepted for PEARC 17. </li>
+<li>
+    Ben Fulton, Steven Gallo, Matt Link, Robert Henschel, Tom Yearke, Katy Borner, Robert L. DeLeon, Thomas Furlani and Craig A. Stewart,
+    "Value Analytics: A Financial Module for the Open XDMoD Project".
+    <i>PEARC17 Proceedings of the Practice and Experience in Advanced Research Computing 2017 on Sustainability, Success and Impact (Article No. 49). 9-13 July 2017 New Orleans, LA.</i>
+    <a href="http://dx.doi.org/10.1145/3093338.3093358" target="_blank">10.1145/3093338.3093358</a>
+</li>
 </ol>
 
 <div><b>2016:</b></div>
+
 <ol>
-<li>Nikolay Simakov, Robert L. DeLeon, Joseph P. White, Thomas R. Furlani, Martins Innus, Steven M. Gallo, Matthew D. Jones, Abani Patra, Benjamin D. Plessinger, Jeanette M. Sperhac, Thomas Yearke, Ryan Rathsam, Jeffrey T. Palmer "A Quantitative Analysis of Node Sharing on HPC Clusters Using XDMoD Application Kernels" , XSEDE16: Proceedings of the XSEDE16 Conference on Diversity, Big Data, and Science at Scale (Article No. 32). Miami, FL. <a href="http://dx.doi.org/10.1145/2949550.2949553" target="_blank">10.1145/2949550.2949553</a></li>
+<li>
+    Nikolay Simakov, Robert L. DeLeon, Joseph P. White, Thomas R. Furlani, Martins Innus, Steven M. Gallo, Matthew D. Jones, Abani Patra, Benjamin D. Plessinger, Jeanette M. Sperhac, Thomas Yearke, Ryan Rathsam, Jeffrey T. Palmer,
+    "A Quantitative Analysis of Node Sharing on HPC Clusters Using XDMoD Application Kernels",
+    <i>XSEDE16 Proceedings of the XSEDE16 Conference on Diversity, Big Data, and Science at Scale (Article No. 32). 17-21 July 2016 Miami, FL.</i>
+    <a href="http://dx.doi.org/10.1145/2949550.2949553" target="_blank">10.1145/2949550.2949553</a>
+</li>
 </ol>
 
 <div><b>2015:</b></div>
+
 <ol>
-<li>Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert L. DeLeon, Joseph P. White, Nikolay Simakov, Abani K. Patra, Jeanette Sperhac, Thomas Yearke, Ryan Rathsam, Martins Innus, Cynthia D. Cornelius, James C. Browne, William L. Barth, Richard T. Evans, "Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources", <i>Computing in Science & Engineering</i> 17.4 (2015):52-62, 2015
-<a href="http://dx.doi.org/10.1109/MCSE.2015.68" target="_blank">doi:10.1109/MCSE.2015.68</a></li>
+<li>
+    Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert L. DeLeon, Joseph P. White, Nikolay Simakov, Abani K. Patra, Jeanette Sperhac, Thomas Yearke, Ryan Rathsam, Martins Innus, Cynthia D. Cornelius, James C. Browne, William L. Barth, Richard T. Evans,
+    "Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources",
+    <i>Computing in Science &amp; Engineering</i>, Vol 17, Issue 4, 2015, pp. 52-62.
+    <a href="http://dx.doi.org/10.1109/MCSE.2015.68" target="_blank">doi:10.1109/MCSE.2015.68</a>
+</li>
 <br>
-<li>Robert L. DeLeon, Thomas R. Furlani, Steven M. Gallo, Joseph P. White, Matthew D. Jones, Abani Patra, Martins Innus, Thomas Yearke, Jeffrey T. Palmer, Jeanette M. Sperhac, Ryan Rathsam, Nikolay Simakov, Gregor von Laszewski and Fugang Wang, "TAS view of XSEDE users and usage”, Proceedings of the 2015 XSEDE Conference: Scientific Advancements Enabled by Enhanced Cyberinfrastructure", Article No. 21 <a href="http://dx.doi.org/10.1145/2792745.2792766" target="_blank">10.1145/2792745.2792766</a></li>
+<li>
+    Robert L. DeLeon, Thomas R. Furlani, Steven M. Gallo, Joseph P. White, Matthew D. Jones, Abani Patra, Martins Innus, Thomas Yearke, Jeffrey T. Palmer, Jeanette M. Sperhac, Ryan Rathsam, Nikolay Simakov, Gregor von Laszewski and Fugang Wang,
+    "TAS view of XSEDE users and usage",
+    <i>XSEDE15 Proceedings of the 2015 XSEDE Conference: Scientific Advancements Enabled by Enhanced Cyberinfrastructure (Article No. 21). 26-30 July 2016 St. Louis, MO.</i>
+    <a href="http://dx.doi.org/10.1145/2792745.2792766" target="_blank">10.1145/2792745.2792766</a>
+</li>
 <br>
-<li>Steven M. Gallo, Joseph P. White, Robert L. DeLeon, Thomas R. Furlani, Helen Ngo, Abani Patra, Matthew D. Jones, Jeffrey T. Palmer, Nikolay Simakov, Jeanette M. Sperhac, Martins Innus, Thomas Yearke, Ryan Rathsam "Analysis of XDMoD/SUPReMM Data Using Machine Learning Techniques" 2015 IEEE International Conference on Cluster Computing. <a href="http://doi.ieeecomputersociety.org/10.1109/CLUSTER.2015.114" target="_blank">doi:10.1109/CLUSTER.2015.114</a></li>
+<li>
+    Steven M. Gallo, Joseph P. White, Robert L. DeLeon, Thomas R. Furlani, Helen Ngo, Abani Patra, Matthew D. Jones, Jeffrey T. Palmer, Nikolay Simakov, Jeanette M. Sperhac, Martins Innus, Thomas Yearke, Ryan Rathsam,
+    "Analysis of XDMoD/SUPReMM Data Using Machine Learning Techniques"
+    <i>2015 IEEE International Conference on Cluster Computing. September 8-11, 2015. Chicago, IL.</i>
+    <a href="http://doi.ieeecomputersociety.org/10.1109/CLUSTER.2015.114" target="_blank">doi:10.1109/CLUSTER.2015.114</a>
+</li>
+<br>
+<li>
+    Simakov, N. A., White, J. P., DeLeon, R. L., Ghadersohi, A., Furlani, T. R., Jones, M. D., Gallo, S. M., and Patra, A. K.
+    "Application kernels: HPC resources performance monitoring and variance analysis."
+    <i>Concurrency and Computation: Practice and Experience</i>, Vol 27, Issue 17, 2015, pp. 5238–5260.
+    <a href="http://doi.ieeecomputersociety.org/10.1002/cpe.3564" target="_blank">doi:10.1002/cpe.3564</a>
 </ol>
 
 <div><b>2014:</b></div>
+
 <ol>
-<li>F. Wang, G. von Laszewski, G. C. Fox, T. R. Furlani, R. L. DeLeon, S. M. Gallo, "Towards a Scientific Impact Measuring Framework for Large Computing Facilities - a Case Study on XSEDE", <i>Proceedings of the Conference on Extreme Science and Engineering Discovery Environment (XSEDE14)</i>, Atlanta, Georgia, July 13 - 18, 2014,
-<a href="http://doi.acm.org/10.1145/2616498.2616507" target="_blank">doi:10.1145/2616498.2616507</a></li>
+<li>
+    F. Wang, G. von Laszewski, G. C. Fox, T. R. Furlani, R. L. DeLeon, S. M. Gallo,
+    "Towards a Scientific Impact Measuring Framework for Large Computing Facilities - a Case Study on XSEDE",
+    <i>XSEDE14: Proceedings of the 2014 Annual Conference on Extreme Science and Engineering Discovery Environment. 13-18 July 2014 Atlanta, Georgia.</i>
+    <a href="http://doi.acm.org/10.1145/2616498.2616507" target="_blank">doi:10.1145/2616498.2616507</a>
+</li>
 <br>
-<li>University at Buffalo Metrics on Demand (UBMoD): Open source web portal for mining data from resource managers in HPC environments.  Developed at the Center for Computational Research at the University at Buffalo, SUNY.  Freely available at SourceForge at <a href="http://ubmod.sourceforge.net" target="_blank">http://ubmod.sourceforge.net</a> [March 30, 2014].</li>
+<li>
+    University at Buffalo Metrics on Demand (UBMoD): Open source web portal for mining data from resource managers in HPC environments.
+    Developed at the Center for Computational Research at the University at Buffalo, SUNY.
+    Freely available at SourceForge <a href="http://ubmod.sourceforge.net" target="_blank">http://ubmod.sourceforge.net</a> [March 30, 2014].
+</li>
 <br>
-<li>T. R. Furlani, M. D. Jones, S. M. Gallo, A. E. Bruno, C. Lu, A. Ghadersohi, R. J. Gentner, A. Patra, R. L. DeLeon, G. von Lazewski, L. Wang and A. Zimmerman.  "Performance Metrics and Auditing Framework Using Applications Kernels for High Performance Computer Systems."  <i>Concurrency and Computation: Practice and Experience</i>.  Vol 25, Issue 7, p 918, (2013).
-<a href="http://onlinelibrary.wiley.com/doi/10.1002/cpe.2871/full" target="_blank">doi:10.1002/cpe.2871</a>
- XDMoD: <a href="http://xdmod.ccr.buffalo.edu" target="_blank">http://xdmod.ccr.buffalo.edu</a>; [March 30, 2014].  Open XDMoD: <a href="http://open.xdmod.org" target=_blank>http://open.xdmod.org</a>; [March 30, 2014].</li>
+<li>
+    T. R. Furlani, M. D. Jones, S. M. Gallo, A. E. Bruno, C. Lu, A. Ghadersohi, R. J. Gentner, A. Patra, R. L. DeLeon, G. von Lazewski, L. Wang and A. Zimmerman.
+    "Performance Metrics and Auditing Framework Using Applications Kernels for High Performance Computer Systems.",
+    <i>Concurrency and Computation: Practice and Experience</i>.  Vol 25, Issue 7, 2015,  pp. 918-931.
+    <a href="http://onlinelibrary.wiley.com/doi/10.1002/cpe.2871/full" target="_blank">doi:10.1002/cpe.2871</a><br>
+    XDMoD: <a href="http://xdmod.ccr.buffalo.edu" target="_blank">http://xdmod.ccr.buffalo.edu</a>; [March 30, 2014].  Open XDMoD: <a href="http://open.xdmod.org" target=_blank>http://open.xdmod.org</a>; [March 30, 2014].
+</li>
 <br>
-<li>J. P. White, R. L. DeLeon, T. R. Furlani, M. D. Jones, A. Ghadersohi, C. D. Cornelius, A. K. Patra, J. C. Browne, W. L. Barth, J. Hammond.  "An Analysis of Node Sharing on HPC Clusters using XDMoD/TACC_Stats." <i>Proceedings of the Conference on Extreme Science and Engineering Discovery Environment: Gateway to Discovery (XSEDE '14).</i>  Atlanta, Georgia, July 13-18, 2014.
-<a href="http://doi.acm.org/10.1145/2616498.2616533" target="_blank">doi:10.1145/2616498.2616533</a></li>
+<li>
+    J. P. White, R. L. DeLeon, T. R. Furlani, M. D. Jones, A. Ghadersohi, C. D. Cornelius, A. K. Patra, J. C. Browne, W. L. Barth, J. Hammond.
+    "An Analysis of Node Sharing on HPC Clusters using XDMoD/TACC_Stats."
+    <i>XSEDE14 Proceedings of the 2014 Annual Conference on Extreme Science and Engineering Discovery Environment. 13-18 July 2014 Atlanta, Georgia.</i>
+    <a href="http://doi.acm.org/10.1145/2616498.2616533" target="_blank">doi:10.1145/2616498.2616533</a>
+</li>
 <br>
-<li>F. Wang, G. von Laszewski, G. C. Fox, T. R. Furlani, R. L. DeLeon, S. M. Gallo, "Towards a Scientific Impact Measuring Framework for Large Computing Facilities - a Case Study on XSEDE." <i>Proceedings of the Conference on Extreme Science and Engineering Discovery Environment: Gateway to Discovery (XSEDE '14).</i> Atlanta, Georgia, July 13 - 18, 2014.
-<a href="http://doi.acm.org/10.1145/2616498.2616507" target="_blank">doi:10.1145/2616498.2616507</a></li>
+<li>
+    F. Wang, G. von Laszewski, G. C. Fox, T. R. Furlani, R. L. DeLeon, S. M. Gallo,
+    "Towards a Scientific Impact Measuring Framework for Large Computing Facilities - a Case Study on XSEDE."
+    <i>XSEDE14 Proceedings of the 2014 Annual Conference on Extreme Science and Engineering Discovery Environment. 13-18 July 2014 Atlanta, Georgia.</i>
+    <a href="http://doi.acm.org/10.1145/2616498.2616507" target="_blank">doi:10.1145/2616498.2616507</a>
+</li>
 </ol>
 
 <div><b>2013:</b></div>
+
 <ol>
-<li>James C. Browne, Robert L. DeLeon, Charng-Da Lu, Matthew D. Jones, Steven M. Gallo, Amin Ghadersohi, Abani K. Patra, William L. Barth, John Hammond, Thomas R. Furlani, and Robert T. McLay. 2013.  "Enabling Comprehensive Data-driven System Management for Large Computational Facilities."  <i>Proceedings of the International Conference on High Performance Computing, Networking, Storage and Analysis (SC '13).</i>  ACM, New York, NY, USA,  Article 86 , 11 pages.
-<a href="http://doi.acm.org/10.1145/2503210.2503230" target="_blank">doi:10.1145/2503210.2503230</a></li>
+<li>
+    James C. Browne, Robert L. DeLeon, Charng-Da Lu, Matthew D. Jones, Steven M. Gallo, Amin Ghadersohi, Abani K. Patra, William L. Barth, John Hammond, Thomas R. Furlani, and Robert T. McLay. 2013.
+    "Enabling Comprehensive Data-driven System Management for Large Computational Facilities."
+    <i>Proceedings of the International Conference on High Performance Computing, Networking, Storage and Analysis (SC '13).</i>  ACM, New York, NY, USA,  Article 86 , 11 pages.
+    <a href="http://doi.acm.org/10.1145/2503210.2503230" target="_blank">doi:10.1145/2503210.2503230</a>
+</li>
 <br>
-<li>T. R. Furlani, B. I. Schneider, M. D. Jones, John Towns, David L. Hart, Steven M. Gallo, Robert L. DeLeon, Charng-Da Lu, A. Ghadersohi, R. J. Gentner, A. K. Patra, G. von Laszewski, F. Wang, J. T. Palmer, and N. Simakov.  2013.  "Using XDMoD to Facilitate XSEDE Operations, Planning and Analysis."  <i>Proceedings of the Conference on Extreme Science and Engineering Discovery Environment: Gateway to Discovery (XSEDE '13).</i> ACM, New York, NY, USA, Article 46 , 8 pages.
-<a href="http://doi.acm.org/10.1145/2484762.2484763" target="_blank">doi:10.1145/2484762.2484763</a></li>
+<li>
+    T. R. Furlani, B. I. Schneider, M. D. Jones, John Towns, David L. Hart, Steven M. Gallo, Robert L. DeLeon, Charng-Da Lu, A. Ghadersohi, R. J. Gentner, A. K. Patra, G. von Laszewski, F. Wang, J. T. Palmer, and N. Simakov.  2013.
+    "Using XDMoD to Facilitate XSEDE Operations, Planning and Analysis."
+    <i>XSEDE13 Proceedings of the Conference on Extreme Science and Engineering Discovery Environment: Gateway to Discovery (Article 46). 22-25 July 2013, San Diego, CA.</i>
+    <a href="http://doi.acm.org/10.1145/2484762.2484763" target="_blank">doi:10.1145/2484762.2484763</a>
+</li>
 <br>
-<li>C. D. Lu, J. Browne, R. L. DeLeon, J. Hammond, W. Barth, T. R. Furlani, S. M. Gallo, M. D. Jones, and A. K. Patra. 2013.  "Comprehensive Job Level Resource Usage Measurement and Analysis for XSEDE HPC Systems."  <i>Proceedings of the Conference on Extreme Science and Engineering Discovery Environment: Gateway to Discovery (XSEDE '13).</i>  ACM, New York, NY, USA, Article 50 , 8 pages.
-<a href="http://doi.acm.org/10.1145/2484762.2484781" target="_blank">doi:10.1145/2484762.2484781</a></li>
+<li>
+    C. D. Lu, J. Browne, R. L. DeLeon, J. Hammond, W. Barth, T. R. Furlani, S. M. Gallo, M. D. Jones, and A. K. Patra. 2013.
+    "Comprehensive Job Level Resource Usage Measurement and Analysis for XSEDE HPC Systems."
+    <i>XSEDE13 Proceedings of the Conference on Extreme Science and Engineering Discovery Environment: Gateway to Discovery (Article 50). 22-25 July 2013, San Diego, CA.</i>
+    <a href="http://doi.acm.org/10.1145/2484762.2484781" target="_blank">doi:10.1145/2484762.2484781</a>
+</li>
 <br>
-<li>J. C. Browne, R. L. DeLeon, A. K. Patra, W. L. Barth, J. Hammond, M. D. Jones, T. R. Furlani, B. I. Schneider, S. M. Gallo, A. Ghadersohi, R. J. Gentner, J. T. Palmer, N. Simakov, M. Innus, A. E. Bruno, J. P. White, C. D. Cornelius, T. Yearke, K. Marcus, G. von Laszewski, F. Wang.  "Comprehensive, Open Source Resource Usage Measurement and Analysis for HPC Systems."  Invited paper accepted in special issue of <i>Concurrency and Computation: Practice and Experience dedicated to XSEDE13 conference</i> (2013).
-<a href="http://onlinelibrary.wiley.com/doi/10.1002/cpe.3245/full" target="_blank">doi:10.1002/cpe.3245</a>
+<li>
+    J. C. Browne, R. L. DeLeon, A. K. Patra, W. L. Barth, J. Hammond, M. D. Jones, T. R. Furlani, B. I. Schneider, S. M. Gallo, A. Ghadersohi, R. J. Gentner, J. T. Palmer, N. Simakov, M. Innus, A. E. Bruno, J. P. White, C. D. Cornelius, T. Yearke, K. Marcus, G. von Laszewski, F. Wang.
+    "Comprehensive, Open Source Resource Usage Measurement and Analysis for HPC Systems."
+    <i>Concurrency and Computation: Practice and Experience</i>, Vol 26, Issue 13, 2013, pp. 2191–2209
+    <a href="http://onlinelibrary.wiley.com/doi/10.1002/cpe.3245/full" target="_blank">doi:10.1002/cpe.3245</a>
 </li>
 </ol>
 
 <div><b>2012:</b></div>
+
 <ol>
-<li>G. von Laszewski, H. Lee, J. Diaz, F. Wang, K. Tanaka, S. Karavinkoppa, G. C. Fox, T. Furlani. "Design of an Accounting and Metric-based Cloud-shifting and Cloud-seeding Framework for FederatedClouds and Bare-metal Environments."  <i>FederatedClouds '12 Proceedings of the 2012 Workshop on Cloud Services, Federation, and the 8th Open Cirrus Summit.</i>  Pages 25-32 (2012).
-<a href="http://doi.acm.org/10.1145/2378975.2378982" target="_blank">doi:10.1145/2378975.2378982</a></li>
+<li>
+    G. von Laszewski, H. Lee, J. Diaz, F. Wang, K. Tanaka, S. Karavinkoppa, G. C. Fox, T. Furlani.
+    "Design of an Accounting and Metric-based Cloud-shifting and Cloud-seeding Framework for FederatedClouds and Bare-metal Environments."
+    <i>FederatedClouds '12 Proceedings of the 2012 Workshop on Cloud Services, Federation, and the 8th Open Cirrus Summit.</i>  Pages 25-32 (2012).
+    <a href="http://doi.acm.org/10.1145/2378975.2378982" target="_blank">doi:10.1145/2378975.2378982</a>
+</li>
 </ol>

--- a/html/about/team.html
+++ b/html/about/team.html
@@ -13,6 +13,7 @@
 <p>Ms. Jeanette Sperhac: XDMoD portal development</p>
 <p>Mr. Ryan Rathsam: XDMoD portal development and XDMoD data warehouse development</p>
 <p>Mr. Benjamin D. Plessinger: XDMoD development, systems architecture, and automation</p>
+<p>Mr. Rudra Chakraborty: XDMoD portal development</p>
 <p>Dr. Abani Patra: coPI</p>
 <br>
 <p><b><font size="3">Indiana University</font></b></p>

--- a/html/about/xdmod.php
+++ b/html/about/xdmod.php
@@ -20,7 +20,9 @@
 
 <p><b>
 When referencing XDMoD, please cite the following publication: <br><br>
-Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert L. DeLeon, Joseph P. White, Nikolay Simakov, Abani K. Patra, Jeanette Sperhac, Thomas Yearke, Ryan Rathsam, Martins Innus, Cynthia D. Cornelius, James C. Browne, William L. Barth, Richard T. Evans, "Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources", <i>Computing in Science & Engineering</i> 17.4 (2015):52-62, 2015
+Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert L. DeLeon, Joseph P. White, Nikolay Simakov, Abani K. Patra, Jeanette Sperhac, Thomas Yearke, Ryan Rathsam, Martins Innus, Cynthia D. Cornelius, James C. Browne, William L. Barth, Richard T. Evans,
+"Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources",
+<i>Computing in Science &amp; Engineering</i>, Vol 17, Issue 4, 2015, pp. 52-62.
 <a href="http://dx.doi.org/10.1109/MCSE.2015.68" target="_blank">10.1109/MCSE.2015.68</a>
 </b></p>
 

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1368,10 +1368,14 @@ CCR.getParameter = function (name, source) {
  *   TAB
  */
 CCR.tokenize = function (hash) {
-    var matches = hash.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
+    var raw = (typeof hash !== 'string')
+      ? String(hash)
+      : hash;
+
+    var matches = raw.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
 
     var tokens = {
-        raw: hash,
+        raw: raw,
         content: matches[1],
         root: matches[2],
         tab: matches[3],


### PR DESCRIPTION
Always regenerate source query string prior to execute to ensure modified ETL variables are properly applied.

**Note that this also includes updates made to the 7.0 branch during testing**

## Description

The Google SQL parser does not handle complex queries well so we need the ability to specify the source record fields in a child class that overrides `pdoIngestor::getSourceQueryString()` to set the query string. In addition, if the query defined in `getSourceQueryString()` makes use of ETL variables/macros, those variables must be re-applied prior to each execution. For example, if we are chunking a ingestion long period into year chunks.

Also ensure that the data endpoints are registered for actions that are not explicitly marked as enabled (now that actions are enabled by default).

## Motivation and Context

Required to support Science Gateways data ingestion.

## Tests performed

Ingested Science Gateway data:

```
./etl_overseer.php -c ../../../etc/etl/etl.json -p science-gateway -s '2009-10-15' -e now -k year  -v debug
```

Verified resource allocations data

```
./etl_overseer.php -c ../../../etc/etl/etl.json -v debug -p resource-allocations -o "truncate_destination=true" -o "experimental_enable_batch_aggregation=true"
../dev/verify_table_data.php -s modw_ra -d modw_ra_etltest -n 1 -v info -t resource_allocations
2017-09-07 11:42:25 [notice] Compare tables src=modw_ra.resource_allocations, dest=modw_ra_etltest.resource_allocations
2017-09-07 11:42:25 [info] 10 columns
2017-09-07 11:42:25 [info] Row counts: modw_ra.resource_allocations = 480; modw_ra_etltest.resource_allocations = 480
2017-09-07 11:42:25 [notice] Identical
../dev/verify_table_data.php -s modw_aggregates -d modw_ra_etltest -n 1 -v info -t resourceallocationfact_by_quarter -t resourceallocationfact_by_year
2017-09-07 11:43:25 [notice] Compare tables src=modw_aggregates.resourceallocationfact_by_quarter, dest=modw_ra_etltest.resourceallocationfact_by_quarter
2017-09-07 11:43:25 [info] 11 columns
2017-09-07 11:43:25 [info] Row counts: modw_aggregates.resourceallocationfact_by_quarter = 478; modw_ra_etltest.resourceallocationfact_by_quarter = 478
2017-09-07 11:43:25 [notice] Identical
2017-09-07 11:43:25 [notice] Compare tables src=modw_aggregates.resourceallocationfact_by_year, dest=modw_ra_etltest.resourceallocationfact_by_year
2017-09-07 11:43:25 [info] 10 columns
2017-09-07 11:43:25 [info] Row counts: modw_aggregates.resourceallocationfact_by_year = 478; modw_ra_etltest.resourceallocationfact_by_year = 478
2017-09-07 11:43:25 [notice] Identical
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
