### PR TITLE
Enable TRACE log level, fix bug when no key columns exist

### DIFF
--- a/tools/dev/verify_table_data.php
+++ b/tools/dev/verify_table_data.php
@@ -204,6 +204,9 @@ foreach ($args as $arg => $value) {
         case 'v':
         case 'verbosity':
             switch ( $value ) {
+                case 'trace':
+                    $scriptOptions['verbosity'] = Log::TRACE;
+                    break;
                 case 'debug':
                     $scriptOptions['verbosity'] = Log::DEBUG;
                     break;
@@ -563,13 +566,14 @@ ORDER BY ordinal_position ASC";
         exit();
     }
 
+    $retval = array();
     $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
     if ( 0 == count($result) ) {
         $logger->err("Table '$tableName' does not exist or does not have a primary key");
-        return false;
+        return $retval;
     }
 
-    $retval = array();
 
     foreach ( $result as $row) {
         $retval[] = $row['name'];
@@ -796,6 +800,10 @@ function compareTableData(
                 // only those differences. Ignored columns are not displayed.
 
                 $keyColumns = getTablePrimaryKeyColumns($srcTable, $srcSchema);
+
+                if ( 0 == count($keyColumns) ) {
+                    continue;
+                }
 
                 $constraints = array();  // JOIN constraints
                 $where = array();        // WHERE clause with parameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable TRACE log level. Fixes bug when comparing tables that do not have a primary key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed

Tested by @plessbd. I trust him.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
