### PR TITLE
Account for Federated User Type when updating a user

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -822,6 +822,11 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                     }
                 }
 
+                // When we are working on a 'Federated' user the cmbUserType will
+                // not have a value ( as it's hidden ). In that case use the
+                // cached_user_type variable which is populated when we fetch
+                // the users details.
+                var userType = cmbUserType.isVisible() ? cmbUserType.getValue() : cached_user_type;
                 var objParams = {
                     operation: 'update_user',
                     uid: selected_user_id,
@@ -833,7 +838,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                     institution: (cmbInstitution.getValue().length === 0) ?
                                  '-1' :
                                  cmbInstitution.getValue(),
-                    user_type: cmbUserType.getValue()
+                    user_type: userType
                 };
 
                 Ext.Ajax.request({


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- There are scenarios when the cmbUserType will not contain a value ( in this
  case when a user is of the 'Federated' user type ). In that case we should
  fall back to the `cached_user_type` variable that is populated when the user's
  details are fetched.

## Motivation and Context
We should be able to update a user regardless of their user type.

## Tests performed
Manual Tests: 

**Test 1:**
- Login to the Internal Dashboard
- Navigate to 'Manage Users' -> 'Existing Users' 
- Select a user that is of the 'Federated' user type
- Ensure that the User Type displays 'Federated'
- Add an acl
- Click 'Save Changes'
- Ensure that the update processes succefully


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
