### PR TITLE
Quote database column names to support reserved keywords

### DIFF
--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1323,14 +1323,14 @@ class pdoAggregator extends aAggregator
 
         $this->insertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
             "("
-            . implode(",\n", array_keys($this->etlSourceQuery->records))
+            . implode(",\n", $this->quoteIdentifierNames(array_keys($this->etlSourceQuery->records)))
             . ")\nVALUES\n("
             . implode(",\n", Utilities::createPdoBindVarsFromArrayKeys($this->etlSourceQuery->records))
             . ")";
 
         $this->optimizedInsertSql = "INSERT INTO " . $this->etlDestinationTable->getFullName($includeSchema) . "\n" .
             "(" .
-            implode(",\n", array_keys($this->etlSourceQuery->records))
+            implode(",\n", $this->quoteIdentifierNames(array_keys($this->etlSourceQuery->records)))
             . ")\n" .
             $this->selectSql;
 

--- a/classes/ETL/DbModel/Query.php
+++ b/classes/ETL/DbModel/Query.php
@@ -377,9 +377,15 @@ class Query extends Entity implements iEntity
         $columnList = array();
         $thisObj = $this;
         foreach ( $this->records as $columnName => $formula ) {
-
-            // Do not quote field names because we may have functions in the query. -smg
-            $columnList[] = "$formula AS $columnName";
+            // Do not quote the source field names because we may have functions in the query, but
+            // do quote the destination names.
+            $columnList[] = sprintf(
+                "%s AS %s%s%s",
+                $formula,
+                $this->systemQuoteChar,
+                $columnName,
+                $this->systemQuoteChar
+            );
         }
 
         // Use the first join as the main FROM table, followined by other joins.

--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -191,7 +191,10 @@ class StructuredFileIngestor extends aIngestor implements iAction
                 $destinationFields
             );
 
-            // Generate one SQL statement per destination table
+            // Generate one SQL statement per destination table. Quote the field names to handle
+            // SQL reserved words.
+
+            $destinationFields = $this->quoteIdentifierNames($destinationFields);
 
             $sql = sprintf(
                 'INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s',
@@ -202,7 +205,7 @@ class StructuredFileIngestor extends aIngestor implements iAction
                     function ($destField) {
                         return "$destField = COALESCE(VALUES($destField), $destField)";
                     },
-                    array_keys($destFieldToSourceFieldMap)
+                    $destinationFields
                 ))
             );
 

--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -511,6 +511,7 @@ class pdoIngestor extends aIngestor
         if ( $this->options->force_load_data_infile_replace_into ) {
             $sql = "REPLACE INTO $qualifiedDestTableName (" . implode(',', $destColumnList) . ")\n" . $this->sourceQueryString;
         } else {
+            $destColumnList = $this->quoteIdentifierNames($destColumnList);
             $destColumns = implode(',', $destColumnList);
             $updateColumnList = array_map(
                 function ($s) {
@@ -609,6 +610,7 @@ class pdoIngestor extends aIngestor
                     . "."
                     . $this->destinationEndpoint->quoteSystemIdentifier("tmp_" . $etlTable->name . "_" . time());
 
+                $destColumnList = $this->quoteIdentifierNames($destColumnList);
                 $destColumns = implode(',', $destColumnList);
                 $updateColumnList = array_map(
                     function ($s) {

--- a/classes/ETL/aRdbmsDestinationAction.php
+++ b/classes/ETL/aRdbmsDestinationAction.php
@@ -928,4 +928,30 @@ abstract class aRdbmsDestinationAction extends aAction
         return $numWarningsLogged;
 
     }  // logSqlWarnings()
+
+    /**
+     * Quote a list of strings with a database system quote character. This is used to ensure that
+     * database reserver words are properly handled. By default, the destination endpoint is used.
+     *
+     * @param array $names The list of names to quote
+     * @param iRdbmsEndpoint $endpoint The endpoint to use when determining the system quote character.
+     *
+     * @return array The list of names quoted with the appropriate system quote character
+     */
+
+    protected function quoteIdentifierNames(array $names, iRdbmsEndpoint $endpoint = null)
+    {
+        // Default to the destination endpoint
+        $endpoint = ( null === $endpoint ? $this->destinationEndpoint : $endpoint);
+
+        $quoteChar = $endpoint->getSystemQuoteChar();
+        $quotedNames = array();
+
+        foreach ( $names as $name ) {
+            $quotedNames[] = sprintf("%s%s%s", $quoteChar, $name, $quoteChar);
+        }
+
+        return $quotedNames;
+
+    }  // quoteIdentifierNames()
 }  // abstract class aRdbmsDestinationAction

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
@@ -271,8 +271,9 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
             "Undefined macros found in source query"
         );
 
-        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/resource_allocations.sql'));
-        $this->assertEquals($expected, $generated);
+        $file = self::TEST_ARTIFACT_OUTPUT_PATH . '/resource_allocations_8.0.0.sql';
+        $expected = trim(file_get_contents($file));
+        $this->assertEquals($expected, $generated, "expected output in $file");
     }
 
     /**
@@ -304,7 +305,7 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
 
         $file = self::TEST_ARTIFACT_OUTPUT_PATH . '/resourceallocationfact_by.aggregation.sql';
         $expected = trim(file_get_contents($file));
-        $this->assertEquals($expected, $generated);
+        $this->assertEquals($expected, $generated, "expected output in $file");
     }
 
     /**
@@ -339,9 +340,9 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
             "Undefined macros found in source query"
         );
 
-        $file = self::TEST_ARTIFACT_OUTPUT_PATH . '/resourceallocationfact_by.query.sql';
+        $file = self::TEST_ARTIFACT_OUTPUT_PATH . '/resourceallocationfact_by.query_8.0.0.sql';
         $expected = trim(file_get_contents($file));
-        $this->assertEquals($expected, $generated);
+        $this->assertEquals($expected, $generated, "expected output in $file");
     }
 
     /**
@@ -369,8 +370,10 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
             $newQuery,
             "Undefined macros found in source query"
         );
-        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/resource_allocations.sql'));
-        $this->assertEquals($expected, $generated);
+
+        $file = self::TEST_ARTIFACT_OUTPUT_PATH . '/resource_allocations_8.0.0.sql';
+        $expected = trim(file_get_contents($file));
+        $this->assertEquals($expected, $generated, "expected output in $file");
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Database column names can be specified in JSON configuration files and may contain SQL reserved words such as `order` and `group`. To support these as column names, they must be quoted using the database system quote character (``` ` ``` in MySQL and `"` in Postgres and Oracle).

## Motivation and Context

Improved handling to allow any column name to be used. One of our tables has a column named `order`.

## Tests performed

Ran component and unit tests against XSEDE docker instance, as well as XSEDE jobs ingestion.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
