### PR TITLE
Fix sendMail() function name capitalization when called

### DIFF
--- a/classes/CCR/MailWrapper.php
+++ b/classes/CCR/MailWrapper.php
@@ -146,6 +146,6 @@ class MailWrapper
         $template->apply($properties);
 
         $properties['body'] = $template->getContents();
-        MailWrapper::sendmail($properties);
+        MailWrapper::sendMail($properties);
     }
 }

--- a/html/controllers/mailer/contact.php
+++ b/html/controllers/mailer/contact.php
@@ -88,7 +88,7 @@ $message .="$user_info\n\n  Token:        {$_POST['token']}\n  Timestamp:    $ti
 
 try {
     //Original sender's e-mail must be in the 'fromAddress' field for the XDMoD Request Tracker to function
-    MailWrapper::sendmail(array(
+    MailWrapper::sendMail(array(
         'body'         => $message,
         'subject'      => $subject,
         'toAddress'    => \xd_utilities\getConfiguration('general', 'contact_page_recipient'),


### PR DESCRIPTION
Fix 2 instances where `sendMail()` was being called in all lower-case `sendmail()`

## Motivation and Context

Bugfix

## Tests performed

Did not perform tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
