### PR TITLE
Improve error message when start_day_id and/or end_day_id not present

### DIFF
--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -543,8 +543,11 @@ class pdoAggregator extends aAggregator
                 }
 
                 if ( 0 != count($missing) ) {
-                    $msg = "Table '$tableName' missing required field: (" . implode(", ", $missing) . ")";
-                    $this->logAndThrowException($msg);
+                    $this->logAndThrowException(sprintf(
+                        "Table to be aggregated '%s' missing required fields and conversion has not been specified: (%s)",
+                        $tableName,
+                        implode(", ", $missing)
+                    ));
                 }
             }
 


### PR DESCRIPTION
## Description

Improve logging message when start_day_id and/or end_day_id are not specified for the source aggregation table.

## Motivation and Context

Improved troubleshooting

## Tests performed

Yes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
