### PR TITLE
Add verification action for ingestion of jobs into XDMoD data warehouse

### DIFF
--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -71,9 +71,15 @@ class EtlOverseer extends Loggable implements iEtlOverseer
             if ( ! $options->enabled ) {
                 continue;
             }
-            $usedEndpointKeys[] = $options->utility;
-            $usedEndpointKeys[] = $options->source;
-            $usedEndpointKeys[] = $options->destination;
+            if ( null !== $options->utility ) {
+                $usedEndpointKeys[] = $options->utility;
+            }
+            if ( null !== $options->source ) {
+                $usedEndpointKeys[] = $options->source;
+            }
+            if ( null !== $options->destination ) {
+                $usedEndpointKeys[] = $options->destination;
+            }
         }
         foreach ( $this->etlOverseerOptions->getSectionNames() as $sectionName ) {
             foreach ( $etlConfig->getSectionActionNames($sectionName) as $actionName ) {
@@ -81,9 +87,15 @@ class EtlOverseer extends Loggable implements iEtlOverseer
                 if ( ! $options->enabled ) {
                     continue;
                 }
-                $usedEndpointKeys[] = $options->utility;
-                $usedEndpointKeys[] = $options->source;
-                $usedEndpointKeys[] = $options->destination;
+                if ( null !== $options->utility ) {
+                    $usedEndpointKeys[] = $options->utility;
+                }
+                if ( null !== $options->source ) {
+                    $usedEndpointKeys[] = $options->source;
+                }
+                if ( null !== $options->destination ) {
+                    $usedEndpointKeys[] = $options->destination;
+                }
             }
         }
 

--- a/configuration/etl/etl.d/verify.json
+++ b/configuration/etl/etl.d/verify.json
@@ -1,0 +1,32 @@
+{
+    "defaults": {
+
+        "global": {
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "XDMoD Datawarehouse",
+                    "config": "datawarehouse",
+                    "schema": "modw"
+                }
+            }
+        },
+
+        "verify-dw": {
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions"
+        }
+    },
+
+    "#": "Perform verification of ingested data",
+
+    "verify-dw": [
+        {
+            "name": "VerifyXdmodJobIngestion",
+            "description": "Check that jobs have been ingested into XDMoD recently",
+            "class": "VerifyDatabase",
+            "#": "Table definition relative to paths.table_config_dir if path not specified",
+            "definition_file": "verify/verify_xdmod_dw_job_ingest.json"
+        }
+    ]
+}

--- a/configuration/etl/etl_tables.d/verify/verify_xdmod_dw_job_ingest.json
+++ b/configuration/etl/etl_tables.d/verify/verify_xdmod_dw_job_ingest.json
@@ -1,0 +1,55 @@
+{
+    "#": "Verify that accounting data is being ingested into the XDMoD DW on a timely basis",
+
+    "source_query": {
+
+        "overseer_restrictions": {
+            "include_only_resource_codes": "r.id IN ${VALUE}",
+            "exclude_resource_codes": "r.id NOT IN ${VALUE}"
+        },
+
+        "records": {
+            "id": "r.id",
+            "name": "r.name",
+            "code": "r.code",
+            "last_entry_date": "max(maxts.max_ts)",
+            "number_of_days": "${NUMBER_OF_DAYS}"
+        },
+
+        "joins": [
+            {
+                "name": "resourcefact",
+                "schema": "${SOURCE_SCHEMA}",
+                "alias": "r"
+            },{
+                "#": "Since HAVING is not yet supported I need to simulate adding this clause:",
+                "#": "HAVING MAX(j.end_time) < (NOW() - INTERVAL '${NUMBER_OF_DAYS} DAYS')",
+                "#": "Note that jobfact does not have the last modified timestamp but job_record and job_task will",
+                "name": "( SELECT resource_id, MAX(j.end_time) AS max_ts FROM ${SOURCE_SCHEMA}.jobfact j GROUP BY j.resource_id )",
+                "alias": "maxts",
+                "on": "maxts.resource_id = r.id"
+            }
+        ],
+
+        "where": [
+            "r.end_date IS NULL",
+            "maxts.max_ts < (NOW() - INTERVAL ${NUMBER_OF_DAYS} DAY)"
+        ],
+
+        "groupby": [
+            "r.id",
+            "r.name",
+            "r.code"
+        ]
+    },
+
+    "verify_database": {
+        "response": {
+            "destination_email": "${DW_ETL_LOG_RECIPIENT}",
+            "subject": "[XDMoD] Accounting data not ingested in ${NUMBER_OF_DAYS} days",
+            "header": "Job accounting data has not been ingested for these resources in ${NUMBER_OF_DAYS} days.",
+            "footer": "Thank You.",
+            "line": "Jobs have not been reported for '${code}' since ${last_entry_date}"
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add verification action for ingestion of jobs into XDMoD data warehouse by checking which active resources have not reported jobs for D days. Essentially, the following query is run:

```
SELECT
r.id AS id,
r.name AS name,
r.code AS code,
max(maxts.max_ts) AS last_entry_date,
5 AS number_of_days
FROM `modw`.`resourcefact` AS r
JOIN ( SELECT resource_id, MAX(j.end_time) AS max_ts FROM modw.jobfact j GROUP BY j.resource_id ) AS maxts ON maxts.resource_id = r.id
WHERE r.end_date IS NULL
AND maxts.max_ts < (NOW() - INTERVAL 5 DAY)
GROUP BY r.id, r.name, r.code;
```

**Note that not all resources have accurate end/decommision dates in the database so we can control the resources to be checked using the `etl_overseer.php` `-x` or `-r` options.**

See also PR ubccr/xdmod-xsede#59.

## Motivation and Context

Catch failure of ingestion.

## Tests performed

Ran ETL action in dry-run mode and tested query manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
