### PR TITLE
Log a warning on drop column

### DIFF
--- a/classes/ETL/DbModel/AggregationTable.php
+++ b/classes/ETL/DbModel/AggregationTable.php
@@ -154,6 +154,10 @@ class AggregationTable extends Table
         foreach ( $columnJson as $def ) {
             if ( null !== $variableMap ) {
                 foreach ( $def as $key => &$value ) {
+                    // Variables are not substituted in processing hints
+                    if ( 'hints' == $key ) {
+                        continue;
+                    }
                     $value = Utilities::substituteVariables($value, $variableMap);
                 }
                 unset($value); // Sever the reference with the last element

--- a/classes/ETL/DbModel/Column.php
+++ b/classes/ETL/DbModel/Column.php
@@ -34,12 +34,10 @@ class Column extends NamedEntity implements iEntity
         'default'  => null,
          // Column extra (see http://dev.mysql.com/doc/refman/5.7/en/create-table.html)
         'extra'    => null,
-        // The trigger definer for ACL purposes
+        // The column comment
         'comment'   => null,
-        // Column hints object
-        'hints'     => null,
-        // The trigger definer for ACL purposes
-        'rename'    => null
+        // Column hints object used to control behavior such as renaming columns
+        'hints'     => null
     );
 
     /* ------------------------------------------------------------------------------------------

--- a/classes/ETL/DbModel/Table.php
+++ b/classes/ETL/DbModel/Table.php
@@ -617,6 +617,7 @@ ORDER BY trigger_name ASC";
 
         foreach ( $dropColNames as $name ) {
             $alterList[] = "DROP COLUMN " . $this->quote($name);
+            $this->logger->warning(sprintf("Dropping column %s!", $this->quote($name)));
         }
 
         foreach ( $changeColNames as $name ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a table column is to be dropped by ETLv2, log a warning so the pipeline can be run in dryrun mode and verified prior to potentially losing data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed

Manually tested against XSEDE docker.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
