### PR TITLE
PHP 5.3.3 fix for DirectoryIterator::getExtension

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -1535,7 +1535,7 @@ function verifyJsonSyntax()
                 if ($fileInfo->isDot()) {
                     continue;
                 }
-                if ($fileInfo->getExtension() === 'json') {
+                if (pathinfo($fileInfo->getFilename(), PATHINFO_EXTENSION) === 'json') {
                     $fileName = $fileInfo->getFilename();
                     $filePath = $confPath.DIRECTORY_SEPARATOR.$fileName;
                     $fileParts = explode(DIRECTORY_SEPARATOR, $filePath);


### PR DESCRIPTION
- DirectorIterator::getExtension did not exist until PHP 5.3.6

<!--- Provide a general summary of your changes in the Title above -->

## Description
The DirectoryIterator::getExtension method was not added until 5.3.6, this causes an issue when used on CentOS6 systems that install 5.3.3 by default.

## Motivation and Context
The code does not execute on CentOS6 & PHP 5.3.3. This modification should resolve that

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
