### PR TITLE
Ensure file is flushed before running load

### DIFF
--- a/classes/DB/PDODBMultiIngestor.php
+++ b/classes/DB/PDODBMultiIngestor.php
@@ -262,9 +262,10 @@ class PDODBMultiIngestor implements Ingestor
                         );
                     }
 
+                    fclose($f);
+
                     $this->_dest_helper->executeStatement($load_statement);
 
-                    fclose($f);
                     $f = fopen($infile_name, 'w');
                 }
                 catch (Exception $e) {


### PR DESCRIPTION
This is a bug found during code inspection. The PDODBMultiIngestor creates a temporary file for use in an SQL load data infile query. This file is not flushed before the sql call so the records may not be written to disk which could result in data loss.

This change closes the file handle before calling mysql. This will ensure that the file contents are flushed to disk.