### PR TITLE
Add 'Select All' button to filter dialog.

### DIFF
--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -4202,6 +4202,10 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
             this.saveQuery();
         }, this);
 
+        this.filtersStore.on('clear', function () {
+            this.saveQuery();
+        }, this);
+
         this.filtersStore.on('update', function(t, record, op) {
             record.commit(true);
             this.saveQuery();


### PR DESCRIPTION
- This change adds a select all button to the filter dialog box. Now that
  a large number of filters can potetially added or removed in one go,
  this change also performance optimizations when large numbers of filters
  change.
- Select all button is grayed out if there are more than 150 filters
  since more that this number has a detrimental performance impact on
  several parts of the XDMoD UI (the database seems to cope fine though).

