### PR TITLE
Correct order by placement in event reconstruction

### DIFF
--- a/classes/ETL/Ingestor/StateReconstructorTransformIngestor.php
+++ b/classes/ETL/Ingestor/StateReconstructorTransformIngestor.php
@@ -108,7 +108,7 @@ class StateReconstructorTransformIngestor extends pdoIngestor implements iAction
             $unionValues[] = 0;
         }
 
-        $sql = "SELECT * FROM ( $sql ) a\nUNION\nSELECT " . implode(',', $unionValues) . "\nORDER BY instance_id ASC, event_time_utc ASC";
+        $sql = "SELECT * FROM ( $sql \nORDER BY instance_id ASC, event_time_utc ASC) a\nUNION ALL\nSELECT " . implode(',', $unionValues);
         return $sql;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a bug where the order by was following the dummy row union, causing a valid row to be discarded instead of the dummy row.

## Motivation and Context
We like good data

## Tests performed
Yes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
