### PR TITLE
Reverting txtAccountStatus to utilize Ext

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -1090,20 +1090,20 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                         '<p>' + json.user_information.time_updated + '</p>'
                     );
 
-                    var txtAccountStatus = document.getElementById('txtAccountStatus');
-                    txtAccountStatus.innerText = json.user_information.is_active;
+                    var txtAccountStatus = Ext.getCmp('txtAccountStatus');
+                    txtAccountStatus.setText(json.user_information.is_active);
 
                     if (json.user_information.is_active == 'active') {
                         Ext.getCmp('disableAccountMenuItem').show();
                         Ext.getCmp('enableAccountMenuItem').hide();
-                        txtAccountStatus.classList.remove('admin_panel_user_user_status_disabled');
-                        txtAccountStatus.classList.add('admin_panel_user_user_status_active');
+                        txtAccountStatus.removeClass('admin_panel_user_user_status_disabled');
+                        txtAccountStatus.addClass('admin_panel_user_user_status_active');
                     }
                     else {
                         Ext.getCmp('enableAccountMenuItem').show();
                         Ext.getCmp('disableAccountMenuItem').hide();
-                        txtAccountStatus.classList.remove('admin_panel_user_user_status_active');
-                        txtAccountStatus.classList.add('admin_panel_user_user_status_disabled');
+                        txtAccountStatus.removeClass('admin_panel_user_user_status_active');
+                        txtAccountStatus.addClass('admin_panel_user_user_status_disabled');
                     }
 
                     if (reset_controls) {


### PR DESCRIPTION
## Description
- Prior to PR: https://github.com/ubccr/xdmod/pull/373 there were two instances
  of `SectionExistingUsers` which did not play well with `Ext.getCmp()`. Now
  that we have made it so that there's only one instance of
  `SectionExistingUsers` we can revert from using `document.getElementById` to
  using `Ext.getCmp()`.
- This also resolves status display / coloring for IE !Edge

## Motivation and Context
It's nice to be able to use your js framework. Also, IE !Edge compatability.

## Tests performed
Manual Tests: 

**Test 1:**
- Login to Internal Dashboard
- Select 'User Management' -> 'Existing Users'
- Double click an existing user ( not your currently logged in user )
- Ensure that the 'status' is displayed / colored appropriately.
- Toggle the users 'Status' ( Enable / Disable user )
- Ensure that the change in status is reflected in the UI 
- force refresh
- Edit that user again
- Verify that the status is displayed properly.
- Toggle the users 'Status' once again ( back to it's original status )
- Verify that the status is displayed properly. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
