### PR TITLE
update shippable

### DIFF
--- a/open_xdmod/modules/xdmod/regression_tests/README.md
+++ b/open_xdmod/modules/xdmod/regression_tests/README.md
@@ -1,6 +1,6 @@
 The regression tests use the integration test framework, which is designed to be used to run tests against an installed and working XDMoD instance.
 
-The tests require a valid user account on XDMoD. The username and password are read from a file called .secrets in the integration test directory. Please follow the instructions in the integration test directory to setup the password file.
+The tests require a valid user account on XDMoD. The username and password are read from a file called .secrets.json in the integration test directory. Please follow the instructions in the integration test directory to setup the password file.
 
 Run the tests with ./runtests.sh
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,8 +8,8 @@ build:
         - /root/.composer
         - /root/.npm
     pre_ci_boot:
-        image_name: tas-tools-ext-01.ccr.xdmod.org/centos7-xdmod7.0.1
-        image_tag: version6
+        image_name: tas-tools-ext-01.ccr.xdmod.org/xdmod-centos7
+        image_tag: open7.5-v4
         pull: true
         options: "--user root -e HOME=/root"
     ci:
@@ -17,7 +17,7 @@ build:
         - ~/bin/buildrpm xdmod
         - ./open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
         - composer install --no-progress
-        - cp ~/assets/secrets open_xdmod/modules/xdmod/integration_tests/.secrets.json
+        - cp ~/assets/secrets.json open_xdmod/modules/xdmod/integration_tests/.secrets.json
         - ./open_xdmod/modules/xdmod/tests/artifacts/update-artifacts.sh
         - ./open_xdmod/modules/xdmod/regression_tests/runtests.sh --junit-output-dir `pwd`/shippable/testresults/
         - ./open_xdmod/modules/xdmod/integration_tests/runtests.sh --log-junit `pwd`/shippable/testresults/xdmod-integration.xml


### PR DESCRIPTION
This does not come from a full rebuild of the docker image, there seems to be some 
issues with our automated browser tests and chrome-stable.

reference: 
https://app.shippable.com/github/plessbd/xdmod/runs/57/summary/
https://app.shippable.com/github/plessbd/xdmod/runs/58/summary/
https://app.shippable.com/github/plessbd/xdmod/runs/59/summary/
https://app.shippable.com/github/plessbd/xdmod/runs/60/summary/


Until those can be figured out this uses the previous version with the following docker file
```
FROM tas-tools-ext-01.ccr.xdmod.org/centos7-xdmod7.0.1:version6
ENV REL=7.5.0
ENV BUILD=1
ENV BRANCH=xdmod7.5

LABEL authors="Joseph P. White <jpwhite4@buffalo.edu>, Benjamin D. Plessinger <bpless@buffalo.edu>"

RUN rpm -qa | grep ^xdmod | xargs yum -y remove
RUN rm -rf /etc/xdmod
RUN rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql
RUN yum -y remove java-1.7.0-openjdk java-1.7.0-openjdk-devel java-1.7.0-openjdk-headless
RUN sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/google-chrome.repo
RUN yum clean all
RUN yum update -y
RUN yum install -y https://github.com/ubccr/xdmod/releases/download/v$REL/xdmod-$REL-$BUILD.0.el7.centos.noarch.rpm
RUN yum clean all
RUN rm -rf /var/cache/yum

ADD . /root

WORKDIR /root

RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
    php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
    php composer-setup.php --install-dir=/bin --filename=composer && \
    php -r "unlink('composer-setup.php');" && \
    rm -rf /root/.composer/cache ; \
    mkdir /root/.composer/cache && \
    tar -zxf assets/composer/composer_cache.tar.gz -C /root/.composer/cache

# Update System Defaults
RUN /bin/cp assets/etc/my.cnf.d/server.cnf /etc/my.cnf.d/server.cnf
RUN sed -i 's/.*date.timezone[[:space:]]*=.*/date.timezone = UTC/' /etc/php.ini
RUN sed -i 's/.*memory_limit[[:space:]]*=.*/memory_limit = -1/' /etc/php.ini

# Start the webserver and database and populate it
# note that we make sure to clean shutdown the database so the data are flushed properly
RUN wget -nv https://raw.githubusercontent.com/ubccr/xdmod/$BRANCH/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl && \
    /root/bin/services start && \
    expect /root/xdmod-setup.tcl | col -b && \
    rm -rf /root/xdmod-setup.tcl && \
    for resource in /root/assets/referencedata/*.log; do xdmod-shredder -r `basename $resource .log` -f slurm -i $resource; done && \
    xdmod-ingestor && \
    xdmod-import-csv -t names -i /root/assets/referencedata/names.csv && \
    xdmod-ingestor && \
    php /root/bin/createusers.php && \
    /root/bin/services stop

```