### PR TITLE
enabling / disabling a user cleared acls

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -451,7 +451,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
 
                         if (objParams.operation == 'update_user') {
                             self.userStoreLoadReset = false;
-                            fetchUserDetails(objParams.uid, false);
+                            fetchUserDetails(objParams.uid, true);
                         }
 
                         // Refresh the user list based on the

--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -451,6 +451,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
 
                         if (objParams.operation == 'update_user') {
                             self.userStoreLoadReset = false;
+                            // eslint-disable-next-line no-use-before-define
                             fetchUserDetails(objParams.uid, true);
                         }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- This calling of fetchUserDetails specified to not 'reset_controls' which meant
  that the controls were cleared but never set. Updating this to
  'reset_controls' to true means that they will be reset w/ the current values.

## Motivation and Context
Enabling / Disabling a user should not clear their acls.

## Tests performed
Manual Test:

**Test1:**
- Login to the Internal Dashboard
- Select 'User Management' -> "Existing Users"
- Double click a user to modify
- Select 'Disable Account' from the 'Actions' drop down
- Ensure that the acls are displayed as they were prior to disabling.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
