### PR TITLE
Acl Tabs

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -745,7 +745,7 @@ SQL;
                 ':display' => $display
             )
         );
-        $aclId =  $record[0]['acl_id'];
+        $aclId =  count($record) > 0 ? $record[0]['acl_id'] : null;
     } elseif ($inserted === 1 ) {
         $log->info("[SUCCESS] Inserted $msg");
         $aclId = $db->handle()->lastInsertId();
@@ -877,12 +877,12 @@ SQL;
     $log->debug($statement);
     $inserted = 0;
     foreach ($hierarchies as $hierarchyName => $hierarchyInfo) {
-        if (null === $hierarchyInfo['level']) {
+        if (!isset($hierarchyInfo['level'])) {
             $log->warning("Malformed hierarchy information for Acl $acl. No level present.");
             continue;
         }
 
-        if (null === $hierarchyInfo['filter_override']) {
+        if (!isset($hierarchyInfo['filter_override'])) {
             $log->warning("Malformed hierarchy information for Acl $acl. No filter_override present.");
             continue;
         }

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -106,7 +106,7 @@ function main()
     $blacklist = array('default');
 
     // the sections of roles.json that we want to process.
-    $sections = array('permitted_modules', 'query_descripters', 'display', 'type');
+    $sections = array('permitted_modules', 'query_descripters', 'display', 'type', 'hierarchies');
 
     // the ultimate destination for the parsed information from
     // roles/datawarehouse

--- a/classes/Models/Services/Tabs.php
+++ b/classes/Models/Services/Tabs.php
@@ -1,4 +1,6 @@
-<?php namespace Models\Services;
+<?php
+
+namespace Models\Services;
 
 use CCR\DB;
 use User\Roles;
@@ -56,7 +58,7 @@ SQL;
         foreach ($rows as $row) {
             $tab = $row['tab'];
             $acl = $row['acl'];
-            if (array_key_exists($acl, $acls)) {
+            if (array_key_exists($acl, $acls) && isset($acls[$acl]['permitted_modules'])) {
                 $tabs = array_reduce(
                     $acls[$acl]['permitted_modules'],
                     function ($carry, $item) use ($tab) {

--- a/classes/Models/Services/Tabs.php
+++ b/classes/Models/Services/Tabs.php
@@ -1,0 +1,63 @@
+<?php namespace Models\Services;
+
+use CCR\DB;
+use Xdmod\Config;
+
+class Tabs
+{
+
+    private function __construct()
+    {
+    }
+
+    public static function getTabs(\XDUser $user)
+    {
+        $userId = $user->getUserID();
+
+        if (!isset($userId)) {
+            throw new \Exception('User must be saved first.');
+        }
+        $results = array();
+
+        $db = DB::factory('database');
+
+        $query = <<<SQL
+SELECT DISTINCT t.name as tab, a.name as acl FROM acl_tabs at
+  JOIN user_acls ua
+    ON at.acl_id = ua.acl_id
+  JOIN tabs t
+    ON at.tab_id = t.tab_id
+  JOIN acls a
+    ON a.acl_id = at.acl_id
+WHERE ua.user_id = :user_id
+SQL;
+        $rows = $db->query($query, array(
+            ':user_id' => $userId
+        ));
+
+        $config = Config::factory();
+
+        $acls = $config['roles']['roles'];
+
+        foreach($rows as $row) {
+            $tab = $row['tab'];
+            $acl = $row['acl'];
+            if (array_key_exists($acl, $acls)) {
+                $tabs = array_reduce(
+                    $acls[$acl]['permitted_modules'],
+                    function($carry, $item) use($tab) {
+                        if ($tab === $item['name']) {
+                            $carry[] = $item;
+                        }
+                        return $carry;
+                    },
+                    array());
+                if (count($tabs) > 0) {
+                    $results = array_merge($results, $tabs);
+                }
+            }
+        }
+
+        return $results;
+    }
+}

--- a/classes/Models/Services/Tabs.php
+++ b/classes/Models/Services/Tabs.php
@@ -23,7 +23,7 @@ class Tabs
         $db = DB::factory('database');
 
         $query = <<<SQL
-SELECT t.name as tab ,a.name as acl FROM acl_tabs at
+SELECT t.name AS tab ,a.name AS acl FROM acl_tabs at
 JOIN (
     SELECT ua.acl_id FROM user_acls ua
       JOIN acl_hierarchies ah
@@ -47,25 +47,26 @@ SQL;
         $acls = array();
 
         $roleNames = Roles::getRoleNames(array('default'));
-        foreach( $roleNames as $roleName) {
-            foreach($sections as $section) {
+        foreach ($roleNames as $roleName) {
+            foreach ($sections as $section) {
                 $acls[$roleName][$section] = Roles::getConfig($roleName, $section);
             }
         }
 
-        foreach($rows as $row) {
+        foreach ($rows as $row) {
             $tab = $row['tab'];
             $acl = $row['acl'];
             if (array_key_exists($acl, $acls)) {
                 $tabs = array_reduce(
                     $acls[$acl]['permitted_modules'],
-                    function($carry, $item) use($tab) {
+                    function ($carry, $item) use ($tab) {
                         if ($tab === $item['name']) {
                             $carry[] = $item;
                         }
                         return $carry;
                     },
-                    array());
+                    array()
+                );
                 if (count($tabs) > 0) {
                     $results = array_merge($results, $tabs);
                 }

--- a/classes/Models/Services/Tabs.php
+++ b/classes/Models/Services/Tabs.php
@@ -1,6 +1,7 @@
 <?php namespace Models\Services;
 
 use CCR\DB;
+use User\Roles;
 use Xdmod\Config;
 
 class Tabs
@@ -35,9 +36,15 @@ SQL;
             ':user_id' => $userId
         ));
 
-        $config = Config::factory();
+        $sections = array('display', 'type', 'permitted_modules', 'query_descripters', 'summary_charts');
+        $acls = array();
 
-        $acls = $config['roles']['roles'];
+        $roleNames = Roles::getRoleNames(array('default'));
+        foreach( $roleNames as $roleName) {
+            foreach($sections as $section) {
+                $acls[$roleName][$section] = Roles::getConfig($roleName, $section);
+            }
+        }
 
         foreach($rows as $row) {
             $tab = $row['tab'];

--- a/classes/OpenXdmod/Migration/Version701To710/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version701To710/ConfigFilesMigration.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Jeffrey T. Palmer <jtpalmer@buffalo.edu>
+ */
+
+namespace OpenXdmod\Migration\Version701To710;
+
+use OpenXdmod\Migration\ConfigFilesMigration as AbstractConfigFilesMigration;
+
+/**
+ * Update config files from version 7.0.1 To 7.1.0.
+ */
+class ConfigFilesMigration extends AbstractConfigFilesMigration
+{
+    /**
+     * Execute the migration.
+     */
+    public function execute()
+    {
+        // Make sure all the config files that will be changed are writable.
+        $this->assertPortalSettingsIsWritable();
+
+        // Set new options in portal_settings.ini.
+        $this->writePortalSettingsFile();
+    }
+}

--- a/classes/OpenXdmod/Migration/Version701To710/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version701To710/DatabasesMigration.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @author Ryan Rathsam <ryanrath@buffalo.edu>
+ **/
+namespace OpenXdmod\Migration\Version701To710;
+
+/**
+ * Ensure that the tables / data exists that will support the Acl subsystem
+ * going into version 7.1.
+ **/
+class DatabasesMigration extends \OpenXdmod\Migration\DatabasesMigration
+{
+    /**
+     * @see \OpenXdmod\Migration\Migration::__construct
+     **/
+    public function __construct($currentVersion, $newVersion)
+    {
+        parent::__construct($currentVersion, $newVersion);
+    }
+
+    /**
+     * @see \OpenXdmod\Migration\Migration::execute
+     **/
+    public function execute()
+    {
+        parent::execute();
+
+        $this->migrateTables();
+        $this->populateTables();
+    }
+
+    /**
+     * Attempt to migrate the acl tables into the current system database. This process will
+     * utilize the script acl-xdmod-management which in turn utilizes the ETL overseer.
+     *
+     * @return void
+     **/
+    public function migrateTables()
+    {
+        $scripts = array(
+            'acl-xdmod-management' => array()
+        );
+        $this->runScripts($scripts);
+    }
+
+    /**
+     * Attempt to execute the scripts: acl-import and acl-config which will
+     * populate the acl related tables with the correct information for this
+     * installation based on the following configuration (directories of) files:
+     *     - CONF_DIR/datawarehouse.[d|json]
+     *     - CONF_DIR/roles.[d|json]
+     *     - CONF_DIR/hierarchies.[d|json]
+     *
+     * @return void
+     **/
+    public function populateTables()
+    {
+        $scripts = array(
+            'acl-config' => array(),
+            'acl-import' => array()
+        );
+
+        $this->runScripts($scripts);
+    }
+
+    public function runScripts(array $scripts)
+    {
+        foreach ($scripts as $scriptName => $params) {
+            $cmd = "$scriptName ". implode(' ', $params);
+            $this->logger->info("Executing $cmd");
+
+            $output = shell_exec($cmd);
+
+            $hadError = strpos($output, 'error') !== false;
+
+            if ($hadError == true) {
+                $this->logger->err(<<<MSG
+There was an error when attempting to execute the the script with the provided
+parameters. Please see the output below, make any corrections necessary and
+re-run this setup.
+
+$output
+MSG
+                );
+                exit(1);
+            } else {
+                $this->logger->notice(<<<MSG
+The script executed without error.
+MSG
+                );
+                $this->logger->notice($output);
+            }
+        }
+    }
+}

--- a/classes/OpenXdmod/Migration/Version701To710/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version701To710/DatabasesMigration.php
@@ -85,10 +85,7 @@ MSG
                 );
                 exit(1);
             } else {
-                $this->logger->notice(<<<MSG
-The script executed without error.
-MSG
-                );
+                $this->logger->notice("The script executed without error.");
                 $this->logger->notice($output);
             }
         }

--- a/configuration/roles.json
+++ b/configuration/roles.json
@@ -257,6 +257,10 @@
         "pub": {
             "display": "Public User",
             "type": "data",
+            "hierarchies": [{
+                "level": 0,
+                "filter_override": false
+            }],
             "permitted_modules": [
                 {
                     "name": "tg_summary",
@@ -346,6 +350,10 @@
         "usr": {
             "display": "User",
             "type": "data",
+            "hierarchies": [{
+                "level": 100,
+                "filter_override": false
+            }],
             "dimensions": [
                 "person"
             ],
@@ -354,6 +362,10 @@
         "cd": {
             "display": "Center Director",
             "type": "feature",
+            "hierarchies": [{
+                "level": 400,
+                "filter_override": false
+            }],
             "dimensions": [
                 "provider"
             ],
@@ -362,6 +374,10 @@
         "pi": {
             "display": "Principal Investigator",
             "type": "data",
+            "hierarchies": [{
+                "level": 200,
+                "filter_override": false
+            }],
             "dimensions": [
                 "pi"
             ],
@@ -370,6 +386,10 @@
         "cs": {
             "display": "Center Staff",
             "type": "data",
+            "hierarchies": [{
+                "level": 300,
+                "filter_override": false
+            }],
             "dimensions": [
                 "provider"
             ],
@@ -378,6 +398,10 @@
         "mgr": {
             "display": "Manager",
             "type": "data",
+            "hierarchies": [{
+                "level": 301,
+                "filter_override": false
+            }],
             "dimensions": [
                 "person"
             ],

--- a/html/controllers/user_interface/get_tabs.php
+++ b/html/controllers/user_interface/get_tabs.php
@@ -2,58 +2,31 @@
 
 // Operation: user_interface->get_tabs
 
+use Models\Services\Tabs;
+
 $returnData = array();
 
 try {
     $user = \xd_security\detectUser(array(XDUser::PUBLIC_USER));
 
-    $tabs = array();
-
-    $roles = $user->getRoles();
-
-    foreach ($roles as $role_abbrev) {
-        if ($role_abbrev == 'dev') {
-            continue;
-        }
-
-        $role = \User\aRole::factory($user->_getFormalRoleName($role_abbrev));
-        $modules = $role->getPermittedModules();
-
-        foreach ($modules as $module) {
-            if (! isset($tabs[$module->getName()])) {
-                $tabs[$module->getName()] = array(
-                    'tab' => $module->getName(),
-                    'isDefault' => $module->isDefault(),
-                    'title' => $module->getTitle(),
-                    'pos' => $module->getPosition(),
-                    'permitted_modules' => $module->getPermittedModules(),
-                    'javascriptClass' => $module->getJavascriptClass(),
-                    'javascriptReference' => $module->getJavascriptReference(),
-                    'tooltip' => $module->getTooltip(),
-                    'userManualSectionName' => $module->getUserManualSectionName()
-                );
-            } else {
-                if ($module->getPermittedModules() !== null) {
-                    // if module with same name already added, merge permitted_modules
-                    if ($tabs[$module->getName()]['permitted_modules'] === null) {
-                        $tabs[$module->getName()]['permitted_modules'] = $module->getPermittedModules();
-                    } else {
-                        $tabs[$module->getName()]['permitted_modules'] = array_values(
-                            array_unique(
-                                array_merge(
-                                    $tabs[$module->getName()]['permitted_modules'], $module->getPermittedModules()
-                                )
-                            )
-                        );
-                    }
-                }
-            }
-        }
+    $results = array();
+    $tabs = Tabs::getTabs($user);
+    foreach($tabs as $tab) {
+        $results[] = array(
+            'tab' => $tab['name'],
+            'isDefault' => isset($tab['default']) ? $tab['default'] : false,
+            'title' => $tab['title'],
+            'pos' => $tab['position'],
+            'permitted_modules' => isset($tab['permitted_modules']) ? $tab['permitted_modules'] : null,
+            'javascriptClass' => $tab['javascriptClass'],
+            'javascriptReference' => $tab['javascriptReference'],
+            'tooltip' => isset($tab['tooltip']) ? $tab['tooltip'] : '',
+            'userManualSectionName' => $tab['userManualSectionName'],
+        );
     }
-
     // Sort tabs
     usort(
-        $tabs,
+        $results,
         function ($a, $b) { return ($a['pos'] < $b['pos']) ? -1 : 1; }
     );
 
@@ -62,7 +35,7 @@ try {
         'totalCount' => 1,
         'message'    => '',
         'data'       => array(
-            array('tabs' => json_encode(array_values($tabs)))
+            array('tabs' => json_encode(array_values($results)))
         ),
     );
 } catch (SessionExpiredException $see)

--- a/html/controllers/user_interface/get_tabs.php
+++ b/html/controllers/user_interface/get_tabs.php
@@ -27,7 +27,9 @@ try {
     // Sort tabs
     usort(
         $results,
-        function ($a, $b) { return ($a['pos'] < $b['pos']) ? -1 : 1; }
+        function ($a, $b) {
+            return ($a['pos'] < $b['pos']) ? -1 : 1;
+        }
     );
 
     $returnData = array(
@@ -54,4 +56,3 @@ try {
 }
 
 xd_controller\returnJSON($returnData);
-

--- a/html/gui/js/Viewer.js
+++ b/html/gui/js/Viewer.js
@@ -430,8 +430,8 @@ Ext.extend(CCR.xdmod.ui.Viewer, Ext.Viewport, {
                 continue;
             }
             tabPanel.add(tabInstance);
-            if (tab.isDefault) {
-                tabToken = tabToken || mainTabToken + CCR.xdmod.ui.tokenDelimiter + tab.tab;
+            if (tab.isDefault === true) {
+                tabToken = tabToken || mainTabToken + CCR.xdmod.ui.tokenDelimiter + tab.name;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the method of determining which tabs should be shown to a user so that it depends on the acl tables as opposed to the Role classes. 

## Motivation and Context
Continue migration from roles to acl framework

## Tests performed
Manual Tests:

**Test 1**
  - Navigate to XDMoD
  - Do not login
  - Ensure that the tabs are displayed as expected
  - Ensure that the Summary tab is displayed by default.

**Test 2**
  - Navigate to XDMoD
  - Log in as a 'normaluser'
  - Ensure that the tabs are displayed as expected
  - Ensure that the Summary tab is displayed by default

**Test 3**
  - Navigate to XDMoD
  - Log in as a 'centerdirector'
  - Ensure that the tabs are displayed as expected
  - Ensure that the Summary Tab is displayed by default
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
