### PR TITLE
Improve xdmod-slurm-helper sacct error checking

### DIFF
--- a/bin/xdmod-slurm-helper
+++ b/bin/xdmod-slurm-helper
@@ -164,36 +164,13 @@ function main()
     }
 
     $args = getSacctCmdArgs($shredder, $startTime, $endTime);
-
-    $logFile   = tempnam(sys_get_temp_dir(), 'sacct-log-');
-    $errorFile = tempnam(sys_get_temp_dir(), 'sacct-error-');
-
-    $args[] = "1>$logFile";
-    $args[] = "2>$errorFile";
-
     array_unshift($args, $sacct);
-
     $cmd = implode(' ', $args);
-    $logger->info("Executing command: $cmd");
 
-    // Set time zone to UTC, execute the command, then restore the
-    // previously set timezone.  This is necessary since the logger uses
-    // the timezone to display the time in log messages.
-
-    $tz = getenv('TZ');
-
-    putenv('TZ=UTC');
-    system($cmd);
-
-    if (empty($tz)) {
-        putenv("TZ");
-    } else {
-        putenv("TZ=$tz");
-    }
-
-    if (filesize($errorFile) > 0) {
-        $error = file_get_contents($errorFile);
-        $logger->crit("Error while executing sacct: $error");
+    try {
+        $logFile = executeSacctCommand($cmd);
+    } catch (Exception $e) {
+        $logger->crit($e->getMessage());
         exit(1);
     }
 
@@ -201,6 +178,10 @@ function main()
 
     $logger->info("Total shredded: $count");
     $logger->info("Done shredding!");
+
+    if (!unlink($logFile)) {
+        $logger->warning("Failed to remove temporary file '$logFile'");
+    }
 
     $logger->notice('Normalizing data');
 
@@ -300,6 +281,101 @@ function getSacctCmdArgs(
     }
 
     return $args;
+}
+
+/**
+ * Execute sacct command.
+ *
+ * @param string $cmd Full sacct command including all arguments.
+ * @return string Path to file containing the output from sacct.
+ * @throws Exception If there was an error opening a temporary file, executing
+ *   the sacct command, getting the output from sacct, or if sacct returns a
+ *   non-zero value.
+ */
+function executeSacctCommand($cmd)
+{
+    global $logger;
+
+    $logFile = tempnam(sys_get_temp_dir(), 'sacct-log-');
+    $logger->debug("Writing sacct output to '$logFile'");
+    $logFilePointer = fopen($logFile, 'w');
+
+    if ($logFilePointer === false) {
+        throw new Exception("Failed to open temporary file '$logFile'");
+    }
+
+    // Set time zone to UTC, execute the command, then restore the previously
+    // set timezone.  This is necessary since the logger uses the timezone to
+    // display the time in log messages.  This is not done using the proc_open
+    // parameter since doing so replaces the entire environment.
+    $tz = getenv('TZ');
+    putenv('TZ=UTC');
+
+    $logger->info("Executing command: $cmd");
+    $process = proc_open(
+        $cmd . ';echo $? >&3', // Direct exit code to pipe 3.
+        array(
+            0 => array('file', '/dev/null', 'r'),
+            1 => $logFilePointer,
+            2 => array('pipe', 'w'),
+            3 => array('pipe', 'w'),
+        ),
+        $pipes
+    );
+
+    // Restore timezone if necessary.
+    if ($tz !== false) {
+        putenv('TZ');
+    } else {
+        putenv("TZ=$tz");
+    }
+
+    if (!is_resource($process)) {
+        throw new Exception('Failed to create sacct subprocess');
+    }
+
+    if (!fclose($logFilePointer)) {
+        $logger->err("Failed to close temporary file '$logFile'");
+    }
+
+    $err = stream_get_contents($pipes[2]);
+
+    if ($err === false) {
+        throw new Exception('Failed to get subprocess STDERR');
+    }
+
+    if (!fclose($pipes[2])) {
+        $logger->err('Failed to close subprocess STDERR');
+    }
+
+    $exitCode = stream_get_contents($pipes[3]);
+
+    if ($exitCode === false) {
+        throw new Exception('Failed to get subprocess exit code');
+    }
+
+    // Remove trailing white space.
+    $exitCode = trim($exitCode);
+
+    if (!fclose($pipes[3])) {
+        $logger->err('Failed to close subprocess pipe 3');
+    }
+
+    $procStatus = proc_close($process);
+
+    if (strlen($err) > 0) {
+        throw new Exception("Error while executing sacct: $err");
+    }
+
+    if ($procStatus === -1) {
+        throw new Exception('Error occurred while closing sacct subprocess');
+    }
+
+    if ($exitCode !== '0') {
+        throw new Exception("sacct returned $exitCode");
+    }
+
+    return $logFile;
 }
 
 function displayHelpText()

--- a/open_xdmod/modules/xdmod/component_tests/lib/SlurmHelperTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/SlurmHelperTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * @package OpenXdmod\ComponentTests
+ * @author Jeffrey T. Palmer <jtpalmer@buffalo.edu>
+ */
+
+namespace ComponentTests;
+
+use CCR\DB;
+
+/**
+ * Test the xdmod-slurm-helper executable.
+ */
+class SlurmHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Database handle for `mod_shredder`.
+     * @var \CCR\DB\PDODB
+     */
+    private static $dbh;
+
+    /**
+     * Maximum id in `shredded_job_slurm` table before tests are run.
+     * @var int
+     */
+    private static $maxSlurmJobId;
+
+    /**
+     * Maximum id in `shredded_job` table before tests are run.
+     * @var int
+     */
+    private static $maxShreddedJobId;
+
+    /**
+     * Test xdmod-slurm-helper with various sacct commands.
+     *
+     * @dataProvider sacctCommandProvider
+     *
+     * @param string $sacctOutputType Output type to simulate.
+     * @param int $sacctExitStatus Exit status to simulate.
+     * @param string $outputRegex Regular expression that output should match.
+     * @param int $exitStatus Exit status expected from slurm helper.
+     */
+    public function testSlurmHelper(
+        $sacctOutputType,
+        $sacctExitStatus,
+        $outputRegex,
+        $exitStatus
+    ) {
+        $result = $this->executeSlurmHelper($sacctOutputType, $sacctExitStatus);
+        $this->assertEquals($exitStatus, $result['exit_status']);
+        $this->assertEquals('', $result['stderr']);
+        $this->assertRegExp($outputRegex, $result['stdout']);
+    }
+
+    /**
+     * Execute the slurm helper.
+     *
+     * Uses a fake sacct script to simulate different types of output and exit
+     * status codes.
+     *
+     * @param string $outputType The output type that will be simulated.
+     * @param integer $exitStatus The exit status that will be simulated.
+     */
+    private function executeSlurmHelper($outputType, $exitStatus)
+    {
+        $process = proc_open(
+            'xdmod-slurm-helper -q -r frearson',
+            array(
+                0 => array('file', '/dev/null', 'r'),
+                1 => array('pipe', 'w'),
+                2 => array('pipe', 'w'),
+            ),
+            $pipes,
+            null,
+            array(
+                'PATH' => realpath(__DIR__ . '/../scripts') . ':' . getenv('PATH'),
+                'XDMOD_SACCT_OUTPUT_TYPE' => $outputType,
+                'XDMOD_SACCT_EXIT_STATUS' => $exitStatus,
+            )
+        );
+
+        if (!is_resource($process)) {
+            throw new Exception('Failed to create xdmod-slurm-helper subprocess');
+        }
+
+        $stdout = stream_get_contents($pipes[1]);
+
+        if ($stdout === false) {
+            throw new Execption('Failed to get subprocess STDOUT');
+        }
+
+        $stderr = stream_get_contents($pipes[2]);
+
+        if ($stderr === false) {
+            throw new Execption('Failed to get subprocess STDERR');
+        }
+
+        $exitStatus = proc_close($process);
+
+        return array(
+            'exit_status' => $exitStatus,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+        );
+    }
+
+    public function sacctCommandProvider()
+    {
+        return array(
+            array(
+                'no_output',
+                0,
+                '/^$/',
+                0,
+            ),
+            array(
+                'valid_output',
+                0,
+                '/^$/',
+                0,
+            ),
+            array(
+                'invalid_output',
+                0,
+                '/Malformed Slurm sacct line/',
+                1,
+            ),
+            array(
+                'stderr_output',
+                0,
+                '/Error while executing sacct/',
+                1,
+            ),
+            array(
+                'no_output',
+                1,
+                '/sacct returned 1/',
+                1,
+            ),
+            array(
+                'valid_output',
+                1,
+                '/sacct returned 1/',
+                1,
+            ),
+            array(
+                'invalid_output',
+                1,
+                '/sacct returned 1/',
+                1,
+            ),
+            array(
+                'stderr_output',
+                1,
+                '/Error while executing sacct/',
+                1,
+            ),
+            array(
+                'no_output',
+                2,
+                '/sacct returned 2/',
+                1,
+            ),
+            array(
+                'valid_output',
+                2,
+                '/sacct returned 2/',
+                1,
+            ),
+            array(
+                'invalid_output',
+                2,
+                '/sacct returned 2/',
+                1,
+            ),
+            array(
+                'stderr_output',
+                2,
+                '/Error while executing sacct/',
+                1,
+            ),
+        );
+    }
+
+    public static function setUpBeforeClass()
+    {
+        static::$dbh = DB::factory('shredder');
+        static::$maxSlurmJobId = static::$dbh->query('SELECT COALESCE(MAX(shredded_job_slurm_id), 0) AS id FROM shredded_job_slurm')[0]['id'];
+        static::$maxShreddedJobId = static::$dbh->query('SELECT COALESCE(MAX(shredded_job_id), 0) AS id FROM shredded_job')[0]['id'];
+    }
+
+    public static function tearDownAfterClass()
+    {
+        static::$dbh->execute('DELETE FROM shredded_job_slurm WHERE shredded_job_slurm_id > :id', array('id' => static::$maxSlurmJobId));
+        static::$dbh->execute('DELETE FROM shredded_job WHERE shredded_job_id > :id', array('id' => static::$maxShreddedJobId));
+    }
+}

--- a/open_xdmod/modules/xdmod/component_tests/scripts/sacct
+++ b/open_xdmod/modules/xdmod/component_tests/scripts/sacct
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Simulate valid and invalid output of the sacct command for use in testing
+# xdmod-slurm-helper.  Depending on the XDMOD_SACCT_OUTPUT_TYPE environment
+# variable the script will output valid sacct data in the expected format,
+# invalid data, no data or an error message to STDERR.  Exits with the value in
+# the XDMOD_SACCT_EXIT_STATUS environment variable.
+
+case "$XDMOD_SACCT_OUTPUT_TYPE" in
+    no_output)
+        ;;
+    valid_output)
+        echo '4103947_100|4103947|hpc|general-compute|anon|anon|918273|unknown|192837|2015-06-26T13:57:00|2015-06-26T13:57:00|2015-06-28T02:55:50|2015-07-01T02:55:50|3-00:00:00|1:0|TIMEOUT|32|256|256|3000Mc|||3-00:00:00|d07n07s02,d07n19s02,d07n25s01,d07n28s01,d07n29s01,d07n31s02,d07n38s02,d09n04s[01-02],d09n05s02,d09n06s01,d09n07s01,d09n08s[01-02],d09n09s01,d09n11s[01-02],d09n13s01,d09n14s01,d09n15s01,d09n16s01,d09n17s01,d09n24s01,d09n25s02,d09n28s01,d09n35s01,d09n38s02,d13n[03,05,07-08,16]|1AbC-2-3'
+        ;;
+    invalid_output)
+        echo This is not valid sacct output
+        ;;
+    stderr_output)
+        echo sacct failed 1>&2
+        ;;
+    *)
+        echo XDMOD_SACCT_OUTPUT_TYPE value not recognized 1>&2
+        exit 1
+        ;;
+esac
+
+if [ "$XDMOD_SACCT_EXIT_STATUS" = "" ]; then
+    echo XDMOD_SACCT_EXIT_STATUS not set 1>&2
+    exit 1
+fi
+
+exit $XDMOD_SACCT_EXIT_STATUS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Replaces use of PHP `system` with `proc_open`, etc..  Adds additional error checking and tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, if the sacct command or whatever is used to run sacct (e.g. ssh) failed, no errors would be reported.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran xdmod-slurm-helper on test system.  Added new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
