### PR TITLE
Completing the addition of GroupByProvider to OpenXDMoD

### DIFF
--- a/classes/OpenXdmod/Migration/Version701To710/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version701To710/ConfigFilesMigration.php
@@ -5,6 +5,7 @@
 
 namespace OpenXdmod\Migration\Version701To710;
 
+use CCR\Json;
 use OpenXdmod\Migration\ConfigFilesMigration as AbstractConfigFilesMigration;
 
 /**
@@ -22,5 +23,32 @@ class ConfigFilesMigration extends AbstractConfigFilesMigration
 
         // Set new options in portal_settings.ini.
         $this->writePortalSettingsFile();
+
+        // Add the 'provider' group_by if it does not already exist.
+        $this->modifyDatawarehouse();
+    }
+
+    public function modifyDatawarehouse()
+    {
+        $datawarehouseFile = $this->config->getFilePath('datawarehouse');
+        $datawarehouse = Json::loadFile($datawarehouseFile);
+        $realms = isset($datawarehouse['realms']) ? $datawarehouse['realms'] : array();
+        $jobs = isset($realms['Jobs']) ? $realms['Jobs'] : array();
+        $groupBys = isset($jobs['group_bys']) ? $jobs['group_bys'] : array();
+
+        $found = array_filter(
+            $groupBys,
+            function ($groupBy) {
+                return isset($groupBy['name']) && $groupBy['name'] === 'provider';
+            }
+        );
+        if (empty($found)) {
+            $groupBys[] = array(
+                'name' => 'provider',
+                'class' => 'GroupByProvider'
+            );
+            $datawarehouse['realms']['Jobs']['group_bys'] = $groupBys;
+            $this->writeJsonConfigFile('datawarehouse', $datawarehouse);
+        }
     }
 }

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -1710,9 +1710,12 @@ FROM (
       gb.group_by_id AS group_by_id,
       :value AS value 
    FROM group_bys gb 
-   WHERE gb.name = 'provider'
-) inc 
-LEFT JOIN user_acl_group_by_parameters cur 
+   JOIN modules m
+     ON gb.module_id = m.module_id
+   WHERE m.name = :module_name AND
+         gb.name = 'provider'
+) inc
+LEFT JOIN user_acl_group_by_parameters cur
   ON cur.user_id = inc.user_id
   AND cur.acl_id = inc.acl_id
   AND cur.group_by_id = inc.group_by_id
@@ -1723,7 +1726,8 @@ SQL
                 array(
                     ':user_id' => $this->_id,
                     ':acl_id' => $acl->getAclId(),
-                    ':value' => $organization_id
+                    ':value' => $organization_id,
+                    ':module_name' => DEFAULT_MODULE_NAME
                 )
             );
         }//foreach

--- a/configuration/datawarehouse.json
+++ b/configuration/datawarehouse.json
@@ -72,6 +72,10 @@
                 {
                     "name": "year",
                     "class": "GroupByYear"
+                },
+                {
+                    "name": "provider",
+                    "class": "GroupByProvider"
                 }
             ],
             "statistics": [

--- a/configuration/etl/etl_sql.d/acls/xdmod/user_acl_group_by_parameters.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/user_acl_group_by_parameters.sql
@@ -23,7 +23,8 @@ INSERT INTO ${DESTINATION_SCHEMA}.user_acl_group_by_parameters (user_id, acl_id,
            JOIN ${DESTINATION_SCHEMA}.group_bys gb
              ON gb.name LIKE CONCAT('%', urp.param_name, '%')
            JOIN ${DESTINATION_SCHEMA}.modules m
-             ON m.module_id = gb.module_id
+             ON gb.module_id = m.module_id
+        WHERE m.name = 'xdmod'
          ORDER BY urp.user_id, urp.role_id, a.acl_id, gb.group_by_id
        ) inc
     LEFT JOIN ${DESTINATION_SCHEMA}.user_acl_group_by_parameters cur

--- a/open_xdmod/modules/xdmod/tests/lib/Xdmod/ConfigTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/Xdmod/ConfigTest.php
@@ -4,10 +4,13 @@ namespace UnitTesting\Xdmod;
 
 require_once __DIR__ . '/../../bootstrap.php';
 
+use CCR\Json;
 use Xdmod\Config;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
+    const TEST_ARTIFACT_OUTPUT_PATH = "/../../artifacts/xdmod-test-artifacts/xdmod/acls/output";
+
     /**
      *
      * @dataProvider moduleSectionProvider
@@ -42,7 +45,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 )
                 : $config->getModuleSection($section);
 
-            $this->assertEquals($expected, json_encode($actual));
+            $this->assertEquals($expected, $actual);
         }
 
     }
@@ -266,31 +269,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
     public function moduleSectionProvider()
     {
-        $rolesExpected = array(
-            '{"roles":{"default":{"permitted_modules":[{"name":"tg_summary","default":true,"title":"Summary","position":100,"javascriptClass":"XDMoD.Module.Summary","javascriptReference":"CCR.xdmod.ui.tgSummaryViewer","tooltip":"Displays summary information","userManualSectionName":"Summary Tab"},{"name":"tg_usage","title":"Usage","position":200,"javascriptClass":"XDMoD.Module.Usage","javascriptReference":"CCR.xdmod.ui.chartViewerTGUsage","tooltip":"Displays usage","userManualSectionName":"Usage Ta',
-            'b"},{"name":"metric_explorer","title":"Metric Explorer","position":300,"javascriptClass":"XDMoD.Module.MetricExplorer","javascriptReference":"CCR.xdmod.ui.metricExplorer","userManualSectionName":"Metric Explorer","tooltip":""},{"name":"report_generator","title":"Report Generator","position":1000,"javascriptClass":"XDMoD.Module.ReportGenerator","javascriptReference":"CCR.xdmod.ui.reportGenerator","userManualSectionName":"Report Generator","tooltip":""},{"name":"about_xdmod","title":"Abo',
-            'ut","position":10000,"javascriptClass":"XDMoD.Module.About","javascriptReference":"CCR.xdmod.ui.aboutXD","userManualSectionName":"About","tooltip":""}],"query_descripters":[{"realm":"Jobs","group_by":"none"},{"realm":"Jobs","group_by":"jobsize"},{"realm":"Jobs","group_by":"jobwalltime"},{"realm":"Jobs","group_by":"nodecount"},{"realm":"Jobs","group_by":"nsfdirectorate"},{"realm":"Jobs","group_by":"parentscience"},{"realm":"Jobs","group_by":"fieldofscience"},{"realm":"Jobs","group_by":"',
-            'pi"},{"realm":"Jobs","group_by":"queue"},{"realm":"Jobs","group_by":"resource"},{"realm":"Jobs","group_by":"resource_type"},{"realm":"Jobs","group_by":"person"},{"realm":"Jobs","group_by":"username"}],"summary_charts":[{"data_series":{"data":[{"combine_type":"stack","display_type":"column","filters":{"data":[],"total":0},"group_by":"resource","has_std_err":false,"id":1.0e-14,"ignore_global":false,"log_scale":false,"long_legend":true,"metric":"total_cpu_hours","realm":"Jobs","sort_type"',
-            ':"value_desc","std_err":false,"value_labels":false,"x_axis":false}],"total":1},"global_filters":{"data":[],"total":0},"legend_type":"right_center","limit":10,"show_filters":true,"start":0,"timeseries":true,"title":"Total CPU Hours By Resource (Top 10)"},{"data_series":{"data":[{"combine_type":"stack","display_type":"column","filters":{"data":[],"total":0},"group_by":"jobsize","has_std_err":false,"id":2.0e-14,"ignore_global":false,"log_scale":false,"long_legend":true,"metric":"total_cpu',
-            '_hours","realm":"Jobs","sort_type":"value_desc","std_err":false,"value_labels":false,"x_axis":false}],"total":1},"global_filters":{"data":[],"total":0},"legend_type":"right_center","limit":20,"show_filters":true,"start":0,"timeseries":true,"title":"Total CPU Hours by Job Size"},{"data_series":{"data":[{"combine_type":"side","display_type":"column","filters":{"data":[],"total":0},"group_by":"none","has_std_err":true,"id":3.0e-14,"ignore_global":false,"log_scale":false,"long_legend":true',
-            ',"metric":"avg_processors","realm":"Jobs","sort_type":"none","std_err":true,"value_labels":false,"x_axis":false}],"total":1},"global_filters":{"data":[],"total":0},"legend_type":"off","limit":20,"show_filters":true,"start":0,"timeseries":true,"title":"Avg Job Size (Core Count)"},{"data_series":{"data":[{"combine_type":"side","display_type":"pie","filters":{"data":[],"total":0},"group_by":"pi","has_std_err":true,"id":4.0e-14,"ignore_global":false,"log_scale":false,"long_legend":true,"me',
-            'tric":"total_cpu_hours","realm":"Jobs","sort_type":"value_desc","std_err":true,"value_labels":true,"x_axis":false}],"total":1},"global_filters":{"data":[],"total":0},"legend_type":"off","limit":10,"show_filters":true,"start":0,"timeseries":false,"title":"Total CPU Hours by PI"}]},"pub":{"display":"Public User","type":"data","hierarchies":[{"level":0,"filter_override":false}],"permitted_modules":[{"name":"tg_summary","default":true,"title":"Summary","position":100,"javascriptClass":"XDM',
-            'oD.Module.Summary","javascriptReference":"CCR.xdmod.ui.tgSummaryViewer","tooltip":"Displays summary information","userManualSectionName":"Summary Tab"},{"name":"tg_usage","title":"Usage","position":200,"javascriptClass":"XDMoD.Module.Usage","javascriptReference":"CCR.xdmod.ui.chartViewerTGUsage","tooltip":"Displays usage","userManualSectionName":"Usage Tab"},{"name":"about_xdmod","title":"About","position":10000,"javascriptClass":"XDMoD.Module.About","javascriptReference":"CCR.xdmod.ui',
-            '.aboutXD","userManualSectionName":"About","tooltip":""}],"query_descripters":[{"realm":"Jobs","group_by":"none"},{"realm":"Jobs","group_by":"fieldofscience"},{"realm":"Jobs","group_by":"jobsize"},{"realm":"Jobs","group_by":"jobwalltime"},{"realm":"Jobs","group_by":"nodecount"},{"realm":"Jobs","group_by":"nsfdirectorate"},{"realm":"Jobs","group_by":"parentscience"},{"realm":"Jobs","group_by":"pi"},{"realm":"Jobs","group_by":"queue"},{"realm":"Jobs","group_by":"resource"},{"realm":"Jobs"',
-            ',"group_by":"resource_type"},{"realm":"Jobs","group_by":"person"},{"realm":"Jobs","group_by":"username","disable":true}]},"usr":{"display":"User","type":"data","hierarchies":[{"level":100,"filter_override":false}],"dimensions":["person"],"extends":"default"},"cd":{"display":"Center Director","type":"feature","hierarchies":[{"level":400,"filter_override":false}],"dimensions":["provider"],"extends":"default"},"pi":{"display":"Principal Investigator","type":"data","hierarchies":[{"level":',
-            '200,"filter_override":false}],"dimensions":["pi"],"extends":"default"},"cs":{"display":"Center Staff","type":"data","hierarchies":[{"level":300,"filter_override":false}],"dimensions":["provider"],"extends":"default"},"mgr":{"display":"Manager","type":"data","hierarchies":[{"level":301,"filter_override":false}],"dimensions":["person"],"extends":"default"}}}'
-        );
-        $datawarehouseExpected = array(
-            '{"realms":{"Jobs":{"schema":"modw_aggregates","table":"jobfact","datasource":"HPcDB","group_bys":[{"name":"none","class":"GroupByNone"},{"name":"nodecount","class":"GroupByNodeCount"},{"name":"person","class":"GroupByPerson"},{"name":"pi","class":"GroupByPI"},{"name":"resource","class":"GroupByResource"},{"name":"resource_type","class":"GroupByResourceType"},{"name":"nsfdirectorate","class":"GroupByNSFDirectorate"},{"name":"parentscience","class":"GroupByParentScience"},{"name":"fieldo',
-            'fscience","class":"GroupByScience"},{"name":"jobsize","class":"GroupByJobSize"},{"name":"jobwalltime","class":"GroupByJobTime"},{"name":"queue","class":"GroupByQueue"},{"name":"username","class":"GroupByUsername"},{"name":"day","class":"GroupByDay"},{"name":"month","class":"GroupByMonth"},{"name":"quarter","class":"GroupByQuarter"},{"name":"year","class":"GroupByYear"}],"statistics":[{"name":"job_count","class":"JobCountStatistic"},{"name":"job_count","class":"JobCountStatistic"},{"nam',
-            'e":"running_job_count","class":"RunningJobCountStatistic","control":true},{"name":"started_job_count","class":"StartedJobCountStatistic","control":true},{"name":"submitted_job_count","class":"SubmittedJobCountStatistic"},{"name":"active_person_count","class":"ActiveUserCountStatistic"},{"name":"active_pi_count","class":"ActivePICountStatistic"},{"name":"total_cpu_hours","class":"TotalCPUHoursStatistic"},{"name":"total_waitduration_hours","class":"TotalWaitHoursStatistic"},{"name":"tota',
-            'l_node_hours","class":"TotalNodeHoursStatistic"},{"name":"total_wallduration_hours","class":"TotalWallHoursStatistic"},{"name":"avg_cpu_hours","class":"AverageCPUHoursStatistic"},{"name":"sem_avg_cpu_hours","class":"SEMAverageCPUHoursStatistic","visible":false},{"name":"avg_node_hours","class":"AverageNodeHoursStatistic"},{"name":"sem_avg_node_hours","class":"SEMAverageNodeHoursStatistic","visible":false},{"name":"avg_waitduration_hours","class":"AverageWaitHoursStatistic"},{"name":"se',
-            'm_avg_waitduration_hours","class":"SEMAverageWaitHoursStatistic","visible":false},{"name":"avg_wallduration_hours","class":"AverageWallHoursStatistic"},{"name":"sem_avg_wallduration_hours","class":"SEMAverageWallHoursStatistic","visible":false},{"name":"avg_processors","class":"AverageProcessorCountStatistic"},{"name":"sem_avg_processors","class":"SEMAverageProcessorCountStatistic","visible":false},{"name":"min_processors","class":"MinProcessorCountStatistic"},{"name":"max_processors",',
-            '"class":"MaxProcessorCountStatistic"},{"name":"utilization","class":"UtilizationStatistic"},{"name":"expansion_factor","class":"ExpansionFactorStatistic"},{"name":"normalized_avg_processors","class":"NormalizedAverageProcessorCountStatistic"},{"name":"avg_job_size_weighted_by_cpu_hours","class":"JobSizeWeightedByCPUHours"},{"name":"active_resource_count","class":"ActiveResourceCountStatistic"}]},"Storage":{"schema":"modw_storage","table":"user_usage","datasource":"File system storage l',
-            'ogs","group_bys":[{"name":"none","class":"GroupByNone"},{"name":"day","class":"GroupByDay"},{"name":"month","class":"GroupByMonth"},{"name":"quarter","class":"GroupByQuarter"},{"name":"year","class":"GroupByYear"},{"name":"file_system","class":"GroupByFileSystem"},{"name":"username","class":"GroupByUsername"},{"name":"directory","class":"GroupByDirectory"}],"statistics":[{"name":"user_count","class":"UserCountStatistic"},{"name":"avg_file_count","class":"FileCountStatistic"},{"name":"s',
-            'em_file_count","class":"SemFileCountStatistic","visible":false},{"name":"avg_logical_usage","class":"LogicalUsageStatistic"},{"name":"sem_logical_usage","class":"SemLogicalUsageStatistic","visible":false},{"name":"avg_physical_usage","class":"PhysicalUsageStatistic"},{"name":"sem_physical_usage","class":"SemPhysicalUsageStatistic","visible":false},{"name":"avg_hard_threshold","class":"HardThresholdStatistic"},{"name":"avg_soft_threshold","class":"SoftThresholdStatistic"},{"name":"avg_l',
-            'ogical_utilization","class":"LogicalUtilizationStatistic"}]}}}'
-        );
+        $rolesExpected = Json::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'roles.json');
+        $datawarehouseExpected = Json::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'datawarehouse.json');
         return array(
             array(
                 'roles',
@@ -301,7 +281,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                                 'xdmod'
                             )
                         ),
-                        'expected' => implode('', $rolesExpected)
+                        'expected' => $rolesExpected
                     )
                 )
             ),
@@ -314,7 +294,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                                 'xdmod'
                             )
                         ),
-                        'expected' => implode('', $datawarehouseExpected)
+                        'expected' => $datawarehouseExpected
                     )
                 )
             )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- The GroupByProvider.php class already exists in OpenXDMoD but does not exist
  in datawarehouse.json. This caused a problem replicating the behavior of
  records being inserted into UserRoleParameters for users being assigned the
  Center Director or Center Staff. The reason for this problem is that the
  param_name column in UserRoleParameters holds what amounts to hard coded
  group_by names, while in the new user_acl_group_by_parameters the equivalent
  column is group_by_id ( an actual fk to the group_by table ). The problem then
  becomes, how do you create a reference to a group_by that doesn't exist? Well,
  you don't, hence the creation of this PR.

  We also ensure that the user experience doesn't change by *not* adding a
  record to roles.json ( a user needs an entry in query_descripters to have any
  access to a realms group_by ). This was per a conversation with @jtpalmer. 

- **NOTE:**
  Other Updates that support these changes:
  - xdmod-test-artifacts: files were added to support the ConfigTest changes.

## Motivation and Context
To ensure that the new acl framework provides the same behaviors as Roles.

## Tests performed
The following Tests were performed on: OpenXDMoD, OpenXDMoD w/ App Kernels, SUPREMM
- component_tests
- integration_tests
- automated_tests
- manual inspection of the db tables: 
```sql
SELECT COUNT(*) as count, 'UserRoleParameters' as 'table'
FROM UserRoleParameters
UNION ALL
SELECT COUNT(*) as count, 'user_acl_group_by_parameters' as 'table'
FROM user_acl_group_by_parameters
```
*Ensure that the counts of both tables are the same*
```sql
SELECT urp.*, uagbp.user_acl_parameter_id IS NOT NULL AS 'exists'
FROM UserRoleParameters urp
  JOIN Roles r ON r.role_id = urp.role_id
  LEFT JOIN acls a ON a.name = r.abbrev
LEFT JOIN user_acl_group_by_parameters uagbp
  ON uagbp.user_id = urp.user_id AND
     uagbp.acl_id = a.acl_id AND 
     uagbp.value = urp.param_value;
```
*Ensure that the content in UserRoleParameters is present in user_acl_group_by_parameters*

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
