### PR TITLE
Make the Chart Name field html 'clean'.

### DIFF
--- a/classes/NewRest/Controllers/MetricExplorerControllerProvider.php
+++ b/classes/NewRest/Controllers/MetricExplorerControllerProvider.php
@@ -120,6 +120,7 @@ class MetricExplorerControllerProvider extends BaseControllerProvider
 
                 foreach ($data as &$query) {
                     $this->removeRoleFromQuery($user, $query);
+                    $query['name'] = htmlspecialchars($query['name'], ENT_COMPAT, 'UTF-8', false);
                 }
 
                 $payload['data'] = $data;
@@ -171,6 +172,7 @@ class MetricExplorerControllerProvider extends BaseControllerProvider
 
                 if (isset($query)) {
                     $payload['data'] = $query;
+                    $payload['data']['name'] = htmlspecialchars($query['name'], ENT_COMPAT, 'UTF-8', false);
                     $payload['success'] = true;
                     $statusCode = 200;
                 } else {

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -3355,26 +3355,26 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                  */
                 change: function(textbox, newValue, oldValue) {
 
-                        var isValid = this.chartNameTextbox.validate();
-                        if (!isValid) {
-                            this.chartNameTextbox.focus();
-                            return;
-                        }
+                    var isValid = this.chartNameTextbox.validate();
+                    if (!isValid) {
+                        this.chartNameTextbox.focus();
+                        return;
+                    }
 
-                        var newHtml = Ext.util.Format.htmlEncode(newValue);
+                    var newHtml = Ext.util.Format.htmlEncode(newValue);
 
-                        XDMoD.TrackEvent('Metric Explorer', 'Updated the Chart Name', Ext.encode({
-                            original_name: oldValue,
-                            new_name: newValue
-                        }));
+                    XDMoD.TrackEvent('Metric Explorer', 'Updated the Chart Name', Ext.encode({
+                        original_name: oldValue,
+                        new_name: newValue
+                    }));
 
-                        if (this.currentQueryRecord) {
-                            this.chartOptionsButton.setText(truncateText(newHtml, XDMoD.Module.MetricExplorer.CHART_OPTIONS_MAX_TEXT_LENGTH));
-                            this.chartOptionsButton.setTooltip(newHtml);
-                            this.currentQueryRecord.set('name', newHtml);
-                            this.currentQueryRecord.stack.add(this.currentQueryRecord.data);
-                        }
-                    } // change
+                    if (this.currentQueryRecord) {
+                        this.chartOptionsButton.setText(truncateText(newHtml, XDMoD.Module.MetricExplorer.CHART_OPTIONS_MAX_TEXT_LENGTH));
+                        this.chartOptionsButton.setTooltip(newHtml);
+                        this.currentQueryRecord.set('name', newHtml);
+                        this.currentQueryRecord.stack.add(this.currentQueryRecord.data);
+                    }
+                } // change
             }
         });
         // ---------------------------------------------------------

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -4968,7 +4968,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                     // to the width of the GridPanel.
                     if (name.length > 73) {
                         /* eslint-disable no-param-reassign */
-                        metaData.attr += 'ext:qtip="' + name + '"';
+                        metaData.attr += 'ext:qtip="' + Ext.util.Format.htmlEncode(name) + '"';
                         /* eslint-enable no-param-reassign */
                     }
                     return name;

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -2236,7 +2236,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
 
         }
 
-        this.chartNameTextbox.setValue(queryName);
+        this.chartNameTextbox.setValue(Ext.util.Format.htmlDecode(queryName));
         this.chartOptionsButton.setText(truncateText(queryName, XDMoD.Module.MetricExplorer.CHART_OPTIONS_MAX_TEXT_LENGTH));
         this.chartOptionsButton.setTooltip(queryName);
     }, //createQueryFunc
@@ -3361,15 +3361,17 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                             return;
                         }
 
+                        var newHtml = Ext.util.Format.htmlEncode(newValue);
+
                         XDMoD.TrackEvent('Metric Explorer', 'Updated the Chart Name', Ext.encode({
                             original_name: oldValue,
                             new_name: newValue
                         }));
 
                         if (this.currentQueryRecord) {
-                            this.chartOptionsButton.setText(truncateText(newValue, XDMoD.Module.MetricExplorer.CHART_OPTIONS_MAX_TEXT_LENGTH));
-                            this.chartOptionsButton.setTooltip(newValue);
-                            this.currentQueryRecord.set('name', newValue);
+                            this.chartOptionsButton.setText(truncateText(newHtml, XDMoD.Module.MetricExplorer.CHART_OPTIONS_MAX_TEXT_LENGTH));
+                            this.chartOptionsButton.setTooltip(newHtml);
+                            this.currentQueryRecord.set('name', newHtml);
                             this.currentQueryRecord.stack.add(this.currentQueryRecord.data);
                         }
                     } // change
@@ -4881,7 +4883,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
             XDMoD.TrackEvent('Metric Explorer', 'Selected chart from list', r.data.name);
             Ext.menu.MenuMgr.hideAll();
 
-            this.chartNameTextbox.setValue(r.data.name);
+            this.chartNameTextbox.setValue(Ext.util.Format.htmlDecode(r.data.name));
             this.chartOptionsButton.setText(truncateText(r.data.name, XDMoD.Module.MetricExplorer.CHART_OPTIONS_MAX_TEXT_LENGTH));
             this.chartOptionsButton.setTooltip(r.data.name);
 
@@ -6292,7 +6294,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                     }
                 }
                 this.currentQueryRecord.endEdit();
-                this.chartNameTextbox.setValue(chartData.name);
+                this.chartNameTextbox.setValue(Ext.util.Format.htmlDecode(chartData.name));
                 this.chartOptionsButton.setText(truncateText(chartData.name, XDMoD.Module.MetricExplorer.CHART_OPTIONS_MAX_TEXT_LENGTH));
                 this.chartOptionsButton.setTooltip(chartData.name);
                 this.loadQuery(JSON.parse(chartData.config), true);

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/MetricExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/MetricExplorerTest.php
@@ -104,4 +104,93 @@ class MetricExplorerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($response[1]['content_type'], 'application/json');
         $this->assertEquals($response[1]['http_code'], 401);
     }
+
+    /**
+     * @dataProvider chartDataProvider
+     */
+    public function testChartQueryEndpoint($chartSettings)
+    {
+        $settings = array(
+            'name' => 'Test &lt; <img src="test.gif" onerror="alert()" />',
+            'ts' => microtime(true),
+            'config' => $chartSettings
+        );
+        $this->helper->authenticate('cd');
+        $response = $this->helper->post('rest/v1/metrics/explorer/queries', null, array('data' => json_encode($settings)));
+
+        $this->assertEquals($response[1]['content_type'], 'application/json');
+        $this->assertEquals($response[1]['http_code'], 200);
+
+        $querydata = $response[0];
+        $this->assertArrayHasKey('data', $querydata);
+        $this->assertArrayHasKey('recordid', $querydata['data']);
+        $this->assertArrayHasKey('name', $querydata['data']);
+        $this->assertArrayHasKey('ts', $querydata['data']);
+        $this->assertArrayHasKey('config', $querydata['data']);
+
+        $recordid = $querydata['data']['recordid'];
+
+        $allcharts = $this->helper->get('rest/v1/metrics/explorer/queries');
+        $this->assertTrue($allcharts[0]['success']);
+
+        $seenchart = false;
+        foreach($allcharts[0]['data'] as $chart)
+        {
+            if ($chart['recordid'] == $recordid) {
+                $this->assertEquals("Test &lt; &lt;img src=&quot;test.gif&quot; onerror=&quot;alert()&quot; /&gt;", $chart['name']);
+                $seenchart = true;
+            }
+        }
+        $this->assertTrue($seenchart);
+
+        $justthischart = $this->helper->get('rest/v1/metrics/explorer/queries/' . $recordid);
+        $this->assertTrue($justthischart[0]['success']);
+        $this->assertEquals("Test &lt; &lt;img src=&quot;test.gif&quot; onerror=&quot;alert()&quot; /&gt;", $justthischart[0]['data']['name']);
+
+        $cleanup = $this->helper->delete('rest/v1/metrics/explorer/queries/' . $recordid);
+        $this->assertTrue($cleanup[0]['success']);
+    }
+
+    public function chartDataProvider()
+    {
+        $emptyChart = <<< EOF
+{
+   "featured": false,
+   "trend_line": false,
+   "x_axis": {},
+   "y_axis": {},
+   "legend": {},
+   "defaultDatasetConfig": {  
+      "display_type": "column"
+   },
+   "swap_xy": false,
+   "share_y_axis": false,
+   "hide_tooltip": true,
+   "show_remainder": false,
+   "timeseries": false,
+   "title": "Test",
+   "legend_type": "bottom_center",
+   "font_size": 3,
+   "show_filters": true,
+   "show_warnings": true,
+   "data_series": {  
+      "data": [ ],
+      "total": 0
+   },
+   "aggregation_unit": "Auto",
+   "global_filters": {  
+      "data": [ ],
+      "total": 0
+   },
+   "timeframe_label": "Previous month",
+   "start_date": "2017-08-01",
+   "end_date": "2017-08-31",
+   "start": 0,
+   "limit": 10
+}
+EOF;
+        return array(
+            array($emptyChart)
+        );
+    }
 }


### PR DESCRIPTION
The chart name field could have been used to inject html into the page. This
pull request addresses this issue.

Notes:

The 'New Chart' dialog already htmlEncoded the chart name so any charts that we created
using this mechanism using the old code will be displayed exactly the same (except of course the
display bug in the chart menu is fixed).

The code change on the server will prevent any existing saved charts with embedded html
from being executed. These charts will obviously have the name appear different in this
new code, by design!

# Testing details

1a) Create a chart name with injected img and script tags using old code
2a) update to new code and confirm that the injected script is not run and the raw html gets displayed instead.

1b) Try to use the Name text box to enter html code. Confirm that the text entered is displayed verbatim in 
- The text box itself
- The chart button on the top right
- The tooltip for the chart button on the top right
- The "Load Chart" grid entry
- The tooltip for the "Load Chart" grid entry
