### PR TITLE
XDUser & Center[Director|Staff]Role Tests

### DIFF
--- a/classes/User/Roles/CenterDirectorRole.php
+++ b/classes/User/Roles/CenterDirectorRole.php
@@ -152,15 +152,6 @@ class CenterDirectorRole extends \User\AuthenticatedRole
 
         $pdo = DB::factory('database');
 
-        $is_primary_role = (
-            ($member->getPrimaryRole()->getIdentifier() == ROLE_ID_CENTER_DIRECTOR) &&
-            ($member->getPrimaryOrganization() == $this->getActiveCenter())
-        );
-
-        if ($is_primary_role == true) {
-            throw new \Exception("Unable to revoke, as this user's default<br />role is Center Director of this Center");
-        }
-
         $active_role_failover_needed = (
             ($member->getActiveRole()->getIdentifier() == ROLE_ID_CENTER_DIRECTOR) &&
             ($member->getActiveOrganization() == $this->getActiveCenter())

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -11,7 +11,7 @@ use Models\Services\Acls;
  *
  * @Class XDUser
  */
-class XDUser
+class XDUser implements JsonSerializable
 {
 
     private $_pdo;                       // PDO Handle (set in __construct)
@@ -3253,4 +3253,32 @@ SQL;
             ':value'   => $organizationId
         ));
     } // addAclOrganization
+
+        /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        $ignored = array(
+            '_pdo', '_primary_role', '_publicUser', '_timeCreated','_timeUpdated',
+            '_timePasswordUpdated'
+        );
+        $reflection = new ReflectionClass($this);
+        $results = array();
+        $properties = $reflection->getProperties();
+        foreach($properties as $property) {
+            $name = $property->getName();
+            if (!in_array($name, $ignored)) {
+                $property->setAccessible(true);
+
+                $value = $property->getValue($this);
+                $results[$name] = $value;
+            }
+        }
+        return $results;
+    }
 }//XDUser

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -3265,7 +3265,7 @@ SQL;
     {
         $ignored = array(
             '_pdo', '_primary_role', '_publicUser', '_timeCreated','_timeUpdated',
-            '_timePasswordUpdated'
+            '_timePasswordUpdated', '_token'
         );
         $reflection = new ReflectionClass($this);
         $results = array();

--- a/open_xdmod/modules/xdmod/component_tests/artifacts/.gitignore
+++ b/open_xdmod/modules/xdmod/component_tests/artifacts/.gitignore
@@ -1,0 +1,1 @@
+/xdmod-test-artifacts

--- a/open_xdmod/modules/xdmod/component_tests/artifacts/update-artifacts.sh
+++ b/open_xdmod/modules/xdmod/component_tests/artifacts/update-artifacts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+xdmod_test_artifacts_source="https://github.com/ubccr/xdmod-test-artifacts.git"
+using_xdmod_test_artifacts_mirror="false"; [ -n "$XDMOD_TEST_ARTIFACTS_MIRROR" ] && using_xdmod_test_artifacts_mirror="true"
+
+# Change directory to this script's directory.
+cd "$(dirname $0)" || exit 1
+
+# If using a mirror of the xdmod-test-artifacts repo, create or update it.
+#
+# Travis will create any directories that are set up for caching if they do
+# not exist, so also check if the directory has contents.
+if "$using_xdmod_test_artifacts_mirror"; then
+    if [ -d "$XDMOD_TEST_ARTIFACTS_MIRROR" ] && [ -n "$(ls -A "$XDMOD_TEST_ARTIFACTS_MIRROR")" ]; then
+        echo "Updating xdmod-test-artifacts mirror..."
+        git -C "$XDMOD_TEST_ARTIFACTS_MIRROR" remote update
+    else
+        echo "Creating mirror of xdmod-test-artifacts..."
+        git clone --mirror "$xdmod_test_artifacts_source" "$XDMOD_TEST_ARTIFACTS_MIRROR"
+    fi
+fi
+
+# If the xdmod-test-artifacts repo already exists locally, update it.
+# Otherwise, clone it.
+artifacts_dir="./xdmod-test-artifacts"
+if [ -d "$artifacts_dir" ]; then
+    echo "Updating local xdmod-test-artifacts clone..."
+    git -C "$artifacts_dir" pull
+else
+    echo "Cloning xdmod-test-artifacts into local directory..."
+    if "$using_xdmod_test_artifacts_mirror"; then
+        local_clone_source="$XDMOD_TEST_ARTIFACTS_MIRROR"
+    else
+        local_clone_source="$xdmod_test_artifacts_source"
+    fi
+    git clone "$local_clone_source" "$artifacts_dir"
+fi

--- a/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
@@ -1,0 +1,113 @@
+<?php namespace ComponentTests;
+
+use CCR\Json;
+use Exception;
+use User\Roles\CenterDirectorRole;
+use XDUser;
+
+/**
+ * Tests meant to exercise the functions in the CenterDirectorRole class.
+ **/
+class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_OUTPUT_PATH = "./../../../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
+     */
+    public function testGetCorrespondingUserIDWithNoUser()
+    {
+        $cd = new CenterDirectorRole();
+        $cd->getCorrespondingUserID();
+    }
+
+    public function testGetCorrespondingUserID()
+    {
+        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $expected = $user->getUserID();
+
+        $cd = new CenterDirectorRole();
+        $cd->configure($user);
+        $actual = $cd->getCorrespondingUserID();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
+     */
+    public function testGetActiveCenterWithNoUser()
+    {
+        $cd = new CenterDirectorRole();
+        $cd->getActiveCenter();
+    }
+
+    public function testGetActiveCenter()
+    {
+        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $expected = 1;
+
+        $cd = new CenterDirectorRole();
+        $cd->configure($user);
+        $actual = $cd->getActiveCenter();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
+     */
+    public function testGetFormalNameWithNoUser()
+    {
+        $cd = new CenterDirectorRole();
+        $cd->getFormalName();
+    }
+
+    public function testGetFormalName()
+    {
+        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $expected = 'Center Director - screw';
+        $cd = new CenterDirectorRole();
+        $cd->configure($user);
+
+        $actual =  $cd->getFormalName();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetIdentifier()
+    {
+        $params = array(
+            false => XDUserTest::CENTER_DIRECTOR_ACL_NAME,
+            true => XDUserTest::CENTER_DIRECTOR_ACL_NAME . ';1'
+        );
+
+        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $cd = new CenterDirectorRole();
+        $cd->configure($user);
+        foreach($params as $param => $expected) {
+            $actual = $cd->getIdentifier($param);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
+     */
+    public function testEnumStaffMembersNoUser()
+    {
+        $cd = new CenterDirectorRole();
+        $cd->enumCenterStaffMembers();
+    }
+
+    public function testEnumStaffMembers()
+    {
+        $expected = Json::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . '/center_director_staff_members.json');
+
+        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $cd = new CenterDirectorRole();
+        $cd->configure($user);
+        $actual = $cd->enumCenterStaffMembers();
+        $this->assertEquals($expected, json_decode(json_encode($actual), true));
+    }
+}

--- a/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
@@ -102,7 +102,7 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testEnumStaffMembers()
     {
-        $expected = Json::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . '/center_director_staff_members.json');
+        $expected = Json::loadFile(XDUserTest::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'center_director_staff_members.json');
 
         $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
         $cd = new CenterDirectorRole();

--- a/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
@@ -10,7 +10,7 @@ use XDUser;
  **/
 class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_OUTPUT_PATH = "./../../../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
+    const TEST_ARTIFACT_OUTPUT_PATH = "/../../../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
     /**
      * @expectedException Exception
      * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()

--- a/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
@@ -1,4 +1,6 @@
-<?php namespace ComponentTests;
+<?php
+
+namespace ComponentTests;
 
 use CCR\Json;
 use Exception;
@@ -10,7 +12,7 @@ use XDUser;
  **/
 class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 {
-    const TEST_ARTIFACT_OUTPUT_PATH = "/../../../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
+    const TEST_ARTIFACT_OUTPUT_PATH = '/../../../artifacts/xdmod-test-artifacts/xdmod/acls/output';
     /**
      * @expectedException Exception
      * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
@@ -102,7 +104,7 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testEnumStaffMembers()
     {
-        $expected = Json::loadFile(XDUserTest::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'center_director_staff_members.json');
+        $expected = Json::loadFile(__DIR__ . CenterDirectorRoleTest::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'center_director_staff_members.json');
 
         $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
         $cd = new CenterDirectorRole();

--- a/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterStaffRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterStaffRoleTest.php
@@ -1,0 +1,69 @@
+<?php namespace ComponentTests;
+
+use Exception;
+use User\Roles\CenterStaffRole;
+use XDUser;
+
+/**
+ * Tests meant to exercise the functions in the CenterStaffRole class
+ **/
+class CenterStaffRoleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
+     */
+    public function testGetIdentifierAbsoluteNoUser()
+    {
+        $cs = new CenterStaffRole();
+        $cs->getIdentifier(true);
+    }
+
+    public function testGetIdentifierAbsolute()
+    {
+        $expected = XDUserTest::CENTER_STAFF_ACL_NAME . ';1';
+        $user = XDUser::getUserByUserName(XDUserTest::CENTER_STAFF_USER_NAME);
+        $cs = new CenterStaffRole();
+        $cs->configure($user);
+        $actual = $cs->getIdentifier(true);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetIdentifier()
+    {
+        $expected = XDUserTest::CENTER_STAFF_ACL_NAME;
+        $user = XDUser::getUserByUserName(XDUserTest::CENTER_STAFF_USER_NAME);
+        $cs = new CenterStaffRole();
+        $cs->configure($user);
+        $actual = $cs->getIdentifier();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
+     */
+    public function testGetActiveCenterNoUser()
+    {
+        $cs = new CenterStaffRole();
+        $cs->getActiveCenter();
+    }
+
+    public function testGetActiveCenter()
+    {
+        $users = array(
+            XDUserTest::CENTER_STAFF_USER_NAME => 1,
+            XDUserTest::CENTER_DIRECTOR_USER_NAME => -1,
+            XDUserTest::PRINCIPAL_INVESTIGATOR_USER_NAME => -1,
+            XDUserTest::NORMAL_USER_USER_NAME => -1,
+            XDUserTest::PUBLIC_USER_NAME => -1
+        );
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $cs = new CenterStaffRole();
+            $cs->configure($user);
+            $actual = $cs->getActiveCenter();
+            $this->assertEquals($expected, $actual);
+        }
+    }
+}

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -16,7 +16,7 @@ use \Exception;
 class XDUserTest extends \PHPUnit_Framework_TestCase
 {
 
-    const TEST_ARTIFACT_OUTPUT_PATH = "/../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/acls/output";
 
     const PUBLIC_USER_NAME = 'Public User';
     const PUBLIC_ACL_NAME = 'pub';
@@ -47,16 +47,16 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testGetUserByUserName()
     {
         $users = array(
-            self::PUBLIC_USER_NAME => '/public_user.json',
-            self::CENTER_STAFF_USER_NAME => '/center_staff.json',
-            self::CENTER_DIRECTOR_USER_NAME => '/center_director.json',
-            self::PRINCIPAL_INVESTIGATOR_USER_NAME => '/principal.json',
-            self::NORMAL_USER_USER_NAME => '/normal_user.json'
+            self::PUBLIC_USER_NAME => 'public_user.json',
+            self::CENTER_STAFF_USER_NAME => 'center_staff.json',
+            self::CENTER_DIRECTOR_USER_NAME => 'center_director.json',
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => 'principal.json',
+            self::NORMAL_USER_USER_NAME => 'normal_user.json'
         );
 
         foreach($users as $userName => $expectedFile) {
             $user = XDUser::getUserByUserName($userName);
-            $expected = JSON::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . $expectedFile);
+            $expected = JSON::loadFile(self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . $expectedFile);
             $actual = json_decode(json_encode($user), true);
             $this->assertEquals($expected, $actual);
         }
@@ -828,7 +828,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
     public function testCenterDirectorEnumAllAvailableRoles()
     {
-        $expected = JSON::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . '/center_director_all_available_roles.json');
+        $expected = JSON::loadFile(self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'center_director_all_available_roles.json');
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
 
         $allAvailableRoles = $user->enumAllAvailableRoles();

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -673,17 +673,6 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $anotherUser->getActiveRole();
     }
 
-    /* NOTE: this will never hit because _getFormalRoleName will never return null.
-     * @expectedException Exception
-     * @expectedExceptionMessage Attempting to set an invalid active role
-     *\/
-    public function testSetActiveRoleWithInvalidRoleNameFails()
-    {
-        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
-
-        $user->setActiveRole(self::INVALID_ACL_NAME);
-    }*/
-
     /**
      * @expectedException Exception
      * @expectedExceptionMessage An additional parameter must be passed for this role (organization id)

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -1,4 +1,6 @@
-<?php namespace ComponentTests;
+<?php
+
+namespace ComponentTests;
 
 use CCR\DB;
 use CCR\Json;
@@ -16,7 +18,7 @@ use \Exception;
 class XDUserTest extends \PHPUnit_Framework_TestCase
 {
 
-    const TEST_ARTIFACT_OUTPUT_PATH = "./artifacts/xdmod-test-artifacts/xdmod/acls/output";
+    const TEST_ARTIFACT_OUTPUT_PATH = "/../artifacts/xdmod-test-artifacts/xdmod/acls/output";
 
     const PUBLIC_USER_NAME = 'Public User';
     const PUBLIC_ACL_NAME = 'pub';
@@ -56,7 +58,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
         foreach($users as $userName => $expectedFile) {
             $user = XDUser::getUserByUserName($userName);
-            $expected = JSON::loadFile(self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . $expectedFile);
+            $expected = JSON::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . $expectedFile);
             $actual = json_decode(json_encode($user), true);
             $this->assertEquals($expected, $actual);
         }
@@ -828,7 +830,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
     public function testCenterDirectorEnumAllAvailableRoles()
     {
-        $expected = JSON::loadFile(self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'center_director_all_available_roles.json');
+        $expected = JSON::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'center_director_all_available_roles.json');
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
 
         $allAvailableRoles = $user->enumAllAvailableRoles();

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -1,7 +1,11 @@
 <?php namespace ComponentTests;
 
+use CCR\DB;
+use CCR\Json;
+use PHPUnit_Framework_Error_Notice;
+use ReflectionClass;
+use User\Roles\CenterDirectorRole;
 use \XDUser;
-use Models\Acl;
 use Models\Services\Acls;
 use \Exception;
 
@@ -11,25 +15,62 @@ use \Exception;
  **/
 class XDUserTest extends \PHPUnit_Framework_TestCase
 {
+
+    const TEST_ARTIFACT_OUTPUT_PATH = "./../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
+
     const PUBLIC_USER_NAME = 'Public User';
     const PUBLIC_ACL_NAME = 'pub';
+    const PUBLIC_USER_EXPECTED = '/public_user.json';
 
     const CENTER_DIRECTOR_USER_NAME = 'centerdirector';
-    const CENTER_DIRECTOR_ACL_NAME  = 'cd';
+    const CENTER_DIRECTOR_ACL_NAME = 'cd';
+    const CENTER_DIRECTOR_EXPECTED = '/center_director.json';
 
-    const PRINCIPAL_INVESTIGTOR_ACL_NAME = 'pi';
+    const CENTER_STAFF_USER_NAME = 'centerstaff';
+    const CENTER_STAFF_ACL_NAME = 'cs';
+    const CENTER_STAFF_EXPECTED = '/center_staff.json';
+
+    const PRINCIPAL_INVESTIGATOR_USER_NAME = 'principal';
+    const PRINCIPAL_INVESTIGATOR_ACL_NAME = 'pi';
+    const PRINCIPAL_INVESTIGATOR_EXPECTED = '/principal.json';
+
+    const NORMAL_USER_USER_NAME = 'normaluser';
+    const NORMAL_USER_ACL = 'usr';
+    const NORMAL_USER_EXPECTED = '/normal_user.json';
+
+    const VALID_SERVICE_PROVIDER_ID = 1;
+    const VALID_SERVICE_PROVIDER_NAME = 'screw';
+
+    const INVALID_ID = -999;
+    const INVALID_ACL_NAME = 'babbaganoush';
+
+    public function testGetUserByUserName()
+    {
+        $users = array(
+            self::PUBLIC_USER_NAME => '/public_user.json',
+            self::CENTER_STAFF_USER_NAME => '/center_staff.json',
+            self::CENTER_DIRECTOR_USER_NAME => '/center_director.json',
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => '/principal.json',
+            self::NORMAL_USER_USER_NAME => '/normal_user.json'
+        );
+
+        foreach($users as $userName => $expectedFile) {
+            $user = XDUser::getUserByUserName($userName);
+            $expected = JSON::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . $expectedFile);
+            $actual = json_decode(json_encode($user), true);
+            $this->assertEquals($expected, $actual);
+        }
+    }
 
     public function testGetPublicUser()
     {
         $user = XDUser::getPublicUser();
-
-        $this->assertTrue($user !== null);
+        $this->assertNotNull($user);
     }
 
     public function testPublicUserIsPublicUser()
     {
         $user = XDUser::getPublicUser();
-
         $this->assertTrue($user->isPublicUser());
     }
 
@@ -43,18 +84,21 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testIsDeveloperInvalid()
     {
         $user = XDUser::getUserByUserName(self::PUBLIC_USER_NAME);
+
         $this->assertFalse($user->isDeveloper());
     }
 
     public function testIsManagerInvalid()
     {
         $user = XDUser::getUserByUserName(self::PUBLIC_USER_NAME);
+
         $this->assertFalse($user->isManager());
     }
 
     public function testGetTokenAsPublic()
     {
         $user = XDUser::getPublicUser();
+
         $token = $user->getToken();
         $this->assertEquals('', $token);
     }
@@ -62,6 +106,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testGetTokenAsNonPublic()
     {
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+
         $token = $user->getToken();
         $this->assertNotEquals('', $token);
     }
@@ -69,6 +114,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testGetTokenExpirationAsPublic()
     {
         $user = XDUser::getPublicUser();
+
         $expiration = $user->getTokenExpiration();
         $this->assertEquals('', $expiration);
     }
@@ -76,6 +122,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testGetTokenExpirationAsNonPublic()
     {
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+
         $expiration = $user->getTokenExpiration();
         $this->assertNotEquals('', $expiration);
     }
@@ -108,7 +155,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(in_array($validOrganizationId, $newOrganizations));
 
         $original = array();
-        foreach(array_values($originalOrganizations) as $organizationId) {
+        foreach (array_values($originalOrganizations) as $organizationId) {
             $original[$organizationId] = $defaultConfig;
         }
 
@@ -173,7 +220,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($newOrganizations);
 
         $original = array();
-        foreach(array_values($originalOrganizations) as $organizationId) {
+        foreach (array_values($originalOrganizations) as $organizationId) {
             $original[$organizationId] = $defaultConfig;
         }
         $user->setOrganizations($original, self::CENTER_DIRECTOR_ACL_NAME);
@@ -210,7 +257,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotNull($roles);
         $this->assertTrue(count($roles) > 0);
-        foreach($roles as $roleDisplay => $roleAbbrev) {
+        foreach ($roles as $roleDisplay => $roleAbbrev) {
             $abbrevLength = strlen($roleAbbrev);
             $displayLength = strlen($roleDisplay);
             $this->assertTrue($displayLength >= $abbrevLength);
@@ -250,7 +297,6 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testGetAcls()
     {
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
-        $self = $this;
         $acls = $user->getAcls();
 
         $this->assertTrue(count($acls) > 0);
@@ -293,7 +339,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
     public function testAddNewAcl()
     {
-        $newAcl = Acls::getAclByName(self::PRINCIPAL_INVESTIGTOR_ACL_NAME);
+        $newAcl = Acls::getAclByName(self::PRINCIPAL_INVESTIGATOR_ACL_NAME);
         $this->assertNotNull($newAcl);
 
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
@@ -367,7 +413,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
     public function testHasAclNotExists()
     {
-        $existingAcl = Acls::getAclByName(self::PRINCIPAL_INVESTIGTOR_ACL_NAME);
+        $existingAcl = Acls::getAclByName(self::PRINCIPAL_INVESTIGATOR_ACL_NAME);
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
 
         $hasAcl = $user->hasAcl($existingAcl);
@@ -377,8 +423,8 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testHasAclsExists()
     {
         $acls = array();
-        $acls []= Acls::getAclByName(self::CENTER_DIRECTOR_ACL_NAME);
-        $acls []= Acls::getAclByName('usr');
+        $acls [] = Acls::getAclByName(self::CENTER_DIRECTOR_ACL_NAME);
+        $acls [] = Acls::getAclByName('usr');
 
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
 
@@ -418,7 +464,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUserByUserNameInvalid()
     {
-        $user = XDUser::getUserByUserName("bilbo");
+        XDUser::getUserByUserName("bilbo");
     }
 
     /**
@@ -427,7 +473,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUserByUserNameEmptyString()
     {
-        $user = XDUser::getUserByUserName("");
+        XDUser::getUserByUserName("");
     }
 
     /**
@@ -436,7 +482,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUserByUserNameNull()
     {
-        $user = XDUser::getUserByUserName(null);
+        XDUser::getUserByUserName(null);
     }
 
     /**
@@ -470,7 +516,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testGetPrimaryRoleWithNewUser()
     {
         $user = new XDUser('test', null, 'test@ccr.xdmod.org', 'test', 'a', 'user');
-        $primaryRole = $user->getPrimaryRole();
+        $user->getPrimaryRole();
     }
 
     public function testGetActiveRoleWithPublicUser()
@@ -487,7 +533,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testGetActiveRoleWithNewUserShouldFail()
     {
         $user = new XDUser('test', null, 'test@ccr.xdmod.org', 'test', 'a', 'user');
-        $activeRole = $user->getActiveRole();
+        $user->getActiveRole();
     }
 
     /**
@@ -527,7 +573,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
     public function testCreateUserWithExistingUserNameShouldFail()
     {
         $anotherUser = new XDUser('test', null, 'test@ccr.xdmod.org', 'test', 'a', 'user');
-        $anoterUser->setUserType(XSEDE_USER_TYPE);
+        $anotherUser->setUserType(XSEDE_USER_TYPE);
         $anotherUser->saveUser();
     }
 
@@ -536,7 +582,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
      **/
     public function testCreateUserWithExistingEmailShouldFail()
     {
-        $anotherUser = new XDUser('test2', null, 'public@ccr.xdmod.org', 'public', 'a', 'user');
+        new XDUser('test2', null, 'public@ccr.xdmod.org', 'public', 'a', 'user');
     }
 
     /**
@@ -547,27 +593,6 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $anotherUser = new XDUser('test2', null, 'public@ccr.xdmod.org', 'public', 'a', 'user');
         $anotherUser->setUserType(DEMO_USER_TYPE);
         $anotherUser->saveUser();
-    }
-
-    public function testRemoveUser()
-    {
-        $user = XDUser::getUserByUserName('test');
-
-        $this->assertNotNull($user);
-
-        $user->removeUser();
-    }
-
-    /**
-     * Cannot remove the public user
-     *
-     * @expectedException Exception
-     **/
-    public function testRemovePublicUserShouldFail()
-    {
-        $user = XDUser::getPublicUser();
-
-        $user->removeUser();
     }
 
     /**
@@ -587,5 +612,601 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
         $user->setUserType(0);
         $user->saveUser();
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage User "test" not found
+     */
+    public function testRemoveUser()
+    {
+        $user = XDUser::getUserByUserName('test');
+
+        $this->assertNotNull($user);
+
+        $user->removeUser();
+
+        XDUser::getUserByUserName('test');
+    }
+
+    /**
+     * Cannot remove the public user
+     *
+     * @expectedException Exception
+     **/
+    public function testRemovePublicUserShouldFail()
+    {
+        $user = XDUser::getPublicUser();
+
+        $user->removeUser();
+    }
+
+
+    public function testGetUserByIDInvalidUID()
+    {
+        $user = XDUser::getUserByID(self::INVALID_ID);
+        $this->assertNull($user);
+    }
+
+    public function testGetuserByIDNull()
+    {
+        $user = XDUser::getUserByID(null);
+        $this->assertNull($user);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage You must call saveUser() on this newly created XDUser prior to using getActiveRole()
+     */
+    public function testGetActiveRoleOnUnSavedUserFails()
+    {
+        $anotherUser = new XDUser('test3', null, 'public3@ccr.xdmod.org', 'public', 'a', 'user');
+        $anotherUser->getActiveRole();
+    }
+
+    /* NOTE: this will never hit because _getFormalRoleName will never return null.
+     * @expectedException Exception
+     * @expectedExceptionMessage Attempting to set an invalid active role
+     *\/
+    public function testSetActiveRoleWithInvalidRoleNameFails()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+
+        $user->setActiveRole(self::INVALID_ACL_NAME);
+    }*/
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage An additional parameter must be passed for this role (organization id)
+     */
+    public function testSetActiveRoleForCenterDirectorWithNoRoleParamShouldFail()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+
+        $user->setActiveRole(self::CENTER_DIRECTOR_ACL_NAME);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage An invalid organization id has been specified for the role you are attempting to make active
+     */
+    public function testSetActiveRoleForCenterDirectorWithInvalidOrgIDShouldFail()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+
+        $user->setActiveRole(self::CENTER_DIRECTOR_ACL_NAME, self::INVALID_ID);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage An additional parameter must be passed for this role (organization id)
+     */
+    public function testSetActiveRoleForCenterStaffWithNoRoleParamShouldFail()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+
+        $user->setActiveRole(self::CENTER_STAFF_ACL_NAME);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage An invalid organization id has been specified for the role you are attempting to make active
+     */
+    public function testSetActiveRoleForCenterStaffWithInvalidOrgIDShouldFail()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+
+        $user->setActiveRole(self::CENTER_STAFF_ACL_NAME, self::INVALID_ID);
+    }
+
+    public function testSetActiveRoleForCenterDirectorWithValidOrgID()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+
+        $user->setActiveRole(self::CENTER_DIRECTOR_ACL_NAME, self::VALID_SERVICE_PROVIDER_ID);
+
+        $activeRole = $user->getActiveRole();
+        $this->assertNotNull($activeRole);
+
+        $activeRoleName = $activeRole->getIdentifier();
+        $this->assertEquals(self::CENTER_DIRECTOR_ACL_NAME, $activeRoleName);
+    }
+
+    public function testSetActiveRoleForCenterStaffWithValidOrgID()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+
+        $user->setActiveRole(self::CENTER_STAFF_ACL_NAME, self::VALID_SERVICE_PROVIDER_ID);
+
+        $activeRole = $user->getActiveRole();
+        $this->assertNotNull($activeRole);
+
+        $activeRoleName = $activeRole->getIdentifier();
+        $this->assertEquals(self::CENTER_STAFF_ACL_NAME, $activeRoleName);
+    }
+
+    public function testUpgradeStaffMemberSaveUser()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+        $cd = new CenterDirectorRole();
+        $cd->configure($user);
+
+        $cd->upgradeStaffMember($user);
+        $newRoles = $user->getRoles();
+
+        $this->assertTrue(in_array(self::CENTER_DIRECTOR_ACL_NAME, $newRoles));
+    }
+
+    /**
+     * @depends testUpgradeStaffMemberSaveUser
+     */
+    public function testDowngradeStaffMemberSaveUser()
+    {
+
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+        $cd = new CenterDirectorRole();
+        $cd->configure($user);
+        $cd->downgradeStaffMember($user);
+        $newRoles = $user->getRoles();
+
+        $this->assertTrue(!in_array(self::CENTER_DIRECTOR_ACL_NAME, $newRoles));
+    }
+
+    public function testSaveUserUpdatePassword()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+        $user->setPassword(self::INVALID_ACL_NAME);
+        $user->saveUser();
+
+        $updatedUser = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+        $reflection = new ReflectionClass($updatedUser);
+        $password = $reflection->getProperty('_password');
+        $password->setAccessible(true);
+        $newPassword = $password->getValue($updatedUser);
+        $this->assertEquals(md5(self::INVALID_ACL_NAME), $newPassword);
+
+        $user->setPassword(self::CENTER_STAFF_USER_NAME);
+        $user->saveUser();
+    }
+
+    public function testGetRoleIDForValidRole()
+    {
+        $user = XDUSer::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+        $reflection = new ReflectionClass($user);
+        $method = $reflection->getMethod('_getRoleID');
+        $method->setAccessible(true);
+        $roleId = $method->invoke($user, self::CENTER_STAFF_ACL_NAME);
+
+        $this->assertNotNull($roleId);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     * @expectedExceptionMessage Undefined offset: 0
+     */
+    public function testGetRoleIDForInvalidRole()
+    {
+        $user = XDUSer::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+        $reflection = new ReflectionClass($user);
+        $method = $reflection->getMethod('_getRoleID');
+        $method->setAccessible(true);
+        $method->invoke($user, self::INVALID_ACL_NAME);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     * @expectedExceptionMessage Undefined offset: 0
+     */
+    public function testGetRoleWithNull()
+    {
+        $user = XDUSer::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+        $reflection = new ReflectionClass($user);
+        $method = $reflection->getMethod('_getRoleID');
+        $method->setAccessible(true);
+        $method->invoke($user, null);
+    }
+
+    public function testCenterDirectorEnumAllAvailableRoles()
+    {
+        $expected = JSON::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . '/center_director_all_available_roles.json');
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+
+        $allAvailableRoles = $user->enumAllAvailableRoles();
+        $this->assertEquals($expected, $allAvailableRoles);
+    }
+
+    public function testGetMostPrivilegedRole()
+    {
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => self::CENTER_DIRECTOR_ACL_NAME,
+            self::CENTER_STAFF_USER_NAME => self::CENTER_STAFF_ACL_NAME,
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => self::PRINCIPAL_INVESTIGATOR_ACL_NAME,
+            self::NORMAL_USER_USER_NAME => self::NORMAL_USER_ACL,
+            self::PUBLIC_USER_NAME => self::PUBLIC_ACL_NAME
+        );
+
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $mostPrivilegedRole = $user->getMostPrivilegedRole();
+            $this->assertNotNull($mostPrivilegedRole);
+            $this->assertEquals($mostPrivilegedRole->getIdentifier(), $expected);
+        }
+    }
+
+    public function testGetAllRoles()
+    {
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => array(
+                self::CENTER_DIRECTOR_ACL_NAME,
+                self::NORMAL_USER_ACL
+            ),
+            self::CENTER_STAFF_USER_NAME => array(
+                self::CENTER_STAFF_ACL_NAME,
+                self::NORMAL_USER_ACL
+            ),
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => array(
+                self::PRINCIPAL_INVESTIGATOR_ACL_NAME,
+                self::NORMAL_USER_ACL
+            ),
+            self::NORMAL_USER_USER_NAME => array(
+                self::NORMAL_USER_ACL
+            ),
+            self::PUBLIC_USER_NAME => array(
+                self::PUBLIC_ACL_NAME
+            )
+        );
+
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $allRoles = $user->getAllRoles();
+            $actual = array_reduce(
+                $allRoles,
+                function ($carry, $item) {
+                    $carry[] = $item->getIdentifier();
+                    return $carry;
+                },
+                array()
+            );
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testIsCenterDirectorOfOrganizationValidCenter()
+    {
+        $validOrganizationId = 1;
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => true,
+            self::CENTER_STAFF_USER_NAME => false,
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => false,
+            self::NORMAL_USER_USER_NAME => false,
+            self::PUBLIC_USER_NAME => false
+        );
+
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $actual = $user->isCenterDirectorOfOrganization($validOrganizationId);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testIsCenterDirectorOfOrganizationInvalidCenter()
+    {
+        $invalidOrganizationId = -999;
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => false,
+            self::CENTER_STAFF_USER_NAME => false,
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => false,
+            self::NORMAL_USER_USER_NAME => false,
+            self::PUBLIC_USER_NAME => false
+        );
+
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $actual = $user->isCenterDirectorOfOrganization($invalidOrganizationId);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testIsCenterDirectorOfOrganizationNull()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+        $actual = $user->isCenterDirectorOfOrganization(null);
+        $this->assertEquals(false, $actual);
+    }
+
+    public function testIsCenterDirectorOfOrganizationEmptyString()
+    {
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+        $actual = $user->isCenterDirectorOfOrganization("");
+        $this->assertEquals(false, $actual);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage This user must be saved prior to calling enumCenterDirectorSites()
+     */
+    public function testEnumCenterDirectorSitesWithUnsavedUserFails()
+    {
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+        $user->enumCenterDirectorSites();
+    }
+
+    public function testEnumCenterDirectorSites()
+    {
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => array(array('provider' => '1', 'is_primary' => '1')),
+            self::CENTER_STAFF_USER_NAME => array(),
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => array(),
+            self::NORMAL_USER_USER_NAME => array(),
+            self::PUBLIC_USER_NAME => array()
+        );
+
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $actual = $user->enumCenterDirectorSites();
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage This user must be saved prior to calling enumCenterStaffSites()
+     */
+    public function testEnumCenterStaffSitesWithUnsavedUserFails()
+    {
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+        $user->enumCenterStaffSites();
+    }
+
+    public function testEnumCenterStaffSites()
+    {
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => array(),
+            self::CENTER_STAFF_USER_NAME => array(array('provider' => '1', 'is_primary' => '1')),
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => array(),
+            self::NORMAL_USER_USER_NAME => array(),
+            self::PUBLIC_USER_NAME => array()
+        );
+
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $actual = $user->enumCenterStaffSites();
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage This user must be saved prior to calling getPrimaryOrganization()
+     */
+    public function testGetPrimaryOrganizationForUnsavedUserFails()
+    {
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+        $user->getPrimaryOrganization();
+    }
+
+    public function testGetPrimaryOrganization()
+    {
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => '1',
+            self::CENTER_STAFF_USER_NAME => '-1',
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => '-1',
+            self::NORMAL_USER_USER_NAME => '-1',
+            self::PUBLIC_USER_NAME => '-1'
+        );
+
+        foreach($users as $userName => $expected) {
+            $user = XDUser::getUserByUserName($userName);
+            $actual = $user->getPrimaryOrganization();
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage This user must be saved prior to calling getOrganizationCollection()
+     */
+    public function testGetOrganizationCollectionWithUnsavedUserFails()
+    {
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+        $user->getOrganizationCollection();
+    }
+
+    public function testGetOrganizationCollection()
+    {
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => array(
+                self::CENTER_STAFF_ACL_NAME => array(),
+                self::CENTER_DIRECTOR_ACL_NAME => array(1),
+                null => array(),
+                '' => array()
+            ),
+            self::CENTER_STAFF_USER_NAME => array(
+                self::CENTER_STAFF_ACL_NAME => array(1),
+                self::CENTER_DIRECTOR_ACL_NAME => array(),
+                null => array(),
+                '' => array()
+            ),
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => array(
+                self::CENTER_STAFF_ACL_NAME => array(),
+                self::CENTER_DIRECTOR_ACL_NAME => array(),
+                null => array(),
+                '' => array()
+            ),
+            self::NORMAL_USER_USER_NAME => array(
+                self::CENTER_STAFF_ACL_NAME => array(),
+                self::CENTER_DIRECTOR_ACL_NAME => array(),
+                null => array(),
+                '' => array()
+            ),
+            self::PUBLIC_USER_NAME => array(
+                self::CENTER_STAFF_ACL_NAME => array(),
+                self::CENTER_DIRECTOR_ACL_NAME => array(),
+                null => array(),
+                '' => array()
+            )
+        );
+
+        foreach($users as $userName => $expectedData) {
+            foreach($expectedData as $centerStaffOrDirector => $expected) {
+                $user = XDUser::getUserByUserName($userName);
+                $actual = $user->getOrganizationCollection($centerStaffOrDirector);
+                $this->assertEquals($expected, $actual);
+            }
+        }
+    }
+
+    public function testGetRoleIDFromIdentifierInvalidFails()
+    {
+        $roles = array(
+            self::INVALID_ACL_NAME,
+            '',
+            null
+        );
+
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+        $reflection = new ReflectionClass($user);
+        $getRoleIdFromIdentifier = $reflection->getMethod('_getRoleIDFromIdentifier');
+        $getRoleIdFromIdentifier->setAccessible(true);
+
+        foreach($roles as $roleName) {
+            $actual = $getRoleIdFromIdentifier->invoke($user, $roleName);
+            $this->assertEquals(-1, $actual);
+        }
+
+    }
+
+    public function testGetRoleIDFromIdentifier()
+    {
+        $db = DB::factory('database');
+        $results = array();
+        $roles = array(
+            self::CENTER_DIRECTOR_ACL_NAME,
+            self::CENTER_STAFF_ACL_NAME,
+            self::PRINCIPAL_INVESTIGATOR_ACL_NAME,
+            self::NORMAL_USER_ACL,
+            self::PUBLIC_ACL_NAME
+        );
+
+        foreach($roles as $role) {
+            $row = $db->query(
+                "SELECT role_id FROM Roles WHERE abbrev = :abbrev",
+                array(':abbrev' => $role)
+            );
+            $this->assertNotEmpty($row);
+            $results[$role] = $row[0]['role_id'];
+        }
+
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+        $reflection = new ReflectionClass($user);
+        $getRoleIdFromIdentifier = $reflection->getMethod('_getRoleIDFromIdentifier');
+        $getRoleIdFromIdentifier->setAccessible(true);
+
+        foreach($results as $roleName => $expected) {
+            $actual = $getRoleIdFromIdentifier->invoke($user, $roleName);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testGetPromoterUnsavedUser()
+    {
+
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+        $promoter = $user->getPromoter(self::CENTER_DIRECTOR_ACL_NAME, 1);
+        $this->assertEquals(-1, $promoter);
+    }
+
+    public function testGetPromoter()
+    {
+        $users = array(
+            self::CENTER_DIRECTOR_USER_NAME => array(
+                self::CENTER_DIRECTOR_ACL_NAME => array(
+                    '1' => '-1',
+                    '' => -1,
+                    null => -1
+                ),
+                self::CENTER_DIRECTOR_ACL_NAME => array(
+                    '1' => -1,
+                    '' => -1,
+                    null => -1
+                )
+            ),
+            self::CENTER_STAFF_USER_NAME => array(
+                self::CENTER_DIRECTOR_ACL_NAME => array(
+                    '1' => '-1',
+                    '' => -1,
+                    null => -1
+                ),
+                self::CENTER_STAFF_ACL_NAME=> array(
+                    '1' => -1,
+                    '' => -1,
+                    null => -1
+                )
+            )
+        );
+
+        foreach($users as $userName => $aclData) {
+            $user = XDUser::getUserByUserName($userName);
+            foreach($aclData as $roleId => $expectedData) {
+                foreach($expectedData as $organizationId => $expected) {
+                    $actual = $user->getPromoter($roleId, $organizationId);
+                    $this->assertEquals($expected, $actual);
+                }
+            }
+        }
+    }
+
+    public function testGetFormalRoleName()
+    {
+        $roles = array(
+            self::CENTER_DIRECTOR_ACL_NAME => 'Center Director',
+            self::CENTER_STAFF_ACL_NAME => 'Center Staff',
+            self::PRINCIPAL_INVESTIGATOR_ACL_NAME => 'Principal Investigator',
+            self::NORMAL_USER_ACL => 'User',
+            self::PUBLIC_ACL_NAME => 'Public',
+            self::INVALID_ACL_NAME => 'Public'
+        );
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+
+        foreach($roles as $roleName => $expected) {
+            $actual = $user->_getFormalRoleName($roleName);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testGetFormalRoleNameNull()
+    {
+        $expected = 'Public';
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+        $actual = $user->_getFormalRoleName(null);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetFormalRoleNameEmptyString()
+    {
+        $expected = 'Public';
+        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
+        $actual = $user->_getFormalRoleName('');
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -16,7 +16,7 @@ use \Exception;
 class XDUserTest extends \PHPUnit_Framework_TestCase
 {
 
-    const TEST_ARTIFACT_OUTPUT_PATH = "./../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
+    const TEST_ARTIFACT_OUTPUT_PATH = "/../../tests/artifacts/xdmod-test-artifacts/xdmod/acls/output";
 
     const PUBLIC_USER_NAME = 'Public User';
     const PUBLIC_ACL_NAME = 'pub';

--- a/open_xdmod/modules/xdmod/component_tests/runtests.sh
+++ b/open_xdmod/modules/xdmod/component_tests/runtests.sh
@@ -10,4 +10,6 @@ if [ ! -x "$phpunit" ]; then
     exit 127
 fi
 
-$phpunit ${PHPUNITARGS} .
+./artifacts/update-artifacts.sh
+
+$phpunit ${PHPUNITARGS} . -v


### PR DESCRIPTION
## Description
Adding component tests that exercise the functions in XDUser, CenterDirectorRole and CenterStaffRole that still use the `Role`, `UserRoles` and `UserRoleParameters` tables. Some of these new tests utilize documents that have been added to the `xdmod-test-artifacts` repo. 

## Motivation and Context
Expand the test coverage for one of our major classes: `XDUser`. 

CenterDirector and CenterStaff were included as they utilize the table `UserRoleParameters`.

## Tests performed
... all of them? 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Additional Tests Added

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
