### PR TITLE
switch to info instead of debug

### DIFF
--- a/bin/acl-import
+++ b/bin/acl-import
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-acl-etl -pacls-import -g
+acl-etl -pacls-import -v

--- a/bin/acl-xdmod-management
+++ b/bin/acl-xdmod-management
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-acl-etl -pacls-xdmod-management -g
+acl-etl -pacls-xdmod-management -v


### PR DESCRIPTION
decrease the default logging level to info instead of debug.

This is more to start a discussion of how and when we do output.

For these cases, should we just pass in the level we want instead of hard coding it as debug?

For Instance during an install or upgrade is this information even needed if there is no error?