### PR TITLE
Fix the filer dialog clear all button so that it actually clears all of the filters.

### DIFF
--- a/html/gui/js/FilterDimensionPanel.js
+++ b/html/gui/js/FilterDimensionPanel.js
@@ -316,7 +316,7 @@ Ext.extend(CCR.xdmod.ui.FilterDimensionPanel, Ext.Panel, {
                         // store. If it does not have one, create one for
                         // purposes of disabling this filter.
                         var filterValue = record.value_id;
-                        var viewRecordIndex = store.find('id', filterValue);
+                        var viewRecordIndex = store.findExact('id', filterValue);
                         var viewRecord;
                         if (viewRecordIndex >= 0) {
                             viewRecord = store.getAt(viewRecordIndex);


### PR DESCRIPTION
## Description
Fix the filer dialog clear all button so that it actually clears all of the filters.

The clear all button does not clear all of the filters. The bug is caused because the code uses the wrong ExtJS API call to obtain the filter information. The wrong code does a substring match on the decimal representation of the numerical ID. For example, if the filter with id 2 is in the list then the clear all button may clear any filter with id 20 - 29 or 200 - 299 or 2000 - 2999. The filters are processed in alphabetical order rather than numerical order.

## Steps to reproduce
In metric explorer on the XSEDE instance click "Add filter" -> "Resource" and select "ANL VIS" and "SDSC DTF" now click "Clear All" button. Observe that the "SDSC DTF" checkbox is incorrectly still checked.

## Tests performed
Ran the test in 'steps to reproduce' and confirmed that the new code correctly unticks all boxes.
