### PR TITLE
Change DELETE FROM to TRUNCATE TABLE in filter generation

### DIFF
--- a/classes/DB/FilterListBuilder.php
+++ b/classes/DB/FilterListBuilder.php
@@ -134,7 +134,7 @@ class FilterListBuilder extends Loggable
             $selectTablesStr = implode(', ', $selectTables);
             $wheresStr = implode(' AND ', $wheres);
 
-            $db->execute("DELETE FROM `{$targetSchema}`.`{$mainTableName}`");
+            $db->execute("TRUNCATE TABLE `{$targetSchema}`.`{$mainTableName}`");
             $db->execute(
                 "INSERT INTO
                     `{$targetSchema}`.`{$mainTableName}`
@@ -232,7 +232,7 @@ class FilterListBuilder extends Loggable
                 $selectTablesStr = implode(', ', array_unique(array_merge($firstSelectTables, $secondSelectTables)));
                 $wheresStr = implode(' AND ', array_unique(array_merge($firstWheres, $secondWheres)));
 
-                $db->execute("DELETE FROM `{$targetSchema}`.`{$pairTableName}`");
+                $db->execute("TRUNCATE TABLE `{$targetSchema}`.`{$pairTableName}`");
                 $db->execute(
                     "INSERT INTO
                         `{$targetSchema}`.`{$pairTableName}`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When generating filters via `FilterListBuilder()`, the filter list tables are cleared using `DELETE FROM`. This generates 1.5M delete events that must be replicated to the slave database. From the MySQL manual: "TRUNCATE TABLE is treated for purposes of binary logging and replication as DROP TABLE followed by CREATE TABLE—that is, as DDL rather than DML"

TRUNCATE TABLE cannot be used if there are triggers (as they won't fire) or foreign keys (ON DELETE clauses will not run) but there are none on the filter tables:
```
SELECT * FROM information_schema.KEY_COLUMN_USAGE
WHERE TABLE_SCHEMA = 'modw_filters'
  AND CONSTRAINT_NAME != 'PRIMARY';

SELECT * FROM information_schema.TRIGGERS
WHERE TRIGGER_SCHEMA = 'modw_filters'
    OR EVENT_OBJECT_SCHEMA = 'modw_filters';
```

## Motivation and Context

Improve database and replication performance.

## Tests performed

Since filter generation is embedded into ETLv1, allow Shippable to run the test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
