### PR TITLE
Do not show future dates in lower right of XDMoD plots

### DIFF
--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -217,8 +217,12 @@ class HighChart2
      * start of the unit that it falls into, similarly the end date may need to be adjusted to align
      * with the end date of the unit. For example, viewing a monthly aggregation unit the date range
      * 2017-1-15 - 2017-08-20 must be adjusted to 2017-01-01 - 2017-08-31 to include entire months
-     * since that is the data that will be returned.  NOTE: For end dates in the future, do not
-     * automatically adjust the end date because XDMoD does not currently support future data.
+     * since that is the data that will be returned.
+     *
+     * NOTE: XDMoD does not currently provide data for the future. For end dates that fall on the
+     * current date or in the future, do not automatically adjust the date to the end of the
+     * aggregation period that it falls into. Rather, adjust it to the end of the current day as
+     * this is the data that will be displayed.
      *
      * @param string $startDate            Start date for the plot in a valid PHP format
      * @param string $endDate              End date for the plot in a valid PHP format


### PR DESCRIPTION
This addresses [Tom Furlani's bug](https://app.asana.com/0/387470245161503/424407219764834).

## Description

The XDMoD UI presents data aggregated at particular units (day, month, quarter, year). It is
sometimes necessary to adjust the user-specified start or end date to align with aggregation
unit boundaries as we do not display partial aggregation units (the user must switch to a
finer-grained unit for this). This means that the start date may need to be adjusted to the
start of the unit that it falls into, similarly the end date may need to be adjusted to align
with the end date of the unit. For example, viewing a monthly aggregation unit the date range
2017-1-15 - 2017-08-20 must be adjusted to 2017-01-01 - 2017-08-31 to include whole months
since that is the data that will be returned.

XDMoD does not currently provide data for the future. For end dates that fall on the current date or in
the future, do not automatically adjust the date to the end of the aggregation period that it falls into.
Rather, adjust it to the end of the current day as this is the data that will be displayed.

## Motivation and Context

When viewing "to date" plots (e.g., "Year To Date"), adding a date in the future is misleading. If we were to plot 2 "Year to date" plots, one on 2017-9-4 and another on 2017-09-30 both plots would state that the date range was 2017-01-01 - 2017-09-30 but would contain different data.

## Tests performed

Compared my development branch to xdmod-dev for several duration selections (including an end date in the future) in both timeseries and aggregate mode. Also verified that report dates are correct in the Report Generator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
