### PR TITLE
Add submission venue id to cloud aggregation

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_common/cloud_metrics_aggregation.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/cloud_metrics_aggregation.json
@@ -42,7 +42,8 @@
                 "num_vms_started": "SUM(IF(cet.start_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, 1, 0))",
                 "num_vms_ended": "SUM(IF(cet.end_day_id BETWEEN ${:PERIOD_START_DAY_ID} AND ${:PERIOD_END_DAY_ID}, 1, 0))",
                 "num_vms_running": "SUM(1)",
-                "wallduration": "COALESCE(SUM(${wallduration_case_statement}), 0)"
+                "wallduration": "COALESCE(SUM(${wallduration_case_statement}), 0)",
+                "submission_venue_id": "cet.submission_venue_id"
             },
             "groupby": [
               "${AGGREGATION_UNIT}_id",

--- a/configuration/etl/etl_action_defs.d/cloud_common/cloud_transient.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/cloud_transient.json
@@ -21,7 +21,8 @@
             "end_time_ts": "UNIX_TIMESTAMP(e.end_time)",
             "start_day_id": "YEAR(e.start_time) * 100000 + DAYOFYEAR(e.start_time)",
             "end_day_id": "YEAR(e.end_time) * 100000 + DAYOFYEAR(e.end_time)",
-            "wallduration": "UNIX_TIMESTAMP(e.end_time) - UNIX_TIMESTAMP(e.start_time)"
+            "wallduration": "UNIX_TIMESTAMP(e.end_time) - UNIX_TIMESTAMP(e.start_time)",
+            "submission_venue_id": "ev.submission_venue_id"
         },
         "joins": [
             {

--- a/configuration/etl/etl_tables.d/cloud_common/cloud_transient.json
+++ b/configuration/etl/etl_tables.d/cloud_common/cloud_transient.json
@@ -93,6 +93,11 @@
                 "name": "wallduration",
                 "type": "bigint(18)",
                 "nullable": true
+            },
+            {
+                "name": "submission_venue_id",
+                "type": "int(5)",
+                "nullable": true
             }
         ]
     }

--- a/configuration/etl/etl_tables.d/cloud_common/cloudfact_by_.json
+++ b/configuration/etl/etl_tables.d/cloud_common/cloudfact_by_.json
@@ -108,7 +108,8 @@
             },{
                 "name": "submission_venue_id",
                 "type": "int(5)",
-                "nullable": true
+                "nullable": true,
+                "comment": "DIMENSION: The venue that a job or cloud instance was initiated from"
             }
         ],
 

--- a/configuration/etl/etl_tables.d/cloud_common/cloudfact_by_.json
+++ b/configuration/etl/etl_tables.d/cloud_common/cloudfact_by_.json
@@ -105,6 +105,10 @@
                 "type": "decimal(18,0)",
                 "nullable": true,
                 "comment": "FACT: (seconds) The wallduration of the VMs that were running during this period."
+            },{
+                "name": "submission_venue_id",
+                "type": "int(5)",
+                "nullable": true
             }
         ],
 


### PR DESCRIPTION
Adding submission_venue_id field to tables used for cloud aggregation. This field is needed for the Submission Venue group by

Tested by running aggregation on my local docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
