### PR TITLE
update timeouts from 1s to 5s to be more consistient

### DIFF
--- a/open_xdmod/modules/xdmod/automated_tests/webdriverHelpers/waitForAllInvisible.js
+++ b/open_xdmod/modules/xdmod/automated_tests/webdriverHelpers/waitForAllInvisible.js
@@ -2,12 +2,12 @@
  *  Wait for all elements that match a selector to be invisible.
  *
  *  @param {string} selector - elements to check
- *  @param {Number} [ms=1000] - Milliseconds to wait for elements to be invisible
+ *  @param {Number} [ms=5000] - Milliseconds to wait for elements to be invisible
  *
  *  @uses commands/waitForVisible
  */
 
 module.exports = function waitForAllInvisible(selector, ms) {
-    var timeOut = ms || 1000;
+    var timeOut = ms || 5000;
     browser.waitUntil(() => $$(selector).filter(el => el.isVisible()).length === 0, timeOut);
 };

--- a/open_xdmod/modules/xdmod/automated_tests/webdriverHelpers/waitForInvisible.js
+++ b/open_xdmod/modules/xdmod/automated_tests/webdriverHelpers/waitForInvisible.js
@@ -2,12 +2,12 @@
  *  Wait for selector to be invisible
  *
  *  @param {string} selector - element to check
- *  @param {Number} [ms=1000] - Milliseconds to wait for element to be invisible
+ *  @param {Number} [ms=5000] - Milliseconds to wait for element to be invisible
  *
  *  @uses commands/waitForVisible
  */
 
 module.exports = function waitForInvisible(selector, ms) {
-    var timeOut = ms || 1000;
+    var timeOut = ms || 5000;
     return this.waitForVisible(selector, timeOut, true);
 };

--- a/open_xdmod/modules/xdmod/automated_tests/webdriverHelpers/waitForLoadedThenClick.js
+++ b/open_xdmod/modules/xdmod/automated_tests/webdriverHelpers/waitForLoadedThenClick.js
@@ -2,7 +2,7 @@
  *  Wait for loadingMask to not exist and selector to exist then click on selector
  *
  *  @param {string} selector - element to click on
- *  @param {Number} [maskMs=500] - Milliseconds to wait for mask to not exist
+ *  @param {Number} [maskMs=9000] - Milliseconds to wait for mask to not exist
  *
  *  @uses commands/waitForVisible, helpers/waitAndClick
  */


### PR DESCRIPTION
1 second to wait was causing errors in the tests, update the default to be 5 seconds.  This also makes the timeouts a bit more consistent, these are also just defaults.

At some point we should look into the real timings and set better defaults.