### PR TITLE
Add a TRACE log level

### DIFF
--- a/classes/CCR/Log.php
+++ b/classes/CCR/Log.php
@@ -2,8 +2,6 @@
 
 namespace CCR;
 
-require_once 'Log.php';
-
 use xd_utilities;
 
 /**
@@ -24,6 +22,7 @@ class Log
     const NOTICE  = PEAR_LOG_NOTICE;
     const INFO    = PEAR_LOG_INFO;
     const DEBUG   = PEAR_LOG_DEBUG;
+    const TRACE   = PEAR_LOG_TRACE;
 
     /**
      * Private constructor for factory pattern.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "egulias/email-validator": "^1.2",
         "taq/pdooci": "^1.0",
         "phpmailer/phpmailer": "^5.2",
-        "ubccr/simplesamlphp-module-authglobus": "1.2.0"
+        "ubccr/simplesamlphp-module-authglobus": "1.2.0",
+        "ubccr/log": "1.13.2"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "65cf0dae717c5d8337d089443560adb3",
+    "content-hash": "c489f183832804cd1e65d3c47520a1bf",
     "packages": [
         {
             "name": "apache/commons-beanutils",
@@ -663,7 +663,62 @@
                 "auth",
                 "yadis"
             ],
-            "time": "2013-10-03T21:21:20+00:00"
+            "time": "2013-10-03 21:21:20"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/8c18719fdae000b690e3912be401c76e406dd13b",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PEAR": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2015-02-10T20:07:52+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -1547,6 +1602,68 @@
                 "MIT"
             ],
             "homepage": "https://github.com/tildeio/rsvp.js"
+        },
+        {
+            "name": "ubccr/log",
+            "version": "1.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ubccr/Log.git",
+                "reference": "a5914dd5a4553f4edb810d0123a2d8d9b3d2297e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ubccr/Log/zipball/a5914dd5a4553f4edb810d0123a2d8d9b3d2297e",
+                "reference": "a5914dd5a4553f4edb810d0123a2d8d9b3d2297e",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear_exception": "1.0.0",
+                "php": ">5.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "pear/db": "Install optionally via your project's composer.json"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Log.php"
+                ]
+            },
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jon Parise",
+                    "email": "jon@php.net",
+                    "homepage": "http://www.indelible.org",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Steve Gallo",
+                    "email": "smgallo@buffalo.edu",
+                    "homepage": "http://open.xdmod.org/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PEAR Logging Framework",
+            "homepage": "http://pear.github.io/Log/",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "support": {
+                "issues": "https://github.com/pear/Log/issues",
+                "source": "https://github.com/pear/Log"
+            },
+            "time": "2018-02-05T19:40:59+00:00"
         },
         {
             "name": "ubccr/simplesamlphp-module-authglobus",

--- a/docs/software-requirements.md
+++ b/docs/software-requirements.md
@@ -16,7 +16,6 @@ Open XDMoD requires the following software:
     - [cURL][php-curl]
     - [DOM][php-dom]
     - [XMLWriter][php-xmlwriter]
-    - [PEAR Log Package][pear-log]
     - [PEAR MDB2 Package][pear-mdb2]
     - [PEAR MDB2 MySQL Driver][pear-mdb2-mysql]
 - [Java][] 1.8 including the [JDK][]
@@ -40,7 +39,6 @@ Open XDMoD requires the following software:
 [php-curl]:        http://php.net/manual/en/book.curl.php
 [php-dom]:         http://php.net/manual/en/book.dom.php
 [php-xmlwriter]:   http://php.net/manual/en/book.xmlwriter.php
-[pear-log]:        http://pear.php.net/package/Log
 [pear-mdb2]:       http://pear.php.net/package/MDB2
 [pear-mdb2-mysql]: http://pear.php.net/package/MDB2_Driver_mysql
 [java]:            http://java.com/
@@ -72,7 +70,7 @@ added with this command for CentOS 7:
     # yum install epel-release
 
     # yum install httpd php php-cli php-mysql php-gd php-mcrypt \
-                  gmp-devel php-gmp php-pdo php-xml php-pear-Log \
+                  gmp-devel php-gmp php-pdo php-xml \
                   php-pear-MDB2 php-pear-MDB2-Driver-mysql \
                   java-1.7.0-openjdk java-1.7.0-openjdk-devel \
                   mariadb-server mariadb cronie logrotate \

--- a/open_xdmod/modules/xdmod/tests/lib/LogTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/LogTest.php
@@ -1,0 +1,77 @@
+<?php
+/** -----------------------------------------------------------------------------------------
+ * Tests for ubccr/Log class forked from pear/Log.
+ *
+ * @author Steve Gallo <smgallo@buffalo.edu>
+ * @date 2018-02-05
+ * ------------------------------------------------------------------------------------------
+ */
+
+namespace UnitTesting;
+
+use CCR\Log;
+
+class LogTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test various log levels including the newly added TRACE.
+     *
+     * @dataProvider logLevelProvider
+     */
+
+    public function testLogLevels($logLevel, $expectedLines)
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), "xdmod_test_");
+
+        $conf = array(
+            'mail'         => false,
+            'db'           => false,
+            'console'      => false,
+            'file'         => $tmpFile,
+            'fileLogLevel' => $logLevel
+        );
+
+        // Note that we can't use setMask() to change the log mask because it will not propogate
+        // to child loggers.
+
+        $logger = Log::factory('', $conf);
+
+        // Log messages at each level and compare the number of actual lines output to the number
+        // expected based on the log level mask.
+
+        $logger->emerg('Emergency');
+        $logger->alert('Alert');
+        $logger->crit('Critical');
+        $logger->err('Error');
+        $logger->warning('Warning');
+        $logger->notice('Notice');
+        $logger->info('Info');
+        $logger->debug('Debug');
+        $logger->trace('Trace');
+
+        $logMessages = file($tmpFile);
+        unlink($tmpFile);
+        $this->assertEquals(
+            $expectedLines,
+            count($logMessages),
+            sprintf("Logger output %d lines, expecting %d", count($logMessages), $expectedLines)
+        );
+    }
+
+    /**
+     * Provide data for the testLogLevels() function.  Return a list of tuples containing the max
+     * level and the expected number of messages for that level.
+     *
+     * @return array An array containing tuples (log_level, num expected results)
+     */
+
+    public function logLevelProvider()
+    {
+        return array(
+            array(Log::TRACE, 9),
+            array(Log::WARNING, 5),
+            array(Log::ALERT, 2)
+        );
+    }
+
+}

--- a/open_xdmod/modules/xdmod/tests/lib/LogTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/LogTest.php
@@ -73,5 +73,4 @@ class LogTest extends \PHPUnit_Framework_TestCase
             array(Log::ALERT, 2)
         );
     }
-
 }

--- a/open_xdmod/modules/xdmod/xdmod.spec.in
+++ b/open_xdmod/modules/xdmod/xdmod.spec.in
@@ -14,7 +14,7 @@ BuildRequires: php-cli
 Requires:      httpd
 Requires:      mariadb >= 5.5.3
 Requires:      php >= 5.4 php-cli php-mysql php-pdo php-gd php-mcrypt php-xml
-Requires:      php-pear-Log php-pear-MDB2 php-pear-MDB2-Driver-mysql
+Requires:      php-pear-MDB2 php-pear-MDB2-Driver-mysql
 Requires:      java-1.8.0-openjdk java-1.8.0-openjdk-devel
 Requires:      cronie
 Requires:      logrotate


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The PEAR Log module supports DEBUG as it's most verbose log level but we would like a TRACE level for even more verbosity when debugging complex processes. The [pear/Log](https://github.com/pear/Log) package has not been updated in over 2 years so the most expedient way to add this was to fork the repo at [ubccr/Log](https://github.com/ubccr/Log) and add the log level ourselves. The [ubccr/Log](https://github.com/ubccr/Log) repo has been added to [Packagist](https://packagist.org/) by @plessbd.

This PR adds the new log level to our own `CCR\Log` class, removes the `php-pear` requirement from the RPM spec file and documentation, and adds a test for the new log level. Running `composer update ubccr/Log` installs the new module. Note that the Log class does not include the log levels as class constants but uses define to make them available in the global namespace (e.g., `define('PEAR_LOG_EMERG', 0);`) so it was necessary to autoload `Log.php` in the composer.json (see https://github.com/ubccr/Log/blob/a5914dd5a4553f4edb810d0123a2d8d9b3d2297e/composer.json#L42-L44) which is acceptable as the logger is used for all REST and ETL actions.

## Motivation and Context

Improved logging.

## Tests performed

Ran existing and new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
