### PR TITLE
Fix exception outside namespace

### DIFF
--- a/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
@@ -85,7 +85,7 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
                     return;
                 }
                 elseif(substr($expectedFile, -13) !== 'reference.csv'){
-                    throw new PHPUnit_Framework_ExpectationFailedException(
+                    throw new \PHPUnit_Framework_ExpectationFailedException(
                         count($failures)." assertions failed:\n\t".implode("\n\t", $failures)
                     );
                 }
@@ -311,7 +311,7 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
                 if($expectedHeader !== $providedHeader){
                     try {
                         $this->assertTrue(false, $testName . ' CSV Headers different');
-                    } catch(PHPUnit_Framework_ExpectationFailedException $e) {
+                    } catch(\PHPUnit_Framework_ExpectationFailedException $e) {
                         $failures[] = $e->getMessage();
                     }
                 }
@@ -328,7 +328,7 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
                 $expectedColumnCount = count($expectedRow);
                 try {
                     $this->assertCount($expectedColumnCount, $providedRow, $testName . ' Column count != ');
-                } catch(PHPUnit_Framework_ExpectationFailedException $e) {
+                } catch(\PHPUnit_Framework_ExpectationFailedException $e) {
                     $failures[] = $e->getMessage();
                 }
                 foreach($expectedHeader as $key => $value){
@@ -352,7 +352,7 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
                         try {
                             $this->assertTrue($relativeError < $this->delta, $testName . " ( $errorFormula ) => " . $relativeError  . ' > ' . $this->delta );
                             self::$messages[] = $testName . " column: $columnName, row: $i ( $errorFormula ) => " . $relativeError  . ' < ' . $this->delta;
-                        } catch(PHPUnit_Framework_ExpectationFailedException $e) {
+                        } catch(\PHPUnit_Framework_ExpectationFailedException $e) {
                             $failures[] = $e->getMessage();
                         }
 
@@ -360,7 +360,7 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
                     else {
                         try {
                             $this->assertEquals($expectedRowValue, $providedRowValue, $rowMessage);
-                        } catch(PHPUnit_Framework_ExpectationFailedException $e) {
+                        } catch(\PHPUnit_Framework_ExpectationFailedException $e) {
                             $failures[] = $e->getMessage();
                         }
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds backslash to exception name so that is resolves properly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes:

```
PHP Fatal error:  Class 'Controllers\PHPUnit_Framework_ExpectationFailedException' not found in /xdmod/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php on line 88
```

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
