### PR TITLE
test updates

### DIFF
--- a/open_xdmod/modules/xdmod/automated_tests/package.json
+++ b/open_xdmod/modules/xdmod/automated_tests/package.json
@@ -27,7 +27,7 @@
     "wdio-sauce-service": "^0.4.0",
     "wdio-selenium-standalone-service": "0.0.9",
     "wdio-spec-reporter": "^0.1.0",
-    "webdriverio": "^4.9.4"
+    "webdriverio": "4.9.4"
   },
   "repository": "https://github.com/ubccr/xdmod"
 }


### PR DESCRIPTION
The webdriverio dependency was set to be ^4.9.4 (my bad) this allows it to be updated to newer versions, the newer versions have changed some things though and until we can go through the tests and make them work with the newer version just force it to be 4.9.4 and only that known version.  We should probably do this for all versions of things going forward.