### PR TITLE
Fix filter building

### DIFF
--- a/bin/xdmod-build-filter-lists
+++ b/bin/xdmod-build-filter-lists
@@ -24,7 +24,7 @@ if ($args === false) {
     usageAndExit("Failed to parse arguments\n");
 }
 $realms = array();
-$logLevel = Log::NOTICE;
+$logLevel = -1;
 foreach ($args as $key => $value) {
     if (is_array($value) && !in_array($key, array('v', 'r'))) {
         usageAndExit("Multiple values not allowed for '$key'");
@@ -58,7 +58,7 @@ foreach ($args as $key => $value) {
             }
             break;
         case 'r':
-        case 'realms':
+        case 'realm':
             $realms = is_array($value) ? $value : array($value);
             break;
         default:
@@ -66,6 +66,11 @@ foreach ($args as $key => $value) {
             break;
     }
 }
+
+if ($logLevel === -1) {
+    $logLevel = Log::NOTICE;
+}
+
 $logger = Log::factory(
     'xdmod-build-filter-lists',
     array(

--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -280,6 +280,11 @@ function main()
         $logger->info('Aggregating data');
         try {
             runEtlPipeline('jobs-xdw.aggregate', $etlParams);
+
+            $filterListBuilder = new FilterListBuilder();
+            $filterListBuilder->setLogger($logger);
+            $filterListBuilder->buildRealmLists('Jobs');
+
         } catch (Exception $e) {
             $logger->crit(array(
                 'message'    => 'Aggregation failed: ' . $e->getMessage(),

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -27,7 +27,6 @@ then
     xdmod-ingestor
     xdmod-import-csv -t names -i $REF_DIR/names.csv
     xdmod-ingestor
-    xdmod-build-filter-lists -r Jobs
     php /root/bin/createusers.php
     acl-import
 fi


### PR DESCRIPTION
Fix xdmod-build-filter-lists so that the command line flags that control log levels work and the long command line flag to specify the realm works.

Add the filter list building back to being run in the `xdmod-ingestor` command, thus keeping the same behaviour as the release software.