### PR TITLE
Update public user

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -745,7 +745,7 @@ SQL;
                 ':display' => $display
             )
         );
-        $aclId =  $record[0]['acl_id'];
+        $aclId =  count($record) > 0 ? $record[0]['acl_id'] : null;
     } elseif ($inserted === 1 ) {
         $log->info("[SUCCESS] Inserted $msg");
         $aclId = $db->handle()->lastInsertId();

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -1412,12 +1412,21 @@ SQL;
             ':user_id' => $this->_id,
         );
 
+        $role_query_6 = "SELECT r.description, r.abbrev AS param_value, urp.is_primary, urp.is_active " .
+            "FROM moddb.UserRoles AS urp, moddb.Roles AS r " .
+            "WHERE r.role_id = urp.role_id AND user_id=:user_id " .
+            "AND r.description = 'Public'";
+        $role_query_6_params = array(
+            ':user_id' => $this->_id,
+        );
+
         $available_roles = array_merge(
             $this->_pdo->query($role_query_1, $role_query_1_params),
             $this->_pdo->query($role_query_2, $role_query_2_params),
             $this->_pdo->query($role_query_3, $role_query_3_params),
             $this->_pdo->query($role_query_4, $role_query_4_params),
-            $this->_pdo->query($role_query_5, $role_query_5_params)
+            $this->_pdo->query($role_query_5, $role_query_5_params),
+            $this->_pdo->query($role_query_6, $role_query_6_params)
         );
 
         return $available_roles;

--- a/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
@@ -38,3 +38,35 @@ LEFT JOIN user_acls cur
         cur.acl_id  = inc.acl_id
 WHERE cur.user_acl_id IS NULL;
 
+-- Create the Role
+INSERT INTO Roles(role_id, abbrev, description)
+SELECT inc.*
+FROM (
+  SELECT MAX(r.role_id) + 1 AS role_id,
+    'pub' AS abbrev,
+    'Public' AS description
+  FROM Roles r
+) inc
+LEFT JOIN Roles cur
+  ON cur.abbrev = inc.abbrev           AND
+     cur.description = inc.description
+WHERE cur.role_id IS NULL;
+
+-- Create the association between the Public User and the Public Role.
+INSERT INTO UserRoles(user_id, role_id, is_primary, is_active)
+SELECT inc.*
+FROM (
+  SELECT
+    u.id as user_id,
+    r.role_id AS role_id,
+    true as is_primary,
+    true as is_active
+  FROM Users u, Roles r
+  WHERE     BINARY u.username = BINARY 'Public User'
+        AND BINARY r.abbrev   = BINARY 'pub'
+) inc
+LEFT JOIN UserRoles cur
+  ON cur.user_id = inc.user_id AND
+     cur.role_id = inc.role_id
+WHERE     cur.role_id IS NULL
+      AND cur.user_id IS NULL;

--- a/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
@@ -62,7 +62,7 @@ FROM (
     true as is_primary,
     true as is_active
   FROM Users u, Roles r
-  WHERE     BINARY u.username = BINARY 'Public User'
+  WHERE     BINARY u.username = BINARY 'Public'
         AND BINARY r.abbrev   = BINARY 'pub'
 ) inc
 LEFT JOIN UserRoles cur

--- a/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
@@ -15,7 +15,7 @@ FROM (
         0        AS field_of_science,
         ut.id    AS user_type
     FROM UserTypes ut
-    WHERE BINARY ut.type = BINARY 'Internal'
+    WHERE BINARY ut.type LIKE BINARY 'Internal%'
 ) inc
 LEFT JOIN Users cur
      ON BINARY cur.username      = BINARY inc.username      AND

--- a/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
@@ -30,7 +30,7 @@ FROM (
         u.id     AS user_id,
         a.acl_id AS acl_id
      FROM Users u, acls a
-     WHERE BINARY u.username = BINARY 'Public User' AND
+     WHERE BINARY u.username = BINARY 'Public' AND
            BINARY a.name     = BINARY 'pub'
 ) inc
 LEFT JOIN user_acls cur

--- a/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
@@ -62,7 +62,7 @@ FROM (
     true as is_primary,
     true as is_active
   FROM Users u, Roles r
-  WHERE     BINARY u.username = BINARY 'Public'
+  WHERE     BINARY u.username = BINARY 'Public User'
         AND BINARY r.abbrev   = BINARY 'pub'
 ) inc
 LEFT JOIN UserRoles cur

--- a/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
@@ -30,7 +30,7 @@ FROM (
         u.id     AS user_id,
         a.acl_id AS acl_id
      FROM Users u, acls a
-     WHERE BINARY u.username = BINARY 'Public' AND
+     WHERE BINARY u.username = BINARY 'Public User' AND
            BINARY a.name     = BINARY 'pub'
 ) inc
 LEFT JOIN user_acls cur

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
@@ -2,6 +2,8 @@
 
 namespace IntegrationTests\Controllers;
 
+use Xdmod\Config;
+
 class UsageExplorerTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
@@ -315,5 +317,64 @@ EOF;
         $ret[] = array($baseSettings, 'text/xml', 'application/xml; charset=us-ascii');
 
         return $ret;
+    }
+
+    /**
+     * Ensure that the public user is able to see all of the realms that are
+     * currently installed in this instance of XDMoD.
+     */
+    public function testPublicUserGetMenus()
+    {
+        $data = <<< EOF
+{
+    "operation": "get_menus",
+    "public_user": "true",
+    "query_group": "tg_usage",
+    "node": "category_"
+}
+EOF;
+
+        $response = $this->helper->post('/controllers/user_interface.php', null, json_decode($data, true));
+
+        $this->assertEquals($response[1]['content_type'], 'application/json');
+        $this->assertEquals($response[1]['http_code'], 200);
+
+        $menus = $response[0];
+
+        $this->assertTrue(count($menus) > 0, "Public User: get_menus has returned no results.");
+
+        $realms = $this->getRealms();
+        $this->assertNotEmpty($realms, "Unable to retrieve realms from datawarehouse.json");
+
+        $categories = array_reduce($menus, function ($carry, $item) {
+            if (isset($item['category'])) {
+                if (!in_array($item['category'], $carry)) {
+                    $carry[] = $item['category'];
+                }
+            }
+            return $carry;
+        }, array());
+
+        $this->assertTrue(count($categories) >= 1, "There were no 'menus' that had a category propery, this is unexpected.");
+
+        $realmCategoryDiff = array_diff($realms, $categories);
+
+        $this->assertEmpty($realmCategoryDiff, "There were realms in datawarehouse.json that were not returned by get_menus.");
+    }
+
+    /**
+     * Retrieve an array of the currently installed realms
+     * ( from datawarehouse.json )
+     *
+     * @returns array
+     **/
+    public function getRealms()
+    {
+        $config = Config::factory();
+        $datawarehouse = $config['datawarehouse'];
+        if (isset($datawarehouse['realms'])) {
+            return array_keys($datawarehouse['realms']);
+        }
+        return array();
     }
 }

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
@@ -343,38 +343,26 @@ EOF;
 
         $this->assertTrue(count($menus) > 0, "Public User: get_menus has returned no results.");
 
-        $realms = $this->getRealms();
+        $realms = array('Jobs');
         $this->assertNotEmpty($realms, "Unable to retrieve realms from datawarehouse.json");
 
-        $categories = array_reduce($menus, function ($carry, $item) {
-            if (isset($item['category'])) {
-                if (!in_array($item['category'], $carry)) {
-                    $carry[] = $item['category'];
+        $categories = array_reduce(
+            $menus,
+            function ($carry, $item) {
+                if (isset($item['category'])) {
+                    if (!in_array($item['category'], $carry)) {
+                        $carry[] = $item['category'];
+                    }
                 }
-            }
-            return $carry;
-        }, array());
+                return $carry;
+            },
+            array()
+        );
 
         $this->assertTrue(count($categories) >= 1, "There were no 'menus' that had a category propery, this is unexpected.");
 
         $realmCategoryDiff = array_diff($realms, $categories);
 
         $this->assertEmpty($realmCategoryDiff, "There were realms in datawarehouse.json that were not returned by get_menus.");
-    }
-
-    /**
-     * Retrieve an array of the currently installed realms
-     * ( from datawarehouse.json )
-     *
-     * @returns array
-     **/
-    public function getRealms()
-    {
-        $config = Config::factory();
-        $datawarehouse = $config['datawarehouse'];
-        if (isset($datawarehouse['realms'])) {
-            return array_keys($datawarehouse['realms']);
-        }
-        return array();
     }
 }

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
@@ -88,7 +88,7 @@ answerQuestion {DB Admin Username} root
 providePassword {DB Admin Password:} {}
 confirmFileWrite yes
 enterToContinue
-set timeout 120
+set timeout 240
 provideInput {Do you want to see the output*} {no}
 provideInput {Do you want to see the output*} {no}
 provideInput {Do you want to see the output*} {no}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Until we completely remove role usage we need to create a 'Public' role as
well as an association to this role for the Public User. As such, we need to ensure that the Public role exists and that the Public User has a relation to it. In addition, the enumAllAvailableRoles function needs to be updated so that it can take this new role into account.

## Motivation and Context
Without these changes the Public User's 'activeRole' returns the user role. This leads to unexpected behavior when viewing the Usage tab ( i.e. there are a number of Realms that are missing when logged in as the Public User ).

## Tests performed
Manual Tests performed: 

Test 1:
  - Navigate to XDMoD ( do not login )
  - Click the Usage tab
  - Double check that the 'Accounts' and 'Allocations' realm are visible / enabled.

Test 2: 
  - Navigate to XDMoD ( login as a 'usr' )
  - Click the Usage tab
  - Double check that the 'Accounts' and 'Allocations' realms are not visible

Test 3:
  - Navigate to XDMoD ( login as a 'cd' )
  - Click the Usage tab
  - Double check that the 'Accounts' and 'Allocations' realms are visible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
