### PR TITLE
Run all Etlv2 migration pipelines on xdmod-upgrade

### DIFF
--- a/classes/OpenXdmod/Migration/Etlv2Migration.php
+++ b/classes/OpenXdmod/Migration/Etlv2Migration.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Runs all etlv2 migration sections. The sections are chosen based
+ * on the section name. The name must end in the string 'migration-X_Y_Z-A_B_C'
+ * for migrations from XDMoD version X.Y.Z to A.B.C
+ *
+ * The migrations are processed in alphabetical order so the Aaaron Aaardvark migration
+ * will run before the Zysel Zywicki one.
+ *
+ */
+
+namespace OpenXdmod\Migration;
+
+use ETL\Configuration\EtlConfiguration;
+use ETL\EtlOverseerOptions;
+use ETL\Utilities;
+use ETL\EtlOverseer;
+
+class Etlv2Migration extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function execute()
+    {
+        $etlConfig = new EtlConfiguration(CONFIG_DIR . '/etl/etl.json', null, $this->logger, array());
+        $etlConfig->initialize();
+        Utilities::setEtlConfig($etlConfig);
+
+        $sectionFilter = 'migration-' . str_replace('.', '_', $this->currentVersion) . '-' . str_replace('.', '_', $this->newVersion);
+
+        $scriptOptions = array(
+            'process-sections' => array()
+        );
+
+        foreach($etlConfig->getSectionNames() as $sectionName) {
+            if (strpos($sectionName, $sectionFilter) === (strlen($sectionName) - strlen($sectionFilter))) {
+                $scriptOptions['process-sections'][] = $sectionName;
+            }
+        }
+
+        if (empty($scriptOptions['process-sections'])) {
+            return;
+        }
+
+        sort($scriptOptions['process-sections']);
+
+        $overseerOptions = new EtlOverseerOptions($scriptOptions, $this->logger);
+        $overseer = new EtlOverseer($overseerOptions, $this->logger);
+        $overseer->execute($etlConfig);
+    }
+}

--- a/classes/OpenXdmod/Migration/MigrationFactory.php
+++ b/classes/OpenXdmod/Migration/MigrationFactory.php
@@ -52,14 +52,17 @@ class MigrationFactory
             );
         }
 
-        if ($updateDatabases && class_exists($databasesMigrationName)) {
-            $msg = "Using databases migration '$databasesMigrationName'";
-            $logger->debug($msg);
+        if ($updateDatabases) {
+            if (class_exists($databasesMigrationName)) {
+                $msg = "Using databases migration '$databasesMigrationName'";
+                $logger->debug($msg);
 
-            $migrations[] = new $databasesMigrationName(
-                $fromVersion,
-                $toVersion
-            );
+                $migrations[] = new $databasesMigrationName(
+                    $fromVersion,
+                    $toVersion
+                );
+            }
+            $migrations[] = new \OpenXdmod\Migration\Etlv2Migration($fromVersion, $toVersion);
         }
 
         $migration = new CompositeMigration(


### PR DESCRIPTION
## Description
`xmod-upgrade` automatically runs ETLv2  for all etlv2 sections (pipelines) that are marked
as migrations. Migration sections (pipelines) are determined based on their name. The name must end in the string 'migration-X_Y_Z-A_B_C' for migrations from XDMoD version X.Y.Z to A.B.C

The migrations are processed in alphabetical order by name.

## Motivation and Context
The SUPReMM module needs to run an etlv2 pipeline at upgrade time.
