### PR TITLE
Etl/remove warning

### DIFF
--- a/classes/ETL/aAction.php
+++ b/classes/ETL/aAction.php
@@ -368,15 +368,19 @@ abstract class aAction extends aEtlObject
         // Set the default time zone and make it available as a variable
         $this->variableMap['TIMEZONE'] = date_default_timezone_get();
 
-        // Make the ETL log email available to actions as a macro
+        // Make the ETL log email available to actions as a macro. If it is not available use
+        // the the debug email instead.
 
         try {
             $section = \xd_utilities\getConfigurationSection("general");
-            if ( array_key_exists("dw_etl_log_recipient", $section) ) {
+            if ( array_key_exists('dw_etl_log_recipient', $section) && ! empty($section['dw_etl_log_recipient']) ) {
                 $this->variableMap['DW_ETL_LOG_RECIPIENT'] = $section['dw_etl_log_recipient'];
+            } elseif ( array_key_exists('debug_recipient', $section) && ! empty($section['debug_recipient']) ) {
+                $this->variableMap['DW_ETL_LOG_RECIPIENT'] = $section['debug_recipient'];
             } else {
-                $msg = "XDMoD configuration option general.dw_etl_log_recipient is not set";
-                $this->logger->warning($msg);
+                $this->logger->warning(
+                    "Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty."
+                );
             }
         } catch (\Exception $e) {
             $msg = "'general' section not defined in XDMoD configuration";


### PR DESCRIPTION
## Description

ETLv2 makes the configuration option general.dw_etl_log_recipient available as a macro for sending email when verification actions fail. This is not defined in the Open XDMoD portal_settings.ini file, so rather than issue a warning default to the value of general.debug_recipient if it is not set. If neither are set (or they are both empty) issue a warning.

## Motivation and Context

Removing unnecessary warning message in Open XDMoD.

## Tests performed

Tested with various combinations of dw_etl_log_recipient and debug_recipient in portal_settings.ini.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
