### PR TITLE
Filter out Open Stack heartbeat events with stopped or deleted state

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_openstack/raw_cloud_job_logs.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/raw_cloud_job_logs.json
@@ -32,7 +32,8 @@
     	      "openstack_resource_id": "resource_id",
     	      "disk_gb": "disk_gb",
             "size": "size",
-            "volume_id": "volume_id"
+            "volume_id": "volume_id",
+            "state": "state"
         },
         "openstack_raw_instance_type": {
             "instance_type": "instance_type",

--- a/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
@@ -81,7 +81,7 @@
         ],
 
         "where": [
-            "NOT (state IN ('stopped', 'deleted') AND event_type = 'compute.instance.exists')"
+            "NOT (state != 'active' AND event_type = 'compute.instance.exists')"
         ],
 
         "groupby": [

--- a/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
@@ -80,6 +80,10 @@
             }
         ],
 
+        "where": [
+            "NOT (state IN ('stopped', 'deleted') AND event_type = 'compute.instance.exists')"
+        ],
+
         "groupby": [
             "raw.resource_id",
             "i.instance_id",

--- a/configuration/etl/etl_tables.d/cloud_openstack/raw_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/raw_event.json
@@ -124,7 +124,7 @@
             		"type": "varchar(64)",
             		"nullable": true,
             		"default": null
-      	    },
+            },
             {
                 "name": "state",
                 "type": "varchar(64)",

--- a/configuration/etl/etl_tables.d/cloud_openstack/raw_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/raw_event.json
@@ -124,7 +124,13 @@
             		"type": "varchar(64)",
             		"nullable": true,
             		"default": null
-      	    }
+      	    },
+            {
+                "name": "state",
+                "type": "varchar(64)",
+                "nullable": true,
+                "default": null
+            }
         ],
         "indexes": [
             {


### PR DESCRIPTION
In Open Stack there are heartbeat events that occur after the VM has been shut down. These heartbeat events have a state that is not active and need to be filtered out. If not filtered out then a second row for an instance is created in the cloud_event_transient table which causes incorrect data when aggregation is run. 

## Motivation and Context
Heartbeat events are events that let us know that a VM is still active. It is expected that heartbeat events only exist when a VM is running. This appears to not be the case for Open Stack. In Open Stack heartbeat events for instances are named compute.instance.exists and they all have a state property. 

When an instance is running the state property equals active. After an instance is shutdown one more heartbeat event for that instance occurs with a state of stopped or deleted. This extra heartbeat event after the instance ends causes the StateReconstructorTransormIngestor to add a second row for the instance to the cloud_event_transient table. 

When aggregation is run these extra rows for the instance cause some statistics, such as Number of VM's ended or Cores: Total, to count the details for these instances twice, leading to incorrect information.

## Tests performed
Tested in local docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
