### PR TITLE
Fix incorrect data filtering

### DIFF
--- a/classes/DataWarehouse/Data/SimpleTimeseriesDataset.php
+++ b/classes/DataWarehouse/Data/SimpleTimeseriesDataset.php
@@ -300,7 +300,7 @@ class SimpleTimeseriesDataset extends SimpleDataset
 
         // we only return a count here, so remove this unneeded order by:
         $agg_query->clearOrders();
-        $agg_query->setParameters($this->_query->parameters);
+        $agg_query->cloneParameters($this->_query);
 
         return $agg_query->getCount();
     } // getUniqueCount
@@ -373,7 +373,7 @@ class SimpleTimeseriesDataset extends SimpleDataset
             }
         }
 
-        $agg_query->setParameters($this->_query->parameters);
+        $agg_query->cloneParameters($this->_query);
 
         $dataObject = new \DataWarehouse\Data\SimpleTimeseriesData($column_name);
 
@@ -775,7 +775,7 @@ class SimpleTimeseriesDataset extends SimpleDataset
         }
 
         // if we have additional parameters:
-        $q->setParameters($this->_query->parameters);
+        $q->cloneParameters($this->_query);
 
         // group on the where clause column, which will be enforced after time agg. unit
         $q->addGroupBy($where_name);

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -761,7 +761,7 @@ class Query
      * The where conditions and role parameters from the other class will
      * overwrite any existing settings in this class.
      */
-    public function cloneParameters($other)
+    public function cloneParameters(Query $other)
     {
         $this->_where_conditions = $other->_where_conditions;
         $this->parameters = $other->parameters;

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -756,6 +756,21 @@ class Query
         }
     }
 
+    /**
+     * Copy the parameters and role parameters from another query class
+     * The where conditions and role parameters from the other class will
+     * overwrite any existing settings in this class.
+     */
+    public function cloneParameters($other)
+    {
+        $this->_where_conditions = $other->_where_conditions;
+        $this->parameters = $other->parameters;
+        $this->restrictedByRoles = $other->restrictedByRoles;
+        $this->roleRestrictions = $other->roleRestrictions;
+        $this->roleParameters = $other->roleParameters;
+        $this->roleParameterDescriptions = $other->roleParameterDescriptions;
+    }
+
     private function getLeftJoinSql()
     {
         $stmt = '';

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
@@ -383,4 +383,83 @@ EOF;
 
         $this->assertEmpty($realmCategoryDiff, "There were realms in datawarehouse.json that were not returned by get_menus.");
     }
+
+    /**
+     * @dataProvider dataFilteringProvider
+     * @group DataAccess
+     */
+    public function testDataFiltering($user, $chartSettings, $expectedNames)
+    {
+        $this->helper->authenticate($user);
+
+        $response = $this->helper->post('/controllers/user_interface.php', null, $chartSettings);
+
+        $this->assertEquals($response[1]['http_code'], 200);
+
+        $plotdata = json_decode(\TestHarness\UsageExplorerHelper::demanglePlotData($response[0]), true);
+
+        $this->assertTrue($plotdata['success']);
+
+        $this->assertCount(count($expectedNames), $plotdata['data'][0]['hc_jsonstore']['series']);
+
+        foreach($plotdata['data'][0]['hc_jsonstore']['series'] as $seriesIdx => $seriesData) {
+            $this->assertEquals(($seriesIdx + 1) . '. ' . $expectedNames[$seriesIdx] . '*', $seriesData['name']);
+        }
+    }
+
+    /**
+     */
+    public function dataFilteringProvider()
+    {
+        $tests = array();
+
+        $chartSettings = array(
+            'public_user' => 'false',
+            'realm' => 'Jobs',
+            'group_by' => 'username',
+            'statistic' => 'running_job_count',
+            'start_date' => '2016-12-22',
+            'end_date' => '2017-01-01',
+            'timeframe_label' => 'User Defined',
+            'scale' => '1',
+            'aggregation_unit' => 'Auto',
+            'dataset_type' => 'timeseries',
+            'thumbnail' => 'n',
+            'query_group' => 'tg_usage',
+            'display_type' => 'line',
+            'combine_type' => 'stack',
+            'limit' => '10',
+            'offset' => '0',
+            'log_scale' => 'n',
+            'show_guide_lines' => 'y',
+            'show_trend_line' => 'n',
+            'show_error_bars' => 'n',
+            'show_aggregate_labels' => 'n',
+            'show_error_labels' => 'n',
+            'hide_tooltip' => 'false',
+            'show_title' => 'y',
+            'width' => '1529',
+            'height' => '706',
+            'legend_type' => 'bottom_center',
+            'font_size' => '3',
+            'interactive_elements' => 'y',
+            'operation' => 'get_charts',
+            'controller_module' => 'user_interface'
+        );
+
+        $expectedNames = array('swath', 'savsp', 'ovenb', 'ybsbu', 'litst', 'sante');
+
+        $tests[] = array('pi', $chartSettings, $expectedNames);
+
+        $chartSettings['limit'] = 2;
+
+        $expectedNames = array('swath', 'savsp', 'Avg of 4 Others');
+        $tests[] = array('pi', $chartSettings, $expectedNames);
+
+        $chartSettings['limit'] = 10;
+        $expectedNames = array('whimb');
+        $tests[] = array('usr', $chartSettings, $expectedNames);
+
+        return $tests;
+    }
 }


### PR DESCRIPTION
Fixes issue with data filtering when an unpriv user tries to view
timeseries data for a realm / stat that is protected (i.e. has
additional role-specific filters applied).

Added integration test that confirms the correct behaviour.
