### PR TITLE
Improve template class error handling

### DIFF
--- a/classes/Xdmod/Template.php
+++ b/classes/Xdmod/Template.php
@@ -85,7 +85,11 @@ class Template
      */
     public function resetContents()
     {
-        $this->contents = file_get_contents($this->filePath);
+        if (!is_file($this->filePath)) {
+            throw new Exception("Template '{$this->filePath}' is not a file");
+        }
+
+        $this->contents = @file_get_contents($this->filePath);
 
         if ($this->contents === false) {
             $msg = "Failed to load template '{$this->name}' contents";


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Checks that the expected template file is a file and suppresses warning messages from `file_get_contents`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The upgrade process checks for the existence of template files for each file in `portal_settings.d` to determine what modules are installed.  If a template does not exist it currently produces a warning message such as:

```
PHP Warning:  file_get_contents(/usr/share/xdmod/templates/etl/portal_settings.template): failed to open stream: No such file or directory in /usr/share/xdmod/classes/Xdmod/Template.php on line 88
```

This change will prevent that warning message.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
