### PR TITLE
update tests to catch and throw errors properly

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
@@ -16,7 +16,7 @@ lappend resources [list robertson Robertson 400 4000]
 # Helper functions
 
 proc selectMenuOption { option } {
-	
+
 	expect {
 		-re "\nSelect an option .*: "
 	}
@@ -95,15 +95,15 @@ provideInput {Do you want to see the output*} {no}
 set timeout 10
 
 selectMenuOption 3
-provideInput {Organization Name:} Screwdriver 
-provideInput {Organization Abbreviation:} screw 
+provideInput {Organization Name:} Screwdriver
+provideInput {Organization Abbreviation:} screw
 confirmFileWrite yes
 enterToContinue
 
 selectMenuOption 4
 foreach resource $resources {
 	selectMenuOption 1
-	provideInput {Resource Name:} [lindex $resource 0]	
+	provideInput {Resource Name:} [lindex $resource 0]
 	provideInput {Formal Name:} [lindex $resource 1]
 	provideInput {How many nodes does this resource have?} [lindex $resource 2]
 	provideInput {How many total processors (cpu cores) does this resource have?} [lindex $resource 3]
@@ -133,3 +133,6 @@ confirmFileWrite yes
 enterToContinue
 
 selectMenuOption q
+
+lassign [wait] pid spawnid os_error_flag value
+exit $value

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade.tcl
@@ -20,3 +20,5 @@ set timeout 60
 spawn "xdmod-upgrade"
 confirmUpgrade
 expect eof
+lassign [wait] pid spawnid os_error_flag value
+exit $value


### PR DESCRIPTION
The expect script can "gobble" the spawned processes exit status.  Lets not do that...