### PR TITLE
Ensure Contact Us and Sign Up emails have correct metadata

### DIFF
--- a/classes/CCR/MailWrapper.php
+++ b/classes/CCR/MailWrapper.php
@@ -13,6 +13,7 @@ class MailWrapper
         $mail->isSendMail();
         $address = \xd_utilities\getConfiguration('mailer', 'sender_email');
         $mail->Sender = $address;
+        $mail->addCustomHeader('Sender', $address);
         $mail->Body = $properties['body'];
 
         if(!empty($properties['subject'])) {

--- a/html/controllers/mailer/contact.php
+++ b/html/controllers/mailer/contact.php
@@ -76,8 +76,7 @@ try {
         'subject'      => $subject,
         'toAddress'    => \xd_utilities\getConfiguration('general', 'contact_page_recipient'),
         'fromAddress'  => $_POST['email'],
-        'fromName'     => $_POST['name'],
-        'replyAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email')
+        'fromName'     => $_POST['name']
         )
     );
 }

--- a/html/controllers/mailer/sign_up.php
+++ b/html/controllers/mailer/sign_up.php
@@ -94,8 +94,7 @@ try {
         'subject'      => "[" . \xd_utilities\getConfiguration('general', 'title') . "] A visitor has signed up",
         'toAddress'    => \xd_utilities\getConfiguration('general', 'contact_page_recipient'),
         'fromAddress'  => $_POST['email'],
-        'fromName'     => $_POST['last_name'] . ', ' . $_POST['first_name'],
-        'replyAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email')
+        'fromName'     => $_POST['last_name'] . ', ' . $_POST['first_name']
     ));
     $response['success'] = true;
 }


### PR DESCRIPTION
## Description
The "Contact Us" and "Sign Up" dialogs sent emails where the reply address was the noreply address. The XDMoD ticketing system used the reply address from the reply address field (which as you recall was set to the noreply address). This reply address caused the email reply to bounce (due to it being sent to a noreply address).

This changes the email headers so that:
a) The XDMoD ticketing system now gets the correct reply address
b) The Sender email header is now set so that the actual message sender information shows up in mail clients.

Original:

![image](https://user-images.githubusercontent.com/5342179/41437508-a569f6b2-6ff2-11e8-8d3d-86ad49265789.png)

Now:
![image](https://user-images.githubusercontent.com/5342179/41437427-6a7a6a50-6ff2-11e8-820f-e3399e6238df.png)

Also view from email client of email sent directly
![image](https://user-images.githubusercontent.com/5342179/41437326-1841dffc-6ff2-11e8-9aaf-3058731088d7.png)

