### PR TITLE
Use absolute paths for executing ACL commands

### DIFF
--- a/bin/acl-import
+++ b/bin/acl-import
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-acl-etl -p acls-import "$@"
+__XDMOD_BIN_PATH__/acl-etl -p acls-import "$@"

--- a/bin/acl-xdmod-management
+++ b/bin/acl-xdmod-management
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-acl-etl -p acls-xdmod-management "$@"
+__XDMOD_BIN_PATH__/acl-etl -p acls-xdmod-management "$@"

--- a/open_xdmod/build_scripts/templates/install.template
+++ b/open_xdmod/build_scripts/templates/install.template
@@ -495,6 +495,7 @@ function substitutePaths($dirs)
         '/__XDMOD_SHARE_PATH__/' => $dirs['data'],
         '/__XDMOD_LIB_PATH__/'   => $dirs['lib'],
         '/__XDMOD_ETC_PATH__/'   => $dirs['conf'],
+        '/__XDMOD_BIN_PATH__/'   => $dirs['bin'],
     ));
 
     substituteInDir($destDir . $dirs['lib'], array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes the path of ACL commands being executed by other ACL commands so that they are absolute paths.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See #544.  For non-RPM installations there is no guarantee that the user will have the Open XDMoD `bin` path in their `PATH` environment variable.  This results in a variety of problems since it isn't obvious that the commands are not running properly.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
