### PR TITLE
Fix ETL external process error messages

### DIFF
--- a/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
+++ b/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
@@ -185,6 +185,10 @@ class ExternalProcess extends \php_user_filter
         // http://php.net/manual/en/function.stream-bucket-new.php
 
         if ( false === ($this->tmpResource = @fopen('php://temp', 'w+')) ) {
+            $errorMessage = '';
+            if ( null !== ($err = error_get_last()) ) {
+                $errorMessage = $err['message'];
+            }
             $this->logError($errorMessage);
             return false;
         }
@@ -205,6 +209,10 @@ class ExternalProcess extends \php_user_filter
         );
 
         if ( false === $this->filterResource ) {
+            $errorMessage = '';
+            if ( null !== ($err = error_get_last()) ) {
+                $errorMessage = $err['message'];
+            }
             $this->logError($errorMessage);
             return false;
         }

--- a/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
+++ b/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
@@ -185,7 +185,7 @@ class ExternalProcess extends \php_user_filter
         // http://php.net/manual/en/function.stream-bucket-new.php
 
         if ( false === ($this->tmpResource = @fopen('php://temp', 'w+')) ) {
-            $errorMessage = '';
+            $errorMessage = 'Could not open php://temp for writing';
             if ( null !== ($err = error_get_last()) ) {
                 $errorMessage = $err['message'];
             }
@@ -209,7 +209,7 @@ class ExternalProcess extends \php_user_filter
         );
 
         if ( false === $this->filterResource ) {
-            $errorMessage = '';
+            $errorMessage = 'Error executing command: ' . $this->command;
             if ( null !== ($err = error_get_last()) ) {
                 $errorMessage = $err['message'];
             }

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/DirectoryScannerTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DataEndpoint/DirectoryScannerTest.php
@@ -28,7 +28,7 @@ class DirectoryScanner extends \PHPUnit_Framework_TestCase
             'file' => false,
             'db' => false,
             'mail' => false,
-            'consoleLogLevel' => Log::INFO
+            'consoleLogLevel' => Log::WARNING
         );
 
         $this->logger = Log::factory('PHPUnit', $conf);


### PR DESCRIPTION

## Description

While reviewing @jpwhite4's code I noticed that I had an undefined variable in the ETL external process error reporting. This fixes that and also reduces the log level of the DirectoryScanner tests from `INFO` to `WARNING` for cleaner test output.

## Motivation and Context

Bugfix

## Tests performed

Ran tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
