### PR TITLE
Supress and fix wanrings

### DIFF
--- a/configuration/etl/etl.d/hpcdb-modw.json
+++ b/configuration/etl/etl.d/hpcdb-modw.json
@@ -210,7 +210,12 @@
         "name": "hosts",
         "class": "HpcdbHostsIngestor",
         "definition_file": "hpcdb-modw/host.json",
-        "description": "hosts records"
+        "description": "hosts records",
+        "#": "there are currently duplications allowed here for ease of",
+        "#": "generating the query this might be cleaned up later.",
+        "hide_sql_warning_codes": [
+            1062
+        ]
     }, {
         "name": "job-hosts",
         "definition_file": "hpcdb-modw/jobhosts.json",
@@ -227,7 +232,12 @@
     }, {
         "name": "job-record",
         "definition_file": "hpcdb-modw/job_record_hpc.json",
-        "description": "HPC job records from the hpcdb"
+        "description": "HPC job records from the hpcdb",
+        "#": "job records will be duplicated for each job array",
+        "#": "this hides those warnings. This will be cleaned up later.",
+        "hide_sql_warning_codes": [
+            1062
+        ]
     }, {
         "name": "HpcdbPostIngestJobUpdates",
         "namespace": "ETL\\Maintenance",

--- a/configuration/etl/etl_tables.d/hpcdb-modw/allocation-on-resource.json
+++ b/configuration/etl/etl_tables.d/hpcdb-modw/allocation-on-resource.json
@@ -5,7 +5,8 @@
     "source_query": {
         "records": {
             "allocation_id": "aorf.allocation_id",
-            "resource_id": "aorf.resource_id"
+            "resource_id": "aorf.resource_id",
+            "allocation_state_id": 0
         },
         "joins": [
             {

--- a/configuration/etl/etl_tables.d/hpcdb-modw/allocation.json
+++ b/configuration/etl/etl_tables.d/hpcdb-modw/allocation.json
@@ -11,7 +11,16 @@
             "principalinvestigator_person_id": "pif.person_id",
             "fos_id": "reqf.primary_fos_id",
             "charge_number": "af.account_name",
-            "order_id": "NULL"
+            "order_id": "NULL",
+            "boardtype_id": 0,
+            "initial_allocation": 0,
+            "initial_start_date": "'0000-00-00'",
+            "initial_start_date_ts": 0,
+            "initial_end_date": "'0000-00-00'",
+            "base_allocation": 0,
+            "remaining_allocation": 0,
+            "end_date": "'0000-00-00'",
+            "end_date_ts": 0
         },
         "joins": [
             {

--- a/configuration/etl/etl_tables.d/hpcdb-modw/person.json
+++ b/configuration/etl/etl_tables.d/hpcdb-modw/person.json
@@ -15,7 +15,8 @@
             "email_address": "ef.email_address",
             "long_name": "IF(pf.first_name IS NULL OR pf.first_name = '', pf.last_name, CONCAT(pf.last_name, ', ', pf.first_name, COALESCE( CONCAT(' ', pf.middle_name), '')))",
             "short_name": "IF(pf.first_name IS NULL OR pf.first_name = '', pf.last_name, CONCAT(pf.last_name, ', ', SUBSTR(pf.first_name, 1, 1)))",
-            "order_id": "NULL"
+            "order_id": "NULL",
+            "nsfstatuscode_id": 0
         },
         "joins": [
             {

--- a/configuration/etl/etl_tables.d/hpcdb-modw/request.json
+++ b/configuration/etl/etl_tables.d/hpcdb-modw/request.json
@@ -6,7 +6,11 @@
         "records": {
             "id": "rf.request_id",
             "primary_fos_id": "rf.primary_fos_id",
-            "account_id": "rf.account_id"
+            "account_id": "rf.account_id",
+            "request_type_id": 0,
+            "grant_number": "''",
+            "start_date": "'0000-00-00'",
+            "end_date": "'0000-00-00'"
         },
         "joins": [
             {


### PR DESCRIPTION
hosts and job_record contain duplicate entries and are expected to.  This supresses those warnings.
This also fixes other tables having warnings that were appearing about fields not having defaults.  Instead of allowing them on the table level, this just sets them on the ingest query.