### PR TITLE
Updating update_user to handle new acl structure

### DIFF
--- a/html/controllers/user_admin/update_user.php
+++ b/html/controllers/user_admin/update_user.php
@@ -59,7 +59,7 @@ $params = array('uid' => RESTRICTION_UID);
    	if (isset($_POST['acls'])) {
    	
          $role_config = json_decode($_POST['acls'], true);
-         if (!in_array(ROLE_ID_MANAGER, $role_config)) {
+         if (!array_key_exists(ROLE_ID_MANAGER, $role_config)) {
                 $returnData['success'] = false;
                 $returnData['status'] = 'You are not allowed to revoke manager access from yourself.';
                 xd_controller\returnJSON($returnData);

--- a/html/controllers/user_admin/update_user.php
+++ b/html/controllers/user_admin/update_user.php
@@ -123,7 +123,7 @@ $params = array('uid' => RESTRICTION_UID);
          $user_to_update->disassociateWithInstitution();
       }
       else {
-         $user_to_update->setInstitution($_POST['institution'], ($role_config['primaryRole'] == ROLE_ID_CAMPUS_CHAMPION));	
+         $user_to_update->setInstitution($_POST['institution'], array_key_exists(ROLE_ID_CAMPUS_CHAMPION, $role_config));
       }
 
    }//if (isset($_POST['institution']))


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- the structure of acls as they're sent over from the front end has changed from
  ['acl1', 'acl2', 'acl3'] -> {'acl1': ['center1', 'center2'], 'acl2': []}
  and as such the function used to test for the absence of the 'mgr' role needs
  to be changed from `in_array` to `array_key_exists`.
## Motivation and Context
Because you should be able to modify your own user.

## Tests performed
Manual Test:
-  Login to the internal dashboard 
- Select 'User management' tab
- Select the 'Existing Users' tab
- Double click on the account that you are currently logged in as.
- Click the checkbox next to the 'Principal Investigator' acl. ( It doesn't matter if it was checked previously or not )
- Click 'Save Changes' 
- It should save successfully. 
- To double check force refresh the page and navigate to the acct again.
- Ensure that the 'Principal Investigator' acl is the same as it was after the previous update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
