### PR TITLE
Remove use of shredder and hpcdb config sections

### DIFF
--- a/configuration/etl/etl.d/hpcdb.json
+++ b/configuration/etl/etl.d/hpcdb.json
@@ -9,13 +9,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB Database",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }

--- a/configuration/etl/etl.d/shredder.json
+++ b/configuration/etl/etl.d/shredder.json
@@ -6,7 +6,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }

--- a/configuration/etl/etl.d/staging.json
+++ b/configuration/etl/etl.d/staging.json
@@ -9,13 +9,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }

--- a/configuration/etl/etl.d/xdmod-migration-7_5_1-8_0_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-7_5_1-8_0_0.json
@@ -24,7 +24,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }
@@ -45,7 +45,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }
@@ -68,7 +68,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB Database",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -89,7 +89,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB Database",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -113,7 +113,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }
@@ -129,13 +129,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB Database",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -151,7 +151,7 @@
                 "source": {
                     "type": "mysql",
                     "name": "HPCDB Database",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 },
                 "destination": {

--- a/configuration/etl/etl_sql.d/hpcdb/fields-of-science-hierarchy.sql
+++ b/configuration/etl/etl_sql.d/hpcdb/fields-of-science-hierarchy.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE VIEW `hpcdb_fields_of_science_hierarchy` AS SELECT
+CREATE OR REPLACE VIEW ${DESTINATION_SCHEMA}.`hpcdb_fields_of_science_hierarchy` AS SELECT
     `fos`.`field_of_science_id` AS `field_of_science_id`,
     `fos`.`description` AS `description`,
     IF(
@@ -26,8 +26,8 @@ CREATE OR REPLACE VIEW `hpcdb_fields_of_science_hierarchy` AS SELECT
         `p`.`abbrev`,
         `fos`.`abbrev`
     ) AS `directorate_abbrev`
-FROM `hpcdb_fields_of_science` `fos`
-LEFT JOIN `hpcdb_fields_of_science` `p`
+FROM ${DESTINATION_SCHEMA}.`hpcdb_fields_of_science` `fos`
+LEFT JOIN ${DESTINATION_SCHEMA}.`hpcdb_fields_of_science` `p`
     ON `fos`.`parent_id` = `p`.`field_of_science_id`
-LEFT JOIN `hpcdb_fields_of_science` `gp`
+LEFT JOIN ${DESTINATION_SCHEMA}.`hpcdb_fields_of_science` `gp`
     ON `p`.`parent_id` = `gp`.`field_of_science_id`//

--- a/configuration/etl/etl_sql.d/jobs/shredder/job-slurm.sql
+++ b/configuration/etl/etl_sql.d/jobs/shredder/job-slurm.sql
@@ -1,6 +1,6 @@
 -- This table contains an index with a column that specifies a length.  This
 -- feature is not currently supported by ETL table management.
-CREATE TABLE `shredded_job_slurm` (
+CREATE TABLE ${DESTINATION_SCHEMA}.`shredded_job_slurm` (
   `shredded_job_slurm_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `job_id` int(10) unsigned NOT NULL,
   `job_array_index` int(10) NOT NULL DEFAULT '-1',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes config sections used by ETL.  Also adds schema qualifiers to a couple SQL statements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These sections do not exist in the XSEDE XDMoD configuration.  This
prevents errors in that situation.  Since we require a single database
user to have access to all the databases any section may be used as long
as all database queries contain schema names for each table.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
