### PR TITLE
Adding a managed table that was initially missed

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -419,6 +419,7 @@ function wipeManagedTables(iDatabase $db)
         'acl_tabs',
         'tabs',
         'acl_hierarchies',
+        'acl_group_bys',
         'acls',
         'acl_types',
         'group_bys',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A managed table ( acl_group_bys ) was added because it was not added during the initial commit.

## Motivation and Context
Because this table should be "managed" ( i.e. completely re-generated from the config file source ) to accurately reflect the state of those configuration files.

## Tests performed
Manual Tests: 
- Have a db w/ the acl_group_bys table in an inconsistent state ( the db values are different than the config file values 
- run acl-config
- notice that acl_group_bys should now be consistent with the config file values

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
