### PR TITLE
Code fixes as a result of running PHP Static Analysis on ETL code (phpstan)

### DIFF
--- a/classes/ETL/Aggregator.php
+++ b/classes/ETL/Aggregator.php
@@ -12,8 +12,8 @@ namespace ETL;
 
 use ETL\Configuration\EtlConfiguration;
 use ETL\Aggregator\AggregatorOptions;
-use \Exception;
-use \Log;
+use Exception;
+use Log;
 
 class Aggregator
 {

--- a/classes/ETL/Aggregator/AggregatorOptions.php
+++ b/classes/ETL/Aggregator/AggregatorOptions.php
@@ -16,7 +16,7 @@ namespace ETL\Aggregator;
 
 use ETL\aOptions;
 use ETL\DataEndpoint\iDataEndpoint;
-use \Exception;
+use Exception;
 
 class AggregatorOptions extends aOptions
 {

--- a/classes/ETL/Aggregator/DummyAggregator.php
+++ b/classes/ETL/Aggregator/DummyAggregator.php
@@ -11,7 +11,9 @@
 
 namespace ETL\Aggregator;
 
+use ETL\aOptions;
 use ETL\iAction;
+use ETL\aAction;
 use ETL\Configuration\EtlConfiguration;
 use ETL\EtlOverseerOptions;
 
@@ -19,7 +21,7 @@ use Log;
 
 class DummyAggregator extends aAction implements iAction
 {
-    public function __construct(AggregatorOptions $options, EtlConfiguration $etlConfig, Log $logger = null)
+    public function __construct(aOptions $options, EtlConfiguration $etlConfig, Log $logger = null)
     {
         parent::__construct($options, $etlConfig, $logger);
     }

--- a/classes/ETL/Aggregator/aAggregator.php
+++ b/classes/ETL/Aggregator/aAggregator.php
@@ -22,7 +22,7 @@ use ETL\aRdbmsDestinationAction;
 use ETL\EtlOverseerOptions;
 use ETL\Configuration\EtlConfiguration;
 use ETL\aOptions;
-use \Log;
+use Log;
 
 abstract class aAggregator extends aRdbmsDestinationAction
 {

--- a/classes/ETL/Configuration/Configuration.php
+++ b/classes/ETL/Configuration/Configuration.php
@@ -702,6 +702,8 @@ class Configuration extends Loggable implements \Iterator
 
     public function deleteKeyTransformer($transformer)
     {
+        $className = null;
+
         if ( is_object($transformer) && $transformer instanceof iConfigFileKeyTransformer ) {
             $className = get_class($transformer);
         } elseif ( is_string($transformer) ) {

--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -591,7 +591,7 @@ class EtlConfiguration extends Configuration
 
         if ( isset($defaults->$globalDefaultKey->$pathsKey) && isset($actionConfig->endpoints) ) {
             foreach ( $actionConfig->endpoints as $endpointName => &$endpointConfig ) {
-                if ( ! isset($endpointconfig->paths) ) {
+                if ( ! isset($endpointConfig->paths) ) {
                     $endpointConfig->paths = $defaults->$globalDefaultKey->$pathsKey;
                 }
             }

--- a/classes/ETL/Configuration/JsonReferenceWithMacroTransformer.php
+++ b/classes/ETL/Configuration/JsonReferenceWithMacroTransformer.php
@@ -13,6 +13,8 @@
 
 namespace ETL\Configuration;
 
+use ETL\Utilities;
+
 class JsonReferenceWithMacroTransformer extends JsonReferenceTransformer implements iConfigFileKeyTransformer
 {
     /* ------------------------------------------------------------------------------------------

--- a/classes/ETL/DataEndpoint/DataEndpointOptions.php
+++ b/classes/ETL/DataEndpoint/DataEndpointOptions.php
@@ -16,7 +16,7 @@
 namespace ETL\DataEndpoint;
 
 use ETL\aOptions;
-use \Exception;
+use Exception;
 
 class DataEndpointOptions extends aOptions
 {

--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -113,7 +113,7 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
     /** -----------------------------------------------------------------------------------------
      * The iterator for the current file that we are parsing.
      *
-     * @var Iterator
+     * @var \Iterator
      * ------------------------------------------------------------------------------------------
      */
 
@@ -133,7 +133,7 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
      * The iterator for the first file that was parsed. This allows us to reset the iterator witout
      * re-parsing the first file.
      *
-     * @var Iterator
+     * @var \Iterator
      * ------------------------------------------------------------------------------------------
      */
 
@@ -758,7 +758,7 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
      * and contain no records) then we need to move on to the next file in the list. Only after we
      * have processed all files and all records in the final file should valid() return FALSE.
      *
-     * @return boolen TRUE if the current position is valid, FALSE otherwise.
+     * @return boolean TRUE if the current position is valid, FALSE otherwise.
      *
      * @see Iterator::valid()
      * ------------------------------------------------------------------------------------------

--- a/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
+++ b/classes/ETL/DataEndpoint/Filter/ExternalProcess.php
@@ -51,7 +51,7 @@ class ExternalProcess extends \php_user_filter
      * arguments: Optional argument string to be passed to the application
      * logger: Optional logger for displying error messages
      *
-     * @var stdClass
+     * @var object
      */
 
     public $params = null;

--- a/classes/ETL/DataEndpoint/JsonFile.php
+++ b/classes/ETL/DataEndpoint/JsonFile.php
@@ -113,7 +113,7 @@ class JsonFile extends aStructuredFile implements iStructuredFile, iComplexDataR
         $schemaData = @file_get_contents($this->recordSchemaPath);
 
         if ( false === $schemaData ) {
-            $err = err_get_last();
+            $err = error_get_last();
             $this->logAndThrowException(
                 sprintf("Error reading JSON schema '%s': %s", $this->recordSchemaPath, $err['message'])
             );

--- a/classes/ETL/DataEndpoint/Oracle.php
+++ b/classes/ETL/DataEndpoint/Oracle.php
@@ -11,6 +11,7 @@ namespace ETL\DataEndpoint;
 
 use ETL\DataEndpoint\DataEndpointOptions;
 use Log;
+use PDOException;
 
 class Oracle extends aRdbmsEndpoint implements iRdbmsEndpoint
 {
@@ -115,7 +116,7 @@ AND table_name = UPPER(:tablename)";
             }
         } catch (PDOException $e) {
             $this->logAndThrowException(
-                "Error querying for table '$schema'.'$tableName':",
+                "Error querying for table '$schemaName'.'$tableName':",
                 array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
             );
         }
@@ -147,6 +148,7 @@ WHERE owner = UPPER(:schema)
 AND table_name = UPPER(:tablename)
 ORDER BY column_id ASC";
 
+        $result = null;
         $params = array(":schema" => $this->getSchema(),
                         ":tablename"  => $tableName);
 

--- a/classes/ETL/DataEndpoint/StructuredFile.php
+++ b/classes/ETL/DataEndpoint/StructuredFile.php
@@ -10,7 +10,7 @@ abstract class StructuredFile extends File implements iDataEndpoint
     /**
      * Decode a file and return the parsed representation.
      *
-     * @return An object generated from the parsed file.
+     * @return object An object generated from the parsed file.
      *
      * @throw Exception If the file could not be read.
      * @throw Exception If the file could not be parsed.

--- a/classes/ETL/DataEndpoint/aDataEndpoint.php
+++ b/classes/ETL/DataEndpoint/aDataEndpoint.php
@@ -15,8 +15,8 @@ namespace ETL\DataEndpoint;
 
 use ETL\aEtlObject;
 use ETL\DataEndpoint\iDataEndpoint;
-use \Exception;
-use \Log;
+use Exception;
+use Log;
 
 abstract class aDataEndpoint extends aEtlObject
 {
@@ -124,4 +124,12 @@ abstract class aDataEndpoint extends aEtlObject
         $keyIndex = self::$currentUniqueKeyIndex++;
         $this->key = "DataEndpoint{$keyIndex}";
     }
+
+    /**
+     * Connect the data endpoint
+     *
+     */
+
+    abstract function connect();
+
 }  // abstract class aDataEndpoint

--- a/classes/ETL/DataEndpoint/aDataEndpoint.php
+++ b/classes/ETL/DataEndpoint/aDataEndpoint.php
@@ -126,10 +126,8 @@ abstract class aDataEndpoint extends aEtlObject
     }
 
     /**
-     * Connect the data endpoint
-     *
+     * See iDataEndpoint::connect()
      */
 
-    abstract function connect();
-
+    abstract public function connect();
 }  // abstract class aDataEndpoint

--- a/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
+++ b/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
@@ -13,8 +13,8 @@ namespace ETL\DataEndpoint;
 
 use ETL\DataEndpoint\DataEndpointOptions;
 use CCR\DB;
-use \Log;
-use \xd_utilities;
+use Log;
+use xd_utilities;
 use Exception;
 use PDOException;
 
@@ -211,6 +211,7 @@ AND table_name = :tablename";
             $schemaName = $this->getSchema();
         }
 
+        $result = null;
         $params = array(
             ":schema" => $schemaName,
             ":tablename"  => $tableName
@@ -224,7 +225,7 @@ AND table_name = :tablename";
             }
         } catch (PDOException $e) {
             $this->logAndThrowException(
-                "Error querying for table '$schema'.'$tableName':",
+                "Error querying for table '$schemaName'.'$tableName':",
                 array('exception' => $e, 'sql' => $sql, 'endpoint' => $this)
             );
         }
@@ -258,6 +259,7 @@ ORDER BY ordinal_position ASC";
 
         $params = array(":schema" => $schemaName,
                         ":tablename"  => $tableName);
+        $result = null;
 
         try {
             $dbh = $this->getHandle();
@@ -339,4 +341,18 @@ ORDER BY ordinal_position ASC";
             (null !== $this->username ? ", user={$this->username}" : "" ) .
             ")";
     }  // __toString()
+
+    /* ------------------------------------------------------------------------------------------
+     * @see iRdbmsEndpoint::schemaExists()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    abstract function schemaExists($schemaName = null);
+
+    /* ------------------------------------------------------------------------------------------
+     * @see iRdbmsEndpoint::createSchema()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    abstract function createSchema($schemaName = null);
 }  // class aRdbmsEndpoint

--- a/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
+++ b/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
@@ -347,12 +347,12 @@ ORDER BY ordinal_position ASC";
      * ------------------------------------------------------------------------------------------
      */
 
-    abstract function schemaExists($schemaName = null);
+    abstract public function schemaExists($schemaName = null);
 
     /* ------------------------------------------------------------------------------------------
      * @see iRdbmsEndpoint::createSchema()
      * ------------------------------------------------------------------------------------------
      */
 
-    abstract function createSchema($schemaName = null);
+    abstract public function createSchema($schemaName = null);
 }  // class aRdbmsEndpoint

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -267,7 +267,7 @@ abstract class aStructuredFile extends File
      *
      * @param string $path The path of the file to parse.
      *
-     * @return The number of bytes read
+     * @return integer The number of bytes read
      *
      * @throw Exception If the file could not be read.
      * @throw Exception If the file could not be parsed.

--- a/classes/ETL/DbModel/Table.php
+++ b/classes/ETL/DbModel/Table.php
@@ -26,6 +26,7 @@ namespace ETL\DbModel;
 use ETL\DataEndpoint\iRdbmsEndpoint;
 use Log;
 use stdClass;
+use Exception;
 
 class Table extends SchemaEntity implements iEntity, iDiscoverableEntity, iAlterableEntity
 {

--- a/classes/ETL/Ingestor.php
+++ b/classes/ETL/Ingestor.php
@@ -12,8 +12,8 @@ namespace ETL;
 
 use ETL\Configuration\EtlConfiguration;
 use ETL\Ingestor\IngestorOptions;
-use \Exception;
-use \Log;
+use Exception;
+use Log;
 
 class Ingestor
 {

--- a/classes/ETL/Ingestor/DummyIngestor.php
+++ b/classes/ETL/Ingestor/DummyIngestor.php
@@ -13,8 +13,10 @@ namespace ETL\Ingestor;
 
 use ETL\aOptions;
 use ETL\iAction;
+use ETL\aAction;
 use ETL\Configuration\EtlConfiguration;
 use ETL\EtlOverseerOptions;
+
 use Log;
 
 class DummyIngestor extends aAction implements iAction

--- a/classes/ETL/Ingestor/IngestorOptions.php
+++ b/classes/ETL/Ingestor/IngestorOptions.php
@@ -15,7 +15,7 @@
 namespace ETL\Ingestor;
 
 use ETL\aOptions;
-use \Exception;
+use Exception;
 
 class IngestorOptions extends aOptions
 {

--- a/classes/ETL/Ingestor/RestIngestor.php
+++ b/classes/ETL/Ingestor/RestIngestor.php
@@ -283,6 +283,7 @@ class RestIngestor extends aIngestor implements iAction
      * ------------------------------------------------------------------------------------------
      */
 
+     // @codingStandardsIgnoreLine
     protected function _execute()
     {
         // Support a source query, mapping from the source to rest parameters, rest field map

--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -405,7 +405,7 @@ class StructuredFileIngestor extends aIngestor implements iAction
                 $this->logAndThrowException(
                     sprintf(
                         "custom_insert_values_components must be an object, %s given",
-                        gettype($customInsertValuesComponents)
+                        gettype($this->customInsertValuesComponents)
                     )
                 );
             }

--- a/classes/ETL/Ingestor/UpdateIngestor.php
+++ b/classes/ETL/Ingestor/UpdateIngestor.php
@@ -9,7 +9,8 @@
 namespace ETL\Ingestor;
 
 // PEAR logger
-use \Log;
+use Log;
+use PDOException;
 
 use ETL\iAction;
 use ETL\Configuration;
@@ -27,7 +28,7 @@ class UpdateIngestor extends aRdbmsDestinationAction implements iAction
      * This action does not (yet) support multiple destination tables. If multiple
      * destination tables are present, store the first here and use it.
      *
-     * @var Table
+     * @var \ETL\DbModel\Table
      */
 
     protected $etlDestinationTable = null;
@@ -79,7 +80,7 @@ class UpdateIngestor extends aRdbmsDestinationAction implements iAction
         $this->etlDestinationTable = current($this->etlDestinationTableList);
         $etlTableKey = key($this->etlDestinationTableList);
         if ( count($this->etlDestinationTableList) > 1 ) {
-            $logger->warning(
+            $this->logger->warning(
                 sprintf(
                     "%s does not support multiple ETL destination tables, using first table with key: '%s'",
                     $this,
@@ -94,6 +95,7 @@ class UpdateIngestor extends aRdbmsDestinationAction implements iAction
             'update' => 'object'
         );
 
+        $messages = null;
         if ( ! \xd_utilities\verify_object_property_types($this->parsedDefinitionFile, $requiredKeys, $messages) ) {
             $this->logAndThrowException(sprintf("Definition file error: %s", implode(', ', $messages)));
         }

--- a/classes/ETL/Ingestor/aIngestor.php
+++ b/classes/ETL/Ingestor/aIngestor.php
@@ -16,7 +16,7 @@ use ETL\aRdbmsDestinationAction;
 use ETL\EtlOverseerOptions;
 use ETL\Configuration\EtlConfiguration;
 use ETL\aOptions;
-use \Log;
+use Log;
 
 abstract class aIngestor extends aRdbmsDestinationAction
 {

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -53,6 +53,7 @@ use ETL\DbModel\Query;
 
 use CCR\DB\MySQLHelper;
 use PDOException;
+use Exception;
 use PDO;
 use Log;
 
@@ -158,6 +159,15 @@ class pdoIngestor extends aIngestor
      */
 
     protected $stringEnclosure = '';
+
+    /** -----------------------------------------------------------------------------------------
+     * Database helper object such as MySQLHelper
+     *
+     * @var object
+     * ------------------------------------------------------------------------------------------
+     */
+
+    private $_dest_helper = null;
 
     /** -----------------------------------------------------------------------------------------
      * General setup.
@@ -340,6 +350,7 @@ class pdoIngestor extends aIngestor
 
         $query_success = false;
         $n_attempts = 0;
+        $srcStatement = null;
 
         while (false == $query_success) {
             $n_attempts += 1;
@@ -638,6 +649,7 @@ class pdoIngestor extends aIngestor
 
         // Turn off buffering if necessary. This is a MySQL specific optimization.
 
+        $originalBufferedQueryAttribute = null;
         if ( ! $this->options->buffered_query && $this->sourceEndpoint instanceof Mysql ) {
             $this->logger->info("Switching to un-buffered query mode");
             $pdo = $this->sourceHandle->handle();

--- a/classes/ETL/Maintenance.php
+++ b/classes/ETL/Maintenance.php
@@ -12,8 +12,8 @@ namespace ETL;
 
 use ETL\Configuration\EtlConfiguration;
 use ETL\Maintenance\MaintenanceOptions;
-use \Exception;
-use \Log;
+use Exception;
+use Log;
 
 class Maintenance
 {

--- a/classes/ETL/Maintenance/MaintenanceOptions.php
+++ b/classes/ETL/Maintenance/MaintenanceOptions.php
@@ -16,7 +16,7 @@
 namespace ETL\Maintenance;
 
 use ETL\aOptions;
-use \Exception;
+use Exception;
 
 class MaintenanceOptions extends aOptions
 {

--- a/classes/ETL/Maintenance/ManageTables.php
+++ b/classes/ETL/Maintenance/ManageTables.php
@@ -19,7 +19,8 @@ use ETL\DbModel\Table;
 use ETL\aOptions;
 use ETL\iAction;
 use ETL\aRdbmsDestinationAction;
-use \Log;
+use Log;
+use Exception;
 
 class ManageTables extends aRdbmsDestinationAction implements iAction
 {

--- a/classes/ETL/Maintenance/VerifyDatabase.php
+++ b/classes/ETL/Maintenance/VerifyDatabase.php
@@ -17,9 +17,9 @@ use ETL\iAction;
 use ETL\aAction;
 use ETL\DataEndpoint\iRdbmsEndpoint;
 use ETL\DbModel\Query;
-use \PDOException;
+use PDOException;
 use ETL\Utilities;
-use \Log;
+use Log;
 
 use PHPSQLParser\PHPSQLParser;
 
@@ -40,6 +40,9 @@ class VerifyDatabase extends aAction implements iAction
         'header'  => null,
         'footer'  => null
     );
+
+    // SQL to execute to perform the verification
+    protected $sqlQueryString = null;
 
     /* ------------------------------------------------------------------------------------------
      * @see aAction::__construct()

--- a/classes/ETL/aEtlObject.php
+++ b/classes/ETL/aEtlObject.php
@@ -13,10 +13,10 @@
 namespace ETL;
 
 use ETL\DataEndpoint\DataEndpointOptions;
-use \Log;
-use \Exception;
-use \PDOException;
-use \stdClass;
+use Log;
+use Exception;
+use PDOException;
+use stdClass;
 
 abstract class aEtlObject extends Loggable
 {

--- a/classes/ETL/aOptions.php
+++ b/classes/ETL/aOptions.php
@@ -19,7 +19,7 @@
 
 namespace ETL;
 
-use \Exception;
+use Exception;
 
 // Extending stdClass allows us to use aOptions with when a general class is used, such as verifying
 // required keys in an aOptions class or a standard parsed JSON object.
@@ -160,7 +160,7 @@ abstract class aOptions extends \stdClass implements \Iterator
 
             case 'paths':
                 if ( ! is_object($value) ) {
-                    get_class($this) . ": '$property' must be an object (type = " . gettype($value) . ")";
+                    $msg = get_class($this) . ": '$property' must be an object (type = " . gettype($value) . ")";
                     throw new Exception($msg);
                 }
                 break;
@@ -300,6 +300,7 @@ abstract class aOptions extends \stdClass implements \Iterator
                 return $path;
             }
 
+            $value = null;
             $objectPath = '$this->' . implode("->", $parts);
             $evalStr = "\$value = ( isset($objectPath) ? $objectPath : null);";
             eval($evalStr);

--- a/classes/ETL/aRdbmsDestinationAction.php
+++ b/classes/ETL/aRdbmsDestinationAction.php
@@ -556,7 +556,7 @@ abstract class aRdbmsDestinationAction extends aAction
             } catch (PDOException $e) {
                 $this->logAndThrowException(
                     "Error verifying table $tableName",
-                    array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->destinationEndpoint)
+                    array('exception' => $e, 'endpoint' => $this->destinationEndpoint)
                 );
             }
 

--- a/classes/ETL/iAction.php
+++ b/classes/ETL/iAction.php
@@ -14,7 +14,7 @@
 namespace ETL;
 
 use ETL\Configuration\EtlConfiguration;
-use \Log;
+use Log;
 
 interface iAction
 {


### PR DESCRIPTION

See [phpstan](https://github.com/phpstan/phpstan)

## Description

Ran a php static analysis tool on the ETL code and fixed the following types of issues:

- `use` statements that had a leading backslash (e.g., Changed `use \Log;` to `use Log;`) for improved PHP 7 compatibility
- Added `use Exception;` in several places so an exception is thrown with the proper namespace
- Added `use` statements in several other instances where they were needed
- Declared variables outside of block scopes in instances where they were declared inside of a block and then referenced outside of the block afterward such as `if` and `try-catch` blocks. For example,
```
if ( true ) {
    $myVar = some_function();
}
return $myVar;
```
becomes
```
$myVar = null;
if ( true ) {
    $myVar = some_function();
}
return $myVar;
```
- Several fixes for undefined or mis-named variables, especially those in error handling that was copied from elsewhere.
- Fixed documentation to be consistent with code changes
- Added abstract functions in certain cases where an object implementing an interface uses an abstract parent class to define common functionality and the abstract class references a method required by the interface. For example, the `createSchema()` and `schemaExists()` methods in classes/ETL/DataEndpoint/aRdbmsEndpoint.php.

## Motivation and Context

Code quality improvements

## Tests performed

Ran tests and also ran re-ingestion of XSEDE jobs.
```
php etl_overseer.php -c ../../../etc/etl/etl.json -p jobs-common -p jobs-xdcdb -v info -k month -s 2017-01-01 -e 2017-06-30 -o "experimental_enable_batch_aggregation=true"

../dev/verify_table_data.php -s modw_cloud_baseline -d modw_cloud_etltest -n 1 -v info \
>   -x last_modified \
>   -t job_records \
>   -t job_tasks
2017-10-10 12:36:51 [notice] Compare tables src=modw_cloud_baseline.job_records, dest=modw_cloud_etltest.job_records
2017-10-10 12:36:51 [info] Exclude columns: last_modified
2017-10-10 12:36:51 [info] 34 columns
2017-10-10 12:36:51 [info] Row counts: modw_cloud_baseline.job_records = 3,106,738; modw_cloud_etltest.job_records = 3,106,738
2017-10-10 12:37:11 [notice] Identical
2017-10-10 12:37:11 [notice] Compare tables src=modw_cloud_baseline.job_tasks, dest=modw_cloud_etltest.job_tasks
2017-10-10 12:37:11 [info] Exclude columns: last_modified
2017-10-10 12:37:11 [info] 30 columns
2017-10-10 12:37:11 [info] Row counts: modw_cloud_baseline.job_tasks = 3,106,738; modw_cloud_etltest.job_tasks = 3,106,738
2017-10-10 12:37:36 [notice] Identical

../dev/verify_table_data.php -s modw_cloud_baseline -d modw_cloud_etltest -n 1 -v info \
>   -x last_modified \
>   -t jobfact_by_year \
>   -t jobfact_by_month \
>   -t jobfact_by_quarter \
>   -t jobfact_by_year
2017-10-10 12:39:06 [notice] Compare tables src=modw_cloud_baseline.jobfact_by_year, dest=modw_cloud_etltest.jobfact_by_year
2017-10-10 12:39:06 [info] Exclude columns: last_modified
2017-10-10 12:39:06 [info] 46 columns
2017-10-10 12:39:06 [info] Row counts: modw_cloud_baseline.jobfact_by_year = 66,115; modw_cloud_etltest.jobfact_by_year = 66,115
2017-10-10 12:39:07 [notice] Identical
2017-10-10 12:39:07 [notice] Compare tables src=modw_cloud_baseline.jobfact_by_month, dest=modw_cloud_etltest.jobfact_by_month
2017-10-10 12:39:07 [info] Exclude columns: last_modified
2017-10-10 12:39:07 [info] 47 columns
2017-10-10 12:39:07 [info] Row counts: modw_cloud_baseline.jobfact_by_month = 96,689; modw_cloud_etltest.jobfact_by_month = 96,689
2017-10-10 12:39:13 [notice] Identical
2017-10-10 12:39:13 [notice] Compare tables src=modw_cloud_baseline.jobfact_by_quarter, dest=modw_cloud_etltest.jobfact_by_quarter
2017-10-10 12:39:13 [info] Exclude columns: last_modified
2017-10-10 12:39:13 [info] 47 columns
2017-10-10 12:39:13 [info] Row counts: modw_cloud_baseline.jobfact_by_quarter = 74,411; modw_cloud_etltest.jobfact_by_quarter = 74,411
2017-10-10 12:39:14 [notice] Identical
2017-10-10 12:39:14 [notice] Compare tables src=modw_cloud_baseline.jobfact_by_year, dest=modw_cloud_etltest.jobfact_by_year
2017-10-10 12:39:14 [info] Exclude columns: last_modified
2017-10-10 12:39:14 [info] 46 columns
2017-10-10 12:39:14 [info] Row counts: modw_cloud_baseline.jobfact_by_year = 66,115; modw_cloud_etltest.jobfact_by_year = 66,115
2017-10-10 12:39:14 [notice] Identical
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
