### PR TITLE
Update _getFormalRoleName to use the acl table

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2583,7 +2583,8 @@ FROM (
        AND a.name = :abbrev;
 SQL;
 
-        $roleData = $pdo->query($query,
+        $roleData = $pdo->query(
+            $query,
             array(
                 ':abbrev' => $role_abbrev,
                 ':pub_abbrev' => ROLE_ID_PUBLIC

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2566,23 +2566,19 @@ SQL;
 
     public function _getFormalRoleName($role_abbrev)
     {
-
-        if ($role_abbrev == ROLE_ID_PUBLIC) {
-            return 'Public';
-        }
-
-        if ($role_abbrev == NULL) {
-            return 'Public';
+        $publicAclDisplay = 'Public';
+        if ($role_abbrev == ROLE_ID_PUBLIC || $role_abbrev == NULL) {
+            return $publicAclDisplay;
         }
 
         $pdo = DB::factory('database');
 
-        $roleData = $pdo->query("SELECT description FROM Roles WHERE abbrev=:abbrev", array(
+        $roleData = $pdo->query("SELECT display as description FROM acls WHERE name = :abbrev", array(
             ':abbrev' => $role_abbrev,
         ));
 
         if (count($roleData) == 0) {
-            return 'Public';
+            return $publicAclDisplay;
         }
 
         return $roleData[0]['description'];

--- a/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
+++ b/configuration/etl/etl_sql.d/acls/xdmod/create_public_user.sql
@@ -22,6 +22,9 @@ LEFT JOIN Users cur
         BINARY cur.email_address = BINARY inc.email_address
 WHERE cur.id IS NULL;
 
+-- Update public acl display
+UPDATE acls SET display = 'Public' WHERE name = 'pub';
+
 -- Create the association between the public user and the public acl.
 INSERT INTO user_acls(user_id, acl_id)
 SELECT inc.*

--- a/configuration/roles.json
+++ b/configuration/roles.json
@@ -255,7 +255,7 @@
             ]
         },
         "pub": {
-            "display": "Public User",
+            "display": "Public",
             "type": "data",
             "hierarchies": [{
                 "level": 0,

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -1292,23 +1292,9 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
             array(self::PRINCIPAL_INVESTIGATOR_ACL_NAME, 'Principal Investigator'),
             array(self::NORMAL_USER_ACL, 'User'),
             array(self::PUBLIC_ACL_NAME, 'Public'),
-            array(self::INVALID_ACL_NAME, 'Public')
+            array(self::INVALID_ACL_NAME, 'Public'),
+            array(null, 'Public'),
+            array('', 'Public')
         );
-    }
-
-    public function testGetFormalRoleNameNull()
-    {
-        $expected = 'Public';
-        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
-        $actual = $user->_getFormalRoleName(null);
-        $this->assertEquals($expected, $actual);
-    }
-
-    public function testGetFormalRoleNameEmptyString()
-    {
-        $expected = 'Public';
-        $user = new XDUser('test4', null, 'test4@ccr.xdmod.org', 'test', 'a', 'user');
-        $actual = $user->_getFormalRoleName('');
-        $this->assertEquals($expected, $actual);
     }
 }

--- a/open_xdmod/modules/xdmod/tests/lib/Xdmod/ConfigTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/Xdmod/ConfigTest.php
@@ -23,8 +23,6 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($section);
         $this->assertNotEmpty($testCases);
 
-        echo "Section: $section\n";
-
         $config = Config::factory();
         $this->assertNotNull($config);
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Just another incremental PR for converting XDUser over to acls. 
- Also reduced the lines of code where I could.

## Motivation and Context
To continue migrating XDUser to acls.

## Tests performed
Tests have been included for this function as well as functions that utilize this function. They include: 
- `getMostPrivilegedRole`
- `getAllRoles`
- `setActiveRole`
- `__construct` ( via the testCreateUser* functions )

These tests reside within `component_tests/lib/XDUserTest.php`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
