### PR TITLE
Updating default log level for acl-config

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -27,7 +27,7 @@ $opts = array(
 );
 
 $dryRun = false;
-$logLevel = Log::NOTICE;
+$logLevel = Log::ERR;
 
 try {
     $options = getopt(implode('', array_keys($opts)), array_values($opts));


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Changed the default log level to be `ERR` so that the script runs silent by
  default.

## Motivation and Context
We should only see log entries on error.

## Tests performed
Manual Tests: 

**Test 1:**
- Logged into xdmod-dev
- Manually updated the default log level of acl-config
- ran acl-config 
- noted that there was no output to stdout

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
