### PR TITLE
update dump database tables script

### DIFF
--- a/tools/etl/dump_database_table_definition.sh
+++ b/tools/etl/dump_database_table_definition.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ETL_TABLE_MANAGER=etl_table_manager.php
-PRETTY_PRINTER="$HOME/bin/jq '.'"
+PRETTY_PRINTER="jq '.'"
 OUTPUT_DIR=.
 DATABASE=
 DB_HOST=
@@ -69,7 +69,7 @@ for table in $TABLE_LIST; do
     tablename=${DATABASE}.${table}
 
     outputfile=${OUTPUT_DIR}/${tablename}.json
-    tmpfile=`tempfile`
+    tmpfile=`mktemp`
 
     echo "Dumping $tablename to $outputfile"
 


### PR DESCRIPTION
tempfile has been deprecated, this also makes this work in centos
https://manpages.debian.org/stretch/debianutils/tempfile.1.en.html#BUGS

use the globally installed jq