### PR TITLE
Removing invalid package-lock.json

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
@@ -3,6 +3,7 @@ httpd -k stop
 cd /root
 git clone https://github.com/mcguinness/saml-idp/
 cd saml-idp
+rm -f package-lock.json
 openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/C=US/ST=New York/L=Buffalo/O=UB/CN=CCR Test Identity Provider' -keyout idp-private-key.pem -out idp-public-cert.pem -days 7300
 echo "installing saml idp server"
 npm set progress=false


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Just added a line to the `samlSetup.sh` script to remove `package-lock.json` as it has a SHA1 hash specified for a dep `xmldom` that doesn't match. This keeps `npm instal` from running successfully && keeps the saml tests from passing.

**NOTE: I've opened an issue w/ `saml-idp` for this problem (https://github.com/mcguinness/saml-idp/issues/32). In the mean time this should allow our shippable builds to pass.** 

## Motivation and Context
I'm a fan of Shippable builds that pass.

## Tests performed
Manual tests were performed: 
- Manually spin up an xsede docker image
- Make sure that the line `rm -f package-lock.json` is added to `samlSetup.sh`
- Execute `samlSetup.sh` 
- Open a web browser and navigate to the hosted XDMoD site
- Login via SAML
- Notice that the login is successful

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
