### PR TITLE
Tidy up the Simplify job viewer analytics handling

### DIFF
--- a/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
+++ b/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
@@ -22,7 +22,7 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
             },
             chart: {
                 type: 'bar',
-                height: 150,
+                height: 65,
                 options: {
                 },
                 reflow: false
@@ -32,9 +32,10 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
                 min: 0,
                 gridLineColor: '#c0c0c0',
                 labels: {
-                    y: 13 // tighten vertical distance between axis and its labels
+                    enabled: false
                 },
                 title: {
+                    text: '',
                     margin: 1, // tighten vertical distance between axis title and labels
                     style: {
                         fontWeight: 'bold',
@@ -49,6 +50,12 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
                 }
             },
             tooltip: {
+                enabled: false
+            },
+            credits: {
+                enabled: false
+            },
+            legend: {
                 enabled: false
             },
             plotOptions: {

--- a/html/gui/js/modules/job_viewer/JobPanel.js
+++ b/html/gui/js/modules/job_viewer/JobPanel.js
@@ -1,43 +1,6 @@
 Ext.ns('XDMoD', 'XDMoD.Module', 'XDMoD.Module.JobViewer');
 
 // =============================================================================
-// Global Defaults                                                            ||
-// =============================================================================
-
-// default ids of various important containers within the job panel.
-var DEFAULT_IDS = {
-    delim             : '-',
-    analyticsContainer: 'analytics_container',
-    jobTabs           : 'job_tabs',
-    help              : 'job_help'
-};
-
-// Helper objects for use with the Analytic Metrics display.
-var ANALYTIC_METRICS = [
-    {
-        key   : 'CPU User Balance',
-        id    : 'metric1',
-        format: function (value) {
-            return parseFloat(value).toFixed(3);
-        }
-    },
-    {
-        key   : 'Homogeneity',
-        id    : 'metric2',
-        format: function (value) {
-            return parseFloat(value).toFixed(3);
-        }
-    },
-    {
-        key   : 'CPU User',
-        id    : 'metric3',
-        format: function (value) {
-            return parseFloat(value).toFixed(3);
-        }
-    }
-];
-
-// =============================================================================
 // Class Definition                                                           ||
 // =============================================================================
 
@@ -48,61 +11,58 @@ var ANALYTIC_METRICS = [
  */
 XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
 
-    _DEFAULTS: {
+    MAX_ANALYTICS: 4,
+
+    COMPONENT_DEFAULTS: {
         closable: true,
-        layout  : 'border',
-        items   : [
+        layout: 'border',
+        items: [
             {
-                region  : 'center',
-                layout  : 'border',
+                itemId: 'analytics_container',
+                xtype: 'panel',
+                layout: 'hbox',
+                layoutConfig: {
+                    align: 'stretch'
+                },
+                defaults: {
+                    margins: '0'
+                },
+                region: 'north',
+                hidden: 'true',
+                height: 95,
                 minWidth: 775,
-                items   : [
-                    {
-                        title   : 'Analytics',
-                        id      : 'analytics_container',
-                        xtype   : 'portal',
-                        region  : 'north',
-                        hidden  : 'true',
-                        height  : 174,
-                        minWidth: 775
-                    },
-                    {
-                        xtype      : 'tabpanel',
-                        id         : 'job_tabs',
-                        collapsible: false,
-                        enableTabScroll: true,
-                        region     : 'center',
-                        flex       : 1,
-                        defaults   : {
-                            collapsible: false
-                        },
-                        bubbleEvents : ['tabchange'],
-                        listeners  : {
-                            activate: function (panel) {
-                                console.log('Inner Tab activated...');
-                            }
-                        },
-                        activeTab  : 0,
-                        items      : []
-                    },
-                    {
-                        title: 'Description',
-                        id: DEFAULT_IDS.help,
-                        region: 'south',
-                        height: 100,
-                        collapsible: true,
-                        collapsed: false,
-                        autoScroll: true,
-                        layout: 'fit',
-                        tpl: new Ext.XTemplate('<div class="jobviewer_helpcontent"><tpl if="title"><ul><li><strong>{title}:</strong> {documentation}</li></ul></tpl></div>'),
-                        updateHelpText: function(data) {
-                            this.update(this.tpl.apply(data));
-                        },
-                        plugins: new Ext.ux.collapsedPanelTitlePlugin('Help')
-                    }
-                ]
+                items: []
+            },
+            {
+                xtype: 'tabpanel',
+                id: 'job_tabs',
+                collapsible: false,
+                enableTabScroll: true,
+                region: 'center',
+                flex: 1,
+                defaults: {
+                    collapsible: false
+                },
+                bubbleEvents: ['tabchange'],
+                activeTab: 0,
+                items: []
+            },
+            {
+                title: 'Description',
+                itemId: 'help',
+                region: 'south',
+                height: 100,
+                collapsible: true,
+                collapsed: false,
+                autoScroll: true,
+                layout: 'fit',
+                tpl: new Ext.XTemplate('<div class="jobviewer_helpcontent"><tpl if="title"><ul><li><strong>{title}:</strong> {documentation}</li></ul></tpl></div>'),
+                updateHelpText: function (data) {
+                    this.update(this.tpl.apply(data));
+                },
+                plugins: new Ext.ux.collapsedPanelTitlePlugin('Help')
             }
-        ] // items
+        ]
     }, // DEFAULTS
 
     // ========================================================================
@@ -117,19 +77,40 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
      * Constructor method
      */
     initComponent: function () {
-        var exists = CCR.exists;
+        if (!this.jobId) {
+            throw new Error('Must provide a Job Id (jobId) when constructing this component.');
+        }
 
-        if (!exists(this.jobId)) throw new Error('Must provide a Job Id (jobId) when constructing this component.');
+        for (var i = 0; i < this.MAX_ANALYTICS; i++) {
+            this.COMPONENT_DEFAULTS.items[0].items[i] = {
+                title: 'No Data Available',
+                xtype: 'panel',
+                margin: '0',
+                padding: '1',
+                flex: 1,
+                itemId: 'metric' + i,
+                tools: [{
+                    id: 'help',
+                    qtip: ''
+                }],
+                items: new XDMoD.Module.JobViewer.AnalyticChartPanel({
+                    itemId: 'chart',
+                    chartOptions: {
+                        title: 'No Data Available'
+                    }
+                }),
+                listeners: {
+                    update_data: function (data) {
+                        this.getComponent('chart').fireEvent('update_data', data);
+                        this.getTool('help').dom.qtip = data.documentation;
+                    }
+                }
+            };
+        }
 
-        this.ids = {};
-        this.metrics = [];
-
-        Ext.apply(this, this._DEFAULTS);
+        Ext.apply(this, this.COMPONENT_DEFAULTS);
 
         XDMoD.Module.JobViewer.JobPanel.superclass.initComponent.apply(this, arguments);
-
-        this._modifyIds(this.jobId);
-        this._populateAnalytics(ANALYTIC_METRICS, this.jobId);
 
         this.revert = true;
     }, // initComponent
@@ -150,8 +131,12 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
             var toInt = CCR.toInt;
 
             var jv = panel.jobViewer;
-            var activeTab = this._getActiveTab();
-            activeTab = !exists(activeTab) ? this._getTab(0) : activeTab;
+
+            var tabPanel = this.getComponent('job_tabs');
+            var activeTab = tabPanel.getActiveTab();
+            if (!activeTab) {
+                activeTab = tabPanel.items.get(0);
+            }
 
             var nodePath = panel.path;
             var windowPath = jv._getPath(document.location.hash);
@@ -166,7 +151,6 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
 
             if (replaceJobId) {
                 path = nodePath.concat(path.slice(-1 * (path.length - nodePath.length)));
-                /*jv._replace('jobid', nodeJobId, path);*/
             }
             if (panel.revert || replaceJobId) {
                 // just make sure the token is up to date.
@@ -179,17 +163,6 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
         }, // activate
 
         /**
-         * Event that's fired when this panel is no longer the active tab.
-         *
-         * @param panel
-         */
-        deactivate: function (panel) {
-
-            // TODO: implement what happens when this panel is removed from being the active tab.
-
-        }, // deactivate
-
-        /**
          * Event that is fired after this component has been rendered to the
          * page. During this event we attempt to find the analyticsContainer.
          * Which, if found, will be refreshed visually. This serves to both
@@ -199,229 +172,51 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
          * @param panel
          */
         afterrender: function (panel) {
-            var isType = CCR.isType;
-            var found = this.find('id', this.ids.analyticsContainer);
-            var container = isType(found, CCR.Types.Array) && found.length > 0 ? found[0] : null;
+            var container = panel.getComponent('analytics_container');
             if (container) {
                 container.doLayout(false, true);
             }
         }, // afterrender
 
         /**
-         * Update the analytics components with the provided data. If the
-         * 'show' parameter is provided and true then the components will
-         * be shown if hidden.
+         * Update the analytics components with the provided data.
          *
          * @param {array} data
-         * @param {boolean} show
          */
-        update_analytics: function (data, show) {
-            var isType = CCR.isType;
-
-            var found = this.find('id', this.ids.analyticsContainer);
-            var analyticsPanel = isType(found, CCR.Types.Array) && found.length > 0 ? found[0] : null;
-
-            if (analyticsPanel) {
-                if (show === true) {
-                    analyticsPanel.show();
-                    this.doLayout(false, true);
-                }
-                var metrics = data;
-                for (var i = 0; i < metrics.length; i++) {
-                    var metric = metrics[i];
-                    var value = metric['value'];
-                    for (var j = 0; j < this.metrics.length; j++) {
-                        var am = this.metrics[j];
-                        if (am['key'] === metric['key']) {
-                            var formatted = am.format(value);
-                            found = analyticsPanel.find('id', am['id']);
-                            var cmp = isType(found, CCR.Types.Array) && found.length > 0 ? found[0] : null;
-                            if (cmp) {
-                                cmp.fireEvent('update_data', {
-                                    name: am.key,
-                                    value: metric.error == '' ? parseFloat(formatted) : 'N/A',
-                                    error: metric.error
-                                });
-                                am.container.getTool('help').dom.qtip = metric.documentation;
-                            }
-                            break;
-                        }
-                    }
-                }
-
-                analyticsPanel.doLayout(false, true);
+        update_analytics: function (data) {
+            var analyticsPanel = this.getComponent('analytics_container');
+            if (!analyticsPanel) {
+                return;
             }
-        }, // update_analytics
+
+            analyticsPanel.show();
+            this.doLayout();
+
+            var i;
+            var metricPanel;
+            var nMetrics = Math.min(data.length, this.MAX_ANALYTICS);
+
+            for (i = 0; i < nMetrics; i++) {
+                metricPanel = analyticsPanel.getComponent('metric' + i);
+                metricPanel.fireEvent('update_data', {
+                    name: data[i].key,
+                    value: data[i].error === '' ? parseFloat(parseFloat(data[i].value).toFixed(3)) : 'N/A',
+                    error: data[i].error,
+                    documentation: data[i].documentation
+                });
+            }
+        },
 
         display_help: function (data) {
-            var help = this._getComponent(DEFAULT_IDS.help);
+            var help = this.getComponent('help');
             if (help) {
                 help.updateHelpText(data);
             }
         },
 
-        tabchange: function(tabpanel) {
-            this.fireEvent("display_help", tabpanel.activeTab.helptext);
+        tabchange: function (tabpanel) {
+            this.fireEvent('display_help', tabpanel.activeTab.helptext);
             return false;
         }
-    }, // listeners
-
-    // ========================================================================
-    // Public Methods                                                        ||
-    // ========================================================================
-
-    // ========================================================================
-    // Private Methods                                                       ||
-    // ========================================================================
-
-    /**
-     * Modify the id's of the components of interest w/ the provided jobId. Also
-     * updates this instances 'id' object with the modified value.
-     *
-     * @param {number} jobId
-     * @private
-     */
-    _modifyIds: function (jobId) {
-        var isType = CCR.isType;
-        for (var key in DEFAULT_IDS) {
-            var found = this.find('id', DEFAULT_IDS[key]);
-            if (isType(found, CCR.Types.Array) && found.length > 0) {
-                var child = found[0];
-                this.ids[key] = child.id += (DEFAULT_IDS.delim + jobId);
-            }
-        }
-    }, // modifyIds
-
-    /**
-     * Populate the Analytic Container with Metrics components.
-     *
-     * @param {array} metrics to be used to populate the container.
-     * @param {number} jobid to be used in the correct identification of each metric component.
-     * @private
-     */
-    _populateAnalytics: function (metrics, jobId) {
-        var isType = CCR.isType;
-
-        var found = this.find('id', this.ids.analyticsContainer);
-        var analyticsPanel = isType(found, CCR.Types.Array) && found.length > 0 ? found[0] : null;
-
-        var tools = this._getTools();
-
-        for (var i = 0; i < metrics.length; i++) {
-
-            var metric = metrics[i];
-            var id = i + 1;
-            var metricId = 'metric' + DEFAULT_IDS.delim + id + DEFAULT_IDS.delim + jobId;
-            var cmp = new XDMoD.Module.JobViewer.AnalyticChartPanel({
-                id          : metricId,
-                height      : 174,
-                chartOptions: {
-                    title: 'No Data Available',
-                    yAxis: {
-                        min: 0,
-                        max: 1
-                    }
-                }
-            });
-
-            var container = new Ext.Panel({
-                columnWidth: .33,
-                style      : 'padding:8px 0 8px 8px',
-                title      : metric.key,
-                height     : 146,
-                id         : metricId + DEFAULT_IDS.delim + 'container',
-                tools: [{
-                    id: 'help',
-                    qtip: metric.key
-                }],
-                items      : cmp
-            });
-
-            this.metrics[i] = Ext.apply({}, metric);
-            this.metrics[i].component = cmp;
-            this.metrics[i].container = container;
-            this.metrics[i].id = metricId;
-
-            analyticsPanel.add(container);
-        }
-    }, // _populateAnalytics
-
-    /**
-     * Helper function that returns a newly constructed array representation of
-     * this components 'tools'.
-     *
-     * @returns {*[]}
-     * @private
-     */
-    _getTools: function () {
-        return [{
-            id     : 'gear',
-            handler: function () {
-                Ext.Msg.alert('Message', 'The Settings tool was clicked.');
-            }
-        }, {
-            id     : 'close',
-            handler: function (e, target, panel) {
-                panel.ownerCt.remove(panel, true);
-            }
-        }];
-    }, // _getTools
-
-    /**
-     * Helper function that retrieves this panels active informational tab.
-     *
-     * @returns {*}
-     * @private
-     */
-    _getActiveTab: function () {
-        var isType = CCR.isType;
-        var tabs = this.find('id', this.ids.jobTabs);
-        return isType(tabs, CCR.Types.Array) && tabs.length > 0 ? tabs[0].getActiveTab() : undefined;
-    }, // _getActiveTab
-
-    /**
-     * Helper function that attempts to retrieve the informational tab located
-     * at the provided index. If it is not found then undefined is returned.
-     *
-     * @param {Number} index
-     * @returns {*}
-     * @private
-     */
-    _getTab: function (index) {
-        var isType = CCR.isType;
-        if (!isType(index, CCR.Types.Number) || index < 0) return undefined;
-        var found = this.find('id', this.ids.jobTabs);
-        return isType(found, CCR.Types.Array) && found.length > 0 && found[0].items
-                ? found[0].items.get(index)
-                : undefined;
-    }, // _getTab
-
-    /**
-     * Helper function that generates a unique id from the provided id and this
-     * components jobId.
-     *
-     * @param id
-     * @returns {string}
-     * @private
-     */
-    _generateId: function (id) {
-        var base = CCR.isType(id, CCR.Types.String) ? id : String(id);
-        return base + DEFAULT_IDS.delim + this.jobId
-    }, // _generateId
-
-    /**
-     *
-     * @param {String} id
-     * @return {Null|Ext.Component}
-     * @private
-     */
-    _getComponent: function (id) {
-        if (!CCR.exists(id)) return undefined;
-
-        var localId = this._generateId(id);
-        var found = this.find('id', localId);
-        return CCR.isType(found, CCR.Types.Array) && found.length > 0
-                ? found[0]
-                : null;
-    } // _getComponent
+    }
 });

--- a/html/gui/js/modules/job_viewer/JobPanel.js
+++ b/html/gui/js/modules/job_viewer/JobPanel.js
@@ -35,7 +35,7 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
             },
             {
                 xtype: 'tabpanel',
-                id: 'job_tabs',
+                itemId: 'job_tabs',
                 collapsible: false,
                 enableTabScroll: true,
                 region: 'center',

--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -1111,8 +1111,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                                 if (success) {
                                     var views = data.results;
 
-                                    var jobTabs = jobTab.find('id', jobTab.ids.jobTabs);
-                                    jobTabs = isType(jobTabs, CCR.Types.Array) && jobTabs.length > 0 ? jobTabs[0] : null;
+                                    var jobTabs = jobTab.getComponent('job_tabs');
 
                                     var tab;
                                     for (var i = 0; i < views.length; i++) {
@@ -1210,7 +1209,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                         }
 
                         // RETRIEVE: the tab panel that holds the informational tabs.
-                        var infoTabs = self._fromArray(jobTab.find('id', jobTab.ids.jobTabs), 0);
+                        var infoTabs = jobTab.getComponent('job_tabs');
 
                         if (exists(infoTabs)) {
                             var isChild = self.children_ids.indexOf(dType) >= 0;
@@ -1825,9 +1824,7 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
                 tabs.setActiveTab(jobTab);
             }
 
-            found = jobTab.find('id', jobTab.ids.jobTabs);
-            var jobTabs = isType(found, CCR.Types.Array) && found.length > 0 ? found[0] : null;
-
+            var jobTabs = jobTab.getComponent('job_tabs');
             if (exists(jobTabs)) {
                 var hasTabs = jobTabs.items.length > 0;
                 if (hasTabs) {


### PR DESCRIPTION
This change cleans up the UI for the analytics panel removing superfluous text and condensing whitespace (as per the UI recommendations from D L'averne). Also remove the hardcoded metrics from the front end. 

Old
![old](https://user-images.githubusercontent.com/5342179/41116496-78b538f6-6a58-11e8-9d25-7854f8c87f92.png)

New
![new](https://user-images.githubusercontent.com/5342179/41116498-7bbb1d86-6a58-11e8-89ed-8fed807b0c8a.png)

Job viewer also included a significant amount of code that as responsible for managing the DOM ids. This change also removes the hard-coded analytics names and removes the unneeded id management code.

