### PR TITLE
Fix generation of test artifacts

### DIFF
--- a/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
@@ -102,7 +102,16 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
             }
             $outputDir = realpath($outputDir);
 
-            $outputFile = $outputDir . '/' . $datasetType . '-' . $aggUnit . '-' . (empty($expectedFile) ? 'reference' : $userRole ) . '.csv';
+            $referenceFile = $outputDir . '/' . $datasetType . '-' . $aggUnit . '-reference.csv';
+            if (file_exists($referenceFile)) {
+                $reference = file_get_contents($referenceFile);
+                if ($reference === $csvdata) {
+                    return;
+                }
+            }
+
+            $outputFile = $outputDir . '/' . $datasetType . '-' . $aggUnit . '-' . ($userRole == 'public' ? 'reference' : $userRole ) . '.csv';
+
             file_put_contents(
                 $outputFile,
                 $csvdata

--- a/open_xdmod/modules/xdmod/regression_tests/runtests.sh
+++ b/open_xdmod/modules/xdmod/regression_tests/runtests.sh
@@ -35,11 +35,11 @@ if [ ! -x "$phpunit" ]; then
 fi
 if [ "$REG_TEST_ALL" == "1" ]; then
     set +e
+    $phpunit $PUB .
     REG_TEST_USER_ROLE=usr $phpunit $REGUSER lib/Controllers/UsageExplorerTest.php
     REG_TEST_USER_ROLE=pi $phpunit $PI lib/Controllers/UsageExplorerTest.php
     REG_TEST_USER_ROLE=cd $phpunit $CD lib/Controllers/UsageExplorerTest.php
     REG_TEST_USER_ROLE=cs $phpunit $CS lib/Controllers/UsageExplorerTest.php
-    $phpunit $PUB .
 else
     REG_TEST_USER_ROLE=usr $phpunit $REGUSER lib/Controllers/UsageExplorerTest.php & usrpid=$!
     REG_TEST_USER_ROLE=pi $phpunit $PI lib/Controllers/UsageExplorerTest.php & pipid=$!


### PR DESCRIPTION
The test harness has a mechanism to create test artifacts if they are absent. This is used to update the tests when the code changes. The harness did not correctly create the non-reference files.