### PR TITLE
Fixing Admin Panel error css rule

### DIFF
--- a/html/internal_dashboard/css/AdminPanel.css
+++ b/html/internal_dashboard/css/AdminPanel.css
@@ -5,11 +5,10 @@
 }
 
 .admin_panel_invalid_text_entry {
-    padding-left: 19px !important;
     background-color: #fdc6c8 !important;
     background-image: url('../../gui/images/exclamation.png') !important;
     background-repeat:  no-repeat !important;
-    background-position: 1px 2px !important;
+    background-position: right !important;
 }
 
 .testing {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Previously the application of this rule to the 'Map To' or 'Institution'
  fields in `SectionNewUser.js` would blow the drop down button off the right
  hand side of the control. This change instead displays the error symbol on the
  right hand side of the combobox next to the drop down button.

## Motivation and Context
Not having portions of the UI dissapear unexpectedly is a good thing

## Tests performed
Manual Tests: 

**Test 1:**
- Login to the Internal Dashboard
- Navigate to 'User Management' -> 'Existing Users'
- Click the 'Create & Manage Users' button
- Select 'New User'
- Enter first, last and user name. Enter an email address
- Select the 'Campus Champion' acl 
- Click 'Save User' 
- Ensure that the 'Map To' combobox is marked as being in error but that you can still see / utilize the drop down button
- Select a person from the 'Map To' combobox
- Click 'Save User'
- Ensure that the 'Institution' is marked as being in error but that you can still see / utilize the drop down button. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
