### PR TITLE
Updating filter column

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByProvider.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByProvider.php
@@ -121,7 +121,7 @@ class GroupByProvider extends \DataWarehouse\Query\Jobs\GroupBy
     }
     public function pullQueryParameters(&$request)
     {
-        return parent::pullQueryParameters2($request, '_filter_', 'organization_id');
+        return parent::pullQueryParameters2($request, '_filter_', 'resource_organization_id');
     }
     public function pullQueryParameterDescriptions(&$request)
     {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
The `organization_id` column has been renamed to `resource_organization_id`.
This was causing a problem when logging into the site as a center director ( sql
syntax error as the column was not found ).

## Motivation and Context
Users should be able to login regardless of their Acl assignments

## Tests performed
Manual Test:
- Login as a user who's highest privileged acl is center director to an unpatched XDMoD 8.0 site. 
- Notice that an exception is presented and the site is unusable. 

Apply this PR

- Login as a user who's highest privileged acl is center director
- Notice that an exception is **not** thrown and the site is usable again

**NOTE**: I didn't add any new tests as just running the automated tests on an XSEDE instance would find this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
