### PR TITLE
Update mappings from open stack events to event_type table

### DIFF
--- a/configuration/etl/etl_data.d/cloud_openstack/openstack_event_map.json
+++ b/configuration/etl/etl_data.d/cloud_openstack/openstack_event_map.json
@@ -36,7 +36,7 @@
     [34, 42,    "compute.instance.finish_resize.start"],
     [35, 43,    "compute.instance.finish_resize.end"],
     [36, 44,    "compute.instance.power_off.start"],
-    [37, 45,    "compute.instance.power_off.end"],
+    [37, 17,    "compute.instance.power_off.end"],
     [38, 46,    "compute.instance.rebuild.start"],
     [39, 47,    "compute.instance.rebuild.end"],
     [40, 48,    "compute.instance.resize.confirm.start"],
@@ -45,5 +45,7 @@
     [43, 51,    "compute.instance.resize.end"],
     [44, 52,    "compute.instance.resize.prep.start"],
     [45, 53,    "compute.instance.resize.prep.end"],
-    [46, 54,    "compute.instance.shelve_offload.start"]
+    [46, 54,    "compute.instance.shelve_offload.start"],
+    [47, 7,    "compute.instance.power_on.start"],
+    [48, 8,    "compute.instance.power_off.end"]
 ]


### PR DESCRIPTION
Updating the mappings for Open Stack events to our event_type table.

## Description
Some events in our Open Stack logs were not mapped to an event in the event_type table and should have been and one Open Stack event was mapped to the wrong event type. The mappings added will map.

- compute.instance.power_off.end to SUSPEND 
- compute.instance.power_off.end to RESUME
- compute.instance.power_on.start to REQUEST_RESUME

## Motivation and Context
Correct mappings mean more accurate data reporting

## Tests performed
Testing in Docker locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
