### PR TITLE
Improve method of calling single ETL action during testing

### DIFF
--- a/classes/ETL/Configuration/Configuration.php
+++ b/classes/ETL/Configuration/Configuration.php
@@ -167,6 +167,12 @@ class Configuration extends Loggable implements \Iterator
 
     protected $variableStore = null;
 
+    /**
+     * @var boolean TRUE if the configuration has already been initialized.
+     */
+
+    protected $initialized = false;
+
     /** -----------------------------------------------------------------------------------------
      * Constructor. Read and parse the configuration file.
      *
@@ -250,12 +256,19 @@ class Configuration extends Loggable implements \Iterator
     }  // __construct()
 
     /** -----------------------------------------------------------------------------------------
-     * Initialize the configuration objecton
+     * Initialize the configuration objecton.
+     *
+     * @param boolean $force TRUE to force re-initialization of the configuration even if it has
+     *   previously been initialized.
      * ------------------------------------------------------------------------------------------
      */
 
-    public function initialize()
+    public function initialize($force = false)
     {
+        if ( $this->initialized && ! $force ) {
+            return;
+        }
+
         $this->logger->info("Loading" . ( $this->isLocalConfig ? " local" : "" ) . " configuration file " . $this->filename);
 
         // Parse the configuration file
@@ -317,6 +330,8 @@ class Configuration extends Loggable implements \Iterator
         }  // if ( null !== $confSubdirectory )
 
         $this->postMergeTasks();
+
+        $this->initialized = true;
 
     }  // initialize()
 

--- a/classes/ETL/aAction.php
+++ b/classes/ETL/aAction.php
@@ -59,7 +59,7 @@ abstract class aAction extends aEtlObject
     /**
      * @var string Path to the JSON configuration file containing the action definition.
      */
-    
+
     protected $definitionFile = null;
 
     /**
@@ -103,15 +103,15 @@ abstract class aAction extends aEtlObject
     /**
      * @var iDataEndpoint The utility data endpoint, must implement iDataEndpoint.
      */
-    
+
     protected $utilityEndpoint = null;
 
     /**
      * @var iDataEndpoint The utility data endpoint, must implement iDataEndpoint.
      */
-    
+
     protected $sourceEndpoint = null;
-    
+
     /**
      * @var mixed An object or resource representing the connection to the underlying utility
      *   endopint. For example, a database handle or PDO object.
@@ -124,7 +124,7 @@ abstract class aAction extends aEtlObject
      */
 
     protected $destinationEndpoint = null;
-    
+
     /**
      * @var mixed An object or resource representing the connection to the underlying utility
      *   endopint. For example, a database handle or PDO object.
@@ -186,6 +186,25 @@ abstract class aAction extends aEtlObject
         }  // if ( null !== $this->options->definition_file )
 
     }  // __construct()
+
+    /** -----------------------------------------------------------------------------------------
+     * Helper function to instantiate an action based on the provided EtlConfiguration object.
+     *
+     * @param EtlConfiguration $etlConfig Object containing the parsed ETL configuration.
+     * @param string $actionName The name of the action to instantiate.
+     * @param Log $logger A PEAR Log object or null to use the null logger
+     *
+     * @return iAction An object implementing the iAction interface
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public static function factory(EtlConfiguration $etlConfig, $actionName, Log $logger = null)
+    {
+        $etlConfig->initialize();
+        $options = $etlConfig->getActionOptions($actionName);
+        // We are using the action's own factory method
+        return forward_static_call(array($options->factory, 'factory'), $options, $etlConfig, $logger);
+    }  // factory()
 
     /** -----------------------------------------------------------------------------------------
      * @see iAction::initialize()
@@ -267,6 +286,16 @@ abstract class aAction extends aEtlObject
     {
         return $this->supportDateRangeChunking;
     }  // supportsDateRangeChunking()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iAction::isEnabled()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function isEnabled()
+    {
+        return $this->options->enabled;
+    } // isEnabled()
 
     /** -----------------------------------------------------------------------------------------
      * @return The ETL overseer options

--- a/classes/ETL/aAction.php
+++ b/classes/ETL/aAction.php
@@ -22,63 +22,117 @@ use ETL\Configuration\EtlConfiguration;
 
 abstract class aAction extends aEtlObject
 {
-    // aOptions object with configuration information for this action
+    /**
+     * @var aOptions object with configuration information for this action
+     */
+
     protected $options = null;
 
-    // EtlConfiguration object. This is the parsed configuration.
+    /**
+     * @var EtlConfiguration Object containing a representation of the parsed configuration file.
+     */
+
     protected $etlConfig = null;
 
-    // EtlOverseerOptions object. Contains the options for this ingestion run and is
-    // private so we can enforce updating the variable map when it is set.
+    /**
+     * @var EtlOverseerOptions Object containing the options for this ingestion run. This is private
+     *   so that we can enforce updating of the variable map.
+     */
+
     private $etlOverseerOptions = null;
 
-    // Individual actions may override ETL overseer restrictions. Store the overrides as an
-    // associative array where the key is the restriction name and the value is the overriden
-    // restriction.
+    /**
+     * @var array An associative array where the key is the restriction name and the value is the overriden
+     *   restriction. Individual actions may override ETL overseer restrictions.
+     */
+
     protected $overseerRestrictionOverrides = array();
 
-    // A list of key/value pairs mapping a variable name to a value. This is used to substitute
-    // variables in queries or other strings. Note that keys do not include ${}, only the name of the
-    // variable.
+    /**
+     * @var VariableStore An object storing a list of key/value pairs mapping a variable name to a
+     *   value. This is used to substitute variables in queries or other strings. Note that keys do
+     *   not include ${}, only the name of the variable.
+     */
+
     protected $variableStore = null;
 
-    // Path to the JSON configuration file containing ETL table and source query configurations, among
-    // other things.
+    /**
+     * @var string Path to the JSON configuration file containing the action definition.
+     */
+    
     protected $definitionFile = null;
 
-    // The stdClass representing a parsed definition file
+    /**
+     * @var stdClass A class representing the parsed definition file.
+     */
+
     protected $parsedDefinitionFile = null;
 
-    // Does this action support chunking of date ranges? Ingestors may support this to
-    // mitigate timeouts on long-running queries but other actions may not. Defaults to
-    // FALSE.
+    /**
+     * @var boolean True if this action supports chunking of date ranges. Ingestors may support this
+     *   to mitigate timeouts on long-running queries but other actions may not. Defaults to FALSE.
+     */
+
     protected $supportDateRangeChunking = false;
 
-    // The current start date that this action is working with. Note that not all actions
-    // utilize a start/end date.
+    /**
+     * @var string The current start date that this action is working with. Note that not all
+     *   actions utilize a start/end date.
+     */
+
     protected $currentStartDate = null;
 
-    // The current end date that this action is working with. Note that not all actions
-    // utilize a start/end date.
+    /**
+     * @var string The current end date that this action is working with. Note that not all actions
+     *   utilize a start/end date.
+     */
+
     protected $currentEndDate = null;
 
-    // --------------------------------------------------------------------------------
-    // NOTE: If we want to support additional endpoint names, these should be implemented as an array
-    // of endpoints. -smg
+    /*
+     * NOTE: If we want to support additional endpoint names, these should be implemented as an array of endpoints. -smg
+     */
 
-    // Handle to the utility database, must implement iDataEndpoint and be a DataEndpoint\Mysql object
+    /**
+     * @var mixed An object or resource representing the connection to the underlying utility
+     *   endopint. For example, a database handle or PDO object.
+     */
+
     protected $utilityHandle = null;
+
+    /**
+     * @var iDataEndpoint The utility data endpoint, must implement iDataEndpoint.
+     */
+    
     protected $utilityEndpoint = null;
 
-    // Handle to the source, must implement iDataEndpoint
-    protected $sourceHandle = null;
+    /**
+     * @var iDataEndpoint The utility data endpoint, must implement iDataEndpoint.
+     */
+    
     protected $sourceEndpoint = null;
+    
+    /**
+     * @var mixed An object or resource representing the connection to the underlying utility
+     *   endopint. For example, a database handle or PDO object.
+     */
 
-    // Handle to the destination, must implement iDataEndpoint. This is typically a database.
-    protected $destinationHandle = null;
+    protected $sourceHandle = null;
+
+    /**
+     * @var iDataEndpoint The utility data endpoint, must implement iDataEndpoint.
+     */
+
     protected $destinationEndpoint = null;
+    
+    /**
+     * @var mixed An object or resource representing the connection to the underlying utility
+     *   endopint. For example, a database handle or PDO object.
+     */
 
-    /* ------------------------------------------------------------------------------------------
+    protected $destinationHandle = null;
+
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::__construct()
      * ------------------------------------------------------------------------------------------
      */
@@ -133,7 +187,7 @@ abstract class aAction extends aEtlObject
 
     }  // __construct()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::initialize()
      * ------------------------------------------------------------------------------------------
      */
@@ -164,7 +218,7 @@ abstract class aAction extends aEtlObject
 
     }  // initialize()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::getClass()
      * ------------------------------------------------------------------------------------------
      */
@@ -174,7 +228,7 @@ abstract class aAction extends aEtlObject
         return get_class($this);
     }  // getClass()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::getOptions()
      * ------------------------------------------------------------------------------------------
      */
@@ -184,7 +238,7 @@ abstract class aAction extends aEtlObject
         return $this->options;
     }  // getOptions()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::getCurrentStartDate()
      * ------------------------------------------------------------------------------------------
      */
@@ -194,7 +248,7 @@ abstract class aAction extends aEtlObject
         return $this->currentStartDate;
     }  // getCurrentStartDate()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::getCurrentEndDate()
      * ------------------------------------------------------------------------------------------
      */
@@ -204,7 +258,7 @@ abstract class aAction extends aEtlObject
         return $this->currentEndDate;
     }  // getCurrentEndDate()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::supportsDateRangeChunking()
      * ------------------------------------------------------------------------------------------
      */
@@ -214,7 +268,7 @@ abstract class aAction extends aEtlObject
         return $this->supportDateRangeChunking;
     }  // supportsDateRangeChunking()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @return The ETL overseer options
      * ------------------------------------------------------------------------------------------
      */
@@ -224,7 +278,7 @@ abstract class aAction extends aEtlObject
         return $this->etlOverseerOptions;
     }  // getEtlOverseerOptions()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * Set the current EtlOverseerOptions object
      *
      * @return This object for method chaining
@@ -238,7 +292,7 @@ abstract class aAction extends aEtlObject
         return $this;
     }  // setEtlOverseerOptions()
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * @see iAction::getOverseerRestrictionOverrides()
      * ------------------------------------------------------------------------------------------
      */
@@ -248,12 +302,12 @@ abstract class aAction extends aEtlObject
         return $this->overseerRestrictionOverrides;
     }  // getOverseerRestrictionOverrides()
 
-    /* ----------------------------------------------------------------------------------------------------
+    /** ---------------------------------------------------------------------------------------------------
      * The ETL overseer provides the ability to specify parameters that are interpreted as
-     * restrictions on actions such as the ETL start/end dates and resources to include or
-     * exclude from the ETL process.  However, in some cases these options may be
-     * overriden by the configuration of an individual action such as resources to include
-     * or exclude for that action. Keep track of the restrictions here.
+     * restrictions on actions such as the ETL start/end dates and resources to include or exclude
+     * from the ETL process.  However, in some cases these options may be overriden by the
+     * configuration of an individual action such as resources to include or exclude for that
+     * action. Keep track of the restrictions here.
      * ----------------------------------------------------------------------------------------------------
      */
 
@@ -272,8 +326,10 @@ abstract class aAction extends aEtlObject
 
     }  // setOverseerRestrictionOverrides()
 
-    /* ------------------------------------------------------------------------------------------
-     * Initialized the variable map based on ETL settings in the overseer options
+    /** -----------------------------------------------------------------------------------------
+     * Initialize the variable map based on ETL settings in the overseer options.
+     *
+     * @return This object to support method chaining.
      * ------------------------------------------------------------------------------------------
      */
 
@@ -349,15 +405,14 @@ abstract class aAction extends aEtlObject
                 );
             }
         } catch (\Exception $e) {
-            $msg = "'general' section not defined in XDMoD configuration";
-            $this->logAndThrowException($msg);
+            $this->logAndThrowException("'general' section not defined in XDMoD configuration");
         }
 
         return $this;
     }  // initializeVariableMap()
 
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * Initialize the utility endpoint based on the options provided for this action
      *
      * @return This object to support method chaining
@@ -377,7 +432,7 @@ abstract class aAction extends aEtlObject
         return $this;
     }
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * Initialize the utility endpoint based on the options provided for this action
      *
      * @return This object to support method chaining
@@ -397,7 +452,7 @@ abstract class aAction extends aEtlObject
         return $this;
     }
 
-    /* ------------------------------------------------------------------------------------------
+    /** -----------------------------------------------------------------------------------------
      * Initialize the utility endpoint based on the options provided for this action
      *
      * @return This object to support method chaining

--- a/classes/ETL/iAction.php
+++ b/classes/ETL/iAction.php
@@ -18,7 +18,7 @@ use Log;
 
 interface iAction
 {
-    /* ------------------------------------------------------------------------------------------
+    /**
      * Set up the action. This typically entails verifying that the data endpoints are of the
      * correct type and setting up configuration and option information.
      *
@@ -26,21 +26,20 @@ interface iAction
      *   ETL configuration file.
      * @param EtlConfiguration $etlConfig The complete ETL configuration as parsed from the
      *   configuration file.
-     * ------------------------------------------------------------------------------------------
+     * @param Log $logger A PEAR Log object or null to use the null logger.
      */
 
     public function __construct(aOptions $options, EtlConfiguration $etlConfig, Log $logger = null);
 
-    /* ------------------------------------------------------------------------------------------
+    /**
      * Execute the action.
      *
      * @param EtlOverseerOptions $etlOptions Options set for this ETL run.
-     * ------------------------------------------------------------------------------------------
      */
 
     public function execute(EtlOverseerOptions $etlOptions);
 
-    /* ------------------------------------------------------------------------------------------
+    /**
      * Perform initialization and verification on this action before executing it,
      * allowing us to detect configuration errors. We pass the EtlOverseerOptions here
      * because verification may occur pre-execution. Since multiple classes may implement
@@ -53,81 +52,71 @@ interface iAction
      * @param EtlOverseerOptions $etlOverseerOptions Options set for this ETL run. This may be null
      *   if it was set elsewhere in the chain.
      *
-     * @return TRUE if verification was successful
-     * ------------------------------------------------------------------------------------------
+     * @return boolean TRUE if verification was successful
      */
 
     public function initialize(EtlOverseerOptions $etlOverseerOptions = null);
 
-    /* ------------------------------------------------------------------------------------------
-     * @return The name of the action.
-     * ------------------------------------------------------------------------------------------
+    /**
+     * @return string The name of the action.
      */
 
     public function getName();
 
-    /* ------------------------------------------------------------------------------------------
-     * @return The class name that implements the action.
-     * ------------------------------------------------------------------------------------------
+    /**
+     * @return string The class name that implements the action.
      */
 
     public function getClass();
 
-    /* ------------------------------------------------------------------------------------------
-     * @return The action options (aOptions)
-     * ------------------------------------------------------------------------------------------
+    /**
+     * @return aOptions The action options object
      */
 
     public function getOptions();
 
-    /* ------------------------------------------------------------------------------------------
-     * @return The current start date that this action is operating on.
-     * ------------------------------------------------------------------------------------------
+    /**
+     * @return string The current start date that this action is operating on.
      */
 
     public function getCurrentStartDate();
 
-    /* ------------------------------------------------------------------------------------------
-     * @return The current start date that this action is operating on.
-     * ------------------------------------------------------------------------------------------
+    /**
+     * @return string The current end date that this action is operating on.
      */
 
     public function getCurrentEndDate();
 
-    /* ------------------------------------------------------------------------------------------
-     * @return TRUE if this action supports chunking of the overall ETL start and end date
+    /**
+     * @return boolean TRUE if this action supports chunking of the overall ETL start and end date
      *   into smaller pieces to make it more manageable.
-     * ------------------------------------------------------------------------------------------
      */
 
     public function supportsDateRangeChunking();
 
-    /* ----------------------------------------------------------------------------------------------------
+    /**
      * The ETL overseer provides the ability to specify parameters that are interpreted as
      * restrictions on actions such as the ETL start/end dates and resources to include or
      * exclude from the ETL process.  However, in some cases these options may be
      * overriden by the configuration of an individual action such as resources to include
      * or exclude for that action.
      *
-     * @return An associative array of optional overrides to overseer restrictions.
-     * ----------------------------------------------------------------------------------------------------
+     * @return array An associative array of optional overrides to overseer restrictions.
      */
 
     public function getOverseerRestrictionOverrides();
 
-    /* ------------------------------------------------------------------------------------------
+    /**
      * @return TRUE if initialization has been performed on this action.
-     * ------------------------------------------------------------------------------------------
      */
 
     public function isInitialized();
 
-    /* ------------------------------------------------------------------------------------------
-     * Generate a string representation of the action. Typically the name, plus other pertinant
-     * information as appropriate such as the implementing class.
+    /**
+     * Generate a string representation of the action. This typically includes the name, plus other
+     * pertinant information as appropriate such as the implementing class.
      *
-     * @return A string representation of the endpoint
-     * ------------------------------------------------------------------------------------------
+     * @return string A human-readable representation of the endpoint
      */
 
     public function __toString();

--- a/classes/ETL/iAction.php
+++ b/classes/ETL/iAction.php
@@ -113,6 +113,12 @@ interface iAction
     public function isInitialized();
 
     /**
+     * @return TRUE if this action is enabled, FALSE otherwise.
+     */
+
+    public function isEnabled();
+
+    /**
      * Generate a string representation of the action. This typically includes the name, plus other
      * pertinant information as appropriate such as the implementing class.
      *

--- a/open_xdmod/modules/xdmod/component_tests/lib/ETL/BaseEtlTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/ETL/BaseEtlTest.php
@@ -9,6 +9,7 @@ namespace ComponentTests\ETL;
 use CCR\Log;
 use ETL\EtlOverseerOptions;
 use ETL\Configuration\EtlConfiguration;
+use ETL\aAction;
 
 /**
  * Base class for ETL tests providing common functionality.
@@ -71,8 +72,7 @@ abstract class BaseEtlTest extends \PHPUnit_Framework_TestCase
         EtlConfiguration $etlConfig,
         EtlOverseerOptions $overseerOptions
     ) {
-        $options = $etlConfig->getActionOptions($actionName);
-        $action = forward_static_call(array($options->factory, "factory"), $options, $etlConfig);
+        $action = aAction::factory($etlConfig, $actionName);
         $action->execute($overseerOptions);
     }
 }

--- a/open_xdmod/modules/xdmod/component_tests/lib/ETL/IngestorTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/ETL/IngestorTest.php
@@ -137,8 +137,8 @@ class IngestorTest extends \PHPUnit_Framework_TestCase
     private function executeOverseerAction($action, $localOptions = "")
     {
         // Note that tests are run in the directory where the PHP class is defined.
-        $overseer = realpath(__DIR__ . '/../../../../../../tools/etl/etl_overseer.php');
-        $configFile = realpath(__DIR__ . '/../../artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/input/xdmod_etl_config_8.0.0.json');
+        $overseer = realpath(BASE_DIR . '/tools/etl/etl_overseer.php');
+        $configFile = realpath(BASE_DIR . '/tests/artifacts/xdmod-test-artifacts/xdmod/etlv2/configuration/input/xdmod_etl_config_8.0.0.json');
         $options = sprintf('-c %s -a %s %s -v warning', $configFile, $action, $localOptions);
         $pipes = array();
 

--- a/open_xdmod/modules/xdmod/tests/lib/ETL/SqlParser/SqlParserTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/ETL/SqlParser/SqlParserTest.php
@@ -10,6 +10,7 @@ namespace UnitTesting\ETL\SqlParser;
 
 use ETL\Configuration\EtlConfiguration;
 use ETL\EtlOverseerOptions;
+use ETL\aAction;
 
 class SqlParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,11 +63,8 @@ class SqlParserTest extends \PHPUnit_Framework_TestCase
             null,
             array('default_module_name' => self::$defaultModuleName)
         );
-        $etlConfig->initialize();
         // The "TableManagement" action is defined in etl.d/maintenance.json
-        $options = $etlConfig->getActionOptions('xdmod.maintenance.TableManagement');
-        $action = forward_static_call(array($options->factory, "factory"), $options, $etlConfig);
-
+        $action = aAction::factory($etlConfig, 'xdmod.maintenance.TableManagement');
         $sql = <<<SQL
 SELECT
 DISTINCT o.organization_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide a factory method `aAction::factory()` for creating action objects directly. This is useful during testing and also when executing actions via the `EtlOverseer` class.

## Motivation and Context

Simplify testing.

## Tests performed

Ran unit and component tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
