### PR TITLE
Updates shippable to image 7.0.1

### DIFF
--- a/bin/xdmod-upgrade
+++ b/bin/xdmod-upgrade
@@ -26,8 +26,8 @@ ini_set('memory_limit', -1);
  * @var array
  */
 $supportedUpgrades = array(
-    '6.6.0' => '7.0.0',
     '7.0.0' => '7.0.1',
+    '7.0.1' => '7.1.0',
 );
 
 /**
@@ -315,4 +315,3 @@ Usage: xdmod-upgrade [-v]
 
 EOF;
 }
-

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -6,7 +6,7 @@ contact_page_recipient = ""
 tech_support_recipient = ""
 
 ; The version number is updated during the upgrade process.
-version = "7.0.1"
+version = "7.1.0"
 
 debug_mode = "off"
 debug_recipient = ""

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod",
-    "version": "7.0.1",
+    "version": "7.1.0",
     "release": "1.0",
     "files": {
         "include_paths": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xdmod",
-    "version": "7.0.1",
+    "version": "7.1.0",
     "description": "An open framework for collecting and analyzing HPC metrics.",
     "dependencies": {},
     "devDependencies": {

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,7 +8,7 @@ build:
         - /root/.composer
         - /root/.npm
     pre_ci_boot:
-        image_name: tas-tools-ext-01.ccr.xdmod.org/centos7-xdmod6.6.0
+        image_name: tas-tools-ext-01.ccr.xdmod.org/centos7-xdmod7.0.1
         image_tag: version6
         pull: true
         options: "--user root -e HOME=/root"


### PR DESCRIPTION
This seems to work with my changes to the docker file to allow the base shippable image to be version 7.0.1
even though https://app.shippable.com/github/plessbd/xdmod/runs/9/summary/console failed, it was because of the UI tests which seem to have a few more bugs to work out and not because of the shippable updates