### PR TITLE
Allow ETL ingestors to skip calling ANALYZE TABLE

### DIFF
--- a/classes/ETL/Aggregator/AggregatorOptions.php
+++ b/classes/ETL/Aggregator/AggregatorOptions.php
@@ -65,6 +65,9 @@ class AggregatorOptions extends aOptions
             // See http://dev.mysql.com/doc/refman/5.7/en/alter-table.html
             "disable_keys" => false,
 
+            // Perform an ANALYZE or OPTIMIZE TABLE following ingestion
+            "analyze_table" => true,
+
             // A list of the only resources that should be included for this action. This is mainly
             // used for actions that are resource-specific, but it is up to the action to heed this
             // setting.

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -417,7 +417,7 @@ class pdoAggregator extends aAggregator
             $tableFullName =  $utilitySchema . "." . $tableName;
             if ( false === $this->utilityEndpoint->tableExists($tableName, $utilitySchema) ) {
                 $this->logger->info("Table does not exist: '$tableFullName', skipping.");
-                continue;
+                return false;
             }
         } catch (PDOException $e) {
             $this->logAndThrowException(

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -193,8 +193,6 @@ class pdoAggregator extends aAggregator
         // An individual action may override restrictions provided by the overseer.
         $this->setOverseerRestrictionOverrides();
 
-        $this->getEtlOverseerOptions()->applyOverseerRestrictions($this->etlSourceQuery, $this->sourceEndpoint, $this);
-
         if ( null === $this->etlSourceQuery ) {
             $msg = "ETL source query is not set";
             $this->logAndThrowException($msg);
@@ -202,6 +200,8 @@ class pdoAggregator extends aAggregator
             $msg = "ETL source query is not an instance of Query";
             $this->logAndThrowException($msg);
         }
+
+        $this->getEtlOverseerOptions()->applyOverseerRestrictions($this->etlSourceQuery, $this->sourceEndpoint, $this);
 
         // Group by fields must match existing column names. Variables are not substituted at this point
         // but it doesn't matter because the naming will still be consistent.
@@ -381,7 +381,7 @@ class pdoAggregator extends aAggregator
         foreach ( $this->etlDestinationTableList as $etlTableKey => $etlTable ) {
             $qualifiedDestTableName = $etlTable->getFullName();
 
-            if ( $numAggregationPeriodsProcessed > 0 ) {
+            if ( $numAggregationPeriodsProcessed > 0 && $this->options->analyze_table ) {
                 $sqlList[] = "OPTIMIZE TABLE $qualifiedDestTableName";
             }
 
@@ -1002,7 +1002,9 @@ class pdoAggregator extends aAggregator
                     $sql =
                         "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
                         . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
-                    $this->logger->debug("[EXPERIMENTAL] Batch temp table " . $this->sourceEndpoint . ": $sql");
+                    $this->logger->debug(
+                        sprintf("[EXPERIMENTAL] Batch temp table %s: %s", $this->sourceEndpoint, $sql)
+                    );
                     $result = $this->sourceHandle->execute($sql, $usedParams);
                 } catch (PDOException $e ) {
                     $this->logAndThrowException(

--- a/classes/ETL/Ingestor/IngestorOptions.php
+++ b/classes/ETL/Ingestor/IngestorOptions.php
@@ -67,7 +67,7 @@ class IngestorOptions extends aOptions
             // http://dev.mysql.com/doc/refman/5.7/en/alter-table.html
             "disable_keys" => false,
 
-            // Perform an ANALYZE TABLE following ingestion
+            // Perform an ANALYZE or TABLE following ingestion
             "analyze_table" => true,
 
             // A list of the only resources that should be included for this action. This is mainly

--- a/classes/ETL/Ingestor/IngestorOptions.php
+++ b/classes/ETL/Ingestor/IngestorOptions.php
@@ -67,6 +67,9 @@ class IngestorOptions extends aOptions
             // http://dev.mysql.com/doc/refman/5.7/en/alter-table.html
             "disable_keys" => false,
 
+            // Perform an ANALYZE TABLE following ingestion
+            "analyze_table" => true,
+
             // A list of the only resources that should be included for this action. This is mainly
             // used for actions that are resource-specific, but it is up to the action to heed this
             // setting.

--- a/classes/ETL/aRdbmsDestinationAction.php
+++ b/classes/ETL/aRdbmsDestinationAction.php
@@ -650,7 +650,11 @@ abstract class aRdbmsDestinationAction extends aAction
                 }
             }
 
-            if ( null !== $numRecordsProcessed && $numRecordsProcessed > 0 ) {
+            if (
+                null !== $numRecordsProcessed &&
+                $numRecordsProcessed > 0 &&
+                $this->options->analyze_table
+            ) {
                 $sqlList[] = "ANALYZE TABLE $qualifiedDestTableName";
             }
         }
@@ -691,7 +695,9 @@ abstract class aRdbmsDestinationAction extends aAction
             try {
                 $this->logger->debug($sql);
                 if ( ! $this->getEtlOverseerOptions()->isDryrun() ) {
+                    $start = microtime(true);
                     $endpoint->getHandle()->execute($sql);
+                    $this->logger->debug(sprintf('Completed in %fs', round(microtime(true) - $start, 5)));
                 }
             }
             catch (PDOException $e) {

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -16,7 +16,7 @@ ini_set('memory_limit', -1);
 // Character to use when separating list output
 const LIST_SEPARATOR = "\t";
 
-use \Exception;
+use Exception;
 use CCR\Log;
 use CCR\DB;
 use ETL\EtlOverseer;

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -171,6 +171,9 @@ foreach ($args as $arg => $value) {
                 case 'month':
                     $scriptOptions['chunk-size-days'] = 30;
                     break;
+                case 'quarter':
+                    $scriptOptions['chunk-size-days'] = 91;
+                    break;
                 case 'year':
                     $scriptOptions['chunk-size-days'] = 365;
                     break;
@@ -683,7 +686,7 @@ Usage: {$argv[0]}
     -g, --group
     Process the specified ETL group. May use multiple times.
 
-    -k, --chunk-size {none, day, week, month, year}
+    -k, --chunk-size {none, day, week, month, quarter, year}
     Break up ingestion into chunks of this size. Helps to make more recent data available faster. [default year]
 
     -l, --list {resources, sections, actions, endpoint-types, configured-endpoints} | <etl_section_name>


### PR DESCRIPTION
## Description

When executing multiple ETL actions that insert data into the same table it is not necessary to call `ANALYZE TABLE` after each action, only the final one.

Added "quarter" to the list of ETL chunk size options.

## Motivation and Context

Performance improvements.

## Tests performed

Ran Jetstream ingestion and verified that `ANALYZE TABLE` is only called when expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
