### PR TITLE
Add foreign key constraints to ETL

### DIFF
--- a/classes/ETL/DbModel/ForeignKeyConstraint.php
+++ b/classes/ETL/DbModel/ForeignKeyConstraint.php
@@ -57,7 +57,7 @@ class ForeignKeyConstraint extends NamedEntity implements iEntity
     public function initialize(stdClass $config)
     {
         if (!isset($config->name)) {
-            $config->name = $this->generateConstraintName($config->columns);
+            $config->name = $this->generateForeignKeyConstraintName($config->columns);
         }
 
         parent::initialize($config);
@@ -151,30 +151,29 @@ class ForeignKeyConstraint extends NamedEntity implements iEntity
     }
 
     /**
-     * Auto-generate a constraint name.
+     * Auto-generate a foreign key constraint name.
      *
-     * If this is a foreign key constraint use the columns included in the
-     * constraint.  If the length of the index name would be too large use a
-     * hash.
+     * Uses the columns included in the foreign key constraint.  If the length
+     * of the constraint name would be too large use a hash.
      *
      * @param array $columns The array of constraint column names
      *
-     * @return string The generated index name
+     * @return string The generated foreign key constraint name
      */
-    private function generateConstraintName(array $columns)
+    private function generateForeignKeyConstraintName(array $columns)
     {
         $str = implode('_', $columns);
         $name = ( strlen($str) <= 32 ? $str : md5($str) );
 
-        return 'constraint_' . $name;
+        return 'fk_' . $name;
     }
 
     /**
-     * Constraints are considered equal if all non-null properties are the same.
+     * Foreign key constraints are considered equal if all properties are the same.
      */
     public function compare(iEntity $cmp)
     {
-        if (!$cmp instanceof Constraint) {
+        if (!$cmp instanceof ForeignKeyConstraint) {
             return 1;
         }
 

--- a/classes/ETL/DbModel/Table.php
+++ b/classes/ETL/DbModel/Table.php
@@ -14,6 +14,7 @@
  * The Table class makes use of the following classes:
  * - Column
  * - Index
+ * - Constraint
  * - Trigger
  *
  * @author Steve Gallo <smgallo@buffalo.edu>
@@ -50,6 +51,9 @@ class Table extends SchemaEntity implements iEntity, iDiscoverableEntity, iAlter
 
         // Associative array where the keys are index names and the values are Index objects
         'indexes'  => array(),
+
+        // Associative array where the keys are constraint names and the values are Constraint objects
+        'constraints'  => array(),
 
         // Associative array where the keys are trigger names and the values are Trigger objects
         'triggers' => array(),
@@ -100,6 +104,7 @@ class Table extends SchemaEntity implements iEntity, iDiscoverableEntity, iAlter
         switch ( $property ) {
             case 'columns':
             case 'indexes':
+            case 'constraints':
             case 'triggers':
                 // Note that we are only checking that the value is an array here and not
                 // the array elements. That must come later.
@@ -152,6 +157,17 @@ class Table extends SchemaEntity implements iEntity, iDiscoverableEntity, iAlter
                 );
             }
         }  // foreach ( $this->indexes as $index )
+
+        // Verify constraint columns match table columns
+
+        foreach ( $this->constraints as $constraint ) {
+            $missingColumnNames = array_diff($constraint->columns, $columnNames);
+            if ( 0 != count($missingColumnNames) ) {
+                $this->logAndThrowException(
+                    sprintf("Columns in constraint '%s' not found in table definition: %s", $constraint->name, implode(", ", $missingColumnNames))
+                );
+            }
+        }  // foreach ( $this->constraints as $constraint )
 
         return true;
 
@@ -292,6 +308,39 @@ ORDER BY index_name ASC";
         foreach ( $result as $row ) {
             $row['columns'] = explode(",", $row['columns']);
             $this->addIndex((object) $row);
+        }
+
+        // Query constraints.
+
+        $sql = <<<SQL
+SELECT
+    tc.constraint_name AS name,
+    GROUP_CONCAT(kcu.column_name ORDER BY position_in_unique_constraint ASC) AS columns,
+    kcu.referenced_table_name AS referenced_table,
+    GROUP_CONCAT(kcu.referenced_column_name ORDER BY position_in_unique_constraint ASC) AS referenced_columns
+FROM information_schema.table_constraints tc
+INNER JOIN information_schema.key_column_usage kcu
+    ON tc.table_schema = kcu.table_schema
+    AND tc.table_name = kcu.table_name
+    AND tc.constraint_schema = kcu.constraint_schema
+    AND tc.constraint_name = kcu.constraint_name
+WHERE tc.constraint_type = 'FOREIGN KEY'
+    AND tc.table_schema = :schema
+    AND tc.table_name = :tablename
+GROUP BY tc.constraint_name
+ORDER BY tc.constraint_name ASC
+SQL;
+
+        try {
+            $result = $endpoint->getHandle()->query($sql, $params);
+        } catch (Exception $e) {
+            $this->logAndThrowException("Error discovering table '$qualifiedTableName' constraints: " . $e->getMessage());
+        }
+
+        foreach ( $result as $row ) {
+            $row['columns'] = explode(',', $row['columns']);
+            $row['referenced_columns'] = explode(',', $row['referenced_columns']);
+            $this->addConstraint((object) $row);
         }
 
         // Query triggers
@@ -437,6 +486,64 @@ ORDER BY trigger_name ASC";
     }  // getIndex()
 
     /* ------------------------------------------------------------------------------------------
+     * Add a constraint to this table.
+     *
+     * @param $config An object containing the column definition, or a Column object to add
+     * @param $overwriteDuplicates TRUE to allow overwriting of duplicate column names. If false, throw
+     * an exception if a duplicate column is added.
+     *
+     * @return This object to support method chaining.
+     *
+     * @throw Exception if the new item has the same name as an existing item and
+     *   overwrite is not TRUE
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function addConstraint($config, $overwriteDuplicates = false)
+    {
+        $item = ( is_object($config) && $config instanceof Constraint
+                  ? $config
+                  : new Constraint($config, $this->systemQuoteChar, $this->logger) );
+
+        if ( array_key_exists($item->name, $this->constraints) && ! $overwriteDuplicates ) {
+            $this->logAndThrowException(
+                sprintf("Cannot add duplicate constraint '%s'", $item->name)
+            );
+        }
+
+        $this->properties['constraints'][$item->name] = $item;
+
+        return $this;
+
+    }  // addConstraint()
+
+    /* ------------------------------------------------------------------------------------------
+     * Get the list of constraint names.
+     *
+     * @return array An array of column names.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getConstraintNames()
+    {
+        return array_keys($this->constraints);
+    }  // getConstraintNames()
+
+    /* ------------------------------------------------------------------------------------------
+     * Get an Constraint object with the specified name.
+     *
+     * @param $name The name of the constraint to retrieve.
+     *
+     * @return The Constraint object with the specified name or FALSE if the trigger does not exist
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function getConstraint($name)
+    {
+        return ( array_key_exists($name, $this->constraints) ? $this->properties['constraints'][$name] : false );
+    }  // getConstraint()
+
+    /* ------------------------------------------------------------------------------------------
      * Add a trigger to this table.
      *
      * @param $config An object containing the column definition, or a Column object to add
@@ -520,6 +627,11 @@ ORDER BY trigger_name ASC";
             $indexCreateList[$name] = $index->getSql($includeSchema);
         }
 
+        $constraintCreateList = array();
+        foreach ( $this->constraints as $name => $constraint ) {
+            $constraintCreateList[$name] = $constraint->getSql($includeSchema);
+        }
+
         $triggerCreateList = array();
         foreach ( $this->triggers as $name => $trigger ) {
             // The table schema may have been set after the table was initially created. If the trigger
@@ -535,8 +647,9 @@ ORDER BY trigger_name ASC";
         $sqlList = array();
         $sqlList[] = "CREATE TABLE IF NOT EXISTS $tableName (\n" .
             "  " . implode(",\n  ", $columnCreateList) .
-            ( 0 != count($indexCreateList) ? ",\n  " . implode(",\n  ", $indexCreateList) : "" ) . "\n" .
-            ")" .
+            ( 0 != count($indexCreateList) ? ",\n  " . implode(",\n  ", $indexCreateList) : "" ) .
+            ( 0 != count($constraintCreateList) ? ",\n  " . implode(",\n  ", $constraintCreateList) : "" ) .
+            "\n" . ")" .
             ( null !== $this->engine ? " ENGINE = " . $this->engine : "" ) .
             ( null !== $this->comment && ! empty($this->comment) ? " COMMENT = '" . addslashes($this->comment) . "'" : "" ) .
             ";";
@@ -678,6 +791,35 @@ ORDER BY trigger_name ASC";
         }
 
         // --------------------------------------------------------------------------------
+        // Processes constraints
+
+        $currentConstraintNames = $this->getConstraintNames();
+        $destConstraintNames = $destination->getConstraintNames();
+
+        $dropConstraintNames = array_diff($currentConstraintNames, $destConstraintNames);
+        $addConstraintNames = array_diff($destConstraintNames, $currentConstraintNames);
+        $changeConstraintNames = array_intersect($currentConstraintNames, $destConstraintNames);
+
+        foreach ( $dropConstraintNames as $name ) {
+            $alterList[] = 'DROP FOREIGN KEY ' . $this->quote($name);
+        }
+
+        foreach ( $addConstraintNames as $name ) {
+            $alterList[] = 'ADD ' . $destination->getConstraint($name)->getSql($includeSchema);
+        }
+
+        // Altered constraints need to be dropped then added
+        foreach ( $changeConstraintNames as $name ) {
+            $destConstraint = $destination->getConstraint($name);
+            // Not all properties are required so a simple object comparison isn't possible
+            if ( 0 == $destConstraint->compare($this->getConstraint($name)) ) {
+                continue;
+            }
+            $alterList[] = 'DROP FOREIGN KEY ' . $destConstraint->getName(true);
+            $alterList[] = 'ADD ' . $destConstraint->getSql($includeSchema);
+        }
+
+        // --------------------------------------------------------------------------------
         // Process triggers
 
         // The table schema may have been set after the table was initially created. If the trigger
@@ -758,6 +900,7 @@ ORDER BY trigger_name ASC";
 
         $data->columns = array_values((array) $data->columns);
         $data->indexes = array_values((array) $data->indexes);
+        $data->constraints = array_values((array) $data->constraints);
         $data->triggers = array_values((array) $data->triggers);
 
         return $data;
@@ -772,7 +915,7 @@ ORDER BY trigger_name ASC";
     public function __set($property, $value)
     {
         // If we are not setting a property that is a special case, just call the main setter
-        $specialCaseProperties = array('columns', 'indexes', 'triggers');
+        $specialCaseProperties = array('columns', 'indexes', 'constraints', 'triggers');
 
         if ( ! in_array($property, $specialCaseProperties) ) {
             parent::__set($property, $value);
@@ -808,6 +951,19 @@ ORDER BY trigger_name ASC";
                                    ? $item
                                    : new Index($item, $this->systemQuoteChar, $this->logger) );
                         $this->properties[$property][$index->name] = $index;
+                    }
+                }
+                break;
+
+            case 'constraints':
+                $this->properties[$property] = array();
+                // Clear the array no matter what, that way NULL is handled properly.
+                if ( null !== $value ) {
+                    foreach ( $value as $item ) {
+                        $constraint = ( is_object($item) && $item instanceof Constraint
+                                   ? $item
+                                   : new Constraint($item, $this->systemQuoteChar, $this->logger) );
+                        $this->properties[$property][$constraint->name] = $constraint;
                     }
                 }
                 break;

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
@@ -171,13 +171,13 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
         // Test with a system quote character
         $obj = new ForeignKeyConstraint($config, '`', $this->logger);
         $generated = $obj->getSql();
-        $expected = "CONSTRAINT `constraint_col1_col2` FOREIGN KEY (`col1`, `col2`) REFERENCES `other_table` (`col3`, `col4`)";
+        $expected = "CONSTRAINT `fk_col1_col2` FOREIGN KEY (`col1`, `col2`) REFERENCES `other_table` (`col3`, `col4`)";
         $this->assertEquals($expected, $generated);
 
         // Test with no system quote character
         $obj = new ForeignKeyConstraint($config, null, $this->logger);
         $generated = $obj->getSql();
-        $expected = "CONSTRAINT constraint_col1_col2 FOREIGN KEY (col1, col2) REFERENCES other_table (col3, col4)";
+        $expected = "CONSTRAINT fk_col1_col2 FOREIGN KEY (col1, col2) REFERENCES other_table (col3, col4)";
         $this->assertEquals($expected, $generated);
 
         $config = (object) array(

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
@@ -16,7 +16,7 @@ use ETL\DbModel\AggregationTable;
 use ETL\DbModel\Query;
 use ETL\DbModel\Column;
 use ETL\DbModel\Index;
-use ETL\DbModel\Constraint;
+use ETL\DbModel\ForeignKeyConstraint;
 use ETL\DbModel\Trigger;
 use ETL\Configuration\EtlConfiguration;
 
@@ -169,13 +169,13 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
         );
 
         // Test with a system quote character
-        $obj = new Constraint($config, '`', $this->logger);
+        $obj = new ForeignKeyConstraint($config, '`', $this->logger);
         $generated = $obj->getSql();
         $expected = "CONSTRAINT `constraint_col1_col2` FOREIGN KEY (`col1`, `col2`) REFERENCES `other_table` (`col3`, `col4`)";
         $this->assertEquals($expected, $generated);
 
         // Test with no system quote character
-        $obj = new Constraint($config, null, $this->logger);
+        $obj = new ForeignKeyConstraint($config, null, $this->logger);
         $generated = $obj->getSql();
         $expected = "CONSTRAINT constraint_col1_col2 FOREIGN KEY (col1, col2) REFERENCES other_table (col3, col4)";
         $this->assertEquals($expected, $generated);
@@ -239,7 +239,7 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
             'referenced_table' => 'other_table',
             'referenced_columns' => array('other_column'),
         );
-        $destTable->addConstraint($config);
+        $destTable->addForeignKeyConstraint($config);
 
         $config = (object) array(
             'name' => 'before_ins',

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/DbModel/DbModelTest.php
@@ -16,6 +16,7 @@ use ETL\DbModel\AggregationTable;
 use ETL\DbModel\Query;
 use ETL\DbModel\Column;
 use ETL\DbModel\Index;
+use ETL\DbModel\Constraint;
 use ETL\DbModel\Trigger;
 use ETL\Configuration\EtlConfiguration;
 
@@ -45,14 +46,14 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
     public function testParseJsonFile()
     {
         // Instantiate the reference table
-        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def.json';
+        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def_8.0.0.json';
         $table = new Table($config, '`', $this->logger);
         $table->verify();
 
         // Verify SQL generated from JSON
         $generated = $table->getSql();
         $generated = array_shift($generated);
-        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/table_def.sql'));
+        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/table_def_8.0.0.sql'));
         $this->assertEquals($expected, $generated);
 
         // Run the generated JSON through and verify the generated SQL again.
@@ -162,6 +163,24 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $generated);
 
         $config = (object) array(
+            'columns' => array('col1', 'col2'),
+            'referenced_table' => 'other_table',
+            'referenced_columns' => array('col3', 'col4'),
+        );
+
+        // Test with a system quote character
+        $obj = new Constraint($config, '`', $this->logger);
+        $generated = $obj->getSql();
+        $expected = "CONSTRAINT `constraint_col1_col2` FOREIGN KEY (`col1`, `col2`) REFERENCES `other_table` (`col3`, `col4`)";
+        $this->assertEquals($expected, $generated);
+
+        // Test with no system quote character
+        $obj = new Constraint($config, null, $this->logger);
+        $generated = $obj->getSql();
+        $expected = "CONSTRAINT constraint_col1_col2 FOREIGN KEY (col1, col2) REFERENCES other_table (col3, col4)";
+        $this->assertEquals($expected, $generated);
+
+        $config = (object) array(
             'name' => 'before_ins',
             'time' => 'before',
             'event' => 'insert',
@@ -187,20 +206,20 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
     public function testAlterTable()
     {
         // Instantiate the reference table
-        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def.json';
+        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def_8.0.0.json';
         $currentTable = new Table($config, '`', $this->logger);
         $currentTable->verify();
-        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def_2.json';
+        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def_2_8.0.0.json';
         $destTable = new Table($config, '`', $this->logger);
         $destTable->verify();
 
         $generated = $currentTable->getAlterSql($destTable);
         $generated = array_shift($generated);
-        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/alter_table.sql'));
+        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/alter_table_8.0.0.sql'));
         // Assert that there is no alter sql statement.
         $this->assertEquals($expected, $generated);
 
-        // Alter the table by manually adding a column, index, and trigger.
+        // Alter the table by manually adding a column, index, constraint and trigger.
 
         $config = (object) array(
             'name' => 'new_column',
@@ -214,6 +233,13 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
             'columns' => array('new_column')
         );
         $destTable->addIndex($config);
+
+        $config = (object) array(
+            'columns' => array('new_column'),
+            'referenced_table' => 'other_table',
+            'referenced_columns' => array('other_column'),
+        );
+        $destTable->addConstraint($config);
 
         $config = (object) array(
             'name' => 'before_ins',
@@ -230,7 +256,7 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
         $alterTable = array_shift($generated);
         $trigger = array_shift($generated);
         $generated = $alterTable . PHP_EOL . $trigger;
-        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/alter_table_manually.sql'));
+        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/alter_table_manually_8.0.0.sql'));
         $this->assertEquals($expected, $generated);
     }
 
@@ -241,7 +267,7 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
     public function testDeleteTableElements()
     {
         // Instantiate the reference table
-        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def.json';
+        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def_8.0.0.json';
         $table = new Table($config, '`', $this->logger);
         $table->verify();
 
@@ -383,7 +409,7 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
     public function testGenerateTableStdClass()
     {
         // Instantiate the reference table
-        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def.json';
+        $config = self::TEST_ARTIFACT_INPUT_PATH . '/table_def_8.0.0.json';
         $table = new Table($config, '`', $this->logger);
         $table->verify();
 
@@ -393,7 +419,7 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
         $generated = $newTable->getSql();
         $generated = array_shift($generated);
 
-        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/table_def.sql'));
+        $expected = trim(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/table_def_8.0.0.sql'));
         $this->assertEquals($expected, $generated);
     }
 } // class ConfigurationTest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds foreign key constraint support to ETL.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Tables in `mod_hpcdb` have foreign key constraints.  In order to improve job ingestion these tables should be managed by the ETL process.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated ETL tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
