### PR TITLE
Update to ensure that only one AdminPanel is utilized

### DIFF
--- a/html/internal_dashboard/js/AccountRequests.js
+++ b/html/internal_dashboard/js/AccountRequests.js
@@ -5,8 +5,6 @@ XDMoD.AccountRequests = Ext.extend(Ext.Panel, {
         var self = this;
         var cachedMD5 = '';
 
-        var adminPanel = new XDMoD.AdminPanel();
-
         self.storeProvider = new DashboardStore({
             url: 'controllers/controller.php',
             root: 'response',
@@ -279,7 +277,7 @@ XDMoD.AccountRequests = Ext.extend(Ext.Panel, {
                         text: 'Initialize New User Dialog',
                         disabled: true,
                         handler: function () {
-                            adminPanel.initNewUser({
+                            self.adminPanel.initNewUser({
                                 user_data: self.userGrid.getSelectionModel().getSelected().data,
                                 callback: reloadAccountRequests
                             });
@@ -363,7 +361,7 @@ XDMoD.AccountRequests = Ext.extend(Ext.Panel, {
                                 iconCls: 'btn_group',
                                 id: 'about_button',
                                 handler: function () {
-                                    adminPanel.showPanel({
+                                    self.adminPanel.showPanel({
                                         doListReload: false,
                                         callback: function () {
                                             current_users.reloadUserList();

--- a/html/internal_dashboard/js/CurrentUsers.js
+++ b/html/internal_dashboard/js/CurrentUsers.js
@@ -15,8 +15,6 @@ XDMoD.CurrentUsers = Ext.extend(Ext.Panel,  {
       };
 
       var emptyTextContainer = Ext.id();
-      
-      var adminPanel = new XDMoD.AdminPanel();
 
       // --------------------------------
 
@@ -64,13 +62,13 @@ XDMoD.CurrentUsers = Ext.extend(Ext.Panel,  {
 
          current_state[type] = value;
 
-         current_users.storeProvider.reload({
-            params: {
-               'group_filter' : current_state.group,
-               'role_filter': current_state.role,
-               'context_filter' : current_state.context
-            }
-         });
+          self.storeProvider.reload({
+              params: {
+                  group_filter: current_state.group,
+                  role_filter: current_state.role,
+                  context_filter: current_state.context
+              }
+          });
 
       };//adjustUserListView
 
@@ -316,12 +314,12 @@ XDMoD.CurrentUsers = Ext.extend(Ext.Panel,  {
 
       existingUserGrid.on('rowdblclick', function(grid, ri, e) {
 
-         adminPanel.loadExistingUser({
+          self.adminPanel.loadExistingUser({
 
-            user_data: grid.getSelectionModel().getSelected().data,
-            callback: reloadUserList
+              user_data: grid.getSelectionModel().getSelected().data,
+              callback: reloadUserList
 
-         });
+          });
 
       });//self.userGrid.on('rowdblclick', ...
 
@@ -419,12 +417,12 @@ XDMoD.CurrentUsers = Ext.extend(Ext.Panel,  {
                         iconCls: 'btn_group',
                         id: 'about_button',
                         handler: function () {
-                           adminPanel.showPanel({
-                              doListReload: true,
-                              callback: function () {
-                                 current_users.reloadUserList();
-                              }
-                           });
+                            self.adminPanel.showPanel({
+                                doListReload: true,
+                                callback: function () {
+                                    self.reloadUserList();
+                                }
+                            });
                         },
                         scope: this
                      }

--- a/html/internal_dashboard/js/UserManagement/Panel.js
+++ b/html/internal_dashboard/js/UserManagement/Panel.js
@@ -25,9 +25,13 @@ XDMoD.UserManagement.Panel = Ext.extend(Ext.TabPanel, {
     initialize: function(tabPanel) {
         // Don't create the tab components until the tab is activated. Otherwise, the stores get
         // loaded sending several potentially unused rest requests.
-        
-        current_users = new XDMoD.CurrentUsers();
-        var account_requests = new XDMoD.AccountRequests();
+        var adminPanel = new XDMoD.AdminPanel();
+        var current_users = new XDMoD.CurrentUsers({
+            adminPanel: adminPanel
+        });
+        var account_requests = new XDMoD.AccountRequests({
+            adminPanel: adminPanel
+        });
         var user_stats = new XDMoD.UserStats();
         
         tabPanel.add(account_requests);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Previously both 'Account Requests' and 'Existing Users' would create their own
  instances of `XDMoD.AdminPanel`. This caused issues as there were `id`
  properties being set in 'AdminPanel' which, since there were two sets of dom
  trees, were not unique.
- This creates one instance of `XDMoD.AdminPanel` and passes it to CurrentUsers
  / AccountRequests for them to use.

## Motivation and Context
Would like the 'Status' to update regardless of which 'Create & Manage Users' button you click on which tab in what order. 

## Tests performed
Manual Tests: 

**Test 1:**
- Login to the Internal Dashboard
- Navigate to 'User Management' -> 'XDMoD Account Requests'
- Click 'Create & Manage Users'
- Select the 'Current Users' Tab
- Click on a few users in the default group ( 'Demo Users' ).
  - Ensure that the 'Status' is displayed / correct.
- Select the 'Internal Users' group
- Click on a few users and ensure that the'Status' is displayed correctly.
- Click 'Close'
- Click 'Create & Manage Users'
- Click around on a few more users and ensure that the 'Status' is displayed correctly.

**Test 2:**
- Login to the Internal Dashboard
- Navigate to 'User Management' -> 'Existing Users' ->
- Click 'Create & Manage Users'
- Select the 'Current Users' Tab
- Click on a few users in the default group ( 'Demo Users' ).
  - Ensure that the 'Status' displayed is correct
- Select the 'Internal Users' group
- Click on a few users and ensure that the 'Status' is displayed correctly.
- Click 'Close'
- Click 'Create & Manage Users'
- Click around on a few more users and ensure that the 'Status' is displayed correctly.

**Test 3:**
- Login to the Internal Dashboard
- Navigate to 'User Management' -> 'Existing Users'
- Double click on an existing User account
- Ensure that:
  - the 'User Management' modal has popped up
  - that the user you double clicked is selected
  - that the 'Status' is displayed correctly.
- Click on a few more users in the 'User Management' Modal
- Ensure that the 'Status' is displayed correctly

**Test 4:**
- Login to the Internal Dashboard
- Navigate to the 'User Management' -> 'XDMoD Account Requests' Tab
- Click the 'Create & Manage Users' button
- Select the 'Existing Users' tab
- Select a user
- Ensure that the 'Status' is displayed
- Navigate to the 'User Management' -> 'Existing Users' Tab
- Click the 'Create & Manage Users' button
- Select the 'Existing Users' tab if it is not already selected
- Click on a user
- Ensure that the 'Status' is visible and correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
