### PR TITLE
Add pipeline name verification in EtlOverseer::verifySections()

### DIFF
--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -326,6 +326,24 @@ class EtlOverseer extends Loggable implements iEtlOverseer
             $this->queryResourceCodeToIdMap($etlConfig);
         }
 
+        // Verify requested section names before proceeding
+        $sectionNames = $this->etlOverseerOptions->getSectionNames();
+        if ( count($sectionNames) > 0 ) {
+            $missing = array();
+
+            foreach ( $sectionNames as $sectionName ) {
+                if ( ! $etlConfig->sectionExists($sectionName) ) {
+                    $missing[] = $sectionName;
+                }
+            }
+
+            if ( count($missing) > 0 ) {
+                log_error_and_exit(
+                    sprintf("Unknown sections: %s", implode(", ", $missing))
+                );
+            }
+        }
+
         // Verify connections to the data endpoints prior to verifying the actions. Action
         // initialization may need to connect to a data endpoint to obtain the handle so these need
         // to be done first.
@@ -342,7 +360,6 @@ class EtlOverseer extends Loggable implements iEtlOverseer
         }
 
         // Verify sections that were specified as part of a pipeline
-        $sectionNames = $this->etlOverseerOptions->getSectionNames();
         if ( count($sectionNames) > 0 ) {
             $this->sectionActions = $this->verifySections($etlConfig, $sectionNames);
         }

--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -82,7 +82,11 @@ class EtlOverseer extends Loggable implements iEtlOverseer
             }
         }
         foreach ( $this->etlOverseerOptions->getSectionNames() as $sectionName ) {
-            foreach ( $etlConfig->getSectionActionNames($sectionName) as $actionName ) {
+            $actionNameList = $etlConfig->getSectionActionNames($sectionName);
+            if ( ! $actionNameList ) {
+                throw new Exception(sprintf("section '%s' does not exist", $sectionName));
+            }
+            foreach ( $actionNameList as $actionName ) {
                 $options = $etlConfig->getActionOptions($actionName, $sectionName);
                 if ( ! $options->enabled ) {
                     continue;
@@ -246,11 +250,16 @@ class EtlOverseer extends Loggable implements iEtlOverseer
         $messages = array();
 
         foreach ( $sectionNameList as $sectionName ) {
-            $actionNameList = $etlConfig->getSectionActionNames($sectionName);
-            $actionObjectList = ( array_key_exists($sectionName, $sectionActionObjectList)
-                                      ? $sectionActionObjectList[$sectionName]
-                                      : array() );
             try {
+                $actionNameList = $etlConfig->getSectionActionNames($sectionName);
+                if ( ! $actionNameList ) {
+                    throw new Exception(sprintf("section '%s' does not exist", $sectionName));
+                }
+                $actionObjectList = (
+                    array_key_exists($sectionName, $sectionActionObjectList)
+                    ? $sectionActionObjectList[$sectionName]
+                    : array()
+                );
                 $sectionActionObjectList[$sectionName] = $this->verifyActions(
                     $etlConfig,
                     $actionNameList,

--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -338,7 +338,7 @@ class EtlOverseer extends Loggable implements iEtlOverseer
             }
 
             if ( count($missing) > 0 ) {
-                log_error_and_exit(
+                $this->logAndThrowException(
                     sprintf("Unknown sections: %s", implode(", ", $missing))
                 );
             }

--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -82,11 +82,7 @@ class EtlOverseer extends Loggable implements iEtlOverseer
             }
         }
         foreach ( $this->etlOverseerOptions->getSectionNames() as $sectionName ) {
-            $actionNameList = $etlConfig->getSectionActionNames($sectionName);
-            if ( ! $actionNameList ) {
-                throw new Exception(sprintf("section '%s' does not exist", $sectionName));
-            }
-            foreach ( $actionNameList as $actionName ) {
+            foreach ( $etlConfig->getSectionActionNames($sectionName) as $actionName ) {
                 $options = $etlConfig->getActionOptions($actionName, $sectionName);
                 if ( ! $options->enabled ) {
                     continue;
@@ -250,16 +246,11 @@ class EtlOverseer extends Loggable implements iEtlOverseer
         $messages = array();
 
         foreach ( $sectionNameList as $sectionName ) {
+            $actionNameList = $etlConfig->getSectionActionNames($sectionName);
+            $actionObjectList = ( array_key_exists($sectionName, $sectionActionObjectList)
+                                      ? $sectionActionObjectList[$sectionName]
+                                      : array() );
             try {
-                $actionNameList = $etlConfig->getSectionActionNames($sectionName);
-                if ( ! $actionNameList ) {
-                    throw new Exception(sprintf("section '%s' does not exist", $sectionName));
-                }
-                $actionObjectList = (
-                    array_key_exists($sectionName, $sectionActionObjectList)
-                    ? $sectionActionObjectList[$sectionName]
-                    : array()
-                );
                 $sectionActionObjectList[$sectionName] = $this->verifyActions(
                     $etlConfig,
                     $actionNameList,

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -435,26 +435,6 @@ try {
 Utilities::setEtlConfig($etlConfig);
 
 // ------------------------------------------------------------------------------------------
-// Verify requested actions and sections
-
-if ( count($scriptOptions['process-sections']) > 0 ) {
-
-    $missing = array();
-
-    foreach ( $scriptOptions['process-sections'] as $sectionName ) {
-        if ( ! $etlConfig->sectionExists($sectionName) ) {
-            $missing[] = $sectionName;
-        }
-    }
-
-    if ( count($missing) > 0 ) {
-        log_error_and_exit(
-            sprintf("Unknown sections: %s", implode(", ", $missing))
-        );
-    }
-}  // if ( count($scriptOptions['process-sections'] > 0) )
-
-// ------------------------------------------------------------------------------------------
 // List any requested resources. After listing, exit.
 
 if ( false === ($utilityEndpoint = $etlConfig->getGlobalEndpoint('utility')) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Pipeline name verification is performed in `etl_overseer.php` but when calling without that wrapper script, pipeline names should also be verified. Note that this needs to happen after the `EtlConfiguration` object is created but before actions are actually executed by `EtlOverseer`.

## Motivation and Context


## Tests performed

Manually tested by removing checks from `etl_overrseer.php`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
