### PR TITLE
Fix xdmod-ingest typo in 7.0 hierarchy.md

### DIFF
--- a/docs/hierarchy.md
+++ b/docs/hierarchy.md
@@ -90,7 +90,7 @@ And imported with a command like this:
 After importing this data you must ingest it for the date range of any
 job data you have already shredded.
 
-    $ xdmod-ingest --start-date 2012-01-01 --end-date 2012-12-31
+    $ xdmod-ingestor --start-date 2012-01-01 --end-date 2012-12-31
 
 Disabling Hierarchy Dimensions
 ------------------------------


### PR DESCRIPTION
Fixed typo - Ingestor command is xdmod-ingestor not xdmod-ingest