### PR TITLE
Updates to Config for Cloud Metrics

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -123,15 +123,19 @@ function main()
     if (isset($modules['#'])) {
         unset($modules['#']);
     }
+    if (isset($modules['WARNING'])) {
+        unset($modules['WARNING']);
+    }
+    $moduleNames = array_keys($modules);
     $moduleHierarchies = array();
 
     // Role Retrieval
     $allRoles = Roles::getRoleNames($blacklist);
 
     // Retrieve the annotated combined config information for each section.
-    $rawHierarchies = $config->getModuleSection('hierarchies');
-    $rawRoles = $config->getModuleSection('roles');
-    $rawRealms = $config->getModuleSection('datawarehouse');
+    $rawHierarchies = $config->getModuleSection('hierarchies', $moduleNames);
+    $rawRoles = $config->getModuleSection('roles', $moduleNames);
+    $rawRealms = $config->getModuleSection('datawarehouse', $moduleNames);
 
 
     foreach ($modules as $module => $moduleData) {

--- a/classes/Xdmod/Config.php
+++ b/classes/Xdmod/Config.php
@@ -103,10 +103,10 @@ class Config implements ArrayAccess
      * @param string $section the section to retrieve
      * @return mixed
      */
-    public function getModuleSection($section)
+    public function getModuleSection($section, array $modules = array())
     {
         if (!isset($this->moduleSections[$section])) {
-            $this->moduleSections[$section] = $this->loadModuleSection($section);
+            $this->moduleSections[$section] = $this->loadModuleSection($section, $modules);
         }
         return $this->moduleSections[$section];
     }
@@ -142,7 +142,7 @@ class Config implements ArrayAccess
      *
      * @return mixed
      **/
-    private function loadModuleSection($section)
+    private function loadModuleSection($section, array $modules = array())
     {
         $file = $this->getFilePath($section);
 
@@ -161,6 +161,9 @@ class Config implements ArrayAccess
 
         foreach ($partialFiles as $file) {
             $module = $this->getModule(pathinfo($file, PATHINFO_FILENAME));
+            if (!in_array($module, $modules)) {
+                $module = DEFAULT_MODULE_NAME;
+            }
 
             $partialData = Json::loadFile($file);
             if (!empty($partialData)) {

--- a/open_xdmod/modules/xdmod/tests/lib/Xdmod/ConfigTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/Xdmod/ConfigTest.php
@@ -267,7 +267,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
     public function moduleSectionProvider()
     {
-        $rolesExpected = Json::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'roles-update_enumAllAvailableRoles.json');
+        $rolesExpected = Json::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'roles-config_for_cloud.json');
         $datawarehouseExpected = Json::loadFile(__DIR__ . self::TEST_ARTIFACT_OUTPUT_PATH . DIRECTORY_SEPARATOR . 'datawarehouse-fix_datawarehouse.json');
         return array(
             array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously configuration files were associated with a module ( determined via filenames in the form: (module)(\:feature)?.json. Where feature is optional ). With the Cloud realm we do not have a new module to associate these configuration files with, they are instead associated with the XDMoD module. 
These changes provide for a default module to associate with config files that have no associated module.d file. 

## Motivation and Context
We would like to be able to add, but keep separate, configuration files for the base XDMoD module. 

## Tests performed
Manual tests were performed via adding in the current datawarehouse / roles config files for the 'cloud' feature and inspecting the database & the UI. Specifically the Usage & Metric Explorer. 

There exist automatic tests that exercise the Config class that were updated to account for the newly returned 'storage' realm information.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
