### PR TITLE
 Disable selection of federated type in new user dialog 

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -715,7 +715,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
         // ------------------------------------------
 
         var roleSettings = new Ext.Panel({
-            title: 'Acl Assignment',
+            title: 'ACL Assignment',
             columns: 1,
             layout: 'fit',
             flex: 0.55,
@@ -818,7 +818,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                 var intersection = CCR.intersect(dataAcls, acls);
 
                 if (intersection.length === 0) {
-                    CCR.xdmod.ui.userManagementMessage('You must select a non-flag acl for the user. ( i.e. anything not Manager or Developer ');
+                    CCR.xdmod.ui.userManagementMessage('You must select a non-flag ACL for the user (i.e., anything not Manager or Developer).');
                     return;
                 }
 

--- a/html/internal_dashboard/js/admin_panel/SectionNewUser.js
+++ b/html/internal_dashboard/js/admin_panel/SectionNewUser.js
@@ -52,7 +52,17 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
             root: 'user_types',
             baseParams: { 'operation' : 'enum_user_types' },
             fields: ['id', 'type'],
-            autoLoad: true
+            autoLoad: true,
+            listeners: {
+                load: function (store, records) {
+                    for (var i = 0; i < records.length; i++) {
+                        var record = records[i];
+                        if (parseInt(record.data.id, 10) === CCR.xdmod.FEDERATED_USER_TYPE) {
+                            store.remove(record);
+                        }
+                    }
+                }
+            }
         });
 
         var cmbUserType = new Ext.form.ComboBox({

--- a/html/internal_dashboard/js/admin_panel/SectionNewUser.js
+++ b/html/internal_dashboard/js/admin_panel/SectionNewUser.js
@@ -496,7 +496,7 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
         };
 
         var fsRoleAssignment = new Ext.form.FieldSet({
-            title: 'Acl Assignment',
+            title: 'ACL Assignment',
 
             items: [
                 newUserRoleGrid
@@ -568,7 +568,7 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
                 var intersection = CCR.intersect(dataAcls, acls);
 
                 if (intersection.length === 0) {
-                    CCR.xdmod.ui.userManagementMessage('You must select a non-flag acl for the user. ( i.e. anything not Manager or Developer ');
+                    CCR.xdmod.ui.userManagementMessage('You must select a non-flag ACL for the user (i.e., anything not Manager or Developer).');
                     return;
                 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Federated users should only be created through SSO. This removes the Federated option from the new user dialog.  Additional work is planned to handle filtering on the endpoint that serves the data rather than several places in the front end, see [Allow enum_user_types to filter certain types](https://app.asana.com/0/39212635865052/561134350668840).

## Motivation and Context

Bugfix

## Tests performed

Tested hotfix on metrics-dev.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
