### PR TITLE
Update user displayed message when ACL info is not

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -313,8 +313,7 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
     if ($acls !== null) {
         processAcls($db, $module, ( null !== $realms ? $realms : array() ), $acls);
     } else {
-        $log->err("Unable to process $module, missing acl information. Is there a $module.json file in CONF_DIR/modules.d?");
-        $log->warning("No acl information for module $module skipping...");
+        $log->info("No acl information for module $module skipping...");
     }
 }
 


### PR DESCRIPTION
Update user displayed message when ACL info is not in the module config
file.
