### PR TITLE
Add submission venue for events

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_openstack/event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/event.json
@@ -18,7 +18,8 @@
             "event_type_id": "staging.event_type_id",
             "record_type_id": "staging.record_type_id",
             "host_id": "staging.host_id",
-            "image_id": "staging.image_id"
+            "image_id": "staging.image_id",
+            "submission_venue_id": 3
         },
 
         "joins": [
@@ -45,7 +46,8 @@
             "event_time_utc": "event_time_utc",
             "event_type_id": "event_type_id",
             "record_type_id": "record_type_id",
-            "host_id": "host_id"
+            "host_id": "host_id",
+            "submission_venue_id": "submission_venue_id"
         }
     }
 }

--- a/configuration/etl/etl_tables.d/cloud_common/event.json
+++ b/configuration/etl/etl_tables.d/cloud_common/event.json
@@ -49,6 +49,12 @@
                 "type": "int(11) unsigned",
                 "nullable": false,
                 "comment": "Host where the event occured. Unknown = 1"
+            },
+            {
+                "name": "submission_venue_id",
+                "type": "int(5)",
+                "nullable": false,
+                "default": -1
             }
         ],
         "indexes": [


### PR DESCRIPTION
Added submission_venue_id column to event table and for open stack ingestion set the submission_venue_id to be 3 which matches the row in the submission_venue table for data ingested from the OpenStack API.

## Tests performed
Tested with docker.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
