### PR TITLE
Do not translate 0 to the empty string during ETL

### DIFF
--- a/classes/DB/PDODBMultiIngestor.php
+++ b/classes/DB/PDODBMultiIngestor.php
@@ -206,7 +206,7 @@ class PDODBMultiIngestor implements Ingestor
                         !isset($srcRow[$insert_field])
                         ? '\N'
                         : (
-                            empty($srcRow[$insert_field])
+                            '' === $srcRow[$insert_field]
                             ? $string_enc . '' . $string_enc
                             : str_replace('\\', '\\\\', $srcRow[$insert_field])
                         )

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -962,7 +962,7 @@ class pdoIngestor extends aIngestor
             if ( null === $value ) {
                 // Transform NULL values for MySQL LOAD FILE
                 $value = '\N';
-            } elseif ( empty($value) ) {
+            } elseif ( '' === $value ) {
                 $value = $this->stringEnclosure . '' . $this->stringEnclosure;
             } else {
                 // Handle proper escaping of backslashes to preserve source data containing them.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For historical reasons, the ingestors have always translated `empty($value)` to an empty string. However, since the `empty()` function returns `true` for values of `NULL`, `""`, `0`, `0.0`, and `"0"` this translates valid integer values of 0 to empty strings, which is not desirable in many cases. For numeric values, [MySQL converts](https://dev.mysql.com/doc/refman/5.5/en/insert.html) the empty string back to zero on insert but this causes numerous warnings during the ETL process.

For example, XSEDE defines a person_id = 0 as the Unknown user but this id gets stripped out on ingestion and replaced by an empty string forcing us to convert 0 to -1 in our ingestion queries. 

## Motivation and Context

Cleaning up ETL warnings.

## Tests performed

Deploy 2 instances of XDMoD, each configured to talk to a different docker database.


```
INSTALLDIR=~/xdmod-7.5-baseline; \
  ~/src/ccr-private-xdmod/scripts/deployment/update-open-xdmod-portal.php \
    --source-dir ~/src/xdmod \
    --conf-dir ~/src/ccr-private-xdmod \
    --prefix $INSTALLDIR \
    --xsede && \
  cp ~/xdmod_config_files/8.0-xsede-localhost-to-docker/portal_settings.ini $INSTALLDIR/etc/portal_settings.ini
```

port 3307: empty($value)
```
docker run -h empty --rm -it -p 3307:3306 tas-tools-int-01.ccr.xdmod.org/xdmod-centos7:xsede7.5 /bin/bash
```

```
INSTALLDIR=~/xdmod-7.5-noempty; \
  ~/src/ccr-private-xdmod/scripts/deployment/update-open-xdmod-portal.php \
    --source-dir ~/src/xdmod \
    --conf-dir ~/src/ccr-private-xdmod \
    --prefix $INSTALLDIR \
    --xsede && \
  cp ~/xdmod_config_files/8.0-xsede-localhost-to-docker/portal_settings.ini $INSTALLDIR/etc/portal_settings.ini
```

port 3308: change to "" == $value
```
docker run -h not-empty --rm -it -p 3308:3306 tas-tools-int-01.ccr.xdmod.org/xdmod-centos7:xsede7.5 /bin/bash
```

Edit the following files changing `empty($value)` to `'' === $value`

```
share/classes/DB/PDODBMultiIngestor.php
share/classes/ETL/Ingestor/pdoIngestor.php
```

Ingest data

```
export START=2016-12-15
export END=2017-01-15

php ~/xdmod-7.5-baseline/lib/dw_extract_transform_load.php --start-date $START --end-date $END -l 0
cd ~/xdmod-7.5-baseline/share/tools/etl
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s $START -e $END -p osg -o "experimental_enable_batch_aggregation=true" -v notice
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s $START -e $END -p science-gateway -p resource-allocations -v notice
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s 2003-01-01 -e $END -k none -p xdcdb-accounts -o "experimental_enable_batch_aggregation=true" -v notice
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s $START -e $END -k quarter -a XdcdbJobRecordIngestor -v notice
```

```
export START=2016-12-15
export END=2017-01-15

php ~/xdmod-7.5-noempty/lib/dw_extract_transform_load.php --start-date $START --end-date $END -l 0
cd ~/xdmod-7.5-noempty/share/tools/etl
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s $START -e $END -p osg -o "experimental_enable_batch_aggregation=true" -v notice
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s $START -e $END -p science-gateway -p resource-allocations -v notice
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s 2003-01-01 -e $END -k none -p xdcdb-accounts -o "experimental_enable_batch_aggregation=true" -v notice
php ./etl_overseer.php -c ../../../etc/etl/etl.json -s $START -e $END -k quarter -a XdcdbJobRecordIngestor -v notice
```
Dump tables from 3308 instance and import into 3307 instance for comparison.
```
smgallo@smgallo-dev:dev$ php verify_table_data.php -s modw -d modw_noempty -t jobfact -v info -n 2
2018-03-09 15:21:18 [notice] Compare tables src=modw.jobfact, dest=modw_noempty.jobfact
2018-03-09 15:21:18 [info] 38 columns
2018-03-09 15:21:18 [info] Row counts: modw.jobfact = 433,701; modw_noempty.jobfact = 433,701
2018-03-09 15:21:18 [notice] Identical

# 7 rows different only in the number of jobs run (which is small) because of jobs ended between the
# time the 2 ingestions were run.

smgallo@smgallo-dev:dev$ php verify_table_data.php -s modw -d modw_noempty -t accountfact -v info -x last_modified -n 2
2018-03-12 14:47:42 [notice] Compare tables src=modw.accountfact, dest=modw_noempty.accountfact
2018-03-12 14:47:43 [info] Exclude columns: last_modified
2018-03-12 14:47:43 [info] 6 columns
2018-03-12 14:47:43 [info] Row counts: modw.accountfact = 329,870; modw_noempty.accountfact = 329,884
2018-03-12 14:47:43 [warning] Missing 7 rows in modw_noempty.accountfact


smgallo@smgallo-dev:dev$ php verify_table_data.php -s federated_osg -d federated_osg_noempty -t job_records_osg -x last_modified -v info -n 2 
2018-03-09 15:22:12 [notice] Compare tables src=federated_osg.job_records_osg, dest=federated_osg_noempty.job_records_osg
2018-03-09 15:22:12 [info] Exclude columns: last_modified
2018-03-09 15:22:12 [info] 34 columns
2018-03-09 15:22:12 [info] Row counts: federated_osg.job_records_osg = 1,611,198; federated_osg_noempty.job_records_osg = 1,611,198
2018-03-09 15:22:12 [notice] Identical

smgallo@smgallo-dev:dev$ php verify_table_data.php -s federated_osg -d federated_osg_noempty -t job_tasks_osg -x last_modified -v info -n 2 
2018-03-09 15:22:35 [notice] Compare tables src=federated_osg.job_tasks_osg, dest=federated_osg_noempty.job_tasks_osg
2018-03-09 15:22:35 [info] Exclude columns: last_modified
2018-03-09 15:22:35 [info] 30 columns
2018-03-09 15:22:35 [info] Row counts: federated_osg.job_tasks_osg = 1,611,198; federated_osg_noempty.job_tasks_osg = 1,611,198
2018-03-09 15:22:35 [notice] Identical

smgallo@smgallo-dev:dev$ php verify_table_data.php -s mod_custom -d mod_custom_noempty -t science_gateway_usage -v info -n 2
2018-03-09 15:23:04 [notice] Compare tables src=mod_custom.science_gateway_usage, dest=mod_custom_noempty.science_gateway_usage
2018-03-09 15:23:04 [info] 7 columns
2018-03-09 15:23:04 [info] Row counts: mod_custom.science_gateway_usage = 18,551; mod_custom_noempty.science_gateway_usage = 18,551
2018-03-09 15:23:04 [notice] Identical

smgallo@smgallo-dev:dev$ php verify_table_data.php -s mod_custom -d mod_custom_noempty -t science_gateway_users -v info -n 2
2018-03-09 15:23:31 [notice] Compare tables src=mod_custom.science_gateway_users, dest=mod_custom_noempty.science_gateway_users
2018-03-09 15:23:31 [info] 5 columns
2018-03-09 15:23:31 [info] Row counts: mod_custom.science_gateway_users = 6,343; mod_custom_noempty.science_gateway_users = 6,343
2018-03-09 15:23:31 [notice] Identical

smgallo@smgallo-dev:dev$ php verify_table_data.php -s modw_ra -d modw_ra_noempty -t resource_allocations -v info -n 2
2018-03-12 14:41:31 [notice] Compare tables src=modw_ra.resource_allocations, dest=modw_ra_noempty.resource_allocations
2018-03-12 14:41:31 [info] 11 columns
2018-03-12 14:41:31 [info] Row counts: modw_ra.resource_allocations = 514; modw_ra_noempty.resource_allocations = 514
2018-03-09 15:23:31 [notice] Identical

# Note that column exclusions are to take into account changes in a user's organization between the time
# that the two ingestions ran

smgallo@smgallo-dev:dev$ php verify_table_data.php -s modw_cloud -d modw_cloud_noempty -t job_records -x last_modified -x person_organization_id -x piperson_organization_id -v info -n 2
2018-03-09 15:24:19 [notice] Compare tables src=modw_cloud.job_records, dest=modw_cloud_noempty.job_records
2018-03-09 15:24:19 [info] Exclude columns: last_modified, person_organization_id, piperson_organization_id
2018-03-09 15:24:19 [info] 32 columns
2018-03-09 15:24:19 [info] Row counts: modw_cloud.job_records = 439,945; modw_cloud_noempty.job_records = 439,945
2018-03-09 15:24:21 [notice] Identical

smgallo@smgallo-dev:dev$ php verify_table_data.php -s modw_cloud -d modw_cloud_noempty -t job_tasks -x last_modified -x person_organization_id -x piperson_organization_id -v info -n 2
2018-03-09 15:25:17 [notice] Compare tables src=modw_cloud.job_tasks, dest=modw_cloud_noempty.job_tasks
2018-03-09 15:25:17 [info] Exclude columns: last_modified, person_organization_id, piperson_organization_id
2018-03-09 15:25:17 [info] 29 columns
2018-03-09 15:25:17 [info] Row counts: modw_cloud.job_tasks = 439,945; modw_cloud_noempty.job_tasks = 439,945
2018-03-09 15:25:22 [notice] Identical
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
