### PR TITLE
Documentation pointer to configuring Globus Auth via simplesamlphp-mo…

### DIFF
--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -214,7 +214,7 @@ $ node app.js \
 
 [ssp]: https://simplesamlphp.org/
 [ssp-config]: https://simplesamlphp.org/docs/stable/simplesamlphp-sp
-[ssp-globusconfig]: https://github.com/ubccr/simplesamlphp-module-authglobus/blob/master/README.md#running-globus-auth
+[ssp-globusconfig]: https://github.com/ubccr/simplesamlphp-module-authglobus
 [ssp-idp-remote]: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-remote
 [ssp-apache]: https://simplesamlphp.org/docs/stable/simplesamlphp-install#section_6
 [saml-idp]: https://github.com/mcguinness/saml-idp/

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -31,6 +31,8 @@ Required configuration files to be added to support Single Sign On:
 
 More information on how to set these up can be found in the [SimpleSAMLphp Service Provider QuickStart][ssp-config].
 
+Information on how to set up SimpleSAMLphp to use Globus Auth can be found in the [simplesamlphp-module-authglobus documentation][ssp-globusconfig]
+
 You will need to modify the `config.php` file and make sure you modify the `metadata.sources` and the `certdir` keys to have the **full path** to directories containing the configurations:
 
 **note** make sure the file has opening `<?php`
@@ -212,6 +214,7 @@ $ node app.js \
 
 [ssp]: https://simplesamlphp.org/
 [ssp-config]: https://simplesamlphp.org/docs/stable/simplesamlphp-sp
+[ssp-globusconfig]: https://github.com/ubccr/simplesamlphp-module-authglobus/blob/master/README.md#running-globus-auth
 [ssp-idp-remote]: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-remote
 [ssp-apache]: https://simplesamlphp.org/docs/stable/simplesamlphp-install#section_6
 [saml-idp]: https://github.com/mcguinness/saml-idp/


### PR DESCRIPTION
Adds a pointer in the documentation on how to configure Globus Auth via simplesamlphp-module-authglobus

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a single line and URL to simpleSAMLphp.md that points to simplesamlphp-module-authglobus documentation.
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->


## Motivation and Context
Aside from the 7.5.x release notes, there's no reference to Globus Auth or simplesamlphp-module-authglobus in the xdmod documentation.  This should help those looking to use this new feature.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
This changes only documentation
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
Only documentation changes.
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
