### PR TITLE
make the regression test names actually be unique

### DIFF
--- a/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
@@ -165,7 +165,7 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
                 if (file_exists($expectedFile) ) {
                     $testCase[2] = file_get_contents($expectedFile);
                 }
-                $testData[$testName] = $testCase;
+                $testData[$testName. '-' . $k . '-' . (empty($envUserrole) ? 'public' : $envUserrole)] = $testCase;
             }
         }
         if(empty($testData)){


### PR DESCRIPTION
making the test set have a name caused it to not be unique cause I forgot some parts of the name, this fixes it.