### PR TITLE
Update TIme Aggregation Unit

### DIFF
--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -1380,9 +1380,7 @@ class Query
                                $end_date_parsed['month'],
                                $end_date_parsed['day'],
                                $end_date_parsed['year']);
-
-        $this->_min_date_id = $this->_aggregation_unit->getMinDateId($this->_start_date);
-        $this->_max_date_id = $this->_aggregation_unit->getMaxDateId($this->_end_date);
+        list($this->_min_date_id, $this->_max_date_id) = $this->_aggregation_unit->geDateRangeIds($this->_start_date, $this->_end_date);
 
         if (!$start_date_given && !$end_date_given) {
             return;

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -1380,7 +1380,7 @@ class Query
                                $end_date_parsed['month'],
                                $end_date_parsed['day'],
                                $end_date_parsed['year']);
-        list($this->_min_date_id, $this->_max_date_id) = $this->_aggregation_unit->geDateRangeIds($this->_start_date, $this->_end_date);
+        list($this->_min_date_id, $this->_max_date_id) = $this->_aggregation_unit->getDateRangeIds($this->_start_date, $this->_end_date);
 
         if (!$start_date_given && !$end_date_given) {
             return;

--- a/classes/DataWarehouse/Query/TimeAggregationUnit.php
+++ b/classes/DataWarehouse/Query/TimeAggregationUnit.php
@@ -121,12 +121,6 @@ abstract class TimeAggregationUnit
     private static $_initialized = false;
 
     /**
-     * This is the max date id that will be used if end_date is out of range and greater than the last
-     * date id avaiable in the data table.
-     */
-    public static $_max_date_id = 999999999999999;
-
-    /**
      *  This array keeps track of the TimeAggregationUnit subclasses that have registed
      *   using RegisterUnit
      */

--- a/classes/DataWarehouse/Query/TimeAggregationUnit.php
+++ b/classes/DataWarehouse/Query/TimeAggregationUnit.php
@@ -1,13 +1,12 @@
 <?php
 namespace DataWarehouse\Query;
 
-/* 
-* @author Amin Ghadersohi
-* @date 2011-Jan-07
-*
-* Abstract class for defining classes pertaining to grouping data over time.
-* 
-*/
+/**
+ * @author Amin Ghadersohi
+ * @date 2011-Jan-07
+ *
+ * Abstract class for defining classes pertaining to grouping data over time.
+ */
 abstract class TimeAggregationUnit
 {
     //The unit name is passed to this class via the constructor by extending subclasses
@@ -19,58 +18,54 @@ abstract class TimeAggregationUnit
         $this->_unit_name = $unit_name;
     } //__construct
 
-    /* 
-    * Get this name of this unit.
-    * 
-    * @returns the unit name of this aggregation unit
-    * 
-    */
+    /**
+     * Get this name of this unit.
+     *
+     * @return string the unit name of this aggregation unit
+     */
     public function getUnitName()
     {
         return $this->_unit_name;
     } //getUnitName
 
-    /* 
-    * 
-    * @returns minimum index of the time aggregation unit. example quarter min = 1 
-    * 
-    */		
+    /**
+     *
+     * @return int minimum index of the time aggregation unit. example quarter min = 1
+     */
     abstract public function getMinPeriodPerYear();
 
-    /* 
-    * 
-    * @returns maximum index of the time aggregation unit. example quarter  max = 4
-    * 
-    */			
+    /**
+     *
+     * @return maximum index of the time aggregation unit. example quarter  max = 4
+     */
     abstract public function getMaxPeriodPerYear();
 
 
-	abstract public function getTimeLabel($timestamp);
-    /* 
-    * getMinDateId
-    *
-    * @returns the minimum id from the corresponding time period table based on the 
-    *          value of start_date. Returns 1, if start_date is less than all possible 
-    *		   values in the table.
-    * 
-    */	
+    abstract public function getTimeLabel($timestamp);
+    /**
+     * getMinDateId
+     *
+     * @return int the minimum id from the corresponding time period table based on the
+     *         value of start_date. Returns 1, if start_date is less than all possible
+     *         values in the table.
+     */
     public function getMinDateId($start_date)
     {
-		$q = "select min(id) as id from ".$this->getUnitName()."s 
-        where '$start_date' 
-            between 
-            ".$this->getUnitName()."_start 
+        $q = "select min(id) as id from ".$this->getUnitName()."s
+        where '$start_date'
+            between
+            ".$this->getUnitName()."_start
             and ".$this->getUnitName()."_end";
-		
+
         $startDateResult = \DataWarehouse::connect()->query($q);
-			
+
         $start_date_id = 1;
         if(count($startDateResult) > 0)
         {
             $start_date_id = $startDateResult[0]['id'];
             if(!isset($start_date_id) || $start_date_id == '' )
             {
-				$q = "select case when '$start_date' < min(".$this->getUnitName()."_start) then 1 else ".self::$_max_date_id." end as id  from ".$this->getUnitName()."s";
+                $q = "select case when '$start_date' < min(".$this->getUnitName()."_start) then 1 else ".self::$_max_date_id." end as id  from ".$this->getUnitName()."s";
                 $startDateResult = \DataWarehouse::connect()->query($q);
                 if(count($startDateResult) > 0)
                 {
@@ -83,21 +78,21 @@ abstract class TimeAggregationUnit
         return $start_date_id;
     } //getMinDateId
 
-    /* 
-    * 
-    * @returns the maximum id from the corresponding time period table based on the 
-    *          value of end_date. Returns -1 if end_date is greater than all possible 
-    *		   values in the table
-    * 
-    */	
+    /**
+     *
+     * @return int the maximum id from the corresponding time period table based on the
+     *          value of end_date. Returns -1 if end_date is greater than all possible
+     *         values in the table
+     */
     public function getMaxDateId($end_date)
     {
         $endDateResult = \DataWarehouse::connect()->query(
-            "select max(id) as id from ".$this->getUnitName()."s 
-        where '$end_date' 
-            between 
-            ".$this->getUnitName()."_start 
-            and ".$this->getUnitName()."_end");
+            "select max(id) as id from ".$this->getUnitName()."s
+        where '$end_date'
+            between
+            ".$this->getUnitName()."_start
+            and ".$this->getUnitName()."_end"
+        );
 
             $end_date_id = self::$_max_date_id;
         if(count($endDateResult) > 0)
@@ -106,7 +101,8 @@ abstract class TimeAggregationUnit
             if(!isset($end_date_id))
             {
                 $endDateResult = \DataWarehouse::connect()->query(
-                    "select case when '$end_date' < min(".$this->getUnitName()."_start) then 0 else ".self::$_max_date_id." end as id  from ".$this->getUnitName()."s");
+                    "select case when '$end_date' < min(".$this->getUnitName()."_start) then 0 else ".self::$_max_date_id." end as id  from ".$this->getUnitName()."s"
+                );
                 if(count($endDateResult) > 0)
                 {
                     $end_date_id = $endDateResult[0]['id'];
@@ -116,36 +112,36 @@ abstract class TimeAggregationUnit
         return $end_date_id;
     } //getMaxDateId
 
-    /* 
-    * @returns this object as a string
-    * 
-    */
+    /**
+     * @return string this object as a string
+     */
     public function __toString()
     {
         return $this->getUnitName();
     } //__toString
 
     //////////////Static Members////////////////////////
-    /*
-    * This variable keeps track of all the time units being registered or not. See @registerUnit
-    */
+    /**
+     * This variable keeps track of all the time units being registered or not. See @registerUnit
+     */
     private static $_initialized = false;
 
-    /*
-    * This is the max date id that will be used if end_date is out of range and greater than the last
-    * date id avaiable in the data table.
-    */
+    /**
+     * This is the max date id that will be used if end_date is out of range and greater than the last
+     * date id avaiable in the data table.
+     */
     public static $_max_date_id = 999999999999999;
-    /*
-    *  This array keeps track of the TimeAggregationUnit subclasses that have registed
-    *   using RegisterUnit
-    */
+
+    /**
+     *  This array keeps track of the TimeAggregationUnit subclasses that have registed
+     *   using RegisterUnit
+     */
     public static $_unit_name_to_class_name = array();
 
     /**
      * This provides the approximate length of each aggregation unit in days
      * to allow for comparision of units by length.
-     * 
+     *
      * @var array
      */
     private static $unit_sizes_in_days = array(
@@ -155,79 +151,77 @@ abstract class TimeAggregationUnit
         'year' => 365,
     );
 
-    /* 
-    * Registers an TimeAggregationUnit subclass
-    *
-    * @param $unit_name for example 'week', 'day', 'month', 'quarter'
-    * @param $unit_class_name for example 'DayAggregationUnit'
-    * 
-    */
+    /**
+     * Registers an TimeAggregationUnit subclass
+     *
+     * @param string $unit_name for example 'week', 'day', 'month', 'quarter'
+     * @param string $unit_class_name for example 'DayAggregationUnit'
+     *
+     */
     public static function registerUnit($unit_name, $unit_class_name)
     {
-        self::$_unit_name_to_class_name[$unit_name] = $unit_class_name; 
+        self::$_unit_name_to_class_name[$unit_name] = $unit_class_name;
     } //registerUnit
 
-    /* 
-    * Registers all TimeAggregationUnit subclasses.
-    * 
-    */
+    /**
+     * Registers all TimeAggregationUnit subclasses.
+     *
+     */
     public static function registerAggregationUnits()
     {
-        if(!self::$_initialized)
-        {
+        if(!self::$_initialized) {
             //TODO: automate this by search directory
             self::registerUnit('day', '\\DataWarehouse\\Query\\TimeAggregationUnits\\DayAggregationUnit');
             // self::registerUnit('week', '\\DataWarehouse\\Query\\TimeAggregationUnits\\WeekAggregationUnit');
             self::registerUnit('month', '\\DataWarehouse\\Query\\TimeAggregationUnits\\MonthAggregationUnit');
             self::registerUnit('quarter', '\\DataWarehouse\\Query\\TimeAggregationUnits\\QuarterAggregationUnit');
-			self::registerUnit('year', '\\DataWarehouse\\Query\\TimeAggregationUnits\\YearAggregationUnit');
-			
+            self::registerUnit('year', '\\DataWarehouse\\Query\\TimeAggregationUnits\\YearAggregationUnit');
+
             self::$_initialized = true;
         }
     } //registerAggregationUnits
 
-    /* 
-    * @param $time_period: the name of the time aggregation unit. ie: day, week, month, quarter.
-    * @param $start_date: if time_period is auto this is used to figure out aggregation unit
-    * @param $end_date: if time_period is auto this is used to figure out aggregation unit
-    * @returns a subclass of TimeAggregationUnit based on $time_period requested.
-    * @throws Exception if $time_period is not registered
-    *
-    * TimeAggregationUnit subclasses must be registed using TimeAggregationUnit::registerUnit first
-    * 
-    */		
+    /**
+     * @param $time_period: the name of the time aggregation unit. ie: day, week, month, quarter.
+     * @param $start_date: if time_period is auto this is used to figure out aggregation unit
+     * @param $end_date: if time_period is auto this is used to figure out aggregation unit
+     *
+     * @return class a subclass of TimeAggregationUnit based on $time_period requested.
+     * @throws Exception if $time_period is not registered
+     *
+     * TimeAggregationUnit subclasses must be registed using TimeAggregationUnit::registerUnit first
+     *
+     */
     public static function factory($time_period, $start_date, $end_date)
     {
         self::registerAggregationUnits();
 
-        $time_period = self::deriveAggregationUnitName($time_period,$start_date,$end_date);
+        $time_period = self::deriveAggregationUnitName($time_period, $start_date, $end_date);
 
-        if(isset(self::$_unit_name_to_class_name[$time_period]))
-        {
+        if(isset(self::$_unit_name_to_class_name[$time_period])) {
             $class_name = self::$_unit_name_to_class_name[$time_period];
 
-            return new $class_name;	
+            return new $class_name;
         }
-        else
-        {
+        else {
             throw new Exception("TimeAggregationUnit: Time period {$time_period} is invalid.");
         }
-    } //factory	
+    } //factory
 
-	/*
-	* This function returns a copy of the array that maps the aggregation unit  names to class names
-	*/
-	public static function getRegsiteredAggregationUnits()
-	{
-		self::registerAggregationUnits();
-		return self::$_unit_name_to_class_name;
-	}//getRegsiteredAggregationUnits
+    /**
+    * This function returns a copy of the array that maps the aggregation unit  names to class names
+    */
+    public static function getRegsiteredAggregationUnits()
+    {
+        self::registerAggregationUnits();
+        return self::$_unit_name_to_class_name;
+    }//getRegsiteredAggregationUnits
 
     /**
      * Generate the concrete, proper aggregation unit name for the input unit.
      * If the unit given is 'auto', this function will use the given start and
-     * end dates to figure out the concrete aggregation unit to use. 
-     * 
+     * end dates to figure out the concrete aggregation unit to use.
+     *
      * @param  string $time_period The aggregation unit to get the proper name
      *                             of or 'auto' to automatically determine the
      *                             unit from the given dates.
@@ -245,8 +239,7 @@ abstract class TimeAggregationUnit
     {
         $time_period = strtolower($time_period);
 
-        if ($time_period === 'auto')
-        {
+        if ($time_period === 'auto') {
             $dt_format = '!Y-m-d';
             $utc_tz = new \DateTimeZone('UTC');
             $start_date_dt = \DateTime::createFromFormat($dt_format, $start_date, $utc_tz);
@@ -254,16 +247,13 @@ abstract class TimeAggregationUnit
 
             $date_difference = date_diff($start_date_dt, $end_date_dt);
 
-            if ($date_difference->y >= 10) // >= 10 years
-            {
+            if ($date_difference->y >= 10) {
                 $time_period = 'quarter';
             }
-            else if ((($date_difference->y * 12) + $date_difference->m) >= 6) // >= 6 months
-            {
+            elseif ((($date_difference->y * 12) + $date_difference->m) >= 6) {
                 $time_period = 'month';
             }
-            else
-            {
+            else {
                 $time_period = 'day';
             }
 
@@ -300,12 +290,10 @@ abstract class TimeAggregationUnit
         $unit_2_name = strtolower($unit_2);
 
         // If one unit is unknown, return the other unit.
-        if (!array_key_exists($unit_1_name, self::$unit_sizes_in_days))
-        {
+        if (!array_key_exists($unit_1_name, self::$unit_sizes_in_days)) {
             return $unit_2;
         }
-        if (!array_key_exists($unit_2_name, self::$unit_sizes_in_days))
-        {
+        if (!array_key_exists($unit_2_name, self::$unit_sizes_in_days)) {
             return $unit_1;
         }
 
@@ -318,7 +306,7 @@ abstract class TimeAggregationUnit
 
     /**
      * Find the smallest aggregation unit available for a given realm.
-     * 
+     *
      * @param  string $realm The realm to find the smallest aggregation unit for.
      * @return mixed         The name of the smallest aggregation unit, or null
      *                       if it couldn't be found.
@@ -331,18 +319,15 @@ abstract class TimeAggregationUnit
 
         // Find the config for the given realm.
         $this_realm_config = null;
-        foreach ($dw_config as $key => $realm_config)
-        {
-            if ($key === $realm)
-            {
+        foreach ($dw_config as $key => $realm_config) {
+            if ($key === $realm) {
                 $this_realm_config = $realm_config;
                 break;
             }
         }
 
         // If the given realm could not be found, return null.
-        if ($this_realm_config === null)
-        {
+        if ($this_realm_config === null) {
             return null;
         }
 
@@ -352,14 +337,12 @@ abstract class TimeAggregationUnit
         $min_unit_length = PHP_INT_MAX;
         foreach ($realm_group_bys as $realm_group_by) {
             $realm_group_by_name = $realm_group_by['name'];
-            if (!array_key_exists($realm_group_by_name, self::$unit_sizes_in_days))
-            {
+            if (!array_key_exists($realm_group_by_name, self::$unit_sizes_in_days)) {
                 continue;
             }
 
             $realm_group_by_length = self::$unit_sizes_in_days[$realm_group_by_name];
-            if ($realm_group_by_length < $min_unit_length)
-            {
+            if ($realm_group_by_length < $min_unit_length) {
                 $min_unit = $realm_group_by_name;
                 $min_unit_length = $realm_group_by_length;
             }
@@ -372,7 +355,7 @@ abstract class TimeAggregationUnit
     /**
      * Check if the given string corresponds to the name of a time
      * aggregation unit.
-     * 
+     *
      * @param  string  $name The string to check.
      * @return boolean       True if the string is the name of a time
      *                       aggregation unit, otherwise false.
@@ -394,7 +377,7 @@ abstract class TimeAggregationUnit
         $start_dt = \DateTime::createFromFormat('U', "$time_point");
         $end_dt = \DateTime::createFromFormat('U', "$time_point");
 
-        if($start_dt === False) {
+        if($start_dt === false) {
             throw new \DomainException("Invalid value for time point");
         }
 
@@ -417,11 +400,9 @@ abstract class TimeAggregationUnit
             case 'year':
                 $end_dt->add(new \DateInterval('P1Y'));
                 $end_dt->sub(new \DateInterval('P1D'));
-            break;
+                break;
         }
 
         return array($start_dt->format('Y-m-d'), $end_dt->format('Y-m-d'));
     }
 }
-
-?>

--- a/classes/DataWarehouse/Query/TimeAggregationUnit.php
+++ b/classes/DataWarehouse/Query/TimeAggregationUnit.php
@@ -44,10 +44,11 @@ abstract class TimeAggregationUnit
 
     /**
      * geDateRangeIds
-     * Given the following possible combinations get the possible range of
-     * date ids that are possible forcing the bounds to be min and max job date,
-     * if less than or greater than jobmin or jobmax -1
-     * -1 is used as to force later functions to return the proper values.
+     * Given a date range (start, end) return a new date range that has been
+     * normalized so that it includes only dates that overlap the time for which
+     * data is available. If the desired date range falls fully outside of the
+     * dates for which data is available (either before or after) this is
+     * considered an error.
      *
      *                   minjob---------------------- maxjob
      * (-1) start----end
@@ -56,9 +57,12 @@ abstract class TimeAggregationUnit
      * (start-max)                           start-----------end
      * (-1)                                                      start----end
      *
-     * @return array the miniumum and maximum date ids or -1, -1 if out of bounds
+     * @param string $start start date in fomrat (YYYY-MM-DD)
+     * @param string $end end date in fomrat (YYYY-MM-DD)
+     *
+     * @return array The miniumum and maximum date ids or -1, -1 if out of bounds
      */
-    public function geDateRangeIds($start, $end){
+    public function getDateRangeIds($start, $end){
         $queryParams = array(
             $start,
             $start,
@@ -67,8 +71,8 @@ abstract class TimeAggregationUnit
             $end,
             $end
         );
-        $dateResult = \DataWarehouse::connect()->query('
-            SELECT
+        $dateResult = \DataWarehouse::connect()->query(
+            'SELECT
                 MIN(p.id) as minPeriodId,
                 MAX(p.id) as maxPeriodId
             FROM
@@ -100,9 +104,9 @@ abstract class TimeAggregationUnit
                     );',
             $queryParams
         );
-         if(null === $dateResult[0]['minPeriodId'] || null === $dateResult[0]['minPeriodId']){
-             return array(-1,-1);
-         }
+        if(null === $dateResult[0]['minPeriodId'] || null === $dateResult[0]['minPeriodId']){
+            return array(-1,-1);
+        }
          return array_values($dateResult[0]);
     }
 

--- a/classes/DataWarehouse/Query/TimeAggregationUnit.php
+++ b/classes/DataWarehouse/Query/TimeAggregationUnit.php
@@ -59,6 +59,14 @@ abstract class TimeAggregationUnit
      * @return array the miniumum and maximum date ids or -1, -1 if out of bounds
      */
     public function geDateRangeIds($start, $end){
+        $queryParams = array(
+            $start,
+            $start,
+            $start,
+            $end,
+            $end,
+            $end
+        );
         $dateResult = \DataWarehouse::connect()->query('
             SELECT
                 MIN(p.id) as minPeriodId,
@@ -69,15 +77,15 @@ abstract class TimeAggregationUnit
                 (
                 SELECT
                     CASE
-                      WHEN "' . $start . '" > max_job_date THEN NULL
-                      WHEN "' . $start . '" < min_job_date
+                      WHEN ? > max_job_date THEN NULL
+                      WHEN ? < min_job_date
                       THEN min_job_date
-                      ELSE "' . $start . '"
+                      ELSE ?
                     END AS adj_start_date,
                     CASE
-                      WHEN "' . $end . '" < min_job_date THEN NULL
-                      WHEN "' . $end . '" > max_job_date THEN max_job_date
-                      ELSE "' . $end . '"
+                      WHEN ? < min_job_date THEN NULL
+                      WHEN ? > max_job_date THEN max_job_date
+                      ELSE ?
                     END AS adj_end_date
                   FROM
                     minmaxdate
@@ -89,7 +97,8 @@ abstract class TimeAggregationUnit
                     (
                         mmd.adj_start_date BETWEEN p.' . $this->getUnitName() . '_start AND p.' . $this->getUnitName() . '_end
                         OR mmd.adj_end_date BETWEEN p.' . $this->getUnitName() . '_start AND p.' . $this->getUnitName() . '_end
-                    );'
+                    );',
+            $queryParams
         );
          if(null === $dateResult[0]['minPeriodId'] || null === $dateResult[0]['minPeriodId']){
              return array(-1,-1);

--- a/open_xdmod/modules/xdmod/component_tests/lib/QueryTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/QueryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace UnitTesting\DataWarehouse\Query\Jobs\Aggregate;
+
+/**
+ * This test is designed for class \DataWarehouse\Query\Jobs\Aggregate
+ */
+
+class AggregateTest extends \PHPUnit_Framework_TestCase
+{
+    private $_query;
+    /**
+     * @dataProvider QueryDataProvider
+     */
+    public function testGetDurrationResult($period, $start, $end, $groupby, $expected)
+    {
+        $q = new \DataWarehouse\Query\Jobs\Aggregate(
+             $period,
+             $start,
+             $end,
+             $groupby
+        );
+        $duration = $q->getDurationFormula();
+        $this->assertEquals($expected, $duration->getDefinition());
+    }
+
+    public function QueryDataProvider(){
+        return array(
+            array(
+                'day',
+                '2017-09-01',
+                '2017-09-30',
+                'none',
+                '(1)'
+            ),
+            array(
+                'day',
+                '2016-11-01',
+                '2016-11-30',
+                'none',
+                '(1)'
+            ),
+            array(
+                'day',
+                '2016-12-01',
+                '2016-12-15',
+                'none',
+                '(96)'
+            ),
+            array(
+                'day',
+                '2016-12-15',
+                '2017-01-05',
+                'none',
+                '(432)'
+            ),
+            array(
+                'day',
+                '2016-12-15',
+                '2016-12-29',
+                'none',
+                '(360)'
+            ),
+            array(
+                'day',
+                '2016-12-12',
+                '2017-01-01',
+                'none',
+                '(504)'
+            )
+        );
+    }
+}

--- a/open_xdmod/modules/xdmod/component_tests/lib/QueryTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/QueryTest.php
@@ -15,16 +15,16 @@ class AggregateTest extends \PHPUnit_Framework_TestCase
     public function testGetDurrationResult($period, $start, $end, $groupby, $expected)
     {
         $q = new \DataWarehouse\Query\Jobs\Aggregate(
-             $period,
-             $start,
-             $end,
-             $groupby
+            $period,
+            $start,
+            $end,
+            $groupby
         );
         $duration = $q->getDurationFormula();
         $this->assertEquals($expected, $duration->getDefinition());
     }
 
-    public function QueryDataProvider(){
+    public function queryDataProvider(){
         return array(
             array(
                 'day',


### PR DESCRIPTION
## Description
Fix issue and update for later code changes to work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In updating code to work with cloud metrics found an issue where the get min and max date range would actually return a day previous to the allowed range.  This fixes that error and sets up for the new period tables by bounding the range to be bound to the min and max job time.

Also combined into one database query instead of a possible 4 from before.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran old code and got duration returned which is the only places where getMinMax was called and compared to the new way.  Added tests to make sure this stays the same in the future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
