### PR TITLE
Allow net write timeout and chunk size as ETL variables

### DIFF
--- a/classes/ETL/aOptions.php
+++ b/classes/ETL/aOptions.php
@@ -69,7 +69,15 @@ abstract class aOptions extends \stdClass implements \Iterator
         "truncate_destination" => false,
 
         // Should an exception thrown by this action stop the ETL process?
-        "stop_on_exception" => true
+        "stop_on_exception" => true,
+
+        // Maximum number of records to operate on (e.g., ingest) in a single chunk.
+        "db_insert_chunk_size" => 250000,
+
+        // The number of seconds to allot for the timeout per record chunk per destination. If
+        // multiple table destinations are being populated this will be multiplied by the number
+        // of destinations.
+        "net_write_timeout_per_db_chunk" => 60
         );
 
     /* ------------------------------------------------------------------------------------------
@@ -146,6 +154,14 @@ abstract class aOptions extends \stdClass implements \Iterator
                 $value = \xd_utilities\filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                 if ( null === $value ) {
                     $msg = get_class($this) . ": '$property' must be a boolean (type = " . gettype($origValue) . ")";
+                    throw new Exception($msg);
+                }
+                break;
+
+            case 'db_insert_chunk_size':
+            case 'net_write_timeout_per_db_chunk':
+                if ( ! is_int($value) ) {
+                    $msg = get_class($this) . ": '$property' must be an integer (type = " . gettype($value) . ")";
                     throw new Exception($msg);
                 }
                 break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add 2 new ETL options for flexibility with larger datasets
- `db_insert_chunk_size` The number of seconds to allot for the timeout per file per record chunk
- `net_write_timeout_per_db_chunk` The number of records per chunk (e.g., LOAD DATA INFILE statement)

## Motivation and Context

@jpwhite4 was seeing "MySQL server has gone away" errors when ingesting SUPReMM data.

## Tests performed

Tested against XSEDE docker instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
