### PR TITLE
Should not be able to change a non-federated user to a federated user.

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -215,7 +215,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                 load: function (store, records) {
                     for (var i = 0; i < records.length; i++) {
                         var record = records[i];
-                        if (record.data.id === CCR.xdmod.FEDERATED_USER_TYPE) {
+                        if (parseInt(record.data.id) === CCR.xdmod.FEDERATED_USER_TYPE) {
                             store.remove(record);
                         }
                     }

--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -215,7 +215,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                 load: function (store, records) {
                     for (var i = 0; i < records.length; i++) {
                         var record = records[i];
-                        if (parseInt(record.data.id) === CCR.xdmod.FEDERATED_USER_TYPE) {
+                        if (parseInt(record.data.id, 10) === CCR.xdmod.FEDERATED_USER_TYPE) {
                             store.remove(record);
                         }
                     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- record.data.id is a string while the FEDERATED_USER_TYPE is an int.

## Motivation and Context
If a user can't change their type once they are 'Federated' then we should not allow users to be manually changed to 'Federated'.

## Tests performed
Manual tests:

**Test 1:**
- Login to Internal Dashboard
- Select 'User Management' -> 'Existing Users'
- Double click a user
- Click the 'User Type' drop down
- Ensure that there is no 'Federated' available

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
