### PR TITLE
Add submission venue group by

### DIFF
--- a/classes/DataWarehouse/Query/Cloud/GroupBys/GroupBySubmissionVenue.php
+++ b/classes/DataWarehouse/Query/Cloud/GroupBys/GroupBySubmissionVenue.php
@@ -26,7 +26,7 @@ class GroupBySubmissionVenue extends \DataWarehouse\Query\Cloud\GroupBy
 
     public function getInfo()
     {
-        return "The venue that a piece of cloud data was submitted from.";
+        return "The venue that a job or cloud instance was initiated from.";
     }
 
     public function __construct()
@@ -43,12 +43,12 @@ class GroupBySubmissionVenue extends \DataWarehouse\Query\Cloud\GroupBy
                 submission_venue sv"
         );
 
-      $this->_id_field_name = 'submission_venue_id';
-      $this->_long_name_field_name = 'display';
-      $this->_short_name_field_name = 'submission_venue';
-      $this->_order_id_field_name = 'submission_venue_id';
-      $this->modw_schema = new Schema('modw');
-      $this->submission_venue_table = new Table($this->modw_schema, 'submission_venue', 'sv');
+        $this->_id_field_name = 'submission_venue_id';
+        $this->_long_name_field_name = 'display';
+        $this->_short_name_field_name = 'submission_venue';
+        $this->_order_id_field_name = 'order_id';
+        $this->modw_schema = new Schema('modw');
+        $this->submission_venue_table = new Table($this->modw_schema, 'submission_venue', 'sv');
     }
 
     public function applyTo(\DataWarehouse\Query\Query &$query, \DataWarehouse\Query\Model\Table $data_table, $multi_group = false)
@@ -95,7 +95,7 @@ class GroupBySubmissionVenue extends \DataWarehouse\Query\Cloud\GroupBy
         $query->addWhereCondition(new WhereCondition($submission_venue_id_field, $operation, $whereConstraint));
     }
 
-    public function addOrder(Query &$query, $multi_group = false, $dir = 'asc',$prepend = false)
+    public function addOrder(Query &$query, $multi_group = false, $dir = 'asc', $prepend = false)
     {
         $orderField = new OrderBy(new TableField($this->submission_venue_table, $this->_order_id_field_name), $dir, $this->getName());
         if ($prepend === true) {
@@ -118,4 +118,3 @@ class GroupBySubmissionVenue extends \DataWarehouse\Query\Cloud\GroupBy
         );
     }
 }
-?>

--- a/classes/DataWarehouse/Query/Cloud/GroupBys/GroupBySubmissionVenue.php
+++ b/classes/DataWarehouse/Query/Cloud/GroupBys/GroupBySubmissionVenue.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace DataWarehouse\Query\Cloud\GroupBys;
+
+use Log;
+use DataWarehouse\Query\Query;
+use DataWarehouse\Query\Model\OrderBy;
+use DataWarehouse\Query\Model\Schema;
+use DataWarehouse\Query\Model\Table;
+use DataWarehouse\Query\Model\TableField;
+use DataWarehouse\Query\Model\WhereCondition;
+
+/*
+* @author Greg Dean
+* @date 05/17/2018
+*
+* Group By Submission Venue
+*/
+
+class GroupBySubmissionVenue extends \DataWarehouse\Query\Cloud\GroupBy
+{
+    public static function getLabel()
+    {
+        return 'Submission Venue';
+    }
+
+    public function getInfo()
+    {
+        return "The venue that a piece of cloud data was submitted from.";
+    }
+
+    public function __construct()
+    {
+
+        parent::__construct(
+            "submission_venue",
+            array(),
+            "SELECT DISTINCT
+                sv.submission_venue_id AS id,
+                sv.submission_venue AS short_name,
+                sv.display AS long_name
+             FROM
+                submission_venue sv"
+        );
+
+      $this->_id_field_name = 'submission_venue_id';
+      $this->_long_name_field_name = 'display';
+      $this->_short_name_field_name = 'submission_venue';
+      $this->_order_id_field_name = 'submission_venue_id';
+      $this->modw_schema = new Schema('modw');
+      $this->submission_venue_table = new Table($this->modw_schema, 'submission_venue', 'sv');
+    }
+
+    public function applyTo(\DataWarehouse\Query\Query &$query, \DataWarehouse\Query\Model\Table $data_table, $multi_group = false)
+    {
+        $id_field = new TableField($this->submission_venue_table, $this->_id_field_name, $this->getIdColumnName($multi_group));
+        $submission_venue_name_field = new TableField($this->submission_venue_table, $this->_long_name_field_name, $this->getLongNameColumnName($multi_group));
+        $submission_venue_shortname_field = new TableField($this->submission_venue_table, $this->_short_name_field_name, $this->getShortNameColumnName($multi_group));
+        $order_id_field = new TableField($this->submission_venue_table, $this->_order_id_field_name, $this->getOrderIdColumnName($multi_group));
+        $datatable_submission_venue_id_field = new TableField($data_table, 'submission_venue_id');
+
+        // Table to join to to get submission venue names
+        $query->addTable($this->submission_venue_table);
+
+        // Add fields to be returned from query
+        $query->addField($order_id_field);
+        $query->addField($id_field);
+        $query->addField($submission_venue_name_field);
+        $query->addField($submission_venue_shortname_field);
+
+        // Add field that you are going to group by
+        $query->addGroup($id_field);
+
+        $query->addWhereCondition(new WhereCondition($id_field, '=', $datatable_submission_venue_id_field));
+        $this->addOrder($query, $multi_group);
+
+    }
+
+    public function addWhereJoin(Query &$query, Table $data_table, $multi_group, $operation, $whereConstraint)
+    {
+        $submission_venue_id_field = new TableField($this->submission_venue_table, $this->_id_field_name);
+        $datatable_submission_venue_id_field = new TableField($data_table, 'submission_venue_id');
+
+        // construct the join between the main data_table and this group by table
+        $query->addTable($this->submission_venue_table);
+
+        // the where condition that specifies the join of the tables
+        $query->addWhereCondition(new WhereCondition($submission_venue_id_field, '=', $datatable_submission_venue_id_field));
+
+        // the where condition that specifies the constraint on the joined table
+        if (is_array($whereConstraint)) {
+            $whereConstraint="(". implode(",", $whereConstraint) .")";
+        }
+
+        $query->addWhereCondition(new WhereCondition($submission_venue_id_field, $operation, $whereConstraint));
+    }
+
+    public function addOrder(Query &$query, $multi_group = false, $dir = 'asc',$prepend = false)
+    {
+        $orderField = new OrderBy(new TableField($this->submission_venue_table, $this->_order_id_field_name), $dir, $this->getName());
+        if ($prepend === true) {
+            $query->prependOrder($orderField);
+        } else {
+            $query->addOrder($orderField);
+        }
+    }
+
+    public function pullQueryParameters(&$request)
+    {
+        return parent::pullQueryParameters2($request, '_filter_', 'submission_venue_id');
+    }
+
+    public function pullQueryParameterDescriptions(&$request)
+    {
+        return parent::pullQueryParameterDescriptions2(
+            $request,
+            "select display as field_label from modw.submission_venue where id in (_filter_) order by submission_venue_id"
+        );
+    }
+}
+?>

--- a/configuration/datawarehouse.d/cloud.json
+++ b/configuration/datawarehouse.d/cloud.json
@@ -47,6 +47,10 @@
                 {
                     "name": "vm_size",
                     "class": "GroupByVMCores"
+                },
+                {
+                    "name": "submission_venue",
+                    "class": "GroupBySubmissionVenue"
                 }
             ],
             "statistics": [{

--- a/configuration/etl/etl_data.d/jobs/submission_venue.json
+++ b/configuration/etl/etl_data.d/jobs/submission_venue.json
@@ -1,9 +1,8 @@
 [
-    ["submission_venue_id", "submission_venue", "display", "description"],
-    [-1, "unknown",       "Unknown",       "Unknown" ],
-    [1,  "cli",           "CLI",           "Command Line Interface" ],
-    [2,  "gateway",       "Gateway",       "Science Gateway" ],
-    [3,  "openstack-api", "OpenStack API", "OpenStack API" ],
-    [4,  "atmosphere",    "Atmosphere",    "Atmosphere Portal" ]
+    ["submission_venue_id", "submission_venue", "display", "description", "order_id"],
+    [-1, "unknown",       "Unknown",       "Unknown", "1" ],
+    [1,  "cli",           "CLI",           "Command Line Interface", "2" ],
+    [2,  "gateway",       "Gateway",       "Science Gateway", "3" ],
+    [3,  "openstack-api", "OpenStack API", "OpenStack API", "4" ],
+    [4,  "atmosphere",    "Atmosphere",    "Atmosphere Portal", "5" ]
 ]
-

--- a/configuration/etl/etl_data.d/jobs/submission_venue.json
+++ b/configuration/etl/etl_data.d/jobs/submission_venue.json
@@ -1,8 +1,8 @@
 [
     ["submission_venue_id", "submission_venue", "display", "description", "order_id"],
     [-1, "unknown",       "Unknown",       "Unknown", "1" ],
-    [1,  "cli",           "CLI",           "Command Line Interface", "2" ],
-    [2,  "gateway",       "Gateway",       "Science Gateway", "3" ],
-    [3,  "openstack-api", "OpenStack API", "OpenStack API", "4" ],
-    [4,  "atmosphere",    "Atmosphere",    "Atmosphere Portal", "5" ]
+    [1,  "cli",           "CLI",           "Command Line Interface", "3" ],
+    [2,  "gateway",       "Gateway",       "Science Gateway", "4" ],
+    [3,  "openstack-api", "OpenStack API", "OpenStack API", "5" ],
+    [4,  "atmosphere",    "Atmosphere",    "Atmosphere Portal", "2" ]
 ]

--- a/configuration/etl/etl_tables.d/jobs/submission_venue.json
+++ b/configuration/etl/etl_tables.d/jobs/submission_venue.json
@@ -25,6 +25,11 @@
                 "name": "description",
                 "type": "varchar(1024)",
                 "nullable": true
+            },
+            {
+                "name": "order_id",
+                "type": "int(5) UNSIGNED",
+                "nullable": true
             }
         ],
         "indexes": [

--- a/configuration/etl/etl_tables.d/jobs/submission_venue.json
+++ b/configuration/etl/etl_tables.d/jobs/submission_venue.json
@@ -29,7 +29,7 @@
             {
                 "name": "order_id",
                 "type": "int(5) UNSIGNED",
-                "nullable": true
+                "nullable": false
             }
         ],
         "indexes": [

--- a/configuration/roles.d/cloud.json
+++ b/configuration/roles.d/cloud.json
@@ -28,6 +28,10 @@
                 {
                     "realm": "Cloud",
                     "group_by": "memory_buckets"
+                },
+                {
+                  "realm": "Cloud",
+                  "group_by": "submission_venue"
                 }
             ]
         }

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/acls/output/datawarehouse.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/acls/output/datawarehouse.json
@@ -332,6 +332,10 @@
                 {
                     "name": "vm_size",
                     "class": "GroupByVMCores"
+                },
+                {
+                    "name": "submission_venue",
+                    "class": "GroupBySubmissionVenue"
                 }
             ],
             "statistics": [{

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/acls/output/roles.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/acls/output/roles.json
@@ -131,6 +131,10 @@
                 {
                     "realm": "Cloud",
                     "group_by": "memory_buckets"
+                },
+                {
+                    "realm": "Cloud",
+                    "group_by": "submission_venue"
                 }
             ],
             "summary_charts": [{


### PR DESCRIPTION
Adding a Group By for the Submission Venue

## Motivation and Context
We would like to be able to see data based on the submission venue such as the difference between Jetstream Atmophere portal or the Jetstream API

## Tests performed
Manual testing using XSEDE docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
