### PR TITLE
update xdmod-upgrade

### DIFF
--- a/bin/xdmod-upgrade
+++ b/bin/xdmod-upgrade
@@ -212,7 +212,7 @@ function main()
 
         $configFileVersion = $newVersion;
     }
-
+    $logger->notice('Upgrade Complete');
     exit;
 }
 

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade.tcl
@@ -13,12 +13,20 @@ proc confirmUpgrade { } {
     send yes\n
 }
 
+proc confirmComplete { } {
+    expect {
+        timeout { send_user "\nFailed to get completion notice\n"; exit 1 }
+        -re "\nUpgrade Complete.*"
+    }
+
+}
+
 #-------------------------------------------------------------------------------
 # main body
 
-set timeout 60
+set timeout 180
 spawn "xdmod-upgrade"
 confirmUpgrade
-expect eof
+confirmComplete
 lassign [wait] pid spawnid os_error_flag value
 exit $value


### PR DESCRIPTION
IN the docker instance you dont always get the full output of xdmod-upgrade when using expect.  Adding a "Completion" message and waiting for that seems to fix it.  Also the 7.0 - 7.1 upgrade seems to be taking longer with the addition of the acl and hpcdb-modw etlv2 additions so upped the timeout

Updates to xdmod-upgrade and expect script automating it.