### PR TITLE
Update wdio.conf.js

### DIFF
--- a/open_xdmod/modules/xdmod/automated_tests/wdio.conf.js
+++ b/open_xdmod/modules/xdmod/automated_tests/wdio.conf.js
@@ -38,12 +38,6 @@ var Chrome = {
         ]
     }
 };
-var Safari = {
-    browserName: 'safari',
-    platform: 'macOS 10.12',
-    version: '10',
-    screenResolution: '1024x768'
-};
 
 var secrets = require('../integration_tests/.secrets.json');
 secrets.url = process.env.TEST_URL ? process.env.TEST_URL : secrets.url;

--- a/open_xdmod/modules/xdmod/automated_tests/wdio.conf.js
+++ b/open_xdmod/modules/xdmod/automated_tests/wdio.conf.js
@@ -67,7 +67,7 @@ if (process.env.WDIO_MODE === 'headless') {
     user = process.env.SAUCE_USER;
     key = process.env.SAUCE_KEY;
     services = ['sauce'];
-    capabilities = [InternetExplorer, Chrome, FireFox, Safari];
+    capabilities = [Chrome, FireFox, InternetExplorer];
 }
 if (process.env.JUNIT_OUTDIR) {
     reporters.push('junit');


### PR DESCRIPTION
Seems Safari fails on mouse click so remove from sauce testing.
IE is having an issue where it fails leaving the user in a bad state, move it to the end so firefox / chrome can continue.