### PR TITLE
Updating ComponentTests to use the re-orged artifacts

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -494,6 +494,11 @@ class XDUser implements JsonSerializable
                 $user->_active_role->configure($user, $roleSet['param_value']);
             }
 
+            if ($roleSet['is_primary'] == '1') {
+                $user->_primary_role = \User\aRole::factory($roleSet['description']);
+                $user->_primary_role->configure($user, $roleSet['param_value']);
+            }
+
         }//foreach
 
         // BEGIN: ACL population

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -155,13 +155,13 @@ class XDUser implements JsonSerializable
 
         // =================================
 
-        $primary_role_name = $this->_getFormalRoleName(ROLE_ID_USER);
+        $primary_role_name = $this->_getFormalRoleName($primary_role);
 
         // These roles cannot be used immediately after constructing a new XDUser (since a user id has not been defined at this point).
         // If you are explicitly calling 'new XDUser(...)', saveUser() must be called on the newly created XDUser object before accessing
         // these roles using getPrimaryRole() and getActiveRole()
 
-        $this->_active_role = \User\aRole::factory($primary_role_name);
+        $this->_primary_role = $this->_active_role = \User\aRole::factory($primary_role_name);
     }//construct
 
     // ---------------------------
@@ -977,6 +977,13 @@ SQL;
         $this->_active_role->configure($this);
         /* END: Configure Primary and Active Roles */
 
+        $primary_role_id = $this->_getRoleID($this->_primary_role->getIdentifier());
+
+        $this->_pdo->execute(
+            "UPDATE UserRoles SET is_primary ='1' WHERE user_id=:id AND role_id=:roleId",
+            array('id' => $this->_id, 'roleId' => $primary_role_id)
+        );
+        $this->_primary_role->configure($this);
 
         $timestampData = $this->_pdo->query(
             "SELECT time_created, time_last_updated, password_last_updated

--- a/open_xdmod/modules/xdmod/component_tests/lib/BaseTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/BaseTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace ComponentTests;
+
+abstract class BaseTest extends \PHPUnit_Framework_TestCase
+{
+    private static $TEST_ARTIFACT_OUTPUT_PATH;
+
+    const DEFAULT_TEST_ENVIRONMENT = 'xdmod';
+
+    const DEFAULT_PROJECT = 'acls';
+
+    const DEFAULT_TYPE = 'output';
+
+    const PUBLIC_USER_NAME = 'Public User';
+    const PUBLIC_ACL_NAME = 'pub';
+    const PUBLIC_USER_EXPECTED = '/public_user.json';
+
+    const CENTER_DIRECTOR_USER_NAME = 'centerdirector';
+    const CENTER_DIRECTOR_ACL_NAME = 'cd';
+    const CENTER_DIRECTOR_EXPECTED = '/center_director.json';
+
+    const CENTER_STAFF_USER_NAME = 'centerstaff';
+    const CENTER_STAFF_ACL_NAME = 'cs';
+    const CENTER_STAFF_EXPECTED = '/center_staff.json';
+
+    const PRINCIPAL_INVESTIGATOR_USER_NAME = 'principal';
+    const PRINCIPAL_INVESTIGATOR_ACL_NAME = 'pi';
+    const PRINCIPAL_INVESTIGATOR_EXPECTED = '/principal.json';
+
+    const NORMAL_USER_USER_NAME = 'normaluser';
+    const NORMAL_USER_ACL = 'usr';
+    const NORMAL_USER_EXPECTED = '/normal_user.json';
+
+    const VALID_SERVICE_PROVIDER_ID = 1;
+    const VALID_SERVICE_PROVIDER_NAME = 'screw';
+
+    const INVALID_ID = -999;
+    const INVALID_ACL_NAME = 'babbaganoush';
+
+    const MIN_USERS = 1;
+    const MAX_USERS = 1000;
+    const DEFAULT_TEST_USER_NAME = "test";
+    const DEFAULT_EMAIL_ADDRESS_SUFFIX = "@test.com";
+
+    private static $ENV;
+
+    public static function setUpBeforeClass()
+    {
+        self::setupEnvironment();
+        self::setupPaths();
+    }
+    private static function setupEnvironment()
+    {
+        $testEnvironment = getenv('TEST_ENV');
+        if ($testEnvironment !== false) {
+            self::$ENV = $testEnvironment;
+        } else {
+            self::$ENV = self::DEFAULT_TEST_ENVIRONMENT;
+        }
+    }
+
+    private static function setupPaths()
+    {
+        self::$TEST_ARTIFACT_OUTPUT_PATH = __DIR__ . "/../artifacts/xdmod-test-artifacts/";
+    }
+
+    /**
+     * @param string  $fileName
+     * @param string  $project
+     * @param string  $type
+     * @return string
+     */
+    public function getTestFile($fileName, $project = self::DEFAULT_PROJECT, $type = self::DEFAULT_TYPE)
+    {
+        if (!isset(self::$ENV)){
+            self::setupEnvironment();
+        }
+
+        if (!isset(self::$TEST_ARTIFACT_OUTPUT_PATH)) {
+            self::setupPaths();
+        }
+
+        return implode(
+            '',
+            array(
+                self::$TEST_ARTIFACT_OUTPUT_PATH,
+                DIRECTORY_SEPARATOR,
+                self::$ENV,
+                DIRECTORY_SEPARATOR,
+                $project,
+                DIRECTORY_SEPARATOR,
+                $type,
+                DIRECTORY_SEPARATOR,
+                $fileName
+            )
+        );
+    }
+}

--- a/open_xdmod/modules/xdmod/component_tests/lib/QueryTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/QueryTest.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace UnitTesting\DataWarehouse\Query\Jobs\Aggregate;
+namespace ComponentTests;
+
+use CCR\Json;
 
 /**
  * This test is designed for class \DataWarehouse\Query\Jobs\Aggregate
  */
 
-class AggregateTest extends \PHPUnit_Framework_TestCase
+class AggregateTest extends BaseTest
 {
     private $_query;
     /**
@@ -25,49 +27,8 @@ class AggregateTest extends \PHPUnit_Framework_TestCase
     }
 
     public function queryDataProvider(){
-        return array(
-            array(
-                'day',
-                '2017-09-01',
-                '2017-09-30',
-                'none',
-                '(1)'
-            ),
-            array(
-                'day',
-                '2016-11-01',
-                '2016-11-30',
-                'none',
-                '(1)'
-            ),
-            array(
-                'day',
-                '2016-12-01',
-                '2016-12-15',
-                'none',
-                '(96)'
-            ),
-            array(
-                'day',
-                '2016-12-15',
-                '2017-01-05',
-                'none',
-                '(432)'
-            ),
-            array(
-                'day',
-                '2016-12-15',
-                '2016-12-29',
-                'none',
-                '(360)'
-            ),
-            array(
-                'day',
-                '2016-12-12',
-                '2017-01-01',
-                'none',
-                '(504)'
-            )
-        );
+        $expectedFileName = $this->getTestFile('aggregate_durations.json');
+        $expected = JSON::loadFile($expectedFileName);
+        return $expected;
     }
 }

--- a/open_xdmod/modules/xdmod/component_tests/lib/Roles/CenterDirectorRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/Roles/CenterDirectorRoleTest.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace ComponentTests;
+namespace ComponentTests\Roles;
 
 use CCR\Json;
+use ComponentTests\BaseTest;
+use ComponentTests\XDUserTest;
 use Exception;
 use User\Roles\CenterDirectorRole;
 use XDUser;
@@ -10,9 +12,8 @@ use XDUser;
 /**
  * Tests meant to exercise the functions in the CenterDirectorRole class.
  **/
-class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
+class CenterDirectorRoleTest extends BaseTest
 {
-    const TEST_ARTIFACT_OUTPUT_PATH = '/../../../artifacts/xdmod-test-artifacts/xdmod/acls/output';
     /**
      * @expectedException Exception
      * @expectedExceptionMessage No user ID has been assigned to this role.  You must call configure() before calling getCorrespondingUserID()
@@ -25,7 +26,7 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCorrespondingUserID()
     {
-        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
         $expected = $user->getUserID();
 
         $cd = new CenterDirectorRole();
@@ -46,7 +47,7 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetActiveCenter()
     {
-        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
         $expected = 1;
 
         $cd = new CenterDirectorRole();
@@ -67,13 +68,13 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFormalName()
     {
-        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
-        $expected = 'Center Director - screw';
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+        $expected = 'Center Director';
         $cd = new CenterDirectorRole();
         $cd->configure($user);
 
         $actual =  $cd->getFormalName();
-        $this->assertEquals($expected, $actual);
+        $this->assertNotFalse(strpos($actual, $expected), "Expected to find '$expected' in '$actual'");
     }
 
     public function testGetIdentifier()
@@ -83,7 +84,7 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
             true => XDUserTest::CENTER_DIRECTOR_ACL_NAME . ';1'
         );
 
-        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
         $cd = new CenterDirectorRole();
         $cd->configure($user);
         foreach($params as $param => $expected) {
@@ -104,9 +105,9 @@ class CenterDirectorRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testEnumStaffMembers()
     {
-        $expected = Json::loadFile(XDUserTest::getTestFile('center_director_staff_members.json'));
+        $expected = Json::loadFile($this->getTestFile('center_director_staff_members.json'));
 
-        $user = XDUser::getUserByUserName(XDUserTest::CENTER_DIRECTOR_USER_NAME);
+        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
         $cd = new CenterDirectorRole();
         $cd->configure($user);
         $actual = $cd->enumCenterStaffMembers();

--- a/open_xdmod/modules/xdmod/component_tests/lib/Roles/CenterStaffRoleTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/Roles/CenterStaffRoleTest.php
@@ -1,5 +1,8 @@
-<?php namespace ComponentTests;
+<?php
 
+namespace ComponentTests\Roles;
+
+use ComponentTests\BaseTest;
 use Exception;
 use User\Roles\CenterStaffRole;
 use XDUser;
@@ -7,7 +10,7 @@ use XDUser;
 /**
  * Tests meant to exercise the functions in the CenterStaffRole class
  **/
-class CenterStaffRoleTest extends \PHPUnit_Framework_TestCase
+class CenterStaffRoleTest extends BaseTest
 {
     /**
      * @expectedException Exception
@@ -21,8 +24,8 @@ class CenterStaffRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetIdentifierAbsolute()
     {
-        $expected = XDUserTest::CENTER_STAFF_ACL_NAME . ';1';
-        $user = XDUser::getUserByUserName(XDUserTest::CENTER_STAFF_USER_NAME);
+        $expected = self::CENTER_STAFF_ACL_NAME . ';1';
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
         $cs = new CenterStaffRole();
         $cs->configure($user);
         $actual = $cs->getIdentifier(true);
@@ -31,8 +34,8 @@ class CenterStaffRoleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetIdentifier()
     {
-        $expected = XDUserTest::CENTER_STAFF_ACL_NAME;
-        $user = XDUser::getUserByUserName(XDUserTest::CENTER_STAFF_USER_NAME);
+        $expected = self::CENTER_STAFF_ACL_NAME;
+        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
         $cs = new CenterStaffRole();
         $cs->configure($user);
         $actual = $cs->getIdentifier();
@@ -52,11 +55,11 @@ class CenterStaffRoleTest extends \PHPUnit_Framework_TestCase
     public function testGetActiveCenter()
     {
         $users = array(
-            XDUserTest::CENTER_STAFF_USER_NAME => 1,
-            XDUserTest::CENTER_DIRECTOR_USER_NAME => -1,
-            XDUserTest::PRINCIPAL_INVESTIGATOR_USER_NAME => -1,
-            XDUserTest::NORMAL_USER_USER_NAME => -1,
-            XDUserTest::PUBLIC_USER_NAME => -1
+            self::CENTER_STAFF_USER_NAME => 1,
+            self::CENTER_DIRECTOR_USER_NAME => -1,
+            self::PRINCIPAL_INVESTIGATOR_USER_NAME => -1,
+            self::NORMAL_USER_USER_NAME => -1,
+            self::PUBLIC_USER_NAME => -1
         );
         foreach($users as $userName => $expected) {
             $user = XDUser::getUserByUserName($userName);

--- a/open_xdmod/modules/xdmod/component_tests/lib/SlurmHelperTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/SlurmHelperTest.php
@@ -9,6 +9,7 @@ namespace ComponentTests;
 use CCR\DB;
 
 /**
+ * @group OpenXDMoD
  * Test the xdmod-slurm-helper executable.
  */
 class SlurmHelperTest extends \PHPUnit_Framework_TestCase

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -4,7 +4,6 @@ namespace ComponentTests;
 
 use CCR\DB;
 use CCR\Json;
-use PHPUnit_Framework_Error_Notice;
 use ReflectionClass;
 use User\Roles\CenterDirectorRole;
 use \XDUser;
@@ -15,61 +14,12 @@ use \Exception;
  * modify the isDeveloper function.
  * @group skip
  **/
-class XDUserTest extends \PHPUnit_Framework_TestCase
+class XDUserTest extends BaseTest
 {
 
-    const TEST_ARTIFACT_OUTPUT_PATH = "/../artifacts/xdmod-test-artifacts/xdmod/acls/output";
 
-    const PUBLIC_USER_NAME = 'Public User';
-    const PUBLIC_ACL_NAME = 'pub';
-    const PUBLIC_USER_EXPECTED = '/public_user.json';
-
-    const CENTER_DIRECTOR_USER_NAME = 'centerdirector';
-    const CENTER_DIRECTOR_ACL_NAME = 'cd';
-    const CENTER_DIRECTOR_EXPECTED = '/center_director.json';
-
-    const CENTER_STAFF_USER_NAME = 'centerstaff';
-    const CENTER_STAFF_ACL_NAME = 'cs';
-    const CENTER_STAFF_EXPECTED = '/center_staff.json';
-
-    const PRINCIPAL_INVESTIGATOR_USER_NAME = 'principal';
-    const PRINCIPAL_INVESTIGATOR_ACL_NAME = 'pi';
-    const PRINCIPAL_INVESTIGATOR_EXPECTED = '/principal.json';
-
-    const NORMAL_USER_USER_NAME = 'normaluser';
-    const NORMAL_USER_ACL = 'usr';
-    const NORMAL_USER_EXPECTED = '/normal_user.json';
-
-    const VALID_SERVICE_PROVIDER_ID = 1;
-    const VALID_SERVICE_PROVIDER_NAME = 'screw';
-
-    const INVALID_ID = -999;
-    const INVALID_ACL_NAME = 'babbaganoush';
-
-    const MIN_USERS = 1;
-    const MAX_USERS = 1000;
-    const DEFAULT_TEST_USER_NAME = "test";
-    const DEFAULT_EMAIL_ADDRESS_SUFFIX = "@test.com";
 
     private static $users = array();
-
-    const DEFAULT_TEST_ENVIRONMENT = 'open_xdmod';
-
-    private static $ENV;
-
-    public static function setUpBeforeClass()
-    {
-        self::setupEnvironment();
-    }
-    private static function setupEnvironment()
-    {
-        $testEnvironment = getenv('test_env');
-        if ($testEnvironment !== false) {
-            self::$ENV = $testEnvironment;
-        } else {
-            self::$ENV = self::DEFAULT_TEST_ENVIRONMENT;
-        }
-    }
 
     /**
      * @dataProvider provideGetUserByUserName
@@ -860,39 +810,80 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($roleId);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Notice
-     * @expectedExceptionMessage Undefined offset: 0
-     */
     public function testGetRoleIDForInvalidRole()
     {
-        $user = XDUSer::getUserByUserName(self::CENTER_STAFF_USER_NAME);
-        $reflection = new ReflectionClass($user);
-        $method = $reflection->getMethod('_getRoleID');
-        $method->setAccessible(true);
-        $method->invoke($user, self::INVALID_ACL_NAME);
+        try {
+            $user = XDUSer::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+            $reflection = new ReflectionClass($user);
+            $method = $reflection->getMethod('_getRoleID');
+            $method->setAccessible(true);
+            $result = $method->invoke($user, self::INVALID_ACL_NAME);
+            $this->assertNull($result);
+        } catch (Exception $e) {
+            $expectedMessage = 'Undefined offset: 0';
+            $isCorrectClass = $e instanceof \PHPUnit_Framework_Error_Notice;
+            $message = $e->getMessage();
+
+            $this->assertTrue(
+                $isCorrectClass,
+                "Expected an exception of type [\PHPUnit_Framework_Error_Notice]. Received: [" . get_class($e) . "]"
+            );
+            $this->assertNotFalse(
+                strpos($message, $expectedMessage),
+                "Expected the message to contain [$expectedMessage]. Received: [$message]"
+            );
+        }
+    }
+
+    public function testGetRoleWithNull()
+    {
+        try {
+            $user = XDUSer::getUserByUserName(self::CENTER_STAFF_USER_NAME);
+            $reflection = new ReflectionClass($user);
+            $method = $reflection->getMethod('_getRoleID');
+            $method->setAccessible(true);
+            $result = $method->invoke($user, null);
+            $this->assertNull($result, "Expected [null]. Received [$result]");
+        } catch (Exception $e) {
+            $expectedMessage = 'Undefined offset: 0';
+            $isCorrectClass = $e instanceof \PHPUnit_Framework_Error_Notice;
+            $message = $e->getMessage();
+
+            $this->assertTrue(
+                $isCorrectClass,
+                "Expected an exception of type [\PHPUnit_Framework_Error_Notice]. Received: [" . get_class($e) . "]"
+            );
+            $this->assertNotFalse(
+                strpos($message, $expectedMessage),
+                "Expected the message to contain [$expectedMessage]. Received: [$message]"
+            );
+        }
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error_Notice
-     * @expectedExceptionMessage Undefined offset: 0
+     * @dataProvider provideEnumAllAvailableRoles
+     *
+     * @param string $userName     the name of the user to be tested.
+     * @param string $expectedFile the name of the file that holds the expected
+     *                             results of the test.
      */
-    public function testGetRoleWithNull()
+    public function testEnumAllAvailableRoles($userName, $expectedFile)
     {
-        $user = XDUSer::getUserByUserName(self::CENTER_STAFF_USER_NAME);
-        $reflection = new ReflectionClass($user);
-        $method = $reflection->getMethod('_getRoleID');
-        $method->setAccessible(true);
-        $method->invoke($user, null);
-    }
-
-    public function testCenterDirectorEnumAllAvailableRoles()
-    {
-        $expected = JSON::loadFile($this->getTestFile('center_director_all_available_roles.json'));
-        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
+        $expected = JSON::loadFile($this->getTestFile($expectedFile));
+        $user = XDUser::getUserByUserName($userName);
 
         $allAvailableRoles = $user->enumAllAvailableRoles();
         $this->assertEquals($expected, $allAvailableRoles);
+    }
+
+    public function provideEnumAllAvailableRoles()
+    {
+        return array(
+            array(self::CENTER_DIRECTOR_USER_NAME, 'center_director_all_available_roles.json'),
+            array(self::CENTER_STAFF_USER_NAME, 'center_staff_all_available_roles.json'),
+            array(self::PRINCIPAL_INVESTIGATOR_USER_NAME, 'principal_user_all_available_roles.json'),
+            array(self::NORMAL_USER_USER_NAME, 'normal_user_all_available_roles.json')
+        );
     }
 
     /**
@@ -1424,13 +1415,5 @@ class XDUserTest extends \PHPUnit_Framework_TestCase
             $username = "$username$suffix";
         }
         return $username;
-    }
-
-    public static function getTestFile($fileName)
-    {
-        if (!isset(self::$ENV)){
-            self::setupEnvironment();
-        }
-        return __DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . self::$ENV . DIRECTORY_SEPARATOR . $fileName;
     }
 }

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -491,7 +491,7 @@ class XDUserTest extends BaseTest
         $user = XDUser::getPublicUser();
         $primaryRole = $user->getPrimaryRole();
 
-        $this->assertNull($primaryRole);
+        $this->assertNotNull($primaryRole);
     }
 
     /**
@@ -577,10 +577,7 @@ class XDUserTest extends BaseTest
 
         $actual = $user->getActiveRole()->getIdentifier();
 
-        // NOTE: this isn't actually correct and is corrected in
-        // the xduser_primary_role PR. But, in the interest of getting our tests
-        // to pass this change is necessary.
-        $this->assertEquals(ROLE_ID_USER, $actual);
+        $this->assertEquals(ROLE_ID_MANAGER, $actual);
     }
 
     /**


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updated to use the re-organized test artifacts.
- Also refactored common functionality into a BaseTest and extended where
  appropriate.
- Added a `@group` annotation to the SlurmHelperTest class so that when running
  on an XSEDE system this can be skipped by supplying
  `--exclude-group=OpenXDMoD` to the phpunit command line runner.

## Motivation and Context
Wanted to take advantage of how the test artifacts should ( and are laid out ). Also wanted to add the ability for these tests to be run against both an OpenXDMoD and XSEDE install. 

## Tests performed
Yes?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
