### PR TITLE
Minor fix to logrotate rule

### DIFF
--- a/configuration/logrotate.conf
+++ b/configuration/logrotate.conf
@@ -5,5 +5,7 @@
     compress
     missingok
     dateext
+    su apache apache
+    create 0640 apache apache
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Fix logrotate rule to avoid errors when `/var/log/xdmod` has ownership `apache:xdmod`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

```
error: skipping "/var/log/xdmod/dwi.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
error: skipping "/var/log/xdmod/exceptions.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
error: skipping "/var/log/xdmod/query.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Add `su apache xdmod` to `/etc/logroate.d/xdmod.conf` and run logrotate

```
# logrotate --debug /etc/logrotate.d/xdmod 
reading config file /etc/logrotate.d/xdmod
Allocating hash table for state file, size 15360 B

Handling 1 logs

rotating pattern: /var/log/xdmod/*.log  weekly (4 rotations)
empty log files are rotated, old logs are removed
switching euid to 48 and egid to 80
considering log /var/log/xdmod/dwi.log
  log does not need rotating (log has been rotated at 2018-3-5 9:0, that is not week ago yet)
considering log /var/log/xdmod/exceptions.log
  log does not need rotating (log has been rotated at 2018-3-5 9:0, that is not week ago yet)
considering log /var/log/xdmod/query.log
  log does not need rotating (log has been rotated at 2018-3-5 9:0, that is not week ago yet)
considering log /var/log/xdmod/session_manager.log
  log does not need rotating (log has been already rotated)considering log /var/log/xdmod/simplesamlphp.log
  log does not need rotating (log has been already rotated)switching euid to 0 and egid to 0
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
