### PR TITLE
Add resource id where clause to Project group by in cloud realm

### DIFF
--- a/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByProject.php
+++ b/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByProject.php
@@ -67,7 +67,11 @@ class GroupByProject extends \DataWarehouse\Query\Cloud\GroupBy
         $query->addGroup($accounttable_id_field);
 
         $datatable_account_id_field = new TableField($data_table, 'account_id');
+        $datatable_host_resource_id_field = new TableField($data_table, 'host_resource_id');
+        $accounttable_resource_id_field = new TableField($this->account_table, 'resource_id');
+
         $query->addWhereCondition(new WhereCondition($accounttable_id_field, '=', $datatable_account_id_field));
+        $query->addWhereCondition(new WhereCondition($accounttable_resource_id_field, '=', $datatable_host_resource_id_field));
 
         $this->addOrder($query, $multi_group);
     }


### PR DESCRIPTION
Add a where clause to the Project group by in the Cloud realm to make sure data is joined on resource id as well as account id.

## Description
When grouping by a project in the metric explorer if the VM does not have an account assigned to it the account id is set to 1 which means Unknown.  This account id exists for each XSEDE resource. This group by does not join on the resource id, just the account id. Because of this the value reported for Unknown is the correct value for that statistic times the number of resource id's with the same account id in the Accounts table. Adding a where clause using the resource id prevents this from happening and returns the correct data.

## Motivation and Context
This changes is needed because otherwise data displayed when grouping by Project in the Cloud may return incorrect data

## Tests performed
Tested in XSEDE docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
