### PR TITLE
Ensure post/patch requests are configured correctly in test harness

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/XdmodTestHelper.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/XdmodTestHelper.php
@@ -252,9 +252,11 @@ class XdmodTestHelper
         }
         curl_setopt($this->curl, CURLOPT_URL, $url);
         curl_setopt($this->curl, CURLOPT_POST, true);
+        $postData = '';
         if (isset($data)) {
-            curl_setopt($this->curl, CURLOPT_POSTFIELDS, http_build_query($data));
+            $postData = http_build_query($data);
         }
+        curl_setopt($this->curl, CURLOPT_POSTFIELDS, $postData);
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, $this->getheaders());
 
         return $this->docurl();
@@ -272,9 +274,11 @@ class XdmodTestHelper
         }
         curl_setopt($this->curl, CURLOPT_URL, $url);
         curl_setopt($this->curl, CURLOPT_POST, true);
+        $patchData = '';
         if (isset($data)) {
-            curl_setopt($this->curl, CURLOPT_POSTFIELDS, http_build_query($data));
+            $patchData = http_build_query($data);
         }
+        curl_setopt($this->curl, CURLOPT_POSTFIELDS, $patchData);
         curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'PATCH');
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, $this->getheaders());
         $response = $this->docurl();


### PR DESCRIPTION
## Description
The version of libcurl that ships with Centos 7 needs to have the CURLOPT_POSTFIELDS option set when POSTing. If not then it sends a Content-Length of -1 which results in a 400 Bad Request from the webserver.

## Motivation and Context
Bug fix.