### PR TITLE
Disambiguate the word Federat(ed|iion)

### DIFF
--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -207,7 +207,7 @@ class XDSamlAuthentication
                 print_r($samlAttributes, true);
         }
         if ($error) {
-            $this->logger->err("Error Creating Signle Sign On user" . $body);
+            $this->logger->err("Error Creating Single Sign On user" . $body);
         } else {
             $this->logger->notice("New " . ($linked ? "linked": "unlinked") . " Single Sign On user created" . $body);
         }

--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -29,11 +29,11 @@ class XDSamlAuthentication
     protected $_isConfigured = false;
 
     /**
-     * Whether or not we allow federated users local access. Defaults to true.
+     * Whether or not we allow Single Sign On users local access. Defaults to true.
      *
      * @var boolean
      */
-    protected $_allowLocalAccessViaFederation = true;
+    protected $_allowLocalAccessViaSSO = true;
     private $logger = null;
 
     public function __construct()
@@ -49,7 +49,7 @@ class XDSamlAuthentication
         );
         $this->_sources = \SimpleSAML_Auth_Source::getSources();
         try {
-            $this->_allowLocalAccessViaFederation = strtolower(\xd_utilities\getConfiguration('authentication', 'allowLocalAccessViaFederation')) === "false" ? false: true;
+            $this->_allowLocalAccessViaSSO = strtolower(\xd_utilities\getConfiguration('authentication', 'allowLocalAccessViaFederation')) === "false" ? false: true;
         } catch (Exception $e) {
         }
         if ($this->isSamlConfigured()) {
@@ -99,7 +99,7 @@ class XDSamlAuthentication
             $xdmodUserId = \XDUser::userExistsWithUsername($thisUserName);
             if ($xdmodUserId !== INVALID) {
                 return \XDUser::getUserByID($xdmodUserId);
-            } elseif ($this->_allowLocalAccessViaFederation && isset($samlAttrs['email_address'])) {
+            } elseif ($this->_allowLocalAccessViaSSO && isset($samlAttrs['email_address'])) {
                 $xdmodUserId = \XDUser::userExistsWithEmailAddress($samlAttrs['email_address'][0]);
                 if ($xdmodUserId === AMBIGUOUS) {
                     return "AMBIGUOUS";
@@ -135,7 +135,7 @@ class XDSamlAuthentication
             } catch (Exception $e) {
                 return "EXISTS";
             }
-            $newUser->setUserType(FEDERATED_USER_TYPE);
+            $newUser->setUserType(SSO_USER_TYPE);
             try {
                 $newUser->saveUser();
             } catch (Exception $e) {
@@ -172,7 +172,7 @@ class XDSamlAuthentication
             }
             if ($orgDisplay === "") {
                 $orgDisplay = array(
-                    'en' => 'Federation'
+                    'en' => 'Single Sign On'
                 );
             }
             return array(
@@ -190,8 +190,8 @@ class XDSamlAuthentication
      *
      * @param \XDUser $user The newly minted XDMoD user
      * @param array $samlAttributes SAML attributes associated with this user
-     * @param boolean $linked whether federated user is linked to this account
-     * @param boolean $error whether or not we had issues creating federated user
+     * @param boolean $linked whether Single Sign On user is linked to this account
+     * @param boolean $error whether or not we had issues creating Single Sign On user
      */
     private function notifyAdminOfNewUser($user, $samlAttributes, $linked, $error = false)
     {
@@ -207,9 +207,9 @@ class XDSamlAuthentication
                 print_r($samlAttributes, true);
         }
         if ($error) {
-            $this->logger->err("Error Creating federated user" . $body);
+            $this->logger->err("Error Creating Signle Sign On user" . $body);
         } else {
-            $this->logger->notice("New " . ($linked ? "linked": "unlinked") . " federated user created" . $body);
+            $this->logger->notice("New " . ($linked ? "linked": "unlinked") . " Single Sign On user created" . $body);
         }
     }
 }

--- a/classes/NewRest/Controllers/UserControllerProvider.php
+++ b/classes/NewRest/Controllers/UserControllerProvider.php
@@ -131,7 +131,7 @@ class UserControllerProvider extends BaseControllerProvider
             'first_name' => $user->getFirstName(),
             'last_name' => $user->getLastName(),
             'email_address' => $emailAddress,
-            'is_federated_user' => $user->isFederatedUser(),
+            'is_sso_user' => $user->isSSOUser(),
             'first_time_login' => $user->getCreationTimestamp() == $user->getLastLoginTimestamp(),
             'autoload_suppression' => isset($_SESSION['suppress_profile_autoload']),
             'field_of_science' => $user->getFieldOfScience(),

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -291,13 +291,13 @@ class XDUser extends ETL\Loggable implements JsonSerializable
 
         }
 
-        // We don't want to acknowledge Federated-derived accounts...
+        // We don't want to acknowledge Single Sign On-derived accounts...
 
         $userCheck = $pdo->query(
             $user_check_query,
             array(
                 'email_address' => $email_address,
-                'user_type' => FEDERATED_USER_TYPE
+                'user_type' => SSO_USER_TYPE
             )
         );
 
@@ -545,7 +545,7 @@ SQL;
 
     public function setPassword($raw_password)
     {
-        if ($this->getUserType() === FEDERATED_USER_TYPE) {
+        if ($this->getUserType() === SSO_USER_TYPE) {
             throw new AccessDeniedException("Permission Denied. Only local accounts may have their passwords modified.");
         }
 
@@ -691,22 +691,26 @@ SQL;
     {
 
         if (strlen($uname) == 0 || strlen($pass) == 0) {
-            return NULL;
+            return null;
         }
 
         $pdo = DB::factory('database');
 
-        $userCheck = $pdo->query("SELECT id, password
-        FROM Users
-        WHERE username=:username
-        AND user_type != :federated_user_type",
+        $userCheck = $pdo->query(
+            "SELECT
+                id, password
+            FROM
+                Users
+            WHERE
+                username=:username
+                AND user_type != :user_type",
             array(
                 'username' => $uname,
-                'federated_user_type' => FEDERATED_USER_TYPE
+                'user_type' => SSO_USER_TYPE
             )
         );
         if (count($userCheck) == 0) {
-            return NULL;
+            return null;
         }
 
         if (password_verify($pass, $userCheck[0]['password'])) {
@@ -860,8 +864,8 @@ SQL;
         // A common e-mail address CAN be shared among multiple XSEDE accounts...
         // Each XDMoD (local) account must have a distinct e-mail address (unless that e-mail address is present in moddb.ExceptionEmailAddresses)
 
-        // The second condition is in place to account for the case where a new Federated user is being created (and is not currently in the XDMoD DB)
-        if (($id_of_user_holding_email_address != INVALID) && ($this->getUserType() != FEDERATED_USER_TYPE)) {
+        // The second condition is in place to account for the case where a new Single Sign On user is being created (and is not currently in the XDMoD DB)
+        if (($id_of_user_holding_email_address != INVALID) && ($this->getUserType() != SSO_USER_TYPE)) {
 
             if (!isset($this->_id)) {
                 // This user has no record in the database (never saved).  If $id_of_user_holding_email_address
@@ -2789,7 +2793,7 @@ SQL;
     // --------------------------------
 
     /*
-     * @function isFederatedUser
+     * @function isSSOUser
      *
      * Determines whether the user is an XSEDE-oriented user
      *
@@ -2797,12 +2801,12 @@ SQL;
      *
      */
 
-    public function isFederatedUser()
+    public function isSSOUser()
     {
 
-        return ($this->getUserType() == FEDERATED_USER_TYPE);
+        return ($this->getUserType() == SSO_USER_TYPE);
 
-    }//isFederatedUser
+    }
 
     // --------------------------------
 

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -702,7 +702,7 @@ SQL;
             FROM
                 Users
             WHERE
-                username=:username
+                username = :username
                 AND user_type != :user_type",
             array(
                 'username' => $uname,

--- a/configuration/apache.conf
+++ b/configuration/apache.conf
@@ -47,7 +47,7 @@ Listen 8080
         RewriteRule (.*) index.php [L]
     </Directory>
 
-    ## SimpleSAML federated authentication.
+    ## SimpleSAML Single Sign On authentication.
     #SetEnv SIMPLESAMLPHP_CONFIG_DIR /etc/xdmod/simplesamlphp/config
     #Alias /simplesaml /usr/share/xdmod/vendor/simplesamlphp/simplesamlphp/www
     #<Directory /usr/share/xdmod/vendor/simplesamlphp/simplesamlphp/www>

--- a/configuration/constants.php
+++ b/configuration/constants.php
@@ -27,7 +27,7 @@ define('INVALID', '-1p');
 define('AMBIGUOUS', '-2p');
 define('NO_MAPPING', '-3p');
 define('NO_EMAIL_ADDRESS_SET', 'no_email_address_set');
-define('FEDERATED_USER_TYPE', 5);
+define('SSO_USER_TYPE', 5);
 define('DEMO_USER_TYPE', 4);
 define('UNKNOWN_USER_TYPE', -1);
 

--- a/db/data/moddb.sql
+++ b/db/data/moddb.sql
@@ -24,7 +24,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `UserTypes` WRITE;
 /*!40000 ALTER TABLE `UserTypes` DISABLE KEYS */;
-INSERT INTO `UserTypes` VALUES (1,'External','#000000'),(2,'Internal','#0000ff'),(3,'Testing','#008800'),(4,'Demo','#808000'),(5,'Federated','#b914f6');
+INSERT INTO `UserTypes` VALUES (1,'External','#000000'),(2,'Internal','#0000ff'),(3,'Testing','#008800'),(4,'Demo','#808000'),(5,'Single Sign On','#b914f6');
 /*!40000 ALTER TABLE `UserTypes` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/migrations/7.5.0-8.0.0/moddb.sql
+++ b/db/migrations/7.5.0-8.0.0/moddb.sql
@@ -1,3 +1,11 @@
 ALTER TABLE `Users` CHANGE COLUMN `password` `password` VARCHAR(255) NULL DEFAULT NULL;
 
 INSERT INTO `schema_version_history` VALUES ('moddb', '8.0.0', NOW(), 'upgraded', 'N/A');
+
+-- Change wording of Federated login to Single Sign On
+USE moddb;
+UPDATE
+    moddb.UserTypes
+SET type = 'Single Sign On'
+WHERE type = 'Federated'
+;

--- a/docs/_includes/menu.md
+++ b/docs/_includes/menu.md
@@ -25,7 +25,7 @@ Installing
    - [RPM Installation Guide](install-rpm.html)
    - [Source Installation Guide](install-source.html)
 - [Configuration Guide](configuration.html)
-   - [Federated Authentication](simpleSAMLphp.html)
+   - [Single Sign On Authentication](simpleSAMLphp.html)
      - [LDAP Authentication](simpleSAMLphp-ldap.html)
 - [Database Guide](databases.html)
 - [Upgrade Guide](upgrade.html)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,7 +23,7 @@ extensively, so we recommend MySQL 5.1 or 5.5.
 
 ### How do I enable LDAP Authentication?
 
-Open XDMoD has support for [federated authentication](simpleSAMLphp.html)
+Open XDMoD has support for [Single Sign On](simpleSAMLphp.html)
 using [simpleSAMLphp][simplesaml].  Basic support for [LDAP Authentication](simpleSAMLphp-ldap.html) is also provided.
 
 [simplesaml]: https://simplesamlphp.org/

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -1,10 +1,10 @@
 ---
-title: Federated Authentication Guide
+title: Single Sign On Guide
 ---
 
 ----------
 
-Documentation only covers using [SimpleSAMLphp][ssp] for SAML federated authentication.
+Documentation only covers using [SimpleSAMLphp][ssp] for Single Sign On.
 
 ----------
 
@@ -23,7 +23,7 @@ First you will need to create the folders for the SimpleSAMLphp files to live:
 # mkdir -p /etc/xdmod/simplesamlphp/cert
 ```
 
-Required configuration files to be added to support federated authentication:
+Required configuration files to be added to support Single Sign On:
 
 *   `/etc/xdmod/simplesamlphp/config/config.php`
 *   `/etc/xdmod/simplesamlphp/config/authsources.php`
@@ -71,7 +71,7 @@ Here is an example:
 <?php
 $config = array(
   /*
-   * If you want to support both local auth and federated auth look into
+   * If you want to support both local auth and Single Sign On auth look into
    * https://simplesamlphp.org/docs/stable/multiauth:multiauth
    * https://simplesamlphp.org/docs/stable/sqlauth:sql
    * An updated example will be provided when this is implemented.

--- a/html/controllers/user_admin/delete_user.php
+++ b/html/controllers/user_admin/delete_user.php
@@ -3,42 +3,42 @@
    // Operation: user_admin->delete_user
 
    $logged_in_user = \xd_security\assertDashboardUserLoggedIn();
-   
+
    \xd_security\assertParameterSet('uid', RESTRICTION_UID);
 
    try {
 
       $user_to_remove = XDUser::getUserByID($_POST['uid']);
-   
+
       if ($user_to_remove == NULL) {
          \xd_response\presentError("user_does_not_exist");
       }
-   
+
       if ($logged_in_user->getUsername() == $user_to_remove->getUsername()) {
          \xd_response\presentError("You are not allowed to delete your own account.");
       }
-   
+
       // Remove all entries in this user's profile
       $profile = $user_to_remove->getProfile();
       $profile->clear();
-       
+
       $username = $user_to_remove->getUsername();
-   
-      $statusPrefix = $user_to_remove->isFederatedUser() ? 'Federated ' : '';
+
+      $statusPrefix = $user_to_remove->isSSOUser() ? 'Single Sign On ' : '';
       $displayUsername = $user_to_remove->getUsername();
-      
+
       $user_to_remove->removeUser();
-   
+
       $returnData['success'] = true;
       $returnData['message'] = $statusPrefix."User <b>$displayUsername</b> deleted from the portal";
-   
+
       \xd_controller\returnJSON($returnData);
 
    }
    catch(Exception $e) {
-      
+
       \xd_response\presentError($e->getMessage());
 
    }
-   
+
 ?>

--- a/html/controllers/user_admin/update_user.php
+++ b/html/controllers/user_admin/update_user.php
@@ -81,7 +81,7 @@ if (isset($_POST['email_address'])) {
 
     $email_address = (strlen($_POST['email_address']) > 0) ? $_POST['email_address'] : NO_EMAIL_ADDRESS_SET;
 
-    if (($user_to_update->getUserType() != FEDERATED_USER_TYPE) && ($email_address == NO_EMAIL_ADDRESS_SET)) {
+    if (($user_to_update->getUserType() != SSO_USER_TYPE) && ($email_address == NO_EMAIL_ADDRESS_SET)) {
         $returnData['success'] = false;
         $returnData['status'] = 'This XDMoD user must have an e-mail address set.';
         xd_controller\returnJSON($returnData);
@@ -100,7 +100,7 @@ if (isset($_POST['is_active'])) {
 
 if (isset($_POST['user_type'])) {
 
-    if ($user_to_update->getUserType() != FEDERATED_USER_TYPE) {
+    if ($user_to_update->getUserType() != SSO_USER_TYPE) {
 
         $user_to_update->setUserType($_POST['user_type']);
 
@@ -204,7 +204,7 @@ try {
 
 $returnData['success'] = true;
 
-$statusPrefix = $user_to_update->isFederatedUser() ? 'Federated ' : '';
+$statusPrefix = $user_to_update->isSSOUser() ? 'Single Sign On ' : '';
 $displayUsername = $user_to_update->getUsername();
 
 $returnData['status'] = $statusPrefix . "User <b>$displayUsername</b> updated successfully";

--- a/html/gui/css/LoginPrompt.css
+++ b/html/gui/css/LoginPrompt.css
@@ -47,7 +47,7 @@
     background-position: 0 -18px;
 }
 
-#federated_login_form .x-panel-body, #local_login_form .x-panel-body, #forgot_password_form .x-panel-body {
+#sso_login_form .x-panel-body, #local_login_form .x-panel-body, #forgot_password_form .x-panel-body {
     background-color: #e8e8e8 !important;
     border: 1px;
     border-color: #bbb;
@@ -58,15 +58,15 @@
     padding: 15px;
 }
 
-#federated_login_form form, #local_login_form form, #forgot_password_form form {
+#sso_login_form form, #local_login_form form, #forgot_password_form form {
     padding: 15px;
 }
 
-#federatedLoginLink button {
+#SSOLoginLink button {
     height: 100%;
 }
 
-#federatedLoginLink img {
+#SSOLoginLink img {
     margin: 4px;
 }
 

--- a/html/gui/general/login.php
+++ b/html/gui/general/login.php
@@ -22,7 +22,7 @@ if ($auth && $auth->isSamlConfigured()) {
         $samlError = $xdmodUser;
     }
 }
-// Used for Federated login or samlErrors
+// Used for Single Sign On  or samlErrors
 ?>
 <!DOCTYPE html>
 <html>

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -459,7 +459,7 @@ CCR.xdmod.ui.smallChartScale = 0.61;
 CCR.xdmod.ui.thumbWidth = 400;
 CCR.xdmod.ui.thumbHeight = CCR.xdmod.ui.thumbWidth * CCR.xdmod.ui.thumbAspect;
 
-CCR.xdmod.FEDERATED_USER_TYPE = 5;
+CCR.xdmod.SSO_USER_TYPE = 5;
 
 CCR.xdmod.UserTypes = {
     ProgramOfficer: 'po',
@@ -946,7 +946,7 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
     });
 
     var loginItems = [];
-    var accountName = CCR.xdmod.federationLoginLink && CCR.xdmod.federationLoginLink.organization.en !== 'Federation' ? CCR.xdmod.federationLoginLink.organization.en : CCR.xdmod.org_name;
+    var accountName = CCR.xdmod.SSOLoginLink && CCR.xdmod.SSOLoginLink.organization.en !== 'Single Sign On' ? CCR.xdmod.SSOLoginLink.organization.en : CCR.xdmod.org_name;
 
     var signInWithLocalAccount = function () {
         if (txtLoginUsername.getValue().length === 0) {
@@ -1037,16 +1037,16 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
         })]
     })];
 
-    var federatedLoginFrm = CCR.xdmod.isFederationConfigured ? new Ext.form.FormPanel({
-        id: 'federated_login_form',
+    var SSOLoginFrm = CCR.xdmod.isSSOConfigured ? new Ext.form.FormPanel({
+        id: 'sso_login_form',
         title: 'Sign in with ' + accountName + ':',
         items: [{
             xtype: 'button',
-            text: '<img src="' + CCR.xdmod.federationLoginLink.icon + '" alt="Login here."></img>',
+            text: '<img src="' + CCR.xdmod.SSOLoginLink.icon + '" alt="Login here."></img>',
             anchor: '100%',
-            id: 'federatedLoginLink',
+            id: 'SSOLoginLink',
             handler: function () {
-                document.location = CCR.xdmod.federationLoginLink.url;
+                document.location = CCR.xdmod.SSOLoginLink.url;
             }
         }]
     }) : null;
@@ -1068,8 +1068,8 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
 
     var title = 'Sign into XDMoD';
 
-    if (CCR.xdmod.isFederationConfigured) {
-        loginItems.push(federatedLoginFrm);
+    if (CCR.xdmod.isSSOConfigured) {
+        loginItems.push(SSOLoginFrm);
         loginItems.push(localLoginFrm);
     } else {
         loginItems.push(localLoginFrm);

--- a/html/gui/js/profile_editor/ProfileEditor.js
+++ b/html/gui/js/profile_editor/ProfileEditor.js
@@ -6,7 +6,7 @@ XDMoD.ProfileEditorConstants = {
 
    PASSWORD:             0,
     WELCOME_EMAIL_CHANGE: 1, // designates if we're displaying first time login prompt to validate email
-    FEDERATED_USER: 5 // designates whether or not this is a federated user
+    SSO_USER: 5 // designates whether or not this is a Single Sign On user
 
 };//XDMoD.ProfileEditorConstants
 

--- a/html/gui/js/profile_editor/ProfileGeneralSettings.js
+++ b/html/gui/js/profile_editor/ProfileGeneralSettings.js
@@ -146,7 +146,7 @@ XDMoD.ProfileGeneralSettings = Ext.extend(Ext.form.FormPanel, {
 
         // ------------------------------------------------
 
-        var active_layout_index = CCR.xdmod.ui.userIsFederated ? XDMoD.ProfileEditorConstants.FEDERATED_USER : XDMoD.ProfileEditorConstants.PASSWORD;
+        var active_layout_index = CCR.xdmod.ui.userIsSSO ? XDMoD.ProfileEditorConstants.SSO_USER : XDMoD.ProfileEditorConstants.PASSWORD;
 
 
         // ------------------------------------------------
@@ -179,10 +179,10 @@ XDMoD.ProfileGeneralSettings = Ext.extend(Ext.form.FormPanel, {
                 // ================================================
 
                 // active_layout_index = XDMoD.ProfileEditorConstants.PASSWORD;
-                if (data.results.is_federated_user && data.results.email_address.length === 0) {
+                if (data.results.is_sso_user && data.results.email_address.length === 0) {
                     XDMoD.Profile.logoutOnClose = true;
                 }
-                if (data.results.is_federated_user === true) {
+                if (data.results.is_sso_user === true) {
                     if (data.results.first_time_login) {
                         // If the user is logging in for the first time, prompt them to validate their email address
                         active_layout_index = XDMoD.ProfileEditorConstants.WELCOME_EMAIL_CHANGE;
@@ -349,7 +349,7 @@ XDMoD.ProfileGeneralSettings = Ext.extend(Ext.form.FormPanel, {
             ]
         }); // sectionPassword
 
-        var sectionFederatedUser = new Ext.Panel({
+        var sectionSSOUser = new Ext.Panel({
             labelWidth: 95,
             frame: false,
             bodyStyle: 'padding:0px 5px',
@@ -361,7 +361,7 @@ XDMoD.ProfileGeneralSettings = Ext.extend(Ext.form.FormPanel, {
             }]
         });
 
-        var sectionFederatedEmail = new Ext.Panel({
+        var sectionSSOEmail = new Ext.Panel({
             labelWidth: 95,
             frame: false,
             bodyStyle: 'padding:0px 5px',
@@ -378,11 +378,11 @@ XDMoD.ProfileGeneralSettings = Ext.extend(Ext.form.FormPanel, {
         // ------------------------------------------------
 
         var bottomItems = [
-            sectionFederatedEmail,
-            sectionFederatedUser
+            sectionSSOEmail,
+            sectionSSOUser
         ];
 
-        if (!CCR.xdmod.ui.userIsFederated) {
+        if (!CCR.xdmod.ui.userIsSSO) {
             bottomItems.unshift(sectionPassword);
         }
 

--- a/html/index.php
+++ b/html/index.php
@@ -267,8 +267,8 @@ use Models\Services\Realms;
                print "CCR.xdmod.ui.fullName = " . json_encode($user->getFormalName()) . ";\n";
                $userType = $user->getUserType();
                print "CCR.xdmod.ui.usertype = '$userType';\n";
-               $userIsFederated = ($userType === FEDERATED_USER_TYPE ) ? "true" : "false";
-               print "CCR.xdmod.ui.userIsFederated = $userIsFederated;\n";
+               $userIsSSO= ($userType === SSO_USER_TYPE ) ? "true" : "false";
+               print "CCR.xdmod.ui.userIsSSO = $userIsSSO;\n";
                print "CCR.xdmod.ui.mappedPID = '{$user->getPersonID(TRUE)}';\n";
 
                $obj_warehouse = new XDWarehouse();
@@ -310,10 +310,10 @@ use Models\Services\Realms;
                   // This will catch when a configuration directory does not exist if it is set in the environment level
                }
                if ($auth && $auth->isSamlConfigured()) {
-                    print "CCR.xdmod.isFederationConfigured = true;\n";
-                    print "CCR.xdmod.federationLoginLink = " . json_encode($auth->getLoginLink('/gui/general/login.php')) . ";\n";
+                    print "CCR.xdmod.isSSOConfigured = true;\n";
+                    print "CCR.xdmod.SSOLoginLink = " . json_encode($auth->getLoginLink('/gui/general/login.php')) . ";\n";
                } else {
-                  print "CCR.xdmod.isFederationConfigured = false;";
+                  print "CCR.xdmod.isSSOConfigured = false;";
                }
             }
             if ($userLoggedIn) {
@@ -499,12 +499,12 @@ use Models\Services\Realms;
             $profile_editor_init_flag = '';
             $usersFirstLogin = ($user->getCreationTimestamp() == $user->getLastLoginTimestamp());
 
-            // If the user logging in is an XSEDE/Federated user, he/she may or may not have
+            // If the user logging in is an XSEDE/Single Sign On user, they may or may not have
             // an e-mail address set. The logic below assists in presenting the Profile Editor
             // with the appropriate (initial) view
             $userEmail = $user->getEmailAddress();
             $userEmailSpecified = ($userEmail != NO_EMAIL_ADDRESS_SET && !empty($userEmail));
-            if ($user->isFederatedUser() == true || $usersFirstLogin) {
+            if ($user->isSSOUser() == true || $usersFirstLogin) {
 
                // NOTE: $_SESSION['suppress_profile_autoload'] will be set only upon update of the user's profile (see respective REST call)
 

--- a/html/internal_dashboard/js/UserStats.js
+++ b/html/internal_dashboard/js/UserStats.js
@@ -307,7 +307,7 @@ XDMoD.UserStatsComponents.Visitation = Ext.extend(Ext.Panel, {
             },
 
             {
-                 boxLabel: '<span style="color: #b914f6">Federated Users</span>',
+                 boxLabel: '<span style="color: #b914f6">SSO Users</span>',
                name: 'rb',
                  inputValue: '5',
                checked: true

--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -236,7 +236,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                 load: function (store, records) {
                     for (var i = 0; i < records.length; i++) {
                         var record = records[i];
-                        if (parseInt(record.data.id, 10) === CCR.xdmod.FEDERATED_USER_TYPE) {
+                        if (parseInt(record.data.id, 10) === CCR.xdmod.SSO_USER_TYPE) {
                             store.remove(record);
                         }
                     }
@@ -641,7 +641,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
 
             validator: function (value) {
                 // If the user is an XSEDE user, an email address is not required.
-                if (cached_user_type === CCR.xdmod.FEDERATED_USER_TYPE) {
+                if (cached_user_type === CCR.xdmod.SSO_USER_TYPE) {
                     return true;
                 }
 
@@ -728,7 +728,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
 
         var lblXSEDEUser = new Ext.form.Label({
             fieldLabel: 'User Type',
-            html: '<b style="color: #00f">Federated User</b>'
+            html: '<b style="color: #00f">SSO User</b>'
         });
 
         lblXSEDEUser.hide();
@@ -830,7 +830,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                     }
                 }
 
-                // When we are working on a 'Federated' user the cmbUserType will
+                // When we are working on a 'Single Sign On' user the cmbUserType will
                 // not have a value ( as it's hidden ). In that case use the
                 // cached_user_type variable which is populated when we fetch
                 // the users details.
@@ -1148,7 +1148,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                         cached_user_type = parseInt(json.user_information.user_type);
                         cmbUserMapping.initializeWithValue(json.user_information.assigned_user_id, json.user_information.assigned_user_name);
 
-                        if (cached_user_type === CCR.xdmod.FEDERATED_USER_TYPE) {
+                        if (cached_user_type === CCR.xdmod.SSO_USER_TYPE) {
                             // XSEDE-derived User: Can't change user type
                             cmbUserType.hide();
                             lblXSEDEUser.show();

--- a/html/internal_dashboard/js/admin_panel/SectionNewUser.js
+++ b/html/internal_dashboard/js/admin_panel/SectionNewUser.js
@@ -57,7 +57,7 @@ XDMoD.CreateUser = Ext.extend(Ext.form.FormPanel, {
                 load: function (store, records) {
                     for (var i = 0; i < records.length; i++) {
                         var record = records[i];
-                        if (parseInt(record.data.id, 10) === CCR.xdmod.FEDERATED_USER_TYPE) {
+                        if (parseInt(record.data.id, 10) === CCR.xdmod.SSO_USER_TYPE) {
                             store.remove(record);
                         }
                     }

--- a/open_xdmod/modules/xdmod/automated_tests/package.json
+++ b/open_xdmod/modules/xdmod/automated_tests/package.json
@@ -10,7 +10,7 @@
     "requirements-check": "node check-version.js",
     "postinstall": "npm run requirements-check",
     "test": "wdio wdio.conf.js",
-    "test-federated": "FEDERATED=true npm test -- --spec ./test/specs/xdmod/federatedLogin.js"
+    "test-sso": "SSO=true npm test -- --spec ./test/specs/xdmod/SSOLogin.js"
   },
   "author": "Ben Plessinger",
   "license": "GPL-3.0",

--- a/open_xdmod/modules/xdmod/automated_tests/runtests.sh
+++ b/open_xdmod/modules/xdmod/automated_tests/runtests.sh
@@ -21,9 +21,9 @@ npm install --quiet
 
 ./artifacts/update-artifacts.sh
 
-if [ "$4" = "--federated" ];
+if [ "$4" = "--sso" ];
 then
-    npm run test-federated
+    npm run test-sso
 else
     npm test
 fi

--- a/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/SSOLogin.js
+++ b/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/SSOLogin.js
@@ -1,12 +1,12 @@
-describe('Federated Login', () => {
-    it('Should have the federated option', () => {
+describe('Single Sign On Login', () => {
+    it('Should have the Single Sign On option', () => {
         browser.url('/');
         browser.waitForInvisible('.ext-el-mask-msg');
         browser.waitAndClick('a[href*=actionLogin]');
-        browser.waitForVisible('#federatedLoginLink');
-        browser.waitAndClick('#federatedLoginLink');
+        browser.waitForVisible('#SSOLoginLink');
+        browser.waitAndClick('#SSOLoginLink');
     });
-    it('Should goto the federated login page and login', () => {
+    it('Should goto the Single Sign On login page and login', () => {
         browser.waitForExist('form[action="/sso"]');
         browser.submitForm('form[action="/sso"]');
     });

--- a/open_xdmod/modules/xdmod/automated_tests/wdio.conf.js
+++ b/open_xdmod/modules/xdmod/automated_tests/wdio.conf.js
@@ -38,8 +38,8 @@ secrets.url = process.env.TEST_URL ? process.env.TEST_URL : secrets.url;
 var excludes = [
     './test/**/*.page.js'
 ];
-if (!process.env.FEDERATED) {
-    excludes.push('./test/specs/xdmod/federatedLogin.js');
+if (!process.env.SSO) {
+    excludes.push('./test/specs/xdmod/SSOLogin.js');
 }
 var capabilities = [Chrome];
 var services = ['selenium-standalone'];
@@ -89,8 +89,8 @@ exports.config = {
     // Patterns to exclude.
     exclude: excludes,
     suites: {
-        federatedLogin: [
-            './test/specs/xdmod/federatedLogin.js'
+        SSOLogin: [
+            './test/specs/xdmod/SSOLogin.js'
         ]
     },
     //

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -662,7 +662,7 @@ class XDUserTest extends BaseTest
 
         $this->assertEquals('0', $user->getUserID());
 
-        $user->setUserType(FEDERATED_USER_TYPE);
+        $user->setUserType(SSO_USER_TYPE);
 
         $user->saveUser();
 
@@ -678,7 +678,7 @@ class XDUserTest extends BaseTest
         $user = self::getUser(null, 'test', 'a', 'user', array());
         $this->assertEquals('0', $user->getUserID());
 
-        $user->setUserType(FEDERATED_USER_TYPE);
+        $user->setUserType(SSO_USER_TYPE);
 
         $user->saveUser();
         $this->assertNotNull($user->getUserID());
@@ -715,7 +715,7 @@ class XDUserTest extends BaseTest
     {
         $username = array_keys(self::$users)[count(self::$users) - 1];
         $anotherUser = self::getUser(null, 'test', 'a', 'user', array(ROLE_ID_USER), ROLE_ID_USER, null, $username);
-        $anotherUser->setUserType(FEDERATED_USER_TYPE);
+        $anotherUser->setUserType(SSO_USER_TYPE);
         $anotherUser->saveUser();
     }
 

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ControllerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ControllerTest.php
@@ -109,7 +109,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testEnumUserTypes()
     {
         $expected = JSON::loadFile(
-            $this->getTestFiles()->getFile('controllers', 'enum_user_types')
+            $this->getTestFiles()->getFile('controllers', 'enum_user_types-8.0.0')
         );
 
         $this->helper->authenticateDashboard('mgr');
@@ -275,7 +275,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testEnumUserTypesAndRoles()
     {
         $expected = JSON::loadFile(
-            $this->getTestFiles()->getFile('controllers', 'enum_user_types_and_roles-xsede_to_federated')
+            $this->getTestFiles()->getFile('controllers', 'enum_user_types_and_roles-8.0.0')
         );
 
         $this->helper->authenticateDashboard('mgr');

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UserControllerProviderTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UserControllerProviderTest.php
@@ -17,7 +17,6 @@ class UserControllerProviderTest extends BaseUserAdminTest
     public function testGetCurrentUser(array $options)
     {
         $user = $options['user'];
-
         $expected = $options['expected'];
         $expectedFile = $expected['file'];
         $expectedHttpCode = $expected['http_code'];
@@ -52,7 +51,7 @@ class UserControllerProviderTest extends BaseUserAdminTest
     public function provideGetCurrentUser()
     {
         return JSON::loadFile(
-            $this->getTestFiles()->getFile('user_controller', 'get_current_user', 'input')
+            $this->getTestFiles()->getFile('user_controller', 'get_current_user-8.0.0', 'input')
         );
     }
 }

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
@@ -115,7 +115,7 @@ cat > /usr/share/xdmod/vendor/simplesamlphp/simplesamlphp/config/authsources.php
 <?php
 \$config = array(
   /*
-   * If you want to support both local auth and federated auth look into
+   * If you want to support both local auth and Single Sign On auth look into
    * https://simplesamlphp.org/docs/stable/multiauth:multiauth
    * https://simplesamlphp.org/docs/stable/sqlauth:sql
    * An updated example will be provided when this is implemented.

--- a/shippable.yml
+++ b/shippable.yml
@@ -28,7 +28,7 @@ build:
         - mv ./configuration/portal_settings.ini.old ./configuration/portal_settings.ini
         - ./open_xdmod/modules/xdmod/automated_tests/runtests.sh --headless --log-junit `pwd`/shippable/testresults
         - ./open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
-        - ./open_xdmod/modules/xdmod/automated_tests/runtests.sh --headless --log-junit `pwd`/shippable/testresults --federated
+        - ./open_xdmod/modules/xdmod/automated_tests/runtests.sh --headless --log-junit `pwd`/shippable/testresults --sso
 
     on_failure:
         - cat /var/log/xdmod/*


### PR DESCRIPTION
Use Single Sign On (SSO) instead of Federat(ed|ion)