### PR TITLE
Add SQL debugging info to exception responses

### DIFF
--- a/classes/CCR/DB/PDODB.php
+++ b/classes/CCR/DB/PDODB.php
@@ -148,7 +148,7 @@ class PDODB implements iDatabase
         $stmt = $this->prepare($query);
 
         try {
-            if ( $this->debugging() ) {
+            if ( static::debugging() ) {
                 $this->debug($query, $params);
             }
         } catch (Exception $e) {
@@ -175,7 +175,7 @@ class PDODB implements iDatabase
         $stmt = $this->prepare($query);
 
         try {
-            if ( $this->debugging() ) {
+            if ( static::debugging() ) {
                 $this->debug($query, $params);
             }
         } catch (Exception $e) {
@@ -214,7 +214,7 @@ class PDODB implements iDatabase
         $stmt = $this->prepare($statement);
 
         try {
-            if ( $this->debugging() ) {
+            if ( static::debugging() ) {
                 $this->debug($statement, $params);
             }
         } catch (Exception $e) {
@@ -244,7 +244,7 @@ class PDODB implements iDatabase
         $query = "select count(*) as count_result from $full_tablename";
 
         try {
-            if ( $this->debugging() ) {
+            if ( static::debugging() ) {
                 $this->debug($query, array());
             }
         } catch (Exception $e) {
@@ -310,11 +310,23 @@ class PDODB implements iDatabase
         );
     }
 
+    /**
+     * Enable SQL debugging.
+     *
+     * NOTE: For SQL debugging to be enabled, general debugging must be enabled
+     * in the config file.
+     */
     public static function debugOn()
     {
         PDODB::$debug_mode = true;
     }
 
+    /**
+     * Disable SQL debugging.
+     *
+     * NOTE: This will not disable SQL debugging if SQL debugging has been
+     * enabled in the config file.
+     */
     public static function debugOff()
     {
         PDODB::$debug_mode = false;
@@ -326,12 +338,36 @@ class PDODB implements iDatabase
         unset($GLOBALS['PDODB::$params']);
     }
 
-    private function debugging()
+    /**
+     * Determine if SQL debugging is enabled.
+     *
+     * First, this checks if general debugging is enabled. If not enabled,
+     * then SQL debugging cannot be enabled.
+     *
+     * This then checks if SQL debugging has been enabled either by the config
+     * file or by code. If any method reports that SQL debugging is enabled,
+     * then SQL debugging is considered enabled.
+     *
+     * @return boolean True if enabled, false if disabled.
+     */
+    public static function debugging()
     {
+        $generalDebugEnabled = \xd_utilities\filter_var(
+            \xd_utilities\getConfiguration('general', 'debug_mode'),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        if (!$generalDebugEnabled) {
+            return false;
+        }
+
         $sql_debug_mode = false;
 
         try {
-            $sql_debug_mode = \xd_utilities\getConfiguration('general', 'sql_debug_mode');
+            $sql_debug_mode = \xd_utilities\filter_var(
+                \xd_utilities\getConfiguration('general', 'sql_debug_mode'),
+                FILTER_VALIDATE_BOOLEAN
+            );
         } catch (Exception $e) {
         }
 

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -4,6 +4,7 @@ namespace DataWarehouse\Query;
 use Exception;
 
 use CCR\DB;
+use CCR\DB\PDODB;
 use FilterListHelper;
 use Xdmod\Config;
 
@@ -237,7 +238,7 @@ class Query
 
         $query_string = $this->getQueryString($limit);
 
-        $debug = \xd_utilities\filter_var(\xd_utilities\getConfiguration('general', 'sql_debug_mode'), FILTER_VALIDATE_BOOLEAN);
+        $debug = PDODB::debugging();
         if ($debug == true) {
             $class = get_class($this);
             $this->log->debug(sprintf("%s: \n%s", $class, $query_string));

--- a/classes/NewRest/XdmodApplicationFactory.php
+++ b/classes/NewRest/XdmodApplicationFactory.php
@@ -107,14 +107,7 @@ class XdmodApplicationFactory {
 
         // SETUP: a before middleware that detects / starts the query debug mode for a request.
         $app->before(function (Request $request, Application $app) {
-            $app['debug_sql'] =
-                $app['debug']
-                && (
-                    filter_var(\xd_utilities\getConfiguration('general', 'sql_debug_mode'), FILTER_VALIDATE_BOOLEAN)
-                    || $request->query->getBoolean('debug')
-                )
-            ;
-            if ($app['debug_sql']) {
+            if ($request->query->getBoolean('debug')) {
                 PDODB::debugOn();
             }
         });
@@ -125,10 +118,8 @@ class XdmodApplicationFactory {
         // SETUP: an after middleware that detects the query debug mode and, if true, retrieves
         //        and returns the collected sql queries / params.
         $app->after(function (Request $request, Response $response, Application $app) {
-            if ($app['debug_sql']) {
+            if (PDODB::debugging()) {
                 $debugInfo = PDODB::debugInfo();
-                PDODB::debugOff();
-                PDODB::resetDebugInfo();
 
                 $contentType = $response->headers->get('content-type', null);
                 if ('application/json' === strtolower($contentType)) {

--- a/libraries/response.php
+++ b/libraries/response.php
@@ -6,6 +6,8 @@
 namespace xd_response;
 
 use Exception;
+
+use CCR\DB\PDODB;
 use xd_controller;
 use xd_utilities;
 
@@ -44,6 +46,11 @@ function buildError($error)
         }
     } else {
         $response['message'] = $error;
+    }
+
+    // If SQL debugging is enabled, include query data.
+    if (PDODB::debugging()) {
+        $response['sql'] = PDODB::debugInfo();
     }
 
     return $response;


### PR DESCRIPTION
## Description
This pull request adds SQL debugging information to responses sent by the server when an unhandled exception occurs. (This data is only included if both debug mode and SQL debugging are enabled.)

Before the commit adding this feature, there is a commit that consolidates the logic for determining if SQL debugging is enabled. This refactoring makes the SQL debugging code simpler to interact with.

## Motivation and Context
When trying to figure out why an error occurs, having the SQL queries and parameters that were used is helpful.

## Tests performed
For the refactoring, I tested all combinations of general and SQL debug options being enabled or disabled and verified that SQL debug data was only being sent when both options were enabled. For the feature, I verified that the SQL debug data was included when an unhandled exception occurred.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
