### PR TITLE
Enable User Defined Default Times

### DIFF
--- a/classes/ETL/Ingestor/StateReconstructorTransformIngestor.php
+++ b/classes/ETL/Ingestor/StateReconstructorTransformIngestor.php
@@ -15,10 +15,9 @@ use Log;
 class StateReconstructorTransformIngestor extends pdoIngestor implements iAction
 {
     private $stop_event_ids;
-
     private $start_event_ids;
-
     private $instance_state;
+    private $end_time;
 
     /**
      * @see ETL\Ingestor\pdoIngestor::__construct()
@@ -27,20 +26,23 @@ class StateReconstructorTransformIngestor extends pdoIngestor implements iAction
     {
         parent::__construct($options, $etlConfig, $logger);
 
-        $this->stop_event_ids = array(4, 6);
+        $this->stop_event_ids = array(4, 6, 17, 19);
         $this->start_event_ids = array(2, 8, 9, 10, 11, 16);
         $this->all_event_ids = array_merge($this->start_event_ids, $this->stop_event_ids);
+        $this->end_time = $etlConfig->getVariableStore()->end_time;
 
         $this->resetInstance();
     }
 
     private function initInstance($srcRecord) {
+        $default_end_time = isset($this->end_time) ? strtotime($this->end_time) : $srcRecord['event_time_utc'];
+
         $this->instance_state = array(
             'instance_id' => $srcRecord['instance_id'],
             'start_time' => $srcRecord['event_time_utc'],
             'start_event_id' => $srcRecord['event_type_id'],
-            'end_time' => $srcRecord['event_time_utc'],
-            'end_event_id' => $srcRecord['event_type_id']
+            'end_time' => date('Y-m-d H:i:s', $default_end_time),
+            'end_event_id' => 4
         );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Please do not merge prior to merging [#584](#584)


## Description
When ingesting a discrete set of cloud data, we may run into the issue of having a start date for a VM but no clearly defined end. To remediate this issue, we enable specification of a custom default end date as a string in the etl process.

To use, specify the -d option with etl overseer. Some example commands:

`etl_overseer -r RESOURCE -d end_time 'now - 7 days' -p cloud-state-pipeline`
`etl_overseer -r RESOURCE -d end_time '2018-02-26 + 1 second' -p cloud-state-pipeline`
`etl_overseer -r RESOURCE -d end_time '+ 14 days' -p cloud-state-pipeline`

## Motivation and Context
See above.

## Tests performed
Yes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
