### PR TITLE
Improve usability of dashboard Select User Dialog

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionNewUser.js
+++ b/html/internal_dashboard/js/admin_panel/SectionNewUser.js
@@ -414,10 +414,10 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
                 ],
 
                 listeners: {
-                    rowclick: function (thisgrid, rowIndex) {
+                    rowclick: function (thisGrid, rowIndex) {
                         selectedUser = usersStore.getAt(rowIndex);
                     },
-                    rowdblclick: function (thisgrid, rowIndex) {
+                    rowdblclick: function (thisGrid, rowIndex) {
                         selectedUser = usersStore.getAt(rowIndex);
                         okButton.handler();
                     }

--- a/html/internal_dashboard/js/admin_panel/SectionNewUser.js
+++ b/html/internal_dashboard/js/admin_panel/SectionNewUser.js
@@ -314,7 +314,7 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
         };
 
         this.displayUserGrid = function (users) {
-            var userFields, usersArray, usersStore, grid, win;
+            var userFields, usersArray, usersStore, grid, win, selectedUser = null;
 
             userFields = [
                 'person_id',
@@ -343,6 +343,32 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
             }, this);
 
             usersStore.loadData(usersArray);
+
+            var okButton = new Ext.Button({
+                tooltip: 'Select User',
+                text: 'OK',
+                scope: this,
+                handler: function () {
+                    if ( null === selectedUser ) {
+                        CCR.xdmod.ui.userManagementMessage('Select a user from the list.', false);
+                    } else {
+                        cmbUserMapping.initializeWithValue(
+                            selectedUser.get('person_id'),
+                            selectedUser.get('person_name')
+                        );
+                        win.close();
+                    }
+                }
+            });
+
+            var cancelButton = new Ext.Button({
+                tooltip: 'Cancel',
+                text: 'Cancel',
+                scope: this,
+                handler: function () {
+                    win.close();
+                }
+            });
 
             grid = new Ext.grid.GridPanel({
                 store: usersStore,
@@ -383,19 +409,19 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
                 ],
 
                 listeners: {
-                    rowdblclick: function (grid, rowIndex) {
-                        var user = usersStore.getAt(rowIndex);
-                        cmbUserMapping.initializeWithValue(
-                            user.get('person_id'),
-                            user.get('person_name')
-                        );
-                        win.close();
+                    rowclick: function (grid, rowIndex) {
+                        selectedUser = usersStore.getAt(rowIndex);
                     }
-                }
+                },
+
+                fbar: [
+                    okButton,
+                    cancelButton
+                ]
             });
 
             win = new Ext.Window({
-                title: 'No exact match found, select one',
+                title: 'No exact user match found, please select a user.',
                 autoShow: true,
                 layout: 'fit',
                 border: false,
@@ -661,4 +687,3 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
         XDMoD.CreateUser.superclass.onRender.call(this, ct, position);
     }
 });
-

--- a/html/internal_dashboard/js/admin_panel/SectionNewUser.js
+++ b/html/internal_dashboard/js/admin_panel/SectionNewUser.js
@@ -314,8 +314,13 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
         };
 
         this.displayUserGrid = function (users) {
-            var userFields, usersArray, usersStore, grid, win, selectedUser = null;
-
+            var userFields;
+            var usersArray;
+            var usersStore;
+            var grid;
+            var win;
+            var selectedUser = null;
+            
             userFields = [
                 'person_id',
                 'person_name',
@@ -349,7 +354,7 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
                 text: 'OK',
                 scope: this,
                 handler: function () {
-                    if ( null === selectedUser ) {
+                    if (selectedUser === null) {
                         CCR.xdmod.ui.userManagementMessage('Select a user from the list.', false);
                     } else {
                         cmbUserMapping.initializeWithValue(
@@ -409,7 +414,7 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
                 ],
 
                 listeners: {
-                    rowclick: function (grid, rowIndex) {
+                    rowclick: function (thisgrid, rowIndex) {
                         selectedUser = usersStore.getAt(rowIndex);
                     }
                 },

--- a/html/internal_dashboard/js/admin_panel/SectionNewUser.js
+++ b/html/internal_dashboard/js/admin_panel/SectionNewUser.js
@@ -320,7 +320,7 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
             var grid;
             var win;
             var selectedUser = null;
-            
+
             userFields = [
                 'person_id',
                 'person_name',
@@ -416,6 +416,10 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
                 listeners: {
                     rowclick: function (thisgrid, rowIndex) {
                         selectedUser = usersStore.getAt(rowIndex);
+                    },
+                    rowdblclick: function (thisgrid, rowIndex) {
+                        selectedUser = usersStore.getAt(rowIndex);
+                        okButton.handler();
                     }
                 },
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When creating an XDMoD user and mapping them to an HPC user, an admin can click on the "Find" button to attempt to discover the proper user based on first and last name. This currently displays a grid with no instructions where the admin must double-click a row to select a user. Modify this dialog to improve instructions and add an OK and Cancel button to improve usability.

Current dialog:
![old_dialog](https://user-images.githubusercontent.com/2301909/35997127-901eb7f8-0ce6-11e8-9ca9-16638d2dd62d.png)

Updated dialog:
![new_dialog](https://user-images.githubusercontent.com/2301909/35997149-9ef30266-0ce6-11e8-884d-3925d1b04919.png)

## Motivation and Context

Improved usability.

## Tests performed

Manually tested on dev.
1. Select user, click OK. User set in Create User dialog.
2. Select user, click Cancel. No user set in Create User dialog.
3. Do not select user, click OK, received proper error message.
4. Do not select user, click Cancel. No user set in Create User dialog.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
