### PR TITLE
Updated the isCenterDirectorOfOrganization function to use acls

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -1852,14 +1852,25 @@ SQL
 
     public function isCenterDirectorOfOrganization($organization_id)
     {
+        $query = <<<SQL
+SELECT COUNT(*) AS num_matches
+FROM user_acl_group_by_parameters uagbp
+JOIN group_bys gb ON uagbp.group_by_id = gb.group_by_id
+JOIN acls a ON uagbp.acl_id = a.acl_id
+WHERE
+  a.name        = :acl_name      AND
+  gb.name       = :group_by_name AND
+  uagbp.user_id = :user_id       AND
+  uagbp.value   = :organization_id;
+SQL;
 
         $results = $this->_pdo->query(
-            "SELECT COUNT(*) AS num_matches FROM UserRoleParameters WHERE user_id=:user_id AND role_id=:role_id AND param_name=:param_name AND param_value=:param_value",
+            $query,
             array(
-                'user_id' => $this->_id,
-                'role_id' => \xd_roles\getRoleIDFromIdentifier(ROLE_ID_CENTER_DIRECTOR),
-                'param_name' => 'provider',
-                'param_value' => $organization_id
+                ':user_id' => $this->_id,
+                ':acl_name' => ROLE_ID_CENTER_DIRECTOR,
+                ':group_by_name' => 'provider',
+                ':organization_id' => $organization_id
             )
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Just migrating this function over to utilize the user_acl_group_by_parameters
  table instead of UserRoleParameters.

## Motivation and Context
Continue migration of XDUser functions to acl tables

## Tests performed
Component Tests for this function were added to XDUserTest.php. There are 4 test functions and a total of 12 cases.
- `XDUserTest.php::testIsCenterDirectorOfOrganizationValidCenter`
  - cases included for the following users: 
    - centerdirector
    - centerstaff
    - principal
    - normaluser
    - Public User
- `XDUserTest.php::testIsCenterDirectorOfOrganizationInvalidCenter`
  - cases included for the following users: 
    - centerdirector
    - centerstaff
    - principal
    - normaluser
    - Public User
- `XDUserTest.php::testIsCenterDirectorOfOrganizationNull`
- `XDUserTest.php::testIsCenterDirectorOfOrganizationEmptyString`

Additionally the component,  unit, integration and automated tests were run via docker 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
