### PR TITLE
Improve the performance of the Utilization stats

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/Statistics/NodeUtilizationStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/NodeUtilizationStatistic.php
@@ -44,9 +44,9 @@ class NodeUtilizationStatistic extends \DataWarehouse\Query\Jobs\Statistic
                                 modw.resource_allocated ra,
                                 modw.days inner_days
                             WHERE
-                                    inner_days.day_middle_ts BETWEEN ra.start_date_ts AND COALESCE(ra.end_date_ts, 2147483647)
-                                AND inner_days.day_middle_ts BETWEEN rs.start_date_ts AND COALESCE(rs.end_date_ts, 2147483647)
-                                AND inner_days.day_middle_ts BETWEEN $date_table_start_ts AND $date_table_end_ts
+                                    inner_days.id BETWEEN YEAR(FROM_UNIXTIME(ra.start_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(ra.start_date_ts)) AND COALESCE(YEAR(FROM_UNIXTIME(ra.end_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(ra.end_date_ts)), 999999999)
+                                AND inner_days.id BETWEEN YEAR(FROM_UNIXTIME(rs.start_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(rs.start_date_ts)) AND COALESCE(YEAR(FROM_UNIXTIME(rs.end_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(rs.end_date_ts)), 999999999)
+                                AND inner_days.id BETWEEN YEAR(FROM_UNIXTIME($date_table_start_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME($date_table_start_ts)) AND YEAR(FROM_UNIXTIME($date_table_end_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME($date_table_end_ts))
                                 AND ra.resource_id = rs.resource_id
                                 AND FIND_IN_SET(
                                         rs.resource_id,

--- a/classes/DataWarehouse/Query/Jobs/Statistics/UtilizationStatistic.php
+++ b/classes/DataWarehouse/Query/Jobs/Statistics/UtilizationStatistic.php
@@ -45,9 +45,9 @@ class UtilizationStatistic extends \DataWarehouse\Query\Jobs\Statistic
                                  modw.resource_allocated ra,
                                  modw.days inner_days
                             WHERE
-                                inner_days.day_middle_ts BETWEEN ra.start_date_ts AND coalesce(ra.end_date_ts, 2147483647) AND
-                                inner_days.day_middle_ts BETWEEN rs.start_date_ts AND coalesce(rs.end_date_ts, 2147483647) AND
-                                inner_days.day_middle_ts BETWEEN $date_table_start_ts AND $date_table_end_ts AND
+                                inner_days.id BETWEEN YEAR(FROM_UNIXTIME(ra.start_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(ra.start_date_ts)) AND COALESCE(YEAR(FROM_UNIXTIME(ra.end_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(ra.end_date_ts)), 999999999) AND
+                                inner_days.id BETWEEN YEAR(FROM_UNIXTIME(rs.start_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(rs.start_date_ts)) AND COALESCE(YEAR(FROM_UNIXTIME(rs.end_date_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME(rs.end_date_ts)), 999999999) AND
+                                inner_days.id BETWEEN YEAR(FROM_UNIXTIME($date_table_start_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME($date_table_start_ts)) AND YEAR(FROM_UNIXTIME($date_table_end_ts)) * 100000 + DAYOFYEAR(FROM_UNIXTIME($date_table_end_ts)) AND
                                 ra.resource_id = rs.resource_id
                                 AND FIND_IN_SET(
                                     rs.resource_id,


### PR DESCRIPTION
- The utlization statistic takes an eye-watering large amount of time to
  run (130s) to generate 30 days of data. This new query returns the
  identical results but runs in ~700 ms.
- Also skip running the aggregate query when group by is none.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
