### PR TITLE
Provide default center

### DIFF
--- a/html/controllers/user_admin/create_user.php
+++ b/html/controllers/user_admin/create_user.php
@@ -90,21 +90,6 @@ try {
                 $count += 1;
             }
             $newuser->setOrganizations($centerConfig, $acl);
-        } elseif (in_array($acl, array('cd', 'cs'))) {
-            // This block pertains to OpenXDMoD. Specifically, no centers are
-            // returned with acls in OpenXDMOD as there is only one to choose
-            // from. So we catch that use case here and provide the one center
-            // for 'center' related acls.
-            $currentCenters = Centers::getCenters();
-            if (count($currentCenters) > 0) {
-                $center = $currentCenters[0]['id'];
-                $newuser->setOrganizations(
-                    array(
-                        $center => array('primary' => 1, 'active' => 1)
-                    ),
-                    $acl
-                );
-            }
         }
     }
     // =============================

--- a/html/controllers/user_admin/enum_roles.php
+++ b/html/controllers/user_admin/enum_roles.php
@@ -17,13 +17,15 @@ foreach($roles as $currentRole) {
     // requiresCenter can only be true iff the current install supports
     // multiple service providers.
     if ($currentRole['name'] !== 'pub') {
-        $requiresCenter = $currentRole['requires_center'] && $multipleServiceProviders;
+        $requiresCenters = $currentRole['requires_center'];
+        $displayCenters = $requiresCenters && $multipleServiceProviders;
         $roleEntries[] = array(
             'acl' => $currentRole['display'],
             'acl_id' => $currentRole['name'],
             'include' => false,
             'primary' => false,
-            'requires_center' => $requiresCenter
+            'displays_center' => $displayCenters,
+            'requires_center' => $requiresCenters
         );
     }
 }//foreach

--- a/html/controllers/user_admin/enum_roles.php
+++ b/html/controllers/user_admin/enum_roles.php
@@ -24,8 +24,8 @@ foreach($roles as $currentRole) {
             'acl_id' => $currentRole['name'],
             'include' => false,
             'primary' => false,
-            'displays_center' => $displayCenters,
-            'requires_center' => $requiresCenters
+            'displays_center' => (bool) $displayCenters,
+            'requires_center' => (bool) $requiresCenters
         );
     }
 }//foreach

--- a/html/controllers/user_admin/update_user.php
+++ b/html/controllers/user_admin/update_user.php
@@ -174,19 +174,7 @@ try {
     if (!isset($_POST['is_active'])) {
         if (isset($_POST['acls']) && isset($acls)) {
             foreach ($acls as $aclName => $centers) {
-                // This block pertains to OpenXDMoD. Specifically, no centers are
-                // returned with acls in OpenXDMOD as there is only one to choose
-                // from. So we catch that use case here and provide the one center
-                // for 'center' related acls.
-                if (count($centers) === 0) {
-                    $currentCenters = Centers::getCenters();
-                    if (count($currentCenters) > 0) {
-                        $centers[$aclName] = $currentCenters[0]['id'];
-                    }
-                }
-                // Make sure to set organizations if there are any. But only for
-                // center related acls.
-                if (in_array($aclName, array('cd', 'cs')) && count($centers) > 0) {
+                if ( count($centers) > 0) {
                     $centerConfig = array();
                     $count = 0;
                     foreach ($centers as $center) {

--- a/html/internal_dashboard/index.php
+++ b/html/internal_dashboard/index.php
@@ -210,15 +210,20 @@ if (isset($_POST['direct_to'])) {
 
   <?php echo \OpenXdmod\Assets::generateAssetTags('internal_dashboard'); ?>
 
-  <script type="text/javascript">
-  <?php
-  $features = xd_utilities\getConfigurationSection('features');
-  // Convert array values to boolean
-  array_walk($features, function(&$v) { $v = ($v == 'on'); } );
+    <script type="text/javascript">
+    <?php
+    $features = xd_utilities\getConfigurationSection('features');
+    // Convert array values to boolean
+    array_walk(
+        $features,
+        function (&$v) {
+            $v = ($v == 'on');
+        }
+    );
 
-  print "CCR.xdmod.features = ".json_encode($features).";\n";
-  ?>
-  </script>
+    print "CCR.xdmod.features = ".json_encode($features).";\n";
+    ?>
+    </script>
 
   <script type="text/javascript" src="js/dashboard.js"></script>
 

--- a/html/internal_dashboard/index.php
+++ b/html/internal_dashboard/index.php
@@ -210,6 +210,16 @@ if (isset($_POST['direct_to'])) {
 
   <?php echo \OpenXdmod\Assets::generateAssetTags('internal_dashboard'); ?>
 
+  <script type="text/javascript">
+  <?php
+  $features = xd_utilities\getConfigurationSection('features');
+  // Convert array values to boolean
+  array_walk($features, function(&$v) { $v = ($v == 'on'); } );
+
+  print "CCR.xdmod.features = ".json_encode($features).";\n";
+  ?>
+  </script>
+
   <script type="text/javascript" src="js/dashboard.js"></script>
 
   <?php /* App Kernel code. */ ?>

--- a/html/internal_dashboard/js/admin_panel/AclGrid.js
+++ b/html/internal_dashboard/js/admin_panel/AclGrid.js
@@ -164,7 +164,10 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
         // the default service provider.
         if (CCR.xdmod.features.multiple_service_providers === false) {
             Ext.Ajax.request({
-                url: '/controllers/user_admin/enum_resource_providers.php',
+                url: '../controllers/user_admin.php',
+                params: {
+                    operation: 'enum_resource_providers'
+                },
                 callback: function (options, success, response) {
                     var json;
                     if (success) {

--- a/html/internal_dashboard/js/admin_panel/AclGrid.js
+++ b/html/internal_dashboard/js/admin_panel/AclGrid.js
@@ -172,6 +172,7 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
                     var json;
                     if (success) {
                         json = CCR.safelyDecodeJSONResponse(response);
+                        // eslint-disable-next-line no-param-reassign
                         success = CCR.checkDecodedJSONResponseSuccess(json);
                     }
 

--- a/html/internal_dashboard/js/admin_panel/AclGrid.js
+++ b/html/internal_dashboard/js/admin_panel/AclGrid.js
@@ -53,7 +53,7 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
             renderer: function (val, metaData, record, rowIndex, colIndex, store) {
                 var data = store.getAt(rowIndex).data;
 
-                if (data.requires_center === true) {
+                if (data.displays_center === true) {
                     return '<div style="text-align:center;">' +
                       '<a title="Specify Centers" href="javascript:void(0)">' +
                       '<img src="images/center_edit.png">' +
@@ -81,7 +81,7 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
                     this.grid.getView().findRowIndex(node)
                 );
 
-                if (record.data.requires_center) {
+                if (record.data.displays_center) {
                     // let the center selector handle things.
                     XDMoD.Admin.AclGrid.prepCenterMenu(self.id, record.data.acl, record.data.acl_id, self.id);
                 } else {
@@ -124,7 +124,7 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
                     width: 109,
                     renderer: function (value, metaData, record, rowIndex, colIndex, store) {
                         var data = store.getAt(rowIndex).data;
-                        if (data.requires_center === true) {
+                        if (data.displays_center === true) {
                             if (!record.ref) {
                                 /* eslint-disable no-param-reassign */
                                 record.ref = Ext.id();
@@ -146,7 +146,7 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
             autoDestroy: true,
             url: '../controllers/user_admin.php',
             root: 'acls',
-            fields: ['acl', 'acl_id', 'include', 'requires_center'],
+            fields: ['acl', 'acl_id', 'include', 'requires_center', 'displays_center'],
             listeners: {
                 load: function (dashboardStore, records) {
                     for (var i = 0; i < records.length; i++) {
@@ -248,8 +248,11 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
     },
     getCenters: function (acl) {
         if (CCR.xdmod.features.multiple_service_providers === false &&
-          this.defaultProvider) {
-            return [this.defaultProvider];
+            this.defaultProvider) {
+            var record = this.store.getAt(this.store.find('acl_id', acl));
+            if (record && record.get('requires_center') === true) {
+                return [this.defaultProvider];
+            }
         } else if (this.aclCenters.hasOwnProperty(acl)) {
             return this.aclCenters[acl];
         }

--- a/html/internal_dashboard/js/admin_panel/AclGrid.js
+++ b/html/internal_dashboard/js/admin_panel/AclGrid.js
@@ -249,7 +249,7 @@ XDMoD.Admin.AclGrid = Ext.extend(Ext.grid.EditorGridPanel, {
     getCenters: function (acl) {
         if (CCR.xdmod.features.multiple_service_providers === false &&
           this.defaultProvider) {
-            return this.defaultProvider;
+            return [this.defaultProvider];
         } else if (this.aclCenters.hasOwnProperty(acl)) {
             return this.aclCenters[acl];
         }

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ControllerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ControllerTest.php
@@ -140,7 +140,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testEnumRoles()
     {
         $expected = JSON::loadFile(
-            $this->getTestFiles()->getFile('controllers', 'enum_roles')
+            $this->getTestFiles()->getFile('controllers', 'enum_roles-add_default_center')
         );
 
         $this->helper->authenticateDashboard('mgr');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When XDMoD is operating with the feature MultipleServiceProviders = 'off' we still want to be able to record additional information for certain 'center' related acls. Previously we did the detection / processing of this on the back end. The detection / handing has been moved to the front end which allows our create / update back end processing to be consistent.

An additional property has been added to the enum_roles controller so that we are able to differentiate between when the UI should display the center selection components and when the acl requires additional center information. 

## Motivation and Context
Simplify the back end processing code for creating / updating users. 

## Tests performed
Manual Tests ( Open XDMoD, XSEDE XDMoD )
**Test 1:**
-  Login to the Internal Dashboard
- Select 'User Management' -> 'Existing Users'
- Double click a user that does not have Center Staff / Center Director
- Add 'Center Director'
- Click 'Save Changes'
- Ensure that the user was successfully updated.
- Refresh the page
- Select 'User Management' -> ;Existing Users'
- Double click the user that was updated previously
- Ensure that the users acls are as expected

**Test 2:**
- Login to the Internal Dashboard
- Select 'User Management' -> 'Existing Users'
- Click 'Create & Manage Users'
- Select the 'New User' tab
- Fill out the users information
- Add the 'Center Staff', 'User' and 'Developer' acls 
- Click 'Create User'
- Ensure that the request was successful
- Refresh page
- Select 'User Management' -> 'Existing Users'
- Ensure that the newly created user is visible in the list of existing users
- Double click the newly created user
- Ensure that the acls are selected correctly


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Refactor

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
