### PR TITLE
User's acls were being cleared on save

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -687,9 +687,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
         };
 
         self.resetDirtyState = function () {
-            settingsAreDirty = false;
-            roleGrid.updateDirtyState();
-            roleGrid.reset();
+            roleGrid.setDirtyState(false);
         };
 
         // ------------------------------------------


### PR DESCRIPTION
## Description
After updating a users acls, the acl display would be cleared, thus no longer showing the selected users acls. 

## Motivation and Context
A users acls should be displayed after changes are saved. 

## Tests performed
Manual Tests: 
**Test 1:**
- Login to the internal dashboard
- Select 'User Management' -> 'Existing Users'
- Select a user that has more than one acl
- Remove an acl from that user
- Save changes
- Expected: 
  - The current acls for the user are displayed. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
