### PR TITLE
Pinned automated test dependency

### DIFF
--- a/open_xdmod/modules/xdmod/automated_tests/package.json
+++ b/open_xdmod/modules/xdmod/automated_tests/package.json
@@ -21,7 +21,7 @@
     "require-dir": "^0.3.2",
     "selenium-standalone": "^6.11.0",
     "semver": "^5.4.1",
-    "wdio-chromedriver-service": "^0.1.1",
+    "wdio-chromedriver-service": "0.1.1",
     "wdio-junit-reporter": "^0.3.1",
     "wdio-mocha-framework": "^0.5.11",
     "wdio-sauce-service": "^0.4.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When pulling in the automated test dependencies on shippable,  the 'wdio-cromedriver-service' has been updated to '0.1.2' which breaks the automated tests.

## Motivation and Context
Fix the automated tests by pinning the version of wdio-chromedriver-service to one that we know works

## Tests performed
manual tests: 
tested the update in another branch that was run through shippable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
