### PR TITLE
Revert change to legend item menu location

### DIFF
--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -1354,7 +1354,7 @@ Ext.apply(XDMoD.Module.MetricExplorer, {
                             }
                         } : null
                     );
-                    menu.showAt(Ext.get(series.legendItem.element).getXY());
+                    menu.showAt(Ext.EventObject.getXY());
 
                 }
             });


### PR DESCRIPTION
When plotting a pie chart there is no series.legendItem object. Rather than introducing more convoulted code, this pull request simply reverts the legend item behaviour to the original version. i.e. legend menu appears at click location.