### PR TITLE
Handle single-point timeseries plotting bug in our highcharts wrappers.

### DIFF
--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -696,6 +696,7 @@ class Usage extends Common
 
                 // For each data series...
                 $primaryDataSeriesRank = $usageOffset;
+
                 array_walk($meChart['series'], function (
                     &$meDataSeries,
                     $meDataSeriesIndex
@@ -743,9 +744,22 @@ class Usage extends Common
 
                     // If this is the primary data series and the chart is not a
                     // thumbnail, use line markers if and only if the number of
-                    // points is less than or equal to 30.
+                    // data points is less than or equal to 30,
+                    // or if there's a single y series data point.
                     if ($isPrimaryDataSeries && !$thumbnailRequested) {
-                        $meDataSeries['marker']['enabled'] = count($meDataSeries['data']) <= 30;
+                        // is there a single y data point?
+                        $y_values_count = 0;
+                        foreach ($meDataSeries['data'] as $value) {
+                            if ($value['y'] !== null ) {
+                                ++$y_values_count;
+                            }
+                            // we are only interested in the == 1 case
+                            if ($y_values_count > 1) {
+                                break;
+                            }
+                        }
+                        $meDataSeries['marker']['enabled'] = $y_values_count == 1 ||
+                                            count($meDataSeries['data']) <= 30;
                     }
 
                     // If this is a trend line data series...

--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -1181,6 +1181,12 @@ class HighChart2
                 $pointClick = 'function(event){'.($this->_showContextMenu?'XDMoD.Module.MetricExplorer.pointContextMenu(this,'.
                             $data_description->id.');':'').'}';
 
+                // Display markers for scatter plots, non-thumbnail plots
+                // with fewer than 21 points, or for plots with a single y value.
+                $showMarker = $data_description->display_type == 'scatter' ||
+                    ($values_count < 21 && $this->_width > \DataWarehouse\Visualization::$thumbnail_width) ||
+                    $values_count == 1;
+
                 $data_series_desc = array(
                     'name' => $lookupDataSeriesName,
                     'otitle' => $formattedDataSeriesName,
@@ -1200,9 +1206,7 @@ class HighChart2
                     'lineWidth' => $data_description->display_type !== 'scatter' ?
                                                         $data_description->line_width + $font_size / 4 : 0,
                     'marker' => array(
-                        'enabled' => $data_description->display_type == 'scatter' ||
-                                                        ($values_count < 21 &&
-                                                        $this->_width > \DataWarehouse\Visualization::$thumbnail_width),
+                        'enabled' => $showMarker,
                         'lineWidth' => 1,
                         'lineColor' => $lineColor,
                         'radius' => $font_size / 4 + 5

--- a/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
+++ b/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
@@ -586,11 +586,11 @@ class HighChartTimeseries2 extends HighChart2
                                 break;
                             }
                         }
-                        // Display markers for scatter plots, or for non-thumbnail plots
-                        // with fewer than 21 points or with a single y value.
+                        // Display markers for scatter plots, non-thumbnail plots of data series
+                        // with fewer than 21 points, or for any data series with a single y value.
                         $showMarker = $data_description->display_type == 'scatter' ||
-                            ( ($y_values_count == 1 || $values_count < 21) &&
-                            $this->_width > \DataWarehouse\Visualization::$thumbnail_width);
+                            ($values_count < 21 && $this->_width > \DataWarehouse\Visualization::$thumbnail_width) ||
+                            $y_values_count == 1;
 
                         $isRemainder = $dataTruncated && ($yIndex === $numYAxisDataObjects - 1);
 

--- a/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
+++ b/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
@@ -536,6 +536,7 @@ class HighChartTimeseries2 extends HighChart2
                 // @refer HighChart2 line 866
 
                 $numYAxisDataObjects = count($yAxisDataObjectsArray);
+
                 foreach($yAxisDataObjectsArray as $yIndex => $yAxisDataObject)
                 {
                     if( $yAxisDataObject != null)
@@ -571,7 +572,25 @@ class HighChartTimeseries2 extends HighChart2
                         }
 
                         $values = $yAxisDataObject->getValues();
+
+                        // Decide whether to show data point markers:
                         $values_count = count($values);
+                        // Count datapoints having actual, non-null y values:
+                        $y_values_count = 0;
+                        foreach ($values as $y_value) {
+                            if ($y_value !== null) {
+                                ++$y_values_count;
+                            }
+                            // we are only interested in the == 1 case.
+                            if ($y_values_count > 1) {
+                                break;
+                            }
+                        }
+                        // Display markers for scatter plots, or for non-thumbnail plots
+                        // with fewer than 21 points or with a single y value.
+                        $showMarker = $data_description->display_type == 'scatter' ||
+                            ( ($y_values_count == 1 || $values_count < 21) &&
+                            $this->_width > \DataWarehouse\Visualization::$thumbnail_width);
 
                         $isRemainder = $dataTruncated && ($yIndex === $numYAxisDataObjects - 1);
 
@@ -721,7 +740,7 @@ class HighChartTimeseries2 extends HighChart2
                             //'innerSize' => min(100,(100.0/$totalSeries)*count($this->_chart['series'])).'%',
                             'connectNulls' => $data_description->display_type == 'line' || $data_description->display_type == 'spline',
                             'marker' => array(
-                                'enabled' =>$data_description->display_type == 'scatter' || ($values_count < 21 && $this->_width > \DataWarehouse\Visualization::$thumbnail_width),
+                                'enabled' => $showMarker,
                                 'lineWidth' => 1,
                                 'lineColor' => $lineColor,
                                 'radius' => $font_size/4 + 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
*This pr is intended to address plotting of single point datasets, regardless of selected time aggregation. (The second commit does the same for non-timeseries plots so they display properly in e.g. Summary tab.)* 

This change fixes some faulty logic that determines whether plot point markers will be displayed in line and area charts. Previously, a blank plot resulted from plotting a dataset with a single timeseries point and a long Duration with daily aggregation. 

Example: Usage tab plot with single y data point and more than 30 time points appears to be empty (note that not all x-axis time points are labeled here):
![single-point-before](https://user-images.githubusercontent.com/3996484/36048787-73453abc-0dae-11e8-935d-6081b007ea72.png)

Whereas: Fix to line plot with single y data point and more than 30 time points correctly displays the point:
![single-point-after](https://user-images.githubusercontent.com/3996484/36048786-73330838-0dae-11e8-935f-5950c5b6408d.png)

The change counts up *y* points (plottable points) in timeseries datasets. If a single y point is present, it is plotted with a point marker. Otherwise, the previous logic is used. Namely, XDMoD displays point markers only if fewer than n x-axis points are present (NOTE: n=30 in Usage, n=21 in Metric Explorer. The n value is not changed in this fix.). 

Both the Usage adapter and the HighchartsTimeseries class were changed in this fix.

### Update: a second commit

I have added a second commit which also makes this fix in both timeseries and non-timeseries charts displayed in the Summary tab. 

Here's a Summary tab aggregate chart, prior to the fix. It should contain a single point:
![uncorrected-single-agg-summary](https://user-images.githubusercontent.com/3996484/37716745-9be685a0-2cf5-11e8-8b38-03ddea175936.png)

With the second commit, the point is visible:
![corrected-single-agg-summary](https://user-images.githubusercontent.com/3996484/37716797-bd73e794-2cf5-11e8-9787-da1dc28d899e.png)

Here's another example from the Summary tab, showing timeseries charts.

Before fix, Summary tab chart does not display single point data series:
![uncorrected-single-point-summary](https://user-images.githubusercontent.com/3996484/37716893-eeead7c4-2cf5-11e8-9c34-80d3b0bb6e23.png)

After the fix, single point data series are displayed:
![corrected-single-point-summary](https://user-images.githubusercontent.com/3996484/37716909-f8c1868a-2cf5-11e8-9c56-853ea82acb6f.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix addresses the case in which a single data point is being plotted in a timeseries chart for which there are more than 30 x-axis timepoints. For area or line plots, that single point was not displayed until mouseover of the chart area. 

This issue was found during tests for 7.1. See remarks here:
https://app.asana.com/0/14787510600562/550096118806901

### Second commit

The second commit I added also applies this logic to charts displayed in the Summary tab. Note that aggregate (non-timeseries) charts must also be considered!

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was tested by hand atop 7.1 code base. Note that the parameter whose calculation is changed in this fix is not used to do anything but turn plot point markers on and off.

Checked carefully: Sparse plots, such as Jobs summary plots with User quick filter enabled; toggling between timeseries and non-ts plots; single plot under multiple Durations. 

Comments are welcome as to whether existing tests need to be adapted for this!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Note that this may cause a change to tests that involved plots that incorrectly showed no data...

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
