### PR TITLE
Only verify data endpoints for enabled actions

### DIFF
--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -238,8 +238,8 @@ class EtlConfiguration extends Configuration
         }  // foreach ( $etlSectionNames as $typeName )
 
         // --------------------------------------------------------------------------------
-        // Register the global default endpoints (the overseer script needs access to the utility
-        // endpoint) but note that individual actions may define their own.
+        // Register the global default endpoints but note that individual actions may still define
+        // their own. We should not verify these unless they are actually used by an enabled action.
 
         $this->endpoints = array();
 

--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -59,15 +59,18 @@ class EtlOverseer extends Loggable implements iEtlOverseer
 
         $this->verifiedDataEndpoints = false;
 
-        // This is a quick hack to only verify endpoints used by the actions that we are
-        // processing. The actions are not instantiated at this point because we need to verify the
-        // endpoints first.
+        // Generate a list of data endpoints that are used by enabled actions so we can verify them
+        // prior to executing the actions. The actions are not instantiated at this point because we
+        // need to verify the endpoints first.
 
         $usedEndpointKeys = array();
 
         foreach ( $this->etlOverseerOptions->getActionNames() as $actionName ) {
             list($sectionName, $actionName) = $this->parseSectionFromActionName($actionName);
             $options = $etlConfig->getActionOptions($actionName, $sectionName);
+            if ( ! $options->enabled ) {
+                continue;
+            }
             $usedEndpointKeys[] = $options->utility;
             $usedEndpointKeys[] = $options->source;
             $usedEndpointKeys[] = $options->destination;
@@ -75,6 +78,9 @@ class EtlOverseer extends Loggable implements iEtlOverseer
         foreach ( $this->etlOverseerOptions->getSectionNames() as $sectionName ) {
             foreach ( $etlConfig->getSectionActionNames($sectionName) as $actionName ) {
                 $options = $etlConfig->getActionOptions($actionName, $sectionName);
+                if ( ! $options->enabled ) {
+                    continue;
+                }
                 $usedEndpointKeys[] = $options->utility;
                 $usedEndpointKeys[] = $options->source;
                 $usedEndpointKeys[] = $options->destination;
@@ -87,6 +93,9 @@ class EtlOverseer extends Loggable implements iEtlOverseer
 
         foreach ( $usedEndpointKeys as $endpointKey ) {
             if ( false === ($endpoint = $etlConfig->getDataEndpoint($endpointKey)) ) {
+                $this->logger->warning(
+                    sprintf("Could not retrieve data endpoint object with key %s, skipping", $endpointKey)
+                );
                 continue;
             }
 

--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -344,6 +344,7 @@ class EtlOverseer extends Loggable implements iEtlOverseer
      * ------------------------------------------------------------------------------------------
      */
 
+     // @codingStandardsIgnoreLine
     private function _execute($actionName, iAction $actionObj)
     {
         $this->logger->info(array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As discussed with @ryanrath and @jpwhite4 we should only attempt to verify data endpoints for actions that are enabled. This PR tidys up previous work and ensures that this is the case.

## Motivation and Context

We were attempting to verify data endpoints for actions that were not enabled.

## Tests performed
2 global data endpoints ("Utility DB" and "Cloud DB") are defined and 5 actions configured with no
"enabled" key defined (the default is `"enabled": true`).

```
smgallo@smgallo-dev:etl$ ./etl_overseer.php -c ../../../etc/etl/etl.json -p jobs-cloud -s '2009-10-15' -e now -k year  -v info -t|grep "Verifying endpoint"
2017-09-26 10:09:33 [info] Verifying endpoint: ('Utility DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-09-26 10:09:33 [info] Verifying endpoint: ('Cloud DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw_cloud, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-09-26 10:09:33 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud event types, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/event_type.json)
2017-09-26 10:09:33 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud asset types, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/asset_type.json)
2017-09-26 10:09:33 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud instance types, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/instance_type.json)
2017-09-26 10:09:33 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud regions, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/region.json)
2017-09-26 10:09:33 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud availability zones, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/avail_zone.json)
```

Disabling 2 of the actions shows that we no longer try to verify the endpoints associated with those
actions but still verify the global endpoints because other actions that use them are enabled:

```
2017-09-26 10:12:22 [info] Verifying endpoint: ('Utility DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-09-26 10:12:23 [info] Verifying endpoint: ('Cloud DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw_cloud, host=tas-db1-nofw.ccr.buffalo.edu:3306, user=xdmod)
2017-09-26 10:12:23 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud instance types, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/instance_type.json)
2017-09-26 10:12:23 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud regions, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/region.json)
2017-09-26 10:12:23 [info] Verifying endpoint: ETL\DataEndpoint\JsonFile (name=Cloud availability zones, path=/home/smgallo/xdmod-gw-7.1-current/etc/etl/etl_data.d/cloud/avail_zone.json)
```

Setting a pipeline default option of `"enabled": false` disables all actions and we no longer verify
any endpoints since there are no actions that use them.

```
smgallo@smgallo-dev:etl$ ./etl_overseer.php -c ../../../etc/etl/etl.json -p jobs-cloud -s '2009-10-15' -e now -k year  -v info -t|grep "Verifying endpoint"
smgallo@smgallo-dev:etl$ 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
