### PR TITLE
Improve upgrade prompt

### DIFF
--- a/bin/xdmod-upgrade
+++ b/bin/xdmod-upgrade
@@ -60,8 +60,6 @@ function main()
 {
     global $argv, $logger, $supportedUpgrades, $installedVersion;
 
-    $interactiveMode = true;
-
     $opts = array(
         array('h', 'help'),
         array('v', 'verbose'),
@@ -127,9 +125,6 @@ function main()
             case 'current-version':
                 $configFileVersion = $value;
                 break;
-            case 'batch-mode':
-                $interactiveMode = false;
-                break;
             default:
                 fwrite(STDERR, "Unexpected option '$key'\n");
                 exit(1);
@@ -192,14 +187,12 @@ function main()
     }
 
     $console = Console::factory();
-    $console->setInteractive($interactiveMode);
 
-    if ($interactiveMode) {
-        displayWarning($configFileVersion, $installedVersion);
-        $response = readline('Are you sure you want to continue (yes/no): ');
-        if ($response != 'yes') {
-            exit;
-        }
+    displayWarning($configFileVersion, $installedVersion);
+    $response = $console->prompt('Are you sure you want to continue?', 'no', array('yes', 'no'));
+    if ($response !== 'yes') {
+        $console->displayMessage('No upgrade performed');
+        exit;
     }
 
     while (isset($supportedUpgrades[$configFileVersion])) {

--- a/classes/OpenXdmod/Setup/Console.php
+++ b/classes/OpenXdmod/Setup/Console.php
@@ -29,24 +29,10 @@ class Console
     }
 
     /**
-     * Whether the console is interactive or running in batch mode.
-     */
-    private $interactive = true;
-
-    /**
      * Constructor.
      */
     protected function __construct()
     {
-    }
-
-    /**
-     * Set interaction mode.
-     * @param bool $interactiveMode true for interactive mode, false for batch mode.
-     */
-    public function setInteractive($interactiveMode)
-    {
-        $this->interactive = $interactiveMode;
     }
 
     /**
@@ -145,10 +131,6 @@ class Console
             $prompt .= " [$default]";
         }
 
-        if ($this->interactive === false && !empty($default)) {
-            return $default;
-        }
-
         $prompt .= ' ';
 
         $response = readline($prompt);
@@ -197,9 +179,6 @@ class Console
      */
     public function silentPrompt($prompt)
     {
-        if ($this->interactive === false) {
-            return '';
-        }
         echo "$prompt ";
         $first = preg_replace('/\r?\n$/', '', `stty -echo; head -n1; stty echo`);
         echo "\n(confirm) $prompt ";

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -32,5 +32,5 @@ if [ "$XDMOD_TEST_MODE" = "upgrade" ];
 then
     yum -y install ~/rpmbuild/RPMS/*/*.rpm
     ~/bin/services start
-    xdmod-upgrade --batch-mode | col -b
+    expect $BASEDIR/xdmod-upgrade.tcl | col -b
 fi

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade.tcl
@@ -1,0 +1,22 @@
+#!/usr/bin/env expect
+# Expect script that runs xdmod-upgrade to upgrade an already installed Open
+# XDMoD instance.
+
+#-------------------------------------------------------------------------------
+# Helper functions
+
+proc confirmUpgrade { } {
+    expect {
+        timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+        -re "\nAre you sure you want to continue .*\\\] "
+    }
+    send yes\n
+}
+
+#-------------------------------------------------------------------------------
+# main body
+
+set timeout 60
+spawn "xdmod-upgrade"
+confirmUpgrade
+expect eof


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds better checking for yes/no responses during the upgrade process and outputs a message if no upgrade occurs.

Also replaces the non-interactive upgrade option with an expect script.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, if a user entered "y" instead of "yes", the upgrade script would exit and it was not obvious that the migrations were not performed.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
