### PR TITLE
Added XDMOD_BUILD_ROOT enviroment variable support

### DIFF
--- a/etl/js/config.js
+++ b/etl/js/config.js
@@ -100,9 +100,10 @@ module.exports = {
 			password: loggerConfigSection.pass
 		}
 	},
-	xdmodRoot: xdmodRoot,
-	xdmodConfigDir: xdmodConfigDir,
-	xdmodConfig: xdmodConfig,
+    xdmodBuildRoot: process.env.XDMOD_BUILD_ROOT ? process.env.XDMOD_BUILD_ROOT : xdmodRoot,
+    xdmodBuildConfigDir: process.env.XDMOD_BUILD_ROOT ? process.env.XDMOD_BUILD_ROOT + '/configuration' : xdmodConfigDir,
+    xdmodConfigDir: xdmodConfigDir,
+    xdmodConfig: xdmodConfig,
 
     getXdmodConfigFile: function(filename) {
         var confFile = xdmodConfigDir + '/' + filename + '.json';


### PR DESCRIPTION
This change adds support for an  `XDMOD_BUILD_ROOT` environment variable that, when set,
will cause the (js-based) etl software to write any auto-generated files to the directory structure
rooted at  `XDMOD_BUILD_ROOT`. This will dramatically simply the build scripts for modules that use 
the file auto-generation capabilities.

Also fixed a TODO that was in the way.