### PR TITLE
Metric explorer edit legend item UI improvements

### DIFF
--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -1354,7 +1354,7 @@ Ext.apply(XDMoD.Module.MetricExplorer, {
                             }
                         } : null
                     );
-                    menu.showAt(Ext.EventObject.getXY());
+                    menu.showAt(Ext.get(series.legendItem.element).getXY());
 
                 }
             });
@@ -2465,9 +2465,13 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
         this.saveQuery();
     },
     getTextEditMenu: function(textContent, label, handler, resetButton) {
+        var width = 16;
+        if (textContent.length > width) {
+            width = Math.min(textContent.length, 40);
+        }
         var field = new Ext.form.TextField({
             value: Ext.util.Format.htmlDecode(textContent),
-            width: 200,
+            width: width.toString() + 'em',
             listeners: {
                 specialkey: function(field, e) {
                     if (e.getKey() == e.ENTER) {


### PR DESCRIPTION
- Legend item edit box is now displayed next to the legend
  item that is being edited.
- Text box expands a bit to allow for longer strings to be fully
  visible.
