### PR TITLE
Update php-sql-parser to newer release that does not autoload itself

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
         "silex/silex": "~1.2",
         "simplesamlphp/simplesamlphp": "~1.14",
         "openid/php-openid": "dev-master#ee669c6a9d4d95b58ecd9b6945627276807694fb",
-        "greenlion/php-sql-parser": "~4.0.0",
+        "greenlion/php-sql-parser": "~4.1.0",
         "justinrainbow/json-schema": "~2.0",
         "symfony/process": "~2.0",
         "sencha/extjs-gpl": "3.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "984c7bb4609112f3b26def3c12f7972e",
+    "content-hash": "73644a4f0f9a6af324b257209fb19b0f",
     "packages": [
+        {
+            "name": "analog/analog",
+            "version": "1.0.10-stable",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jbroadway/analog.git",
+                "reference": "65dce6b5aff8c77307c783e607c04a35df8259d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jbroadway/analog/zipball/65dce6b5aff8c77307c783e607c04a35df8259d6",
+                "reference": "65dce6b5aff8c77307c783e607c04a35df8259d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "psr/log": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Analog": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Johnny Broadway",
+                    "email": "johnny@johnnybroadway.com",
+                    "homepage": "http://www.johnnybroadway.com/"
+                }
+            ],
+            "description": "PHP logging class that can be extended via closures. Includes several pre-built handlers including file, mail, syslog, HTTP post, and MongoDB.",
+            "homepage": "https://github.com/jbroadway/analog",
+            "keywords": [
+                "alerts",
+                "debug",
+                "debugging",
+                "error",
+                "log",
+                "logger",
+                "logging",
+                "syslog"
+            ],
+            "time": "2017-09-17T02:30:30+00:00"
+        },
         {
             "name": "apache/commons-beanutils",
             "version": "1.8.0",
@@ -420,31 +469,31 @@
         },
         {
             "name": "greenlion/php-sql-parser",
-            "version": "v4.0.0",
+            "version": "v4.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/greenlion/PHP-SQL-Parser.git",
-                "reference": "c162c6458ee21cc0a7dfe73a3eec303e5c9a6945"
+                "reference": "b4e8522ebca3e5c8bbd4e2c25edaef155a96db20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/greenlion/PHP-SQL-Parser/zipball/c162c6458ee21cc0a7dfe73a3eec303e5c9a6945",
-                "reference": "c162c6458ee21cc0a7dfe73a3eec303e5c9a6945",
+                "url": "https://api.github.com/repos/greenlion/PHP-SQL-Parser/zipball/b4e8522ebca3e5c8bbd4e2c25edaef155a96db20",
+                "reference": "b4e8522ebca3e5c8bbd4e2c25edaef155a96db20",
                 "shasum": ""
             },
             "require": {
+                "analog/analog": "^1.0.6",
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=4.0.14",
-                "squizlabs/php_codesniffer": ">=1.5.1"
+                "phpunit/phpunit": "^4.0.14",
+                "squizlabs/php_codesniffer": "^1.5.1"
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "src/PHPSQLParser/PHPSQLCreator.php",
-                    "src/PHPSQLParser/PHPSQLParser.php"
-                ]
+                "psr-0": {
+                    "PHPSQLParser\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -465,14 +514,14 @@
                 }
             ],
             "description": "A pure PHP SQL (non validating) parser w/ focus on MySQL dialect of SQL",
-            "homepage": "http://code.google.com/p/php-sql-parser/",
+            "homepage": "https://github.com/greenlion/PHP-SQL-Parser",
             "keywords": [
                 "creator",
                 "mysql",
                 "parser",
                 "sql"
             ],
-            "time": "2014-04-16T10:03:29+00:00"
+            "time": "2017-05-16T21:20:45+00:00"
         },
         {
             "name": "highsoft/highcharts",


### PR DESCRIPTION
## Description
profiling the code showed that ~10% of the time of every call the the webserver was spent loading the php-sql-parser library (which is not even used by the webserver code!).

## Tests performed
Ran regression tests with timing and compared the old code with the new code:

![image](https://user-images.githubusercontent.com/5342179/35065679-ee745b2a-fb9b-11e7-99e9-998927d9d0b3.png)

you get a 10% performance improvement.