### PR TITLE
Fix encoding for javascript

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -275,8 +275,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
             print "CCR.xdmod.ui.mappedPID = '{$user->getPersonID(TRUE)}';\n";
 
             $obj_warehouse = new XDWarehouse();
-            $pName = rawurlencode($obj_warehouse->resolveName($user->getPersonID(true)));
-            print "CCR.xdmod.ui.mappedPName = '{$pName}';\n";
+            print 'CCR.xdmod.ui.mappedPName = ' . json_encode($obj_warehouse->resolveName($user->getPersonID(true))) . ";\n";
 
             print "CCR.xdmod.ui.isManager = $manager;\n";
             print "CCR.xdmod.ui.isDeveloper = $developer;\n";


### PR DESCRIPTION
This change fixes a regression that was introduced in #519. The JavaScript variable `CCR.xdmod.ui.mappedPName` needs to be encoded using JavaScript encoding not URL encoding.

Old:
![image](https://user-images.githubusercontent.com/5342179/41003402-ac464cb6-68e4-11e8-94d0-75d847ab805a.png)

New:
![image](https://user-images.githubusercontent.com/5342179/41003335-825ee250-68e4-11e8-9924-e3a2590f5f32.png)
