### PR TITLE
Fix function signatures in child classes of GroupBy

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPI.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPI.php
@@ -152,7 +152,7 @@ class GroupByPI extends \DataWarehouse\Query\Jobs\GroupBy
 		return $parameters;*/
 	}
 	
-	public function getPossibleValues($hint = NULL, $limit = NULL, $offset = NULL, array $parameters = array())
+	public function getPossibleValues($hint = null, $limit = null, $offset = null, array $parameters = array(), $base_query = null, $filter = null)
 	{
 		if($this->_possible_values_query == NULL)
 		{

--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPerson.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByPerson.php
@@ -136,9 +136,9 @@ class GroupByPerson extends \DataWarehouse\Query\Jobs\GroupBy
 							"select long_name as field_label from modw.person  where id in (_filter_) order by order_id");
 	}
 	
-	public function getPossibleValues($hint = NULL, $limit = NULL, $offset = NULL, array $parameters = array())
+	public function getPossibleValues($hint = null, $limit = null, $offset = null, array $parameters = array(), $base_query = null, $filter = null)
 	{
-		if($this->_possible_values_query == NULL)
+		if($this->_possible_values_query == null)
 		{
 			return array();
 		}

--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByUsername.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByUsername.php
@@ -150,7 +150,7 @@ class GroupByUsername extends \DataWarehouse\Query\Jobs\GroupBy
 		return $parameters;*/
 	}
 	
-	public function getPossibleValues($hint = NULL, $limit = NULL, $offset = NULL, array $parameters = array())
+	public function getPossibleValues($hint = null, $limit = null, $offset = null, array $parameters = array(), $base_query = null, $filter = null)
 	{
 		if($this->_possible_values_query == NULL)
 		{

--- a/open_xdmod/modules/xdmod/tests/bootstrap.php
+++ b/open_xdmod/modules/xdmod/tests/bootstrap.php
@@ -2,6 +2,22 @@
 
 $dir = __DIR__;
 
+// Autoloader for mock implementation overrides
+spl_autoload_register(
+    function ($className) use ($dir) {
+        $classPath
+            = $dir
+            . '/lib/TestHelpers/mock/'
+            . str_replace('\\', '/', $className)
+            . '.php';
+        if (is_readable($classPath)) {
+            return include_once $classPath;
+        } else {
+            return false;
+        }
+    }
+);
+
 // Autoloader for test classes.
 spl_autoload_register(
     function ($className) use ($dir) {
@@ -12,7 +28,7 @@ spl_autoload_register(
             . '.php';
 
         if (is_readable($classPath)) {
-            return require_once $classPath;
+            return include_once $classPath;
         } else {
             return false;
         }

--- a/open_xdmod/modules/xdmod/tests/lib/DataWarehouse/Query/Jobs/GroupBy/GroupByPersonTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/DataWarehouse/Query/Jobs/GroupBy/GroupByPersonTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace UnitTesting\DataWarehouse\Query;
+
+use \UnitTesting\mock;
+
+class GroupByPersonTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetPossibleValues()
+    {
+        \DataWarehouse::$mockDatabaseImplementation = $this->getMockBuilder('CCR\DB\iDatabase')->getMock();
+
+        \DataWarehouse::$mockDatabaseImplementation->method('query')-> will(
+            $this->returnCallback(
+                function ($query, $params) {
+                    \PHPUnit_Framework_Assert::assertEquals(
+                        "SELECT distinct
+                        gt.id,
+                        gt.short_name as short_name,
+                        gt.long_name as long_name
+                        FROM person gt
+                        where 1
+                        order by gt.order_id
+                        ",
+                        $query
+                    );
+                }
+            )
+        );
+
+        $q = new \DataWarehouse\Query\Jobs\GroupBys\GroupByPerson();
+        $q->getPossibleValues();
+    }
+}

--- a/open_xdmod/modules/xdmod/tests/lib/TestHelpers/mock/DataWarehouse.php
+++ b/open_xdmod/modules/xdmod/tests/lib/TestHelpers/mock/DataWarehouse.php
@@ -1,0 +1,11 @@
+<?php
+
+class DataWarehouse
+{
+    public static $mockDatabaseImplementation = null;
+
+    public static function connect()
+    {
+        return DataWarehouse::$mockDatabaseImplementation;
+    }
+}


### PR DESCRIPTION
## Description
FOREWORD: Full credit/blame to @jsperhac for this change :). I'm simply rebasing and updating it to work with the current tests, to remedy earlier complaints.

This change fixes signatures for the function getPossibleValues() in the case of child classes that failed to specify default params matching that of their parent class (GroupBy.php).

## Motivation and Context
We do like consistency.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
