### PR TITLE
Add Export support to JobViewer

### DIFF
--- a/html/gui/js/ExportPanel.js
+++ b/html/gui/js/ExportPanel.js
@@ -57,10 +57,10 @@ Ext.extend(CCR.xdmod.ui.ExportPanel, Ext.Panel, {
         this.lastformatSetting = this.formatTypeCombo.getValue();
 
         if(allow) {
-            this.formatTypeCombo.store.loadData(CCR.xdmod.ui.ExportPanel.format_types);
+            this.formatTypeCombo.store.loadData(this.format_types);
             this.settings.format = cachedFormat;
         } else {
-            this.formatTypeCombo.store.loadData(CCR.xdmod.ui.ExportPanel.format_types_noimg);
+            this.formatTypeCombo.store.loadData(this.format_types_noimg);
             this.settings.format = cachedFormat;
         }
         this.formatTypeCombo.setValue(this.settings.format);
@@ -86,6 +86,19 @@ Ext.extend(CCR.xdmod.ui.ExportPanel, Ext.Panel, {
         }
     },
     initComponent: function () {
+
+        this.format_types = CCR.xdmod.ui.ExportPanel.format_types;
+        this.format_types_noimg = CCR.xdmod.ui.ExportPanel.format_types_noimg;
+
+        if (this.config && this.config.allowedExports) {
+            var allowedExports = this.config.allowedExports;
+            this.format_types = CCR.xdmod.ui.ExportPanel.format_types.filter(function (ftype) {
+                return allowedExports.includes(ftype[0]);
+            });
+            this.format_types_noimg = CCR.xdmod.ui.ExportPanel.format_types_noimg.filter(function (ftype) {
+                return allowedExports.includes(ftype[0]);
+            });
+        }
 
         this.settings = { format: 'png', showtitle: true, height: 484, width: 916, font_size: 0, scale: 1};
         this.template = 'medium';
@@ -236,7 +249,7 @@ Ext.extend(CCR.xdmod.ui.ExportPanel, Ext.Panel, {
                     'id',
                     'text'
                 ],
-                data: CCR.xdmod.ui.ExportPanel.format_types
+                data: this.format_types
             }),
             disabled: false,
             value: this.settings.format,

--- a/html/gui/js/modules/job_viewer/ChartPanel.js
+++ b/html/gui/js/modules/job_viewer/ChartPanel.js
@@ -54,47 +54,12 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
             legend: {
                 enabled: false
             },
+            credits: {
+                text: '',
+                href: ''
+            },
             exporting: {
-                enabled: true,
-                buttons: {
-                    contextButton: {
-                        menuClassName: 'job-viewer-timeseries-chart-contextmenu',
-                        symbol: 'menu',
-                        title: 'Chart context menu',
-                        menuItems: [
-                        {
-                            text: 'Print chart',
-                            onclick: function () {
-                                this.print();
-                            }
-                        },
-                        {
-                            separator: true
-                        },
-                        {
-                            text: 'Download PNG image',
-                            onclick: function () {
-                                document.location = this.userOptions.dataurl + '&filetype=image/png';
-                            }
-                        },
-                        {
-                            text: 'Download SVG image',
-                            onclick: function () {
-                                document.location = this.userOptions.dataurl + '&filetype=image/svg';
-                            }
-                        },
-                        {
-                            separator: true
-                        },
-                        {
-                            text: 'Download CSV data',
-                            onclick: function () {
-                                document.location = this.userOptions.dataurl + '&filetype=text/csv';
-                            }
-                        }
-                        ]
-                    }
-                }
+                enabled: false
             },
             tooltip: {
                 dateTimeLabelFormats: {
@@ -221,6 +186,16 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
             }
         },
 
+        export_option_selected: function (exportParams) {
+            document.location = this.dataurl + '&' + Ext.urlEncode(exportParams);
+        },
+
+        print_clicked: function () {
+            if (this.chart) {
+                this.chart.print();
+            }
+        },
+
         /**
          *
          * @param panel
@@ -262,8 +237,10 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
                 chartOptions.series = record.data.series;
                 chartOptions.yAxis.title.text = record.data.schema.units;
                 chartOptions.xAxis.title.text = 'Time (' + record.data.schema.timezone + ')';
+                chartOptions.credits.text = record.data.schema.source + '. Powered by XDMoD/Highcharts';
                 chartOptions.title.text = record.data.schema.description;
                 chartOptions.dataurl = record.store.proxy.url;
+                this.dataurl = record.store.proxy.url;
                 this.displayTimezone = record.data.schema.timezone;
 
                 this.setHighchartTimezone();

--- a/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/exportDialog.js
+++ b/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/exportDialog.js
@@ -1,0 +1,70 @@
+var usage = require('./usageTab.page.js');
+var xdmod = require('./xdmod.page.js');
+
+describe('Export Dialog', function () {
+    it('Select "Usage" tab', function () {
+        browser.url('/');
+        usage.selectTab();
+    });
+    it('Bring up export dialog', function () {
+        browser.waitAndClick(usage.toolbar.exportButton);
+        browser.waitForVisible(xdmod.selectors.exportDialog.window);
+    });
+    it('Check format list', function () {
+        browser.waitAndClick(xdmod.selectors.exportDialog.formatDropdown());
+        browser.waitForVisible(xdmod.selectors.exportDialog.comboList);
+        var expected = [
+            'PNG - Portable Network Graphics',
+            'SVG - Scalable Vector Graphics',
+            'CSV - Comma Separated Values',
+            'XML - Extensible Markup Language',
+            'PDF - Portable Document Format'
+        ];
+        expect(browser.getText(xdmod.selectors.exportDialog.comboListItems)).to.deep.equal(expected);
+        browser.waitAndClick(xdmod.selectors.exportDialog.formatDropdown());
+        browser.waitForInvisible(xdmod.selectors.exportDialog.comboList);
+    });
+    it('Check Image Sizes', function () {
+        browser.waitAndClick(xdmod.selectors.exportDialog.imageSizeDropdown());
+        browser.waitForVisible(xdmod.selectors.exportDialog.comboList);
+        var expected = [
+            'Small',
+            'Medium',
+            'Large',
+            'Poster',
+            'Custom'
+        ];
+        expect(browser.getText(xdmod.selectors.exportDialog.comboListItems)).to.deep.equal(expected);
+        browser.waitAndClick(xdmod.selectors.exportDialog.imageSizeDropdown());
+        browser.waitForInvisible(xdmod.selectors.exportDialog.comboList);
+    });
+    it('Check show chart title exists', function () {
+        browser.waitForVisible(xdmod.selectors.exportDialog.showTitleCheckbox());
+    });
+    it('Switch to CSV output', function () {
+        browser.waitAndClick(xdmod.selectors.exportDialog.formatDropdown());
+        browser.waitForVisible(xdmod.selectors.exportDialog.comboList);
+        browser.waitAndClick(xdmod.selectors.exportDialog.comboListItemByName('CSV'));
+        browser.waitForInvisible(xdmod.selectors.exportDialog.comboList);
+    });
+    it('Make sure title and image options are not visible', function () {
+        browser.waitForInvisible(xdmod.selectors.exportDialog.showTitleCheckbox());
+        browser.waitForInvisible(xdmod.selectors.exportDialog.imageSizeDropdown());
+    });
+    it('Switch to PDF output', function () {
+        browser.waitAndClick(xdmod.selectors.exportDialog.formatDropdown());
+        browser.waitForVisible(xdmod.selectors.exportDialog.comboList);
+        browser.waitAndClick(xdmod.selectors.exportDialog.comboListItemByName('PDF'));
+        browser.waitForInvisible(xdmod.selectors.exportDialog.comboList);
+    });
+    it('Make sure title and size options are visible', function () {
+        browser.waitForVisible(xdmod.selectors.exportDialog.showTitleCheckbox());
+        browser.waitForVisible(xdmod.selectors.exportDialog.widthInput());
+        browser.waitForVisible(xdmod.selectors.exportDialog.heightInput());
+        browser.waitForVisible(xdmod.selectors.exportDialog.fontInput());
+    });
+    it('Close', function () {
+        browser.waitAndClick(xdmod.selectors.exportDialog.cancelButton());
+        browser.waitForInvisible(xdmod.selectors.exportDialog.window);
+    });
+});

--- a/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/usageTab.page.js
+++ b/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/usageTab.page.js
@@ -8,6 +8,9 @@ class Usage {
         this.endField = '#tg_usage input[id^=end_field_ext]';
         this.legendText = 'g.highcharts-legend-item';
         this.refreshButton = '//div[@id="tg_usage"]//button[text()="Refresh"]/ancestor::node()[5]';
+        this.toolbar = {
+            exportButton: '//div[@id="tg_usage"]//button[text()="Export"]/ancestor::node()[5]'
+        };
         this.panel = '//div[@id="tg_usage"]';
         this.availableForReportCheckbox = '//div[@id="tg_usage"]//label[text()="Available For Report"]/parent::node()/input[@type="checkbox"]';
         this.mask = '.ext-el-mask';

--- a/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/xdmod.page.js
+++ b/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/xdmod.page.js
@@ -1,7 +1,42 @@
 class XDMoD {
     constructor() {
         this.selectors = {
-            mask: '.ext-el-mask'
+            mask: '.ext-el-mask',
+            exportDialog: {
+                window: '//body/div[contains(@class,"x-window")]//span[contains(@class, "x-window-header-text") and text() = "Export"]/ancestor::node()[5]',
+                cancelButton: function () {
+                    return module.exports.selectors.exportDialog.window + '//button[contains(text(), "Cancel")]';
+                },
+                formElement: function (formElementName) {
+                    return module.exports.selectors.exportDialog.window + '//input[@name="' + formElementName + '"]';
+                },
+                dropDown: function (formElementName) {
+                    return module.exports.selectors.exportDialog.formElement(formElementName) + '/../img[contains(@class,"x-form-arrow-trigger")]';
+                },
+                formatDropdown: function () {
+                    return module.exports.selectors.exportDialog.dropDown('format_type');
+                },
+                showTitleCheckbox: function () {
+                    return module.exports.selectors.exportDialog.formElement('show_title');
+                },
+                imageSizeDropdown: function () {
+                    return module.exports.selectors.exportDialog.dropDown('image_size');
+                },
+                widthInput: function () {
+                    return module.exports.selectors.exportDialog.formElement('width_inches');
+                },
+                heightInput: function () {
+                    return module.exports.selectors.exportDialog.formElement('height_inches');
+                },
+                fontInput: function () {
+                    return module.exports.selectors.exportDialog.formElement('font_pt');
+                },
+                comboList: '//div[contains(@class, "x-combo-list")]',
+                comboListItems: '//div[contains(@style, "visibility: visible")]//div[contains(@class, "x-combo-list-item")]',
+                comboListItemByName: function (name) {
+                    return '//div[contains(@style, "visibility: visible")]//div[contains(@class, "x-combo-list-item") and contains(text(), "' + name + '")]';
+                }
+            }
         };
     }
     selectTab(tabId) {


### PR DESCRIPTION
## Description
The chart export and printing in the job viewer is now updated to use the same Export and Print toolbar buttons as the rest of XDMoD. The main improvement is that the image size, font size and title presence are now configurable. Secondary improvement is that export UI is now consistent with the rest of XDMoD.

## Motivation and Context
Add configurable export to job viewer; Make Job viewer UI consistent with XDMoD.

## Tests performed
New tests will have been added in the SUPReMM module.

## Types of changes
- New feature (non-breaking change which adds functionality)
