### PR TITLE
Remove javscript from php chart code

### DIFF
--- a/classes/DataWarehouse/Access/Common.php
+++ b/classes/DataWarehouse/Access/Common.php
@@ -340,7 +340,7 @@ class Common
 
             $result = array(
                 "headers" => \DataWarehouse\ExportBuilder::getHeader( $format ),
-                "results" => \xd_charting\encodeJSON( $returnData )
+                "results" => json_encode($returnData)
             );
 
             return $result;

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -323,7 +323,7 @@ class MetricExplorer extends Common
                     $exportedData = $dataset->exportJsonStore();
                     $exportedData['restrictedByRoles'] = $datasetsRestricted[$datasetIndex];
                     $exportedData['roleRestrictionsMessage'] = $datasetsRestrictedMessages[$datasetIndex];
-                    $exportedDatas[] = \xd_charting\encodeJSON($exportedData);
+                    $exportedDatas[] = json_encode($exportedData);
                 }
 
 

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -181,7 +181,7 @@ class Usage extends Common
                         // return a failure response.
                         if ($isTextExport) {
                             return array(
-                                'results' => \xd_charting\encodeJSON(array(
+                                'results' => json_encode(array(
                                     'success' => false,
                                     'message' => "Aggregate data not available for all metrics. Change to timeseries and try again.",
                                     'totalCount' => 0,
@@ -246,7 +246,7 @@ class Usage extends Common
             // If no charts were generated, return a failure response.
             if (empty($meResponses)) {
                 return array(
-                    'results' => \xd_charting\encodeJSON(array(
+                    'results' => json_encode(array(
                         'success' => false,
                         'message' => 'No charts could be generated using the given parameters.',
                         'totalCount' => 0,
@@ -694,6 +694,18 @@ class Usage extends Common
                 // Check if the user's chart pool contains this chart.
                 $usageChartInPool = $chartPool->chartExistsInQueue($usageChartArgsStr);
 
+                $drillDowns = array_map(
+                    function ($drillTarget) {
+                        return explode('-', $drillTarget, 2);
+                    },
+                    $user->getMostPrivilegedRole()->getQueryDescripters(
+                        'tg_usage',
+                        $usageRealm,
+                        $usageGroupBy,
+                        $meRequestMetric->getAlias()->getName()
+                    )->getDrillTargets($meRequestMetric->getAlias())
+                );
+
                 // For each data series...
                 $primaryDataSeriesRank = $usageOffset;
 
@@ -703,6 +715,7 @@ class Usage extends Common
                 ) use (
                     $usageRealm,
                     $usageGroupBy,
+                    $drillDowns,
                     $meRequestIsTimeseries,
                     $thumbnailRequested,
                     $meRequest,
@@ -768,60 +781,10 @@ class Usage extends Common
                         $meDataSeries['dashStyle'] = 'ShortDot';
                     }
 
-                    // If this is not a trend line series and not a thumbnail,
-                    // fill in the drilldown function.
                     if (!$isTrendLineSeries && !$thumbnailRequested) {
-                        $drillDowns = json_encode(
-                            array_map(
-                                function ($drillTarget) {
-                                    return explode('-', $drillTarget, 2);
-                                },
-                                $user->getMostPrivilegedRole()->getQueryDescripters(
-                                    'tg_usage',
-                                    $usageRealm,
-                                    $usageGroupBy,
-                                    $meRequestMetric->getAlias()->getName()
-                                )->getDrillTargets($meRequestMetric->getAlias())
-                            )
-                        );
-                        $usageGroupByUnit = $usageGroupByObject->getUnit();
-                        $groupByNameAndUnit = json_encode(array($usageGroupBy, $usageGroupByUnit));
-
-                        if ($meRequestIsTimeseries) {
-                            $drilldownDetails = $meDataSeries['drilldown'];
-                            $drilldownId = $drilldownDetails['id'];
-                            $drilldownLabel = json_encode($drilldownDetails['label']);
-                            $drilldownFunction = "function(event) {
-                                this.ts = this.x;
-                                XDMoD.Module.Usage.drillChart(
-                                    this,
-                                    $drillDowns,
-                                    $groupByNameAndUnit,
-                                    '$drilldownId',
-                                    $drilldownLabel,
-                                    'none',
-                                    'tg_usage',
-                                    '$usageRealm'
-                                );
-                            }";
-                        } else {
-                            $drilldownFunction = "function(event) {
-                                var id = this.drilldown.id;
-                                var label = this.drilldown.label;
-                                XDMoD.Module.Usage.drillChart(
-                                    this,
-                                    $drillDowns,
-                                    $groupByNameAndUnit,
-                                    id,
-                                    label,
-                                    'none',
-                                    'tg_usage',
-                                    '$usageRealm'
-                                );
-                            }";
-                        }
-
-                        $meDataSeries['point']['events']['click'] = $drilldownFunction;
+                        $meDataSeries['drilldown']['drilldowns'] = $drillDowns;
+                        $meDataSeries['drilldown']['realm'] = $usageRealm;
+                        $meDataSeries['drilldown']['groupUnit'] = array($usageGroupBy, $usageGroupByObject->getUnit());
                     }
 
                     // Set properties that are different.
@@ -832,10 +795,6 @@ class Usage extends Common
                     unset($meDataSeries['datasetId']);
                     unset($meDataSeries['visible']);
                     unset($meDataSeries['events']);
-
-                    if ($meRequestIsTimeseries) {
-                        unset($meDataSeries['drilldown']);
-                    }
 
                     // Note: keep dataLabels color param set, else we lose some of the pie datalabels
                     // in the Usage chart only.

--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -124,28 +124,7 @@ class HighChart2
                 'backgroundColor' => '#FFFFFF',
                 'borderWidth' => 0,
                 'y' => -5,
-                'labelFormatter' => "function()
-				{
-					var ret = '';
-					var x = this.name;
-					var indexOfSQ = x.indexOf(']');
-					var brAlready = false;
-					if( indexOfSQ > 0)
-					{
-						ret += x.substring(0,indexOfSQ+1)+'<br/>';
-						 x = x.substring(indexOfSQ+1,x.length);
-						brAlready = true;
-					}
-					var indexOfBr = x.indexOf('{');
-					if( indexOfBr > 0 && !brAlready)
-					{
-						 ret += x.substring(0,indexOfBr)+'<br/>';
-						 x = x.substring(indexOfBr,x.length);
-					}
-					ret+=x.wordWrap(50,'<br/>');
-					return ret;
-				}
-				"
+                'wordWrap' => true
             ),
             'series' => array(),
             'tooltip' => array(
@@ -547,31 +526,6 @@ class HighChart2
     } // setLegend()
 
     // ---------------------------------------------------------
-    // registerContextMenus()
-    //
-    // Set chart's context menus in javascript, as chart
-    // parameters. Not ideal.
-    //
-    // ---------------------------------------------------------
-    protected function registerContextMenus()
-    {
-        if($this->_showContextMenu)
-        {
-            $this->_chart['chart']['events'] = array(
-                'titleClick' => 'function(event){return XDMoD.Module.MetricExplorer.titleContextMenu(event);}',
-                'subtitleClick' => 'function(event){return XDMoD.Module.MetricExplorer.subtitleContextMenu(event);}',
-                'xAxisClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisContextMenu(axis);}',
-                'yAxisClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisContextMenu(axis);}',
-                'xAxisTitleClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisTitleContextMenu(axis);}',
-                'yAxisTitleClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisTitleContextMenu(axis);}',
-                'xAxisLabelClick' => 'function(axis){return XDMoD.Module.MetricExplorer.xAxisLabelContextMenu(axis);}',
-                'yAxisLabelClick' => 'function(axis){return XDMoD.Module.MetricExplorer.yAxisLabelContextMenu(axis);}',
-                'click' => 'function(event){return XDMoD.Module.MetricExplorer.chartContextMenu.call(this,event);}'
-            );
-        }
-    } // registerContextMenus()
-
-    // ---------------------------------------------------------
     // setMultiCategory()
     //
     // Determine whether plot contains multiple categories; set
@@ -703,12 +657,9 @@ class HighChart2
                                 'fontWeight'=> 'normal',
                                 'fontSize' => (11 + $font_size).'px'
                         ),
-                        'formatter' => "function(){
-								var maxL = ".floor($this->_width*20/580).";
-								var x  = (this.value.length>maxL-3)?this.value.substring(0,maxL-3)+'...':this.value;
-								return x;
-						}
-						" //x.wordWrap(".floor($this->_width*($this->limit<11?22:22)/580).",'<br/>');
+                        'settings' => array(
+                            'maxL' => floor($this->_width*20/580)
+                        )
                 ) // !($this->_swapXY)
                 : array(
                         'enabled' => true,
@@ -717,12 +668,10 @@ class HighChart2
                         'align' => $this->_xAxisDataObject->getCount()<= 8?'center':'right',
                         'step' => $this->_xAxisDataObject->getCount()< 20?0:round($this->_xAxisDataObject->getCount()/20),
                         'style' => array('fontSize' => (11 + $font_size).'px'),
-                        'formatter' => "function(){
-								var maxL = ".floor($this->_height*($this->limit<11?30:15)/400).";
-								var x  = (this.value.length>maxL-3)?this.value.substring(0,maxL-3)+'...':''+this.value;
-								return x.wordWrap(".floor($this->_height*($this->limit<11?18:18)/400).",'<br/>');
-						}
-						"
+                        'settings' => array(
+                            'maxL' => floor($this->_height*($this->limit<11?30:15)/400),
+                            'wrap' => floor($this->_height*($this->limit<11?18:18)/400)
+                        )
                 ),
                 'lineWidth' => 2 + $font_size / 4,
                 'categories' => $this->_xAxisDataObject->getValues()
@@ -805,7 +754,6 @@ class HighChart2
         $this->limit = $limit;
         $this->show_filters = $show_filters;
         $this->setMultiCategory($data_series);
-        $this->registerContextMenus();
 
         // Instantiate the color generator:
         $colorGenerator = new \DataWarehouse\Visualization\ColorGenerator();
@@ -1010,6 +958,11 @@ class HighChart2
                 $std_err_labels_enabled = property_exists($data_description, 'std_err_labels') && $data_description->std_err_labels;
                 $dataLabelsConfig = array(
                     'enabled' => $data_description->value_labels || $std_err_labels_enabled,
+                    'settings' => array(
+                        'value_labels' => $data_description->value_labels,
+                        'error_labels' => $std_err_labels_enabled,
+                        'decimals' => $decimals
+                    ),
                     'style' => array(
                         'fontSize' => (11 + $font_size).'px',
                         'fontWeight' => 'normal',
@@ -1053,12 +1006,11 @@ class HighChart2
                         $dataLabelsConfig,
                         array(
                             'color' => '#000000',
-                            'formatter' => "function(){
-								var maxL = ".floor($this->_width*($this->limit<11?30:15)/580).";
-								var x = (this.point.name.length>maxL+3)?this.point.name.substring(0,maxL-3)+'...':this.point.name;
-								return '<b>'+x.wordWrap( ".floor($this->_width*($this->limit<11?15:15)/580).
-                                            ",'</b><br/><b>')+'</b><br/>'+Highcharts.numberFormat(this.y, $decimals);
-							}"
+                            'settings' => array(
+                                'maxL' => floor($this->_width*($this->limit<11?30:15)/580),
+                                'wrap' => floor($this->_width*($this->limit<11?15:15)/580),
+                                'decimals' => $decimals
+                            )
                          )
                     );
 
@@ -1075,14 +1027,6 @@ class HighChart2
                 }
                 else // ($data_description->display_type !== 'pie')
                 {
-                    if ($data_description->value_labels && $std_err_labels_enabled) {
-                        $dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals)+' [+/-'+Highcharts.numberFormat(this.percentage, $decimals)+']';}";
-                    } elseif ($std_err_labels_enabled) {
-                        $dataLabelsConfig['formatter'] = "function(){ return '+/-'+Highcharts.numberFormat(this.percentage, $decimals);}";
-                    } else {
-                        $dataLabelsConfig['formatter'] = "function(){ return Highcharts.numberFormat(this.y, $decimals);}";
-                    }
-
                     if($this->_swapXY)
                     {
                         $dataLabelsConfig  = array_merge(
@@ -1174,12 +1118,6 @@ class HighChart2
                 {
                     $visible = $data_description->visibility->{$formattedDataSeriesName};
                 }
-                $seriesClick = 'function(event){'.($this->_showContextMenu?'XDMoD.Module.MetricExplorer.seriesContextMenu(this,false,'.
-                            $data_description->id.');':'').'}';
-                $legendItemClick = $this->_showContextMenu?'function(event){XDMoD.Module.MetricExplorer.seriesContextMenu(this,true,'.
-                            $data_description->id.'); return false;}':'function(event){return true;}';
-                $pointClick = 'function(event){'.($this->_showContextMenu?'XDMoD.Module.MetricExplorer.pointContextMenu(this,'.
-                            $data_description->id.');':'').'}';
 
                 // Display markers for scatter plots, non-thumbnail plots
                 // with fewer than 21 points, or for plots with a single y value.
@@ -1217,14 +1155,6 @@ class HighChart2
                     'data' => $values,
                     'cursor' => 'pointer',
                     'visible' => $visible,
-                    'events' => array(
-                        'legendItemClick' => $legendItemClick
-                    ),
-                    'point' => array(
-                        'events' => array(
-                            'click' => $pointClick
-                        )
-                    ),
                     'isRestrictedByRoles' => $data_description->restrictedByRoles,
                 ); // $data_series_desc
 
@@ -1253,9 +1183,7 @@ class HighChart2
                     $formattedDataSeriesName,
                     $yAxisIndex,
                     $semDecimals,
-                    $zIndex,
-                    $legendItemClick,
-                    $pointClick
+                    $zIndex
                 );
 
             } // foreach($yAxisObject->series as $data_description_index => $yAxisDataObjectAndDescription)
@@ -1264,8 +1192,6 @@ class HighChart2
         if ($this->_showWarnings) {
             $this->addRestrictedDataWarning();
         }
-
-        $this->addChartExtensions();
 
         // set title and subtitle for chart
         $this->setChartTitleSubtitle($font_size);
@@ -1287,9 +1213,7 @@ class HighChart2
         $formattedDataSeriesName,
         $yAxisIndex,
         $semDecimals,
-        $zIndex,
-        $legendItemClick,
-        $pointClick
+        $zIndex
     ) {
 
         // build error data series and add it to chart
@@ -1333,13 +1257,6 @@ class HighChart2
                 $visible = $data_description->visibility->{$dsn};
             }
 
-            $err_series_tooltip = "function() { ".
-                "var fErr = Highcharts.numberFormat(this.stderr, $semDecimals); ".
-                "return ".
-                "'<span style=\"color:{$error_color}\">\u25CF</span> {$lookupDataSeriesName}: ".
-                    "<b>+/-' + fErr + '</b><br/>';".
-                "}";
-
             // create the data series description:
             $err_data_series_desc = array(
                 //'name' => $dsn,
@@ -1356,19 +1273,11 @@ class HighChart2
                 'lineWidth' => 2,
                 'yAxis' => $yAxisIndex,
                 'tooltip' => array(
-                        'pointFormatter' => $err_series_tooltip
+                        'valueDecimals' => $semDecimals
                     ),
                 'data' => $error_series,
                 'cursor' => 'pointer',
                 'visible' => $visible,
-                'events' => array(
-                    'legendItemClick' => $legendItemClick
-                ),
-                'point' => array(
-                    'events' => array(
-                        'click' => $pointClick
-                        )
-                    ),
                 'isRestrictedByRoles' => $data_description->restrictedByRoles,
                 );
             if(! $data_description->log_scale)
@@ -1377,123 +1286,6 @@ class HighChart2
             }
         } // if not pie
     } // function buildErrorDataSeries
-
-        /**
-         * Add extension functions to the chart.
-         */
-    protected function addChartExtensions() {
-        // Allow for multiple event handlers for certain events.
-        // Based on: https://stackoverflow.com/a/22337004
-        $this->_chart['chart']['events']['load'] = 'function () {
-					var eventHandlers = this.options.chart.events.loadHandlers;
-					if (!eventHandlers) {
-							return;
-					}
-					for (var i = 0; i < eventHandlers.length; i++) {
-							eventHandlers[i].apply(this, arguments);
-					}
-			}';
-        $this->_chart['chart']['events']['redraw'] = 'function () {
-					var eventHandlers = this.options.chart.events.redrawHandlers;
-					if (!eventHandlers) {
-							return;
-					}
-					for (var i = 0; i < eventHandlers.length; i++) {
-							eventHandlers[i].apply(this, arguments);
-					}
-			}';
-
-        // Add function to add a background color to a chart element.
-        // (This is for chart elements that don't support this natively.)
-        // Idea for using rectangles as background color from: https://stackoverflow.com/a/21625239
-        $this->_chart['chart']['events']['helperFunctions']['addBackgroundColor'] = 'function (element, color) {
-					var xPadding = 3;
-					var yPadding = 2;
-					var rectCornerRadius = 1;
-
-					var elementBBox = element.getBBox();
-					return element.renderer.rect(
-							elementBBox.x - xPadding,
-							elementBBox.y - yPadding,
-							elementBBox.width + (xPadding * 2),
-							elementBBox.height + (yPadding * 2),
-							rectCornerRadius
-					).attr({
-							fill: color,
-							zIndex: (element.zIndex ? element.zIndex : 0) - 1
-					}).add(element.parentGroup);
-			}';
-
-        // Add functions to handle aligned labels.
-        // Based on: https://stackoverflow.com/a/19326076
-        $this->_chart['chart']['events']['helperFunctions']['alignAlignedLabels'] = 'function (chart) {
-					var alignedLabels = chart.alignedLabels;
-					if (!alignedLabels) {
-							return;
-					}
-					for (var i = 0; i < alignedLabels.length; i++) {
-							var alignedLabel = alignedLabels[i];
-							var labelObject = alignedLabel.label;
-							var labelBackground = alignedLabel.background;
-
-							labelObject.align(Highcharts.extend(
-									labelObject.getBBox(),
-									chart.options.alignedLabels.items[i]
-							), null, chart.renderer.spacingBox);
-							if (labelBackground) {
-									labelBackground.align(Highcharts.extend(
-											labelObject.getBBox(),
-											chart.options.alignedLabels.items[i]
-									), null, chart.renderer.spacingBox);
-							}
-					}
-			}';
-        $this->_chart['chart']['events']['loadHandlers'][] = 'function () {
-					var chart = this;
-					var alignedLabelsOptions = chart.options.alignedLabels;
-					if (!alignedLabelsOptions) {
-							return;
-					}
-
-					chart.alignedLabels = [];
-					for (var i = 0; i < alignedLabelsOptions.items.length; i++) {
-							var alignedLabel = {};
-							var alignedLabelOptions = alignedLabelsOptions.items[i];
-							alignedLabel.group = chart.renderer.g().add();
-							alignedLabel.label = chart.renderer.label(alignedLabelOptions.html).add(alignedLabel.group);
-
-							if (alignedLabelOptions.backgroundColor) {
-									alignedLabel.background = chart.options.chart.events.helperFunctions.addBackgroundColor(alignedLabel.label, alignedLabelOptions.backgroundColor);
-									alignedLabel.label.toFront();
-							}
-							chart.alignedLabels.push(alignedLabel);
-					}
-					chart.options.chart.events.helperFunctions.alignAlignedLabels(chart);
-			}';
-        $this->_chart['chart']['events']['redrawHandlers'][] = 'function () {
-					var chart = this;
-					chart.options.chart.events.helperFunctions.alignAlignedLabels(chart);
-			}';
-
-        // Add functions to style labels for data series restricted by roles.
-        $this->_chart['chart']['events']['loadHandlers'][] = 'function () {
-					var chart = this;
-					if (!chart.series || chart.options.chart.showWarnings === false) {
-							return;
-					}
-
-					for (var i = 0; i < chart.series.length; i++) {
-							var series = chart.series[i];
-							if (!series.options.isRestrictedByRoles) {
-									continue;
-							}
-
-                            if (series.legendItem) {
-                                chart.options.chart.events.helperFunctions.addBackgroundColor(series.legendItem, "#DFDFDF");
-                            }
-					}
-			}';
-    }
 
         /**
          * Add a warning to the chart that data may be restricted.

--- a/html/gui/js/HighChartPanel.js
+++ b/html/gui/js/HighChartPanel.js
@@ -36,7 +36,7 @@ Ext.extend(CCR.xdmod.ui.HighChartPanel, Ext.Panel, {
 
         var self = this;
 
-        this.baseChartOptions = {
+        this.baseChartOptions = jQuery.extend(true, {}, {
             chart: {
                 renderTo: this.id,
                 width: this.width,
@@ -67,7 +67,7 @@ Ext.extend(CCR.xdmod.ui.HighChartPanel, Ext.Panel, {
             credits: {
                 enabled: true
             }
-        };
+        }, this.baseChartOptions);
 
         this.on('render', function () {
             this.initNewChart.call(this);
@@ -128,7 +128,7 @@ Ext.extend(CCR.xdmod.ui.HighChartPanel, Ext.Panel, {
         } else {
             jQuery.extend(true, finalChartOptions, this.baseChartOptions, this.chartOptions);
         }
-        this.chart = new Highcharts.Chart(finalChartOptions);
+        this.chart = XDMoD.utils.createChart(finalChartOptions);
     },
 
     /**

--- a/html/gui/js/HighChartWrapper.js
+++ b/html/gui/js/HighChartWrapper.js
@@ -1,0 +1,229 @@
+/* eslint no-param-reassign: ["error", { "props": false }]*/
+
+Ext.namespace('XDMoD.utils');
+
+XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
+    var baseChartOptions = {
+        chart: {
+            events: {
+                load: function () {
+                    var eventHandlers = this.options.chart.events.loadHandlers;
+                    if (!eventHandlers) {
+                        return;
+                    }
+                    for (var i = 0; i < eventHandlers.length; i++) {
+                        eventHandlers[i].apply(this, arguments);
+                    }
+                },
+                redraw: function () {
+                    var eventHandlers = this.options.chart.events.redrawHandlers;
+                    if (!eventHandlers) {
+                        return;
+                    }
+                    for (var i = 0; i < eventHandlers.length; i++) {
+                        eventHandlers[i].apply(this, arguments);
+                    }
+                },
+                helperFunctions: {
+                    // Add function to add a background color to a chart element.
+                    // (This is for chart elements that don't support this natively.)
+                    // Idea for using rectangles as background color from: https://stackoverflow.com/a/21625239
+                    addBackgroundColor: function (element, color) {
+                        var xPadding = 3;
+                        var yPadding = 2;
+                        var rectCornerRadius = 1;
+
+                        var elementBBox = element.getBBox();
+                        return element.renderer.rect(
+                                elementBBox.x - xPadding,
+                                elementBBox.y - yPadding,
+                                elementBBox.width + (xPadding * 2),
+                                elementBBox.height + (yPadding * 2),
+                                rectCornerRadius
+                                ).attr({
+                                    fill: color,
+                                    zIndex: (element.zIndex ? element.zIndex : 0) - 1
+                                }).add(element.parentGroup);
+                    },
+                    // Add functions to handle aligned labels.
+                    // Based on: https://stackoverflow.com/a/19326076
+                    alignAlignedLabels: function (chart) {
+                        var alignedLabels = chart.alignedLabels;
+                        if (!alignedLabels) {
+                            return;
+                        }
+                        for (var i = 0; i < alignedLabels.length; i++) {
+                            var alignedLabel = alignedLabels[i];
+                            var labelObject = alignedLabel.label;
+                            var labelBackground = alignedLabel.background;
+
+                            labelObject.align(Highcharts.extend(
+                                        labelObject.getBBox(),
+                                        chart.options.alignedLabels.items[i]
+                                        ), null, chart.renderer.spacingBox);
+                            if (labelBackground) {
+                                labelBackground.align(Highcharts.extend(
+                                            labelObject.getBBox(),
+                                            chart.options.alignedLabels.items[i]
+                                            ), null, chart.renderer.spacingBox);
+                            }
+                        }
+                    }
+                },
+                loadHandlers: [
+                    function () {
+                        var alignedLabelsOptions = this.options.alignedLabels;
+                        if (!alignedLabelsOptions) {
+                            return;
+                        }
+
+                        this.alignedLabels = [];
+                        for (var i = 0; i < alignedLabelsOptions.items.length; i++) {
+                            var alignedLabel = {};
+                            var alignedLabelOptions = alignedLabelsOptions.items[i];
+                            alignedLabel.group = this.renderer.g().add();
+                            alignedLabel.label = this.renderer.label(alignedLabelOptions.html).add(alignedLabel.group);
+
+                            if (alignedLabelOptions.backgroundColor) {
+                                alignedLabel.background = this.options.chart.events.helperFunctions.addBackgroundColor(alignedLabel.label, alignedLabelOptions.backgroundColor);
+                                alignedLabel.label.toFront();
+                            }
+                            this.alignedLabels.push(alignedLabel);
+                        }
+                        this.options.chart.events.helperFunctions.alignAlignedLabels(this);
+                    },
+                    function () {
+                        if (!this.series || this.options.chart.showWarnings === false) {
+                            return;
+                        }
+
+                        for (var i = 0; i < this.series.length; i++) {
+                            var series = this.series[i];
+                            if (!series.options.isRestrictedByRoles) {
+                                continue;
+                            }
+
+                            this.options.chart.events.helperFunctions.addBackgroundColor(series.legendItem, '#DFDFDF');
+                        }
+                    }
+                ],
+                redrawHandlers: [function () {
+                    this.options.chart.events.helperFunctions.alignAlignedLabels(this);
+                }]
+            }
+        },
+        plotOptions: {
+            series: {
+                dataLabels: {
+                    formatter: function () {
+                        var settings = this.series.userOptions.dataLabels.settings;
+                        if (!settings) {
+                            return this.y.toString();
+                        }
+                        if (this.series.type === 'pie') {
+                            var x = this.point.name;
+                            if (this.point.name.length > settings.maxL + 3) {
+                                x = this.point.name.substring(0, settings.maxL - 3);
+                            }
+                            return '<b>' + x.wordWrap(settings.wrap, '</b><br/><b>') + '</b><br/>' + Highcharts.numberFormat(this.y, settings.decimals);
+                        }
+
+                        if (settings.value_labels && settings.error_labels) {
+                            return Highcharts.numberFormat(this.y, settings.decimals) + ' [+/-' + Highcharts.numberFormat(this.percentage, settings.decimals) + ']';
+                        } else if (settings.error_labels) {
+                            return '+/-' + Highcharts.numberFormat(this.percentage, settings.decimals);
+                        }
+                        return Highcharts.numberFormat(this.y, settings.decimals);
+                    }
+                }
+            },
+            errorbar: {
+                tooltip: {
+                    pointFormatter: function () {
+                        var fErr = Highcharts.numberFormat(this.stderr, this.series.userOptions.tooltip.valueDecimals);
+                        return '<span style="color: ' + this.series.userOptions.color + '">\u25CF</span> ' + this.series.userOptions.name + ': <b>+/-' + fErr + '</b><br/>';
+                    }
+                }
+            }
+
+        }
+    };
+
+    if (chartOptions.xAxis) {
+        if (chartOptions.xAxis.type !== 'datetime') {
+            baseChartOptions.xAxis = {
+                labels: {
+                    formatter: function () {
+                        var settings = this.chart.userOptions.xAxis.labels.settings;
+                        var x = this.value;
+                        if (this.value.length > settings.maxL - 3) {
+                            x = this.value.substring(0, settings.maxL - 3) + '...';
+                        }
+                        if (settings.wrap) {
+                            return x.wordWrap(settings.wrap, '<br />');
+                        }
+                        return x;
+                    }
+                }
+            };
+        }
+    }
+
+    jQuery.extend(true, baseChartOptions, chartOptions);
+
+    if (extraHandlers) {
+        if (extraHandlers.loadHandlers) {
+            baseChartOptions.chart.events.loadHandlers = baseChartOptions.chart.events.loadHandlers.concat(extraHandlers.loadHandlers);
+        }
+        if (extraHandlers.redrawHandlers) {
+            baseChartOptions.chart.events.redrawHandlers = baseChartOptions.chart.events.redrawHandlers.concat(extraHandlers.redrawHandlers);
+        }
+    }
+
+    var addAxisFormatter = function (axis) {
+        var decimals;
+        var minval;
+        if (axis.labels && axis.labels.decimals) {
+            decimals = axis.labels.decimals;
+            minval = Math.pow(10, -decimals);
+
+            axis.labels.formatter = function () {
+                if (this.value < minval) {
+                    return this.value;
+                }
+                return Highcharts.numberFormat(this.value, decimals);
+            };
+        }
+    };
+
+    if (baseChartOptions.yAxis) {
+        if (Array.isArray(baseChartOptions.yAxis)) {
+            baseChartOptions.yAxis.forEach(addAxisFormatter);
+        } else {
+            addAxisFormatter(baseChartOptions.yAxis);
+        }
+    }
+
+    if (baseChartOptions.legend && baseChartOptions.legend.wordWrap) {
+        baseChartOptions.legend.labelFormatter = function () {
+            var ret = '';
+            var x = this.name;
+            var indexOfSQ = x.indexOf(']');
+            var brAlready = false;
+            if (indexOfSQ > 0) {
+                ret += x.substring(0, indexOfSQ + 1) + '<br/>';
+                x = x.substring(indexOfSQ + 1, x.length);
+                brAlready = true;
+            }
+            var indexOfBr = x.indexOf('{');
+            if (indexOfBr > 0 && !brAlready) {
+                ret += x.substring(0, indexOfBr) + '<br/>';
+                x = x.substring(indexOfBr, x.length);
+            }
+            ret += x.wordWrap(50, '<br/>');
+            return ret;
+        };
+    }
+
+    return new Highcharts.Chart(baseChartOptions);
+};

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -2641,6 +2641,33 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
                                 credits: {
                                     enabled: true
+                                },
+
+                                plotOptions: {
+                                    series: {
+                                        events: {
+                                            click: function (evt) {
+                                                var drillId;
+                                                var label;
+                                                var drillInfo = evt.point.series.userOptions.drilldown;
+
+                                                if (!drillInfo) {
+                                                    // dataseries such as the trend line do not have a drilldown
+                                                    return;
+                                                }
+
+                                                if (evt.point.drilldown) {
+                                                    drillId = evt.point.drilldown.id;
+                                                    label = evt.point.drilldown.label;
+                                                } else {
+                                                    evt.point.ts = evt.point.x; // eslint-disable-line no-param-reassign
+                                                    drillId = drillInfo.id;
+                                                    label = drillInfo.label;
+                                                }
+                                                XDMoD.Module.Usage.drillChart(evt.point, drillInfo.drilldowns, drillInfo.groupUnit, drillId, label, 'none', 'tg_usage', drillInfo.realm);
+                                            }
+                                        }
+                                    }
                                 }
 
                             }; //baseChartOptions
@@ -2651,29 +2678,29 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                             chartOptions.exporting.enabled = false;
                             chartOptions.credits.enabled = true;
 
-                            chartOptions.chart.events.loadHandlers.push(function (e) {
-
+                            var extraChartHandlers = {
+                                loadHandlers: [],
+                                redrawHandlers: []
+                            };
+                            extraChartHandlers.loadHandlers.push(function () {
                                 this.checkSeries = function () {
-
-                                    if (this.series.length == 0) {
-
-                                        if (this.placeholder_element) this.placeholder_element.destroy();
+                                    if (this.series.length === 0) {
+                                        if (this.placeholder_element) {
+                                            this.placeholder_element.destroy();
+                                        }
                                         this.placeholder_element = this.renderer.image('gui/images/report_thumbnail_no_data.png', (this.chartWidth - 400) / 2, (this.chartHeight - 300) / 2, 400, 300).add();
-
-                                    } //if (this.series.length == 0)
-
-                                }; //this.checkSeries
+                                    }
+                                };
 
                                 this.checkSeries();
-
                             });
-                            chartOptions.chart.events.redrawHandlers.push(function (e) {
-
-                                if(this.checkSeries) this.checkSeries();
-
+                            extraChartHandlers.redrawHandlers.push(function () {
+                                if (this.checkSeries) {
+                                    this.checkSeries();
+                                }
                             });
 
-                            this.chart = new Highcharts.Chart(chartOptions);
+                            this.chart = XDMoD.utils.createChart(chartOptions, extraChartHandlers);
 
                         }, this); //task
 

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -5898,6 +5898,60 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
 
         var highChartPanel = new CCR.xdmod.ui.HighChartPanel({
             id: 'hc-panel' + this.id,
+            baseChartOptions: {
+                chart: {
+                    events: {
+                        titleClick: function (event) {
+                            return XDMoD.Module.MetricExplorer.titleContextMenu(event);
+                        },
+                        subtitleClick: function (event) {
+                            return XDMoD.Module.MetricExplorer.subtitleContextMenu(event);
+                        },
+                        xAxisClick: function (axis) {
+                            return XDMoD.Module.MetricExplorer.xAxisContextMenu(axis);
+                        },
+                        yAxisClick: function (axis) {
+                            return XDMoD.Module.MetricExplorer.yAxisContextMenu(axis);
+                        },
+                        xAxisTitleClick: function (axis) {
+                            return XDMoD.Module.MetricExplorer.xAxisTitleContextMenu(axis);
+                        },
+                        yAxisTitleClick: function (axis) {
+                            return XDMoD.Module.MetricExplorer.yAxisTitleContextMenu(axis);
+                        },
+                        xAxisLabelClick: function (axis) {
+                            return XDMoD.Module.MetricExplorer.xAxisLabelContextMenu(axis);
+                        },
+                        yAxisLabelClick: function (axis) {
+                            return XDMoD.Module.MetricExplorer.yAxisLabelContextMenu(axis);
+                        },
+                        click: function (event) {
+                            return XDMoD.Module.MetricExplorer.chartContextMenu.call(this, event);
+                        }
+                    }
+                },
+                plotOptions: {
+                    series: {
+                        events: {
+                            legendItemClick: function () {
+                                XDMoD.Module.MetricExplorer.seriesContextMenu(this, true, this.userOptions.datasetId);
+                                return false;
+                            }
+                        },
+                        point: {
+                            events: {
+                                click: function () {
+                                    if (this.options.x) {
+                                        this.ts = this.options.x;
+                                    }
+
+                                    XDMoD.Module.MetricExplorer.pointContextMenu(this, this.series.userOptions.datasetId);
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             store: chartStore
         }); //assistPanel
 

--- a/html/highchart_template.html
+++ b/html/highchart_template.html
@@ -11,6 +11,14 @@
 
       <script type="text/javascript">
 
+        var Ext = {
+            namespace: function(){}
+        };
+        var XDMoD = {
+            utils: {
+            }
+        };
+
          var chart;   // Globally expose the reference to Highcharts.Chart such that the phantomjs script
                       // can access it via page.evaluate()
 
@@ -60,7 +68,7 @@
             }
 
             if (inputChartOptions.series.length == 0) inputChartOptions.subtitle.text = inputChartOptions.subtitle.text+'<br/> <h2>**NO DATA**<h2/>';
-            chart = new Highcharts.Chart(inputChartOptions);
+            chart = XDMoD.utils.createChart(inputChartOptions);
 
          });//$(document).ready(...
 
@@ -73,6 +81,7 @@
       <script type="text/javascript" src="_html_dir_/gui/lib/moment-timezone/moment-timezone-with-data.min.js"></script>
 
       <script type="text/javascript" src="_html_dir_/gui/lib/highcharts/js/highcharts.src.js"></script>
+      <script type="text/javascript" src="_html_dir_/gui/js/HighChartWrapper.js"></script>
 
       <!-- needed for getSVG() -->
       <script type="text/javascript" src="_html_dir_/gui/lib/highcharts/js/modules/exporting.src.js"></script>

--- a/html/index.php
+++ b/html/index.php
@@ -208,6 +208,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
     <script type="text/javascript" src="gui/lib/MessageWindow.js"></script>
 
     <script type="text/javascript" src="gui/js/CCR.js"></script>
+    <script type="text/javascript" src="gui/js/HighChartWrapper.js"></script>
     <script type="text/javascript" src="gui/js/RESTDataProxy.js"></script>
     <script type="text/javascript" src="gui/js/CustomHttpProxy.js"></script>
 

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -132,19 +132,6 @@
       
    }//processForThumbnail
    
-     // --------------------------------------------------
-
-   // @function encodeJSON
-    function encodeJSON($data)
-	{
-		$value_arr = array();
-		$replace_keys = array();
-		$start_index = 1;
-		\xd_charting\replace_functions($data, $value_arr, $replace_keys, $start_index);
-		$json = json_encode($data);
-		$json = str_replace($replace_keys, $value_arr, $json);
-		return $json;
-	}
    // --------------------------------------------------
 
    // @function exportHighchart
@@ -163,9 +150,9 @@
       $template = file_get_contents($html_dir . "/highchart_template.html");
    
       $template = str_replace('_html_dir_', $html_dir, $template);
-      $template = str_replace('_chartOptions_',encodeJSON($chartConfig), $template);
+      $template = str_replace('_chartOptions_', json_encode($chartConfig), $template);
       if ($globalChartConfig !== null) {
-          $template = str_replace('_globalChartOptions_', encodeJSON($globalChartConfig), $template);
+          $template = str_replace('_globalChartOptions_', json_encode($globalChartConfig), $template);
       } else {
           $template = str_replace('_globalChartOptions_', 'null', $template);
       }
@@ -293,32 +280,3 @@ EOC;
 
     return $out;
 }
-
-	function replace_functions(&$object, array &$value_arr, array &$replace_keys, &$xxx = 1)
-	{
-		foreach($object as $key => &$__value){
-		  if(is_array($__value))
-		  {
-			  replace_functions($__value,$value_arr, $replace_keys, $xxx);
-		  }
-		  else
-		   if(is_object($__value))
-		  {
-			  replace_functions($__value,$value_arr, $replace_keys, $xxx);
-		  }
-		  else
-		  // Look for values starting with 'function('
-		  //if(strpos($__value, 'function(')===0){
-		  if(preg_match('/^(\s*)function(.*)/', $__value,$matches)==1){
-
-			// Store function string.
-			$value_arr[] = $__value;
-			// Replace function string in $foo with a 'unique' special key.
-			$__value = '%' . $key. '_' . $xxx . '%';
-			// Later on, we'll look for the value, and replace it.
-			$replace_keys[] = '"' . $__value . '"';
-			$xxx++;
-		  }
-		}
-	}
-

--- a/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageChartsTest.php
+++ b/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageChartsTest.php
@@ -63,7 +63,7 @@ class UsageChartsTest extends \PHPUnit_Framework_TestCase
 
         $expectedHashes = array();
 
-        $hashFile = realpath(__DIR__ . '/../../../tests/artifacts/xdmod-test-artifacts/xdmod') . '/regression/images/expected-1.json';
+        $hashFile = realpath(__DIR__ . '/../../../tests/artifacts/xdmod-test-artifacts/xdmod') . '/regression/images/expected-2.json';
         if (file_exists($hashFile)) {
             $expectedHashes = json_decode(file_get_contents($hashFile), true);
         }


### PR DESCRIPTION
The javascript functions needed for the Highcharts charts are now defined in javascript rather than in php. The API calls that return jchart data now return properly encoded json rather javascript.

The regression tests have been updated: there was a bug in the previous javascript encoding code that did not handle data with single quote characters. The buggy code is removed by this change.

Note that where possible I have tried to keep the existing javascript code in place unmodified (to reduce the chance of inadvertent regressions).