### PR TITLE
ACL: Fix Multi Module Tab Inclusion

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -949,7 +949,7 @@ SQL;
         $log->warning("[FAIL] Attempt to commit hierarchies for Acl [$acl] failed.");
         $rolledBack = $db->rollBack();
 
-        // We throw an Exception so that we do not leave the db in an inconsistent state.
+        // We throw an Exception to indicate that the database may be in an inconsistent state.
         if ($rolledBack === false) {
             throw new \Exception("Unable to rollback Acl [$acl] hierarchy records. Database may be left in an inconsistent state.");
         }

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -33,7 +33,7 @@ try {
     $options = getopt(implode('', array_keys($opts)), array_values($opts));
 
     foreach ($options as $key => $value) {
-        switch($key) {
+        switch ($key) {
             case 't':
             case 'dryrun':
                 $dryRun = true;
@@ -129,11 +129,19 @@ function main()
 
     foreach ($modules as $module => $moduleData) {
         if (isset($rolesData[$module])) {
-            $moduleRoleData = $rolesData[$module]['roles'];
+            $isDefaultModule = $module === DEFAULT_MODULE_NAME;
+            if ($isDefaultModule === true) {
+                $moduleRealmData = $rolesData[$module]['roles'];
+            } else {
+                $defaultRealms = $rolesData[DEFAULT_MODULE_NAME]['roles'];
+                $moduleRealms = $rolesData[$module]['roles'];
+                $moduleRealmData = array_merge_recursive($defaultRealms, $moduleRealms);
+            }
+
             foreach ($roles as $role) {
-                $roleData = isset($moduleRoleData[$role]) ? $moduleRoleData[$role] : array();
+                $roleData = isset($moduleRealmData[$role]) ? $moduleRealmData[$role] : array();
                 if (array_key_exists('extends', $roleData)) {
-                    $roleData = array_merge($moduleRoleData[$roleData['extends']], $roleData);
+                    $roleData = array_merge($moduleRealmData[$roleData['extends']], $roleData);
                 }
                 foreach ($sections as $section) {
                     if (isset($roleData[$section])) {
@@ -148,17 +156,27 @@ function main()
 
     // Datawarehouse Retrieval
     $datawarehouseSource = $config->getModuleSection('datawarehouse');
+
     foreach ($modules as $module => $moduleData) {
-        if ( isset($datawarehouseSource[$module]['realms']) ) {
-            $dwSource= $datawarehouseSource[$module]['realms'];
-            foreach ($dwSource as $realmDisplay => $dwData) {
-                $groupBys = null !== $dwData['group_bys'] ? $dwData['group_bys'] : null;
-                $statistics = null !== $dwData['statistics'] ? $dwData['statistics'] : null;
-                $results[$module]['realms'][$realmDisplay] = array(
-                    'group_bys' => $groupBys,
-                    'statistics' => $statistics
-                );
-            }
+        $isDefaultModule = $module === DEFAULT_MODULE_NAME;
+        $hasModuleRealms = isset($datawarehouseSource[$module]['realms']);
+        if ($isDefaultModule === true && $hasModuleRealms) {
+            $moduleRealmData = $datawarehouseSource[$module]['realms'];
+        } elseif ($hasModuleRealms){
+            $defaultRealms = $datawarehouseSource[DEFAULT_MODULE_NAME]['realms'];
+            $moduleRealms = $datawarehouseSource[$module]['realms'];
+            $moduleRealmData = array_merge_recursive($defaultRealms, $moduleRealms);
+        } else {
+            continue;
+        }
+
+        foreach ($moduleRealmData as $realmDisplay => $dwData) {
+            $groupBys = null !== $dwData['group_bys'] ? $dwData['group_bys'] : null;
+            $statistics = null !== $dwData['statistics'] ? $dwData['statistics'] : null;
+            $results[$module]['realms'][$realmDisplay] = array(
+                'group_bys' => $groupBys,
+                'statistics' => $statistics
+            );
         }
     }
 
@@ -313,7 +331,7 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
     if ($acls !== null) {
         processAcls($db, $module, ( null !== $realms ? $realms : array() ), $acls);
     } else {
-        $log->info("No acl information for module $module skipping...");
+        $log->warning("No acl information for module $module skipping...");
     }
 }
 
@@ -337,8 +355,6 @@ function createModuleVersion(iDatabase $db, $moduleId, $installedOn, array $vers
     $preRelease = $version['pre_release'];
 
     $moduleVersion = "$major.$minor.$patch $preRelease";
-
-
 
     $query = <<<SQL
 INSERT INTO module_versions (
@@ -566,7 +582,7 @@ function processModules(iDatabase $db, array $modules)
         $display = isset($data['display']) ? $data['display'] : $name;
         $enabled = isset($data['enabled']) ? $data['enabled'] : true;
         $version = $data['version'];
-        $installedOn =  isset($data['installed_on'])
+        $installedOn = isset($data['installed_on'])
                      ? $data['installed_on']
                      : date("Y-m-d");
 
@@ -667,7 +683,7 @@ function processAcl(iDatabase $db, $module, $name, $display, $type = null, $hier
         $aclTypeId = processAclType($db, $module, $type);
 
         $query = <<<SQL
-INSERT into acls(module_id, acl_type_Id, name, display, enabled)
+INSERT INTO acls(module_id, acl_type_Id, name, display, enabled)
 SELECT inc.*
 FROM (
     SELECT
@@ -686,7 +702,7 @@ WHERE cur.acl_id IS NULL;
 SQL;
         $params = array(
             ':name' => $name,
-            ':display'=> $display,
+            ':display' => $display,
             ':enabled' => true,
             ':module_name' => $module,
             ':acl_type_id' => $aclTypeId
@@ -710,7 +726,7 @@ WHERE cur.acl_id IS NULL;
 SQL;
         $params = array(
             ':name' => $name,
-            ':display'=> $display,
+            ':display' => $display,
             ':enabled' => true,
             ':module_name' => $module
         );
@@ -726,6 +742,9 @@ SQL;
 
     $aclId = null;
     $inserted = $db->execute($query, $params);
+
+    // If the insert was not successful ( and it didn't error out ), then the
+    // record already exists, take the appropriate steps.
     if ($inserted === 0) {
         $log->info("[ALREADY EXISTS] $msg");
         $query = <<<SQL
@@ -745,8 +764,10 @@ SQL;
                 ':display' => $display
             )
         );
-        $aclId =  count($record) > 0 ? $record[0]['acl_id'] : null;
+        $aclId = count($record) > 0 ? $record[0]['acl_id'] : null;
     } elseif ($inserted === 1 ) {
+        // The record was inserted successfully so retrieve the id that the
+        // table autogenerated.
         $log->info("[SUCCESS] Inserted $msg");
         $aclId = $db->handle()->lastInsertId();
     }
@@ -789,9 +810,7 @@ function processAclType(iDatabase $db, $module, $type)
         WHERE BINARY m.name = BINARY :module_name
     ) inc
     LEFT JOIN acl_types cur
-        ON cur.module_id = inc.module_id AND
-           BINARY cur.name      = BINARY inc.name      AND
-           BINARY cur.display   = BINARY inc.display
+        ON BINARY cur.name = BINARY inc.name
     WHERE cur.acl_type_id IS NULL;
 SQL;
     $aclTypeDisplay = ucfirst($type);
@@ -810,17 +829,23 @@ SQL;
 
     $inserted = $db->execute($query, $params);
     if ($inserted === 0) {
+        // If we did not insert a record then the assumption is that it already
+        // exists, attempt to retrieve the acl_type_id.
         $query = <<<SQL
     SELECT at.acl_type_id
     FROM acl_types at
-        JOIN modules m
-            ON at.module_id = m.module_id
-    WHERE BINARY m.name     = BINARY :module_name    AND
-          BINARY at.name    = BINARY :acl_type_name  AND
-          BINARY at.display = BINARY :acl_type_display
+    WHERE BINARY at.name = BINARY :acl_type_name
 SQL;
-        $results = $db->query($query, $params);
+        $results = $db->query(
+            $query,
+            array(
+                ':acl_type_name' => $type
+            )
+        );
         $log->info("   Retrieved acl type for $type");
+        if (count($results) === 0) {
+            throw new Exception("Unable to determine acl type for [$module][$type][$aclTypeDisplay]");
+        }
         return $results[0]['acl_type_id'];
     }
     $log->info("   Created new acl type record for $type");
@@ -842,7 +867,8 @@ SQL;
  * @throws Exception if there is an exception encountered while attempting to execute
  *                   the sql required to process these acl hierarchy records.
  **/
-function processAclHierarchy(iDatabase $db, $module, $acl, array $hierarchies) {
+function processAclHierarchy(iDatabase $db, $module, $acl, array $hierarchies)
+{
     global $dryRun, $log;
 
     $log->notice("Processing Acl Hierarchy Records...");
@@ -876,6 +902,10 @@ SQL;
 
     $log->debug($statement);
     $inserted = 0;
+
+    // Begin a transaction so that either all of the hierarchies are inserted or
+    // none of them are.
+    $db->beginTransaction();
     foreach ($hierarchies as $hierarchyName => $hierarchyInfo) {
         if (!isset($hierarchyInfo['level'])) {
             $log->warning("Malformed hierarchy information for Acl $acl. No level present.");
@@ -912,6 +942,16 @@ SQL;
             $log->info("[SUCCESS] Processed Acl Hierarchy: $id");
         } else {
             $log->info("[FAIL] Inserted more than one Acl Hierarchy Record for: $id");
+        }
+    }
+    $committed = $db->commit();
+    if ($committed === false) {
+        $log->warning("[FAIL] Attempt to commit hierarchies for Acl [$acl] failed.");
+        $rolledBack = $db->rollBack();
+
+        // We throw an Exception so that we do not leave the db in an inconsistent state.
+        if ($rolledBack === false) {
+            throw new \Exception("Unable to rollback Acl [$acl] hierarchy records. Database may be left in an inconsistent state.");
         }
     }
     $processed = count($hierarchies);
@@ -959,9 +999,7 @@ function createTab(iDatabase $db, $module, $tab)
     global $dryRun, $log;
     $msg = "name: $tab";
 
-
-
-    $query =<<<SQL
+    $query = <<<SQL
     INSERT INTO tabs(module_id, name)
     SELECT inc.*
     FROM (
@@ -972,8 +1010,7 @@ function createTab(iDatabase $db, $module, $tab)
         WHERE BINARY m.name = BINARY :module_name
     ) inc
     LEFT JOIN tabs cur
-        ON        cur.module_id = inc.module_id   AND
-           BINARY cur.name      = BINARY inc.name
+        ON BINARY cur.name = BINARY inc.name
     WHERE cur.tab_id IS NULL;
 SQL;
 
@@ -1002,11 +1039,9 @@ SQL;
     FROM tabs t
         JOIN modules m
             ON t.module_id = m.module_id
-    WHERE BINARY m.name = BINARY :module_name AND
-          BINARY t.name = BINARY :name
+    WHERE BINARY t.name = BINARY :name
 SQL;
         $params = array(
-            ':module_name' => $module,
             ':name' => $tab
         );
 
@@ -1122,7 +1157,7 @@ function processQueryDescriptors(iDatabase $db, $module, $acl, array $realms, ar
      *     :group_by_name  - string
      *     :statistic_name - string
      **/
-    $query =<<<SQL
+    $query = <<<SQL
 INSERT INTO acl_group_bys(realm_id, acl_id, group_by_id, statistic_id, visible, enabled)
 SELECT inc.*
 FROM (
@@ -1163,18 +1198,18 @@ SQL;
     $totalProcessed = 0;
     foreach ($queryDescriptors as $queryDescriptor) {
 
-        $realm = isset($queryDescriptor['realm']) ? $queryDescriptor['realm']: null;
+        $realm = isset($queryDescriptor['realm']) ? $queryDescriptor['realm'] : null;
         $groupBy = isset($queryDescriptor['group_by']) ? $queryDescriptor['group_by'] : null;
         $disable = isset($queryDescriptor['disable']) ? $queryDescriptor['disable'] : false;
 
         if (!array_key_exists($realm, $realms)) {
-            $log->err("Unable to find a corresponding realm record for [$realm]. Skipping Query Descriptor for [ $module, $role, $groupBy ]");
+            $log->err("Unable to find a corresponding realm record for [$realm]. Skipping Query Descriptor for [ $module, $acl, $groupBy ]");
             continue;
         }
 
         $realmData = $realms[$realm];
         if (!isset($realmData['statistics'])) {
-            $log->err("No statistics found for realm $realm. Skipping Query Descriptor for [ $module, $role, $groupBy ]");
+            $log->err("No statistics found for realm $realm. Skipping Query Descriptor for [ $module, $acl, $groupBy ]");
             continue;
         }
         $statistics = $realmData['statistics'];
@@ -1182,7 +1217,7 @@ SQL;
         foreach ($statistics as $statistic) {
 
             $statisticName = isset($statistic['name']) ? $statistic['name'] : null;
-            $hide = isset($statistic['hide']) ? $statistic['hide']: null;
+            $hide = isset($statistic['hide']) ? $statistic['hide'] : null;
             $visible = isset($statistic['visible']) ? $statistic['visible'] : null;
 
             $enabled = null !== $disable ? !$disable : true;
@@ -1204,7 +1239,7 @@ SQL;
                 ':group_by_name' => $groupBy,
                 ':statistic_name' => $statisticName,
                 ':visible' => $visible,
-                ':enabled'=> $enabled
+                ':enabled' => $enabled
             );
 
             $log->debug(json_encode($params));
@@ -1250,7 +1285,7 @@ function processRealms(iDatabase $db, $moduleName, array $realms)
     foreach ($realms as $realm => $realmData) {
         $log->notice("Processing Realm: $realm");
 
-        createRealm($db, $moduleName, strtolower($realm));
+        createRealm($db, $moduleName, $realm);
 
         $groupBys = $realmData['group_bys'];
         $statistics = $realmData['statistics'];
@@ -1264,41 +1299,42 @@ function processRealms(iDatabase $db, $moduleName, array $realms)
  * Attempt to create a realm with the provided realmName associated with the
  * module associated with the provided moduleName.
  *
- * @param iDatabase $db         the database to be used when creating the realm
- * @param string    $moduleName the name of the module to associate this realm
- *                              with.
- * @param string    $realmName  the name that this realm should be created with.
+ * @param iDatabase $db            the database to be used when creating the realm
+ * @param string    $moduleName    the name of the module to associate this realm
+ *                                 with.
+ * @param string    $realmDisplay  the name that this realm should be created with.
  *
  * @return void
  **/
-function createRealm(iDatabase $db, $moduleName, $realmName)
+function createRealm(iDatabase $db, $moduleName, $realmDisplay)
 {
     global $dryRun, $log;
 
-    $realmName = strtolower($realmName);
+    $realmName = strtolower($realmDisplay);
 
-    $log->notice("*** Creating Realm ($realmName)...");
+    $log->notice("*** Creating Realm ($realmDisplay)...");
 
-    $successMsg = "[SUCCESS] Created Realm: $realmName for Module: $moduleName";
+    $successMsg = "[SUCCESS] Created Realm: $realmDisplay for Module: $moduleName";
 
     $query = <<<SQL
-    INSERT INTO realms(module_id, name)
+    INSERT INTO realms(module_id, name, display)
     SELECT inc.*
     FROM (
         SELECT
             m.module_id AS module_id,
-            :realm_name AS name
+            :realm_name AS name,
+            :realm_display AS display
         FROM modules m
         WHERE BINARY m.name = BINARY :module_name
     ) inc
     LEFT JOIN realms cur
-        ON cur.module_id        = inc.module_id   AND
-           BINARY cur.name      = BINARY inc.name
+        ON BINARY cur.name = BINARY inc.name
     WHERE cur.realm_id IS NULL;
 SQL;
 
     $params = array(
         ':realm_name' => $realmName,
+        ':realm_display' => $realmDisplay,
         ':module_name' => $moduleName
     );
 
@@ -1316,7 +1352,23 @@ SQL;
     );
 
     if ($inserted === 0) {
-        $log->info("[ALREADY EXISTS] Realm $realmName for Module $moduleName");
+        $updateQuery = <<<SQL
+    UPDATE realms
+    SET display = :realm_display
+    WHERE name = :realm_name;
+SQL;
+        $updated = $db->execute(
+            $updateQuery,
+            array(
+                ':realm_display' => $realmDisplay,
+                ':realm_name'    => $realmName
+            )
+        );
+        if ($updated === 1) {
+            $log->info("Updated Realm [$realmName] with display [$realmDisplay]");
+        } else {
+            $log->info("[ALREADY EXISTS] Realm $realmDisplay for Module $moduleName");
+        }
     } elseif ($inserted === 1) {
         $log->info($successMsg);
     }
@@ -1527,21 +1579,21 @@ function verifyJsonSyntax()
     );
 
     $invalid = array();
-    $confPrefix = CONFIG_DIR.DIRECTORY_SEPARATOR;
+    $confPrefix = CONFIG_DIR . DIRECTORY_SEPARATOR;
     foreach ($searchSet as $primaryFile => $configDir) {
-        $primaryFilePath = $confPrefix.$primaryFile;
+        $primaryFilePath = $confPrefix . $primaryFile;
         if (file_exists($primaryFilePath)) {
             $fileJson = Json::loadFile($primaryFilePath);
 
             if (null === $fileJson) {
                 $log->err("[FAIL] $primaryFile in an invalid json file");
-                $inalid []= $primaryFile;
+                $inalid [] = $primaryFile;
             } else {
                 $log->info("[SUCCESS] $primaryFile is a valid json file.");
             }
         }
 
-        $confPath = $confPrefix.$configDir;
+        $confPath = $confPrefix . $configDir;
         if (file_exists($confPath)) {
             foreach (new DirectoryIterator($confPath) as $fileInfo) {
                 if ($fileInfo->isDot()) {
@@ -1549,7 +1601,7 @@ function verifyJsonSyntax()
                 }
                 if (pathinfo($fileInfo->getFilename(), PATHINFO_EXTENSION) === 'json') {
                     $fileName = $fileInfo->getFilename();
-                    $filePath = $confPath.DIRECTORY_SEPARATOR.$fileName;
+                    $filePath = $confPath . DIRECTORY_SEPARATOR . $fileName;
                     $fileParts = explode(DIRECTORY_SEPARATOR, $filePath);
                     $parentDir = $fileParts[count($fileParts) - 2];
                     $fileId = implode(
@@ -1563,7 +1615,7 @@ function verifyJsonSyntax()
                     } catch (Exception $e) {
                         $reason = $e->getMessage();
                         $log->err("[FAIL] $fileId is not a valid json file. Reason:\n $reason");
-                        $invalid []= $filePath;
+                        $invalid [] = $filePath;
                     }
                 }
             }
@@ -1651,8 +1703,9 @@ function verifyDatabase()
  *
  * @return string
  **/
-function logLevelToVerbosity($logLevel) {
-    switch($logLevel) {
+function logLevelToVerbosity($logLevel)
+{
+    switch ($logLevel) {
         case Log::INFO:
             return 'verbose';
         case Log::DEBUG:

--- a/classes/Xdmod/Config.php
+++ b/classes/Xdmod/Config.php
@@ -151,7 +151,7 @@ class Config implements ArrayAccess
 
             $partialData = Json::loadFile($file);
             if (isset($results[$module]) && is_array($results[$module])) {
-                $results[$module] = array_merge($results[$module], $this->sanitizeKeys($partialData));
+                $results[$module] = array_merge_recursive($results[$module], $this->sanitizeKeys($partialData));
             } else {
                 $results[$module] = $this->sanitizeKeys($partialData);
             }

--- a/configuration/etl/etl_tables.d/acls/realms.json
+++ b/configuration/etl/etl_tables.d/acls/realms.json
@@ -19,6 +19,11 @@
         "name": "name",
         "type": "varchar(255)",
         "nullable": false
+      },
+      {
+        "name": "display",
+        "type": "varchar(255)",
+        "nullable": true
       }
     ],
     "indexes": [

--- a/configuration/roles.json
+++ b/configuration/roles.json
@@ -257,10 +257,12 @@
         "pub": {
             "display": "Public User",
             "type": "data",
-            "hierarchies": [{
-                "level": 0,
-                "filter_override": false
-            }],
+            "hierarchies": [
+                {
+                    "level": 0,
+                    "filter_override": false
+                }
+            ],
             "permitted_modules": [
                 {
                     "name": "tg_summary",
@@ -350,10 +352,12 @@
         "usr": {
             "display": "User",
             "type": "data",
-            "hierarchies": [{
-                "level": 100,
-                "filter_override": false
-            }],
+            "hierarchies": [
+                {
+                    "level": 100,
+                    "filter_override": false
+                }
+            ],
             "dimensions": [
                 "person"
             ],
@@ -362,10 +366,12 @@
         "cd": {
             "display": "Center Director",
             "type": "feature",
-            "hierarchies": [{
-                "level": 400,
-                "filter_override": false
-            }],
+            "hierarchies": [
+                {
+                    "level": 400,
+                    "filter_override": false
+                }
+            ],
             "dimensions": [
                 "provider"
             ],
@@ -374,10 +380,12 @@
         "pi": {
             "display": "Principal Investigator",
             "type": "data",
-            "hierarchies": [{
-                "level": 200,
-                "filter_override": false
-            }],
+            "hierarchies": [
+                {
+                    "level": 200,
+                    "filter_override": false
+                }
+            ],
             "dimensions": [
                 "pi"
             ],
@@ -386,10 +394,12 @@
         "cs": {
             "display": "Center Staff",
             "type": "data",
-            "hierarchies": [{
-                "level": 300,
-                "filter_override": false
-            }],
+            "hierarchies": [
+                {
+                    "hierarchies": 300,
+                    "filter_override": false
+                }
+            ],
             "dimensions": [
                 "provider"
             ],
@@ -398,10 +408,12 @@
         "mgr": {
             "display": "Manager",
             "type": "data",
-            "hierarchies": [{
-                "level": 301,
-                "filter_override": false
-            }],
+            "hierarchies": [
+                {
+                    "hierarchies": 301,
+                    "filter_override": false
+                }
+            ],
             "dimensions": [
                 "person"
             ],

--- a/html/gui/js/Viewer.js
+++ b/html/gui/js/Viewer.js
@@ -431,7 +431,7 @@ Ext.extend(CCR.xdmod.ui.Viewer, Ext.Viewport, {
             }
             tabPanel.add(tabInstance);
             if (tab.isDefault === true) {
-                tabToken = tabToken || mainTabToken + CCR.xdmod.ui.tokenDelimiter + tab.name;
+                tabToken = tabToken || mainTabToken + CCR.xdmod.ui.tokenDelimiter + tab.tab;
             }
         }
 


### PR DESCRIPTION
## Description
- This commit should resolve the issue where modules add information to the
  'default' role profile and those updates are not picked up for inclusion into
  the database.


## Motivation and Context
Tabs are good, modules should be able to add tabs.

## Tests performed
Manual Testing was performed: 

- Spin up a docker container from: tas-tools-ext-01.ccr.xdmod.org/centos7-xdmod-supremm6.6.0:version3
- `export XDMOD_TEST_MODE=fresh_install`
- `git clone --branch xdmod7.1 https://github.com/ubccr/xdmod.git ~/src/github.com/ubccr/xdmod`
- `git clone --branch xdmod7.1 https://github.com/ubccr/xdmod-appkernels.git ~/src/github.com/ubccr/xdmod-appkernels`
  - **NOTE: I had to update the xdmod-appkernels.spec.in file so that it would allow xdmod versions <= xdmod7.1 ( previously it was < xdmod7.1 )**
- `git clone --branch xdmod7.1 https://github.com/ubccr/xdmod-supremm.git ~/src/github.com/ubccr/xdmod-supremm`
- `git clone --branch acl/fix_multi_module_tabs https://github.com/ryanrath/xdmod.git ~/src/github.com/ryanrath/xdmod`
- `cd ~/src/github.com/ubccr/xdmod-appkernels`
- `ln -s ``pwd`` ../xdmod/open_xdmod/modules/appkernels`
  - NOTE: I couldn't for the life of me get a single back tick to work inside of a code block. 
- `ln -s ``pwd`` ~/src/github.com/ryanrath/xdmod/open_xdmod/modules/appkernels`
- `cd ../xdmod-supremm`
- `ln -s ``pwd`` ../xdmod/open_xdmod/modules/supremm`
- `ln -s  ``pwd`` ~/src/github.com/ryanrath/xdmod/open_xdmod/moduels/supremm`
- `composer install -d ../xdmod`
- `cd ../xdmod`
- `~/bin/buildrpm xdmod appkernels supremm`
- `cd ../xdmod-supremm`
- `./tests/integration_tests/scripts/bootsrap.sh`
- `xdmod-setup`
  - Option 2.) Database
  - Fill in the DB information
  - Wait for the acl scripts to finish
- open up a browser and direct it to the newly installed XDMoD
- log in as a user ( doesn't matter which one )
- The App Kernels & SUPREMM tab should be missing
- go back to the docker container
- `cd ~/src/github.com/ryanrath/xdmod`
  - **NOTE: I  bumped the release version in open_xdmod/modules/xdmod/build.json so that I could yum install the newly built rpm**
- `~/bin/buildrpm xdmod`
- `yum -y localinstall ~/rpmbuild/RPMS/noarch/xdmod-7.1.0-1.1.el7.centos.noarch.rpm`
- `xdmod-setup` ( like last time )
  - Option 2.) Databse
  - Fill in the DB information
  - Wait for the acl scripts to finish
- open up a browser and navigate to the newly upgraded XDMoD
- log in as a user ( doesn't matter which one )
- The App Kernels and SUPREMM tabs should now be present and functional 

Manual Database Tests:
-  start the mysql client inside the docker container
- `use moddb;`
- `SELECT * FROM modules;`
  - This should return 3 entries: appkernels, supremm, and xdmod
- `SELECT * FROM realms;`
  - This should return 2 entries: Jobs, SUPREMM
- `SELECT * FROM acls;`
  - This should return 6 entries: pub, usr, cd, pi, cs, mgr
- `SELECT * FROM tabs;`
  - This should return 7 entries: tg_summary, tg_usage, about_xdmod, metric_explorer, report_generator, app_kernels, and job_viewer.
- `SELECT a.name, t.name FROM acl_tabs at JOIN acls a ON a.acl_id = at.acl_id JOIN tabs t ON t.tab_id = at.tab_id;`
  - This should return 38 records and should correspond to the `permitted_modules` entries in roles.json
  - The important thing to note is that `pub` does not have access to app_kernels / job_viewer and that the other acls do. 
- If you want to check group_bys or statistics ( information in datawarehouse.json ) you can run the following ( but really these records should not be affected by the change ): 
  - `SELECT m.name AS module, r.name AS realm, gb.name AS group_by FROM group_bys gb LEFT JOIN modules m ON m.module_id = gb.module_id LEFT JOIN realms r ON r.realm_id = gb.realm_id;`
  - `SELECT m.name AS module, r.name AS realm, s.name AS statistic FROM statistics s LEFT JOIN modules m ON m.module_id = s.module_id LEFT JOIN realms r ON r.realm_id = s.realm_id;`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
)