### PR TITLE
Do not automatically register global endpoints

### DIFF
--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -238,19 +238,20 @@ class EtlConfiguration extends Configuration
         }  // foreach ( $etlSectionNames as $typeName )
 
         // --------------------------------------------------------------------------------
-        // Register the global default endpoints but note that individual actions may still define
-        // their own. We should not verify these unless they are actually used by an enabled action.
+        // Register the global utility endpoint in the main ETL configuration file because it may be
+        // needed by the etl overseer script to look up resource ids from resource codes. We do not
+        // register other global endpoints because these should only be registered if an enabled
+        // action needs them.
 
         $this->endpoints = array();
 
-        if ( isset($this->localDefaults->global->endpoints) ) {
-            foreach ( $this->localDefaults->global->endpoints as $name => $endpointConfig ) {
-                try {
-                    $endpoint = $this->addDataEndpoint($endpointConfig);
-                    $this->globalEndpoints[$name] = $endpoint->getKey();
-                } catch (Exception $e) {
-                    $this->logAndThrowException("Error registering default endpoint '$name': " . $e->getMessage());
-                }
+        if ( ! $this->isLocalConfig && isset($this->localDefaults->global->endpoints->utility) ) {
+            $name = 'utility';
+            try {
+                $endpoint = $this->addDataEndpoint($this->localDefaults->global->endpoints->utility);
+                $this->globalEndpoints[$name] = $endpoint->getKey();
+            } catch (Exception $e) {
+                $this->logAndThrowException("Error registering default endpoint '$name': " . $e->getMessage());
             }
         }  // if ( isset(($this->localDefaults->global->endpoints) )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The ETL code registers global data endpoints and any endpoint associated with an **enabled** action. This means that a global endpoint could be registered even if the actions that it applied to are **disabled**. This PR changes the behavior to only automatically the global "utility" endpoint defined in the top level `etl.json` file as it may be used by `etl_overseet.php` to look up resource codes from the database. Since global endpoints are applied to individual actions withing their scope, these will still be registered for if any action that uses them is enabled.

## Motivation and Context

Registering global endpoints with no enabled actions was causing testing to fail when it could not connect to the XDCDB mirror.

## Tests performed

1. Renamed a global endpoint database to an incorrect name
2. Disabled all actions that the endpoint applied to
3. Confirmed that the endpoint was registered and failed verification
4. Applied patch
5. Confirmed that the endpoint was no longer registered
6. Re-enabled actions and confirmed that the endpoint verification failed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
