### PR TITLE
Make show_guide lines button work again.

### DIFF
--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -647,6 +647,9 @@ class Usage extends Common
                         unset($meChart['yAxis'][0]['gridLineDashStyle']);
                         unset($meChart['yAxis'][0]['gridLineColor']);
                     }
+                    if ($usageChartSettings['show_guide_lines'] === 'n') {
+                        $meChart['yAxis'][0]['gridLineWidth'] = 0;
+                    }
                 }
 
                 // If there are x-axis categories, they are sorted by value,


### PR DESCRIPTION
This bug was introduced many years ago when the Usage Explorer was
change to use the ME backend. It has been reported many times since then
too:

https://app.asana.com/0/39210960934587/141779761478379
https://app.asana.com/0/159049597309611/72083170607090
https://app.asana.com/0/16817869275975/101854225421037

Once the regression tests pull request #378 is merged then I'll update
this with the extra regression tests to demonstrate the guide lines
selection working correctly.

