### PR TITLE
Throw exception if Public User data is not found

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -392,9 +392,6 @@ class XDUser
         if (null === self::$_publicUser) {
             self::$_publicUser = self::getUserByUserName('Public User');
         }
-        if (null === self::$_publicUser) {
-            throw new Exception('Public User not found');
-        }
         return self::$_publicUser;
     }//getPublicUser
 
@@ -3171,13 +3168,15 @@ SQL;
      * @param string $username the identifier to use when attempting to retrieve
      * the XDUser instance.
      *
-     * @return null|XDUser null if the user cannot be found or if null is provided
-     * as the username, else an instantiated XDUser instance.
+     * @return XDUser An instantiated XDUser instance.
+     *
+     * @throws Exception If the user cannot be found or if null is provided as
+     * the username.
      **/
     public static function getUserByUserName($username)
     {
         if (null === $username) {
-            return null;
+            throw new Exception('No username provided');
         }
 
         // Note: due to the complexity of getUserById ( and it being the sole
@@ -3195,6 +3194,6 @@ SQL;
             $uid = $row[0]['id'];
             return self::getUserByID($uid);
         }
-        return null;
+        throw new Exception("User \"$username\" not found");
     } // getUserByUserName
 }//XDUser

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -392,6 +392,9 @@ class XDUser
         if (null === self::$_publicUser) {
             self::$_publicUser = self::getUserByUserName('Public User');
         }
+        if (null === self::$_publicUser) {
+            throw new Exception('Public User not found');
+        }
         return self::$_publicUser;
     }//getPublicUser
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -127,3 +127,10 @@ As of Open XDMoD 7.0 any job with a start or end time equal to 0 will not be
 ingested into the data warehouse and will not contribute to the job count or
 any other metrics.  Previous versions of Open XDMoD did include these jobs
 which resulted in inaccurate results.
+
+### Why do I see the error message "User "Public User" not found" instead of the portal?
+
+This indicates that the data needed by the new ACL system introduced in 7.0.0 is
+not present.  This is typically caused by failing to migrate the Open XDMoD
+database from 6.6.0 to 7.0.0.  The `xdmod-upgrade` script must be executed
+after upgrading the Open XDMoD RPM or source installation.

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -412,20 +412,27 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($user->getUserID());
     }
 
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage User "bilbo" not found
+     */
     public function testGetUserByUserNameInvalid()
     {
         $user = XDUser::getUserByUserName("bilbo");
-        $this->assertNull($user);
-    }
-
-    public function testGetUserByUserNameEmptyString()
-    {
-        $user = XDUser::getUserByUserName("");
-        $this->assertNull($user);
     }
 
     /**
      * @expectedException Exception
+     * @expectedExceptionMessage User "" not found
+     */
+    public function testGetUserByUserNameEmptyString()
+    {
+        $user = XDUser::getUserByUserName("");
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage No username provided
      */
     public function testGetUserByUserNameNull()
     {

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -424,10 +424,12 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($user);
     }
 
+    /**
+     * @expectedException Exception
+     */
     public function testGetUserByUserNameNull()
     {
         $user = XDUser::getUserByUserName(null);
-        $this->assertNull($user);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

See title.  Any suggestions for a better error message are welcome.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If the public user data is missing, the portal will not be displayed and a blank screen is presented instead.  This happens if the database is not migrated from 6.6. to 7.0.  This PR changes the behaviour to display:

```
{"success":false,"count":0,"total":0,"totalCount":0,"results":[],"data":[],"message":"Public User not found","code":0}
```

Which at least includes an error message.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Installed 6.6
- Upgraded to 7.0
- (Did not run `xdmod-upgrade`)
- Loaded portal
- Observed error message

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
