### PR TITLE
More flexible aggregation period deletes

### DIFF
--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1153,22 +1153,7 @@ class pdoAggregator extends aAggregator
                         $restrictions = $dummyQuery->getOverseerRestrictionValues();
                     }  // if ( isset($this->parsedDefinitionFile->destination_query) ... )
 
-                    foreach ( $this->etlDestinationTableList as $etlTableKey => $etlTable ) {
-                        $qualifiedDestTableName = $etlTable->getFullName();
-
-                        // This will need to get switch back once we start using period_id rather than
-                        // month_id, year_id, etc.
-                        // $deleteSql = "DELETE FROM {$this->qualifiedDestTableName} WHERE period_id = $period_id";
-
-                        $deleteSql = "DELETE FROM $qualifiedDestTableName WHERE {$aggregationUnit}_id = $periodId";
-
-                        if ( count($restrictions) > 0 ) {
-                            $deleteSql .= " AND " . implode(" AND ", $dummyQuery->getOverseerRestrictionValues());
-                        }
-
-                        $this->logger->debug("Delete aggregation unit SQL " . $this->destinationEndpoint . ":\n$deleteSql");
-                        $this->destinationHandle->execute($deleteSql);
-                    }
+                    $this->deleteAggregationPeriodData($aggregationUnit, $periodId, $restrictions);
 
                 } catch (PDOException $e ) {
                     $this->logAndThrowException(
@@ -1247,6 +1232,49 @@ class pdoAggregator extends aAggregator
         return $numPeriodsProcessed;
 
     }  // processAggregationPeriods()
+
+    /**
+     * Delete data associated with a particular aggregation period from the current aggregation
+     * table. Note that we can't simply insert and update on duplicate key because we won't know if
+     * a group-by has changed or if data for a particular dimension has been removed. If additional
+     * data must be deleted, a child class may override this method.
+     *
+     * @param string $aggregationUnit The aggregation unit granularity that we are currently processing
+     *    (e.g., day, month, etc.)
+     * @param string $aggregationUnitId The id of the current aggregation unit that we are processing
+     *    (e.g., specific day)
+     * @param array $sqlRestrictions A list of additional restrictions to add to the SQL DELETE statement,
+     *    such as restricting to a particular resource.
+     *
+     * @return int The total number of rows deleted from all tables.
+     */
+
+    protected function deleteAggregationPeriodData($aggregationUnit, $aggregationPeriodId, array $sqlRestrictions = array())
+    {
+        $totalRowsDeleted = 0;
+
+        foreach ( $this->etlDestinationTableList as $etlTableKey => $etlTable ) {
+            $qualifiedDestTableName = $etlTable->getFullName();
+            $deleteSql = sprintf(
+                "DELETE FROM %s WHERE %s_id = %s",
+                $qualifiedDestTableName,
+                $aggregationUnit,
+                $aggregationPeriodId
+            );
+
+            if ( count($sqlRestrictions) > 0 ) {
+                $deleteSql .= " AND " . implode(" AND ", $sqlRestrictions);
+            }
+
+            $this->logger->debug(
+                sprintf("Delete aggregation unit SQL %s:\n%s", $this->destinationEndpoint, $deleteSql)
+            );
+            $totalRowsDeleted += $this->destinationHandle->execute($deleteSql);
+        }
+
+        return $totalRowsDeleted;
+
+    } // deleteAggregationPeriodData()
 
     /* ------------------------------------------------------------------------------------------
      * Determine if our source and destination databases are the same and we can enable query


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide support for child classes to override or expand the rows deleted from the aggregation table when updating a particular aggregation period. This is useful when a child class needs to also delete data from additional related tables.

## Motivation and Context

Needed by @jpwhite4 for SUPReMM.

## Tests performed

Tested against XSEDE docker:
```
$ docker run -h database --rm -it -p 3306:3306 tas-tools-int-01.ccr.xdmod.org/xdmod-centos7:xsede8.0-latest /bin/bash
$ /root/bin/services start
$ mysql modw_aggregates;

MariaDB [modw_aggregates]> create table jobfact_by_year_orig like jobfact_by_year;
Query OK, 0 rows affected (0.02 sec)

MariaDB [modw_aggregates]> create table jobfact_by_day_orig like jobfact_by_day;
Query OK, 0 rows affected (0.01 sec)

MariaDB [modw_aggregates]> insert into jobfact_by_year_orig select * from jobfact_by_year;
Query OK, 20792 rows affected (0.30 sec)
Records: 20792  Duplicates: 0  Warnings: 0

MariaDB [modw_aggregates]> insert into jobfact_by_day_orig select * from jobfact_by_day;
Query OK, 65955 rows affected (0.89 sec)
Records: 65955  Duplicates: 0  Warnings: 0
```

```
START=2017-12-11
END=2018-01-21

$ php etl_overseer.php -s $START -e $END -p jobs-common -p jobs-xdcdb -p osg -v info

$ ../dev/verify_table_data.php -s modw_aggregates -d modw_aggregates -t jobfact_by_year=jobfact_by_year_orig -v info -n 1
2018-04-24 10:52:28 [notice] Compare tables src=modw_aggregates.jobfact_by_year, dest=modw_aggregates.jobfact_by_year_orig
2018-04-24 10:52:28 [info] 46 columns
2018-04-24 10:52:28 [info] Row counts: modw_aggregates.jobfact_by_year = 20,792; modw_aggregates.jobfact_by_year_orig = 20,792
2018-04-24 10:52:29 [notice] Identical

$ ../dev/verify_table_data.php -s modw_aggregates -d modw_aggregates -t jobfact_by_year=jobfact_by_day_orig -v info -n 1
2018-04-24 10:52:34 [notice] Compare tables src=modw_aggregates.jobfact_by_year, dest=modw_aggregates.jobfact_by_day_orig
2018-04-24 10:52:34 [error] Column number mismatch modw_aggregates.jobfact_by_year (46); dest modw_aggregates.jobfact_by_day_orig (47)
smgallo@smgallo-dev:etl$ ../dev/verify_table_data.php -s modw_aggregates -d modw_aggregates -t jobfact_by_day=jobfact_by_day_orig -v info -n 1
2018-04-24 10:52:50 [notice] Compare tables src=modw_aggregates.jobfact_by_day, dest=modw_aggregates.jobfact_by_day_orig
2018-04-24 10:52:50 [info] 47 columns
2018-04-24 10:52:50 [info] Row counts: modw_aggregates.jobfact_by_day = 65,955; modw_aggregates.jobfact_by_day_orig = 65,955
2018-04-24 10:52:59 [notice] Identical
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
