### PR TITLE
XDUser Construction: Primary Role

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -993,27 +993,30 @@ SQL;
             // If the updater (e.g. Manager) has pulled out the (recently) active role for this user, reassign the active role to the primary role.
 
             $active_role_id = $this->_getRoleID($this->_active_role->getIdentifier());
-            $primary_role_id = $this->_getRoleID($this->_primary_role->getIdentifier());
+
 
             $this->_pdo->execute(
                 "UPDATE UserRoles SET is_active='1' WHERE user_id=:id AND role_id=:roleId",
                 array('id' => $this->_id, 'roleId' => $active_role_id)
             );
 
-            $this->_pdo->execute(
-                "UPDATE UserRoles SET is_primary='1' WHERE user_id = :id AND role_id=:roleId",
-                array(':id' => $this->_id, ':roleId' => $primary_role_id)
-            );
+
             /* END: UserRole Updating */
 
             /* BEGIN: Configure Primary and Active Roles */
             $this->_active_role->configure($this);
-            $this->_primary_role->configure($this);
+
             /* END: Configure Primary and Active Roles */
         }
 
-
-
+        if (isset($this->_primary_role)) {
+            $primary_role_id = $this->_getRoleID($this->_primary_role->getIdentifier());
+            $this->_pdo->execute(
+                "UPDATE UserRoles SET is_primary='1' WHERE user_id = :id AND role_id=:roleId",
+                array(':id' => $this->_id, ':roleId' => $primary_role_id)
+            );
+            $this->_primary_role->configure($this);
+        }
 
         $timestampData = $this->_pdo->query(
             "SELECT time_created, time_last_updated, password_last_updated

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2170,7 +2170,7 @@ SQL;
         // XDUser::enumAllAvailableRoles already orders the roles in terms of 'visibility' / 'highest privilege'
         // so just acquire the first item in the set.
         $mostPrivilegedAcl = Acls::getMostPrivilegedAcl($this);
-        $roleName = XDUser::_getFormalRoleName($mostPrivilegedAcl->getName());
+        $roleName = self::_getFormalRoleName($mostPrivilegedAcl->getName());
         $role = aRole::factory($roleName);
         $role->configure($this);
         return $role;

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -134,7 +134,7 @@ class XDUser implements JsonSerializable
 
         foreach ($this->_roles as $role) {
 
-            if ($this->_getFormalRoleName($role) == NULL) {
+            if (self::_getFormalRoleName($role) == NULL) {
                 throw new Exception("Unrecognized role $role");
             }
 
@@ -156,7 +156,7 @@ class XDUser implements JsonSerializable
 
         // =================================
 
-        $primary_role_name = $this->_getFormalRoleName($primary_role);
+        $primary_role_name = self::_getFormalRoleName($primary_role);
 
         // These roles cannot be used immediately after constructing a new XDUser (since a user id has not been defined at this point).
         // If you are explicitly calling 'new XDUser(...)', saveUser() must be called on the newly created XDUser object before accessing
@@ -977,7 +977,7 @@ SQL;
             throw new Exception('Unable to determine this users most privileged acl. There may be a problem with the state of the database.');
         }
 
-        $activeRoleName = $this->_getFormalRoleName($mostPrivilegedAcl->getName());
+        $activeRoleName = self::_getFormalRoleName($mostPrivilegedAcl->getName());
         $this->_primary_role = $this->_active_role = aRole::factory($activeRoleName);
 
         $active_role_id = $this->_getRoleID($this->_active_role->getIdentifier());
@@ -2105,7 +2105,7 @@ SQL;
     public function setPrimaryRole($primary_role)
     {
 
-        $primary_role_name = $this->_getFormalRoleName($primary_role);
+        $primary_role_name = self::_getFormalRoleName($primary_role);
 
         if ($primary_role_name == NULL) {
             throw new Exception("Attempting to set an invalid primary role");
@@ -2275,7 +2275,7 @@ SQL;
 
         if (empty($active_role)) $active_role = ROLE_ID_PUBLIC;
 
-        $active_role_name = $this->_getFormalRoleName($active_role);
+        $active_role_name = self::_getFormalRoleName($active_role);
 
         $virtual_active_role = \User\aRole::factory($active_role_name);
         $virtual_active_role->configure($this, $role_param);
@@ -2298,7 +2298,7 @@ SQL;
     public function setActiveRole($active_role, $role_param = NULL)
     {
 
-        $active_role_name = $this->_getFormalRoleName($active_role);
+        $active_role_name = self::_getFormalRoleName($active_role);
 
         if ($active_role_name == NULL) {
             throw new Exception("Attempting to set an invalid active role");
@@ -3013,11 +3013,11 @@ SQL;
 
             if ($role_abbrev == 'dev') continue;
 
-            $role = \User\aRole::factory($this->_getFormalRoleName($role_abbrev));
+            $role = \User\aRole::factory(self::_getFormalRoleName($role_abbrev));
             $disabledMenusByRole[$role_abbrev] = $role->getDisabledMenus($realms);
 
         }
-        $role = \User\aRole::factory($this->_getFormalRoleName('pub'));
+        $role = \User\aRole::factory(self::_getFormalRoleName('pub'));
         $disabledMenusByRole['pub'] = $role->getDisabledMenus($realms);
 
         // If the user only has one role, return that role's menus immediately.

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -155,7 +155,7 @@ class XDUser implements JsonSerializable
 
         // =================================
 
-        $primary_role_name = $this->_getFormalRoleName(ROLE_ID_USER);
+        $primary_role_name = $this->_getFormalRoleName($primary_role);
 
         // These roles cannot be used immediately after constructing a new XDUser (since a user id has not been defined at this point).
         // If you are explicitly calling 'new XDUser(...)', saveUser() must be called on the newly created XDUser object before accessing

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -161,8 +161,7 @@ class XDUser implements JsonSerializable
         // These roles cannot be used immediately after constructing a new XDUser (since a user id has not been defined at this point).
         // If you are explicitly calling 'new XDUser(...)', saveUser() must be called on the newly created XDUser object before accessing
         // these roles using getPrimaryRole() and getActiveRole()
-
-        $this->_active_role = \User\aRole::factory($primary_role_name);
+        $this->_primary_role = $this->_active_role = \User\aRole::factory($primary_role_name);
     }//construct
 
     // ---------------------------

--- a/html/controllers/user_admin/create_user.php
+++ b/html/controllers/user_admin/create_user.php
@@ -41,7 +41,7 @@ try {
         '',
         $_POST['last_name'],
         array_keys($acls),
-        null,
+        ROLE_ID_USER,
         NULL,
         $_POST['assignment']
     );

--- a/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/User/Roles/CenterDirectorRoleTest.php
@@ -68,12 +68,13 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
     public function testGetFormalName()
     {
         $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
-        $expected = 'Center Director - screw';
+        $expected = 'Center Director';
         $cd = new CenterDirectorRole();
         $cd->configure($user);
 
         $actual =  $cd->getFormalName();
-        $this->assertEquals($expected, $actual);
+        $found = strpos($actual, $expected);
+        $this->assertTrue($found !== false);
     }
 
     public function testGetIdentifier()

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -91,7 +91,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
             array(self::PUBLIC_USER_NAME,'public_user.json'),
             array(self::CENTER_STAFF_USER_NAME , 'center_staff.json'),
             array(self::CENTER_DIRECTOR_USER_NAME , 'center_director.json'),
-            array(self::PRINCIPAL_INVESTIGATOR_USER_NAME , 'principal.json'),
+            array(self::PRINCIPAL_INVESTIGATOR_USER_NAME , 'principal-xduser_primary_role.json'),
             array(self::NORMAL_USER_USER_NAME , 'normal_user.json')
         );
     }
@@ -305,6 +305,10 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($roles);
     }
 
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage A user must have at least one role.
+     */
     public function testSetRolesEmpty()
     {
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
@@ -316,16 +320,6 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
         $user->setRoles(array());
         $user->saveUser();
-
-        $newRoles = $user->getRoles();
-        $this->assertEmpty($newRoles);
-
-        $user->setRoles($originalRoles);
-        $user->saveUser();
-
-        $roles = $user->getRoles();
-        $this->assertEquals($originalRoles, $roles);
-        $this->assertTrue(in_array(self::CENTER_DIRECTOR_ACL_NAME, $roles));
     }
 
     public function testGetAcls()
@@ -351,6 +345,10 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(in_array(self::CENTER_DIRECTOR_ACL_NAME, $acls));
     }
 
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage A user must have at least one acl.
+     */
     public function testSetAclsEmpty()
     {
         $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
@@ -360,15 +358,6 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
         $user->setAcls(array());
         $user->saveUser();
-
-        $newAcls = $user->getAcls();
-        $this->assertTrue(count($newAcls) === 0);
-
-        $user->setAcls($originalAcls);
-        $user->saveUser();
-
-        $acls = $user->getAcls();
-        $this->assertEquals($originalAcls, $acls);
     }
 
     public function testAddNewAcl()
@@ -541,7 +530,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $user = XDUser::getPublicUser();
         $primaryRole = $user->getPrimaryRole();
 
-        $this->assertNull($primaryRole);
+        $this->assertNotNull($primaryRole);
     }
 
     /**

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -600,6 +600,20 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($user->getUserID());
     }
 
+    public function testCreateUserWithNonStandardPrimaryRole()
+    {
+        $user = new XDUser('test666', null, 'test666@ccr.xdmod.org', 'test', 'a', 'user', array(ROLE_ID_USER, ROLE_ID_MANAGER), ROLE_ID_MANAGER);
+
+        $this->assertEquals('0', $user->getUserID());
+
+        $user->setUserType(DEMO_USER_TYPE);
+
+        $user->saveUser();
+
+        $actual = $user->getActiveRole()->getIdentifier();
+        $this->assertEquals(ROLE_ID_MANAGER, $actual);
+    }
+
     /**
      * @expectedException Exception
      * @expectedExceptionMessage At least one role must be associated with this user

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -627,10 +627,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
 
         $actual = $user->getActiveRole()->getIdentifier();
 
-        // NOTE: this isn't actually correct and is corrected in
-        // the xduser_primary_role PR. But, in the interest of getting our tests
-        // to pass this change is necessary.
-        $this->assertEquals(ROLE_ID_USER, $actual);
+        $this->assertEquals(ROLE_ID_MANAGER, $actual);
     }
 
     /**

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -600,20 +600,6 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($user->getUserID());
     }
 
-    public function testCreateUserWithNonStandardPrimaryRole()
-    {
-        $user = new XDUser('test666', null, 'test666@ccr.xdmod.org', 'test', 'a', 'user', array(ROLE_ID_USER, ROLE_ID_MANAGER), ROLE_ID_MANAGER);
-
-        $this->assertEquals('0', $user->getUserID());
-
-        $user->setUserType(DEMO_USER_TYPE);
-
-        $user->saveUser();
-
-        $actual = $user->getActiveRole()->getIdentifier();
-        $this->assertEquals(ROLE_ID_MANAGER, $actual);
-    }
-
     /**
      * @expectedException Exception
      * @expectedExceptionMessage At least one role must be associated with this user
@@ -1272,7 +1258,7 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $getRoleIdFromIdentifier = $reflection->getMethod('_getRoleIDFromIdentifier');
         $getRoleIdFromIdentifier->setAccessible(true);
 
-        foreach($results as $roleName => $expected) {
+        foreach ($results as $roleName => $expected) {
             $actual = $getRoleIdFromIdentifier->invoke($user, $roleName);
             $this->assertEquals($expected, $actual);
         }

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -18,7 +18,7 @@ use \Exception;
 class XDUserTest extends \PHPUnit_Framework_TestCase
 {
 
-    const TEST_ARTIFACT_OUTPUT_PATH = "/../artifacts/xdmod-test-artifacts/xdmod/acls/output";
+    const TEST_ARTIFACT_OUTPUT_PATH = '/../artifacts/xdmod-test-artifacts/xdmod/acls/output';
 
     const PUBLIC_USER_NAME = 'Public User';
     const PUBLIC_ACL_NAME = 'pub';


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- A slight change that modifies XDUser so that during construction it honors the
  `primary_role` parameter which is used to populate the `activeRole` property.
- Updated the create_user.php to take this change into account ( it now provides
  ROLE_ID_USER )


## Motivation and Context
Ensure that current uses of XDUser::_construct do not break and behave as intended.

## Tests performed
Added a component test to ensure we test for the desired behavior implemented by this change.
- i.e. that the primaryRole supplied during XDUser construction is taken into consideration when retrieving / populating the activeRole. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
