### PR TITLE
Add polyfill for Array.prototype.includes() which is missing from IE.

### DIFF
--- a/html/gui/lib/oldie-array-includes-polyfill.js
+++ b/html/gui/lib/oldie-array-includes-polyfill.js
@@ -1,0 +1,51 @@
+/* eslint no-extend-native: "off", no-bitwise: "off" */
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+if (!Array.prototype.includes) {
+    Object.defineProperty(Array.prototype, 'includes', {
+        value: function (searchElement, fromIndex) {
+            // 1. Let O be ? ToObject(this value).
+            if (this == null) {
+                throw new TypeError('"this" is null or not defined');
+            }
+
+            var o = Object(this);
+
+            // 2. Let len be ? ToLength(? Get(O, "length")).
+            var len = o.length >>> 0;
+
+            // 3. If len is 0, return false.
+            if (len === 0) {
+                return false;
+            }
+
+            // 4. Let n be ? ToInteger(fromIndex).
+            //    (If fromIndex is undefined, this step produces the value 0.)
+            var n = fromIndex | 0;
+
+            // 5. If n ≥ 0, then
+            //  a. Let k be n.
+            // 6. Else n < 0,
+            //  a. Let k be len + n.
+            //  b. If k < 0, let k be 0.
+            var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+            function sameValueZero(x, y) {
+                return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+            }
+
+            // 7. Repeat, while k < len
+            while (k < len) {
+                // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+                // b. If SameValueZero(searchElement, elementK) is true, return true.
+                // c. Increase k by 1.
+                if (sameValueZero(o[k], searchElement)) {
+                    return true;
+                }
+                k++;
+            }
+
+            // 8. Return false
+            return false;
+        }
+    });
+}

--- a/html/index.php
+++ b/html/index.php
@@ -115,6 +115,7 @@
 
       <link rel="shortcut icon" href="gui/icons/favicon_static.ico" />
       <script type="text/javascript" src="gui/lib/oldie-console-patch.js"></script>
+      <script type="text/javascript" src="gui/lib/oldie-array-includes-polyfill.js"></script>
       <?php if (!$userLoggedIn): ?>
       <script type="text/javascript">
          /**


### PR DESCRIPTION
## Description

Add polyfill for Array.prototype.includes() which is missing from IE.

## Motivation and Context
We started using .includes() in #271, turns out that it is not in IE. Rather than removing the calls to the function this just adds the capability to browsers that don't already have it.

## Tests performed
Manually checked that export works in IE. Ran the automated tests in SauceLabs.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)