### PR TITLE
Load ETL resource codes as needed to allow for bootstrapping actions

### DIFF
--- a/classes/ETL/EtlOverseerOptions.php
+++ b/classes/ETL/EtlOverseerOptions.php
@@ -63,6 +63,9 @@ class EtlOverseerOptions extends Loggable
     // A mapping of resource codes to resource ids.
     private $resourceCodeToIdMap = array();
 
+    // SQL query used to populate the resource code to resource id map
+    private $resourcecodeToIdMapSql = null;
+
     // A list of all requested section names
     private $sectionNames = array();
 
@@ -154,6 +157,9 @@ class EtlOverseerOptions extends Loggable
                     break;
                 case 'resource-code-map':
                     $this->setResourceCodeToIdMap($value);
+                    break;
+                case 'resource-code-map-sql':
+                    $this->setResourceCodeToIdMapSql($value);
                     break;
                 case 'process-sections':
                     $this->setSectionNames($value);
@@ -692,6 +698,43 @@ class EtlOverseerOptions extends Loggable
         return $this;
     }  // setResourceCodeToIdMap()
 
+    /* ------------------------------------------------------------------------------------------
+     * @return array An associative array where the keys are resource codes and the values are the
+     *   database ids associated with those codes.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getResourceCodeToIdMap()
+    {
+        return $this->resourceCodeToIdMap;
+    }  // getResourceCodeToIdMap()
+
+    /* ------------------------------------------------------------------------------------------
+     * Set the SQL query that will be used to generate the mapping between resource codes and
+     * resource Ids.
+     *
+     * @param $map An associative array where the keys are resource codes and the values are the
+     *   resource ids that those codes map to.
+     *
+     * @return This object for method chaining.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function setResourceCodeToIdMapSql($sql)
+    {
+        $this->resourceCodeToIdMapSql = $sql;
+        return $this;
+    }  // setResourceCodeToIdMapSql()
+
+    /* ------------------------------------------------------------------------------------------
+     * @return string The SQL query to be used when populating the resource code to id map.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getResourceCodeToIdMapSql()
+    {
+        return $this->resourceCodeToIdMapSql;
+    }  // getResourceCodeToIdMapSql()
 
     /* ------------------------------------------------------------------------------------------
      * Map an array of resource codes to their ids.

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -78,6 +78,8 @@ $scriptOptions = array(
     'exclude-resource-codes' => array(),
     // List of sections to process (e.g., ingestors, aggregators)
     'process-sections'  => array(),
+    // SQL query to use when generating the resource code map
+    'resource-code-map-sql' => null,
     // ETL start date
     'start-date'        => null,
     'verbosity'         => Log::NOTICE
@@ -569,22 +571,9 @@ if ( $showList ) {
     exit(0);
 }  // if ( $showList )
 
-// ------------------------------------------------------------------------------------------
-// Look up resource ids and generate the mapping for resource codes to ids. This can be stored in
-// the overseer and used by actions if needed.
+// Set the SQL query used to look up resource ids and generate the mapping for resource codes to ids.
 
-try {
-    $result = $utilityEndpoint->getHandle()->query("SELECT id, code from {$utilitySchema}.resourcefact");
-} catch (Exception $e) {
-    log_error_and_exit(
-        sprintf("%s%s%s", $e->getMessage(), PHP_EOL, $e->getTraceAsString())
-    );
-}
-$scriptOptions['resource-code-map'] = array();
-
-foreach ( $result as $row ) {
-    $scriptOptions['resource-code-map'][ $row['code'] ] = $row['id'];
-}
+$scriptOptions['resource-code-map-sql'] = sprintf("SELECT id, code from %s.resourcefact", $utilitySchema);
 
 try {
     $overseerOptions = new EtlOverseerOptions($scriptOptions, $logger);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Load resource codes from the database only as needed when specified in an action configuration or on the command line.

## Motivation and Context

Bootstrap actions cannot rely on `modw.resourcefact` existing so it cannot be queried.

## Tests performed

The following cases specify a resource in the action configuration:
```
$ php etl_overseer.php -a JetstreamApiStagingJobRecordIngestor -v debug -t |grep modw.resourcefact
SELECT id, code from modw.resourcefact
$ php etl_overseer.php -a XdcdbJobRecordStagingIngestor  -v debug -t |grep modw.resourcefact
SELECT id, code from modw.resourcefact
```

The following cases demonstrate command line resource arguments:
```
$ php etl_overseer.php -a XdcdbJobRecordIngestor -v debug -t |grep modw.resourcefact
$ php etl_overseer.php -a XdcdbJobRecordIngestor -v debug -t -x IU-TACC-JETSTREAM |grep modw.resourcefact
SELECT id, code from modw.resourcefact
$ php etl_overseer.php -a XdcdbJobRecordIngestor -v debug -t -r IU-TACC-JETSTREAM |grep modw.resourcefact
SELECT id, code from modw.resourcefact
```

Open XMDoD bootstrap pipeline:
```
$ php etl_overseer.php -p jobs-xdw.bootstrap -v debug -t |grep modw.resourcefact
2018-04-24 13:03:45 [debug] Discover table 'modw.resourcefact'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
