### PR TITLE
Adjust subtitle spacing.

### DIFF
--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -392,7 +392,7 @@ class HighChart2
             'color'=> '#5078a0',
             'fontSize' => (12 + $font_size).'px'
         );
-        $this->_chart['subtitle']['y'] = 30 + $font_size;
+        $this->_chart['subtitle']['y'] = 28 + (2 * $font_size);
     } // setSubtitle()
 
     // ---------------------------------------------------------


### PR DESCRIPTION
## Description
The scale factor for the subtitle spacing was incorrect and caused the
title and subtitle to overlap at the bigger font sizes. This uses the
correct scaling factor. The spacing is identical between old and new
code at a font size of 2.

Original (note how the 'y' in by and 'l' in Behavioral overlap):
![old](https://user-images.githubusercontent.com/5342179/31250473-dbf82d0a-a9e8-11e7-83fe-336a89374762.png)

What it looks like now:
![new](https://user-images.githubusercontent.com/5342179/31250478-ded85626-a9e8-11e7-8ee1-bc9a84e261ee.png)
