### PR TITLE
Change ETL configuration for job records/tasks

### DIFF
--- a/configuration/etl/etl.d/hpcdb-xdw.json
+++ b/configuration/etl/etl.d/hpcdb-xdw.json
@@ -140,6 +140,7 @@
         "name": "job-records-job-tasks",
         "definition_file": "jobs/xdw/job-records-job-tasks.json",
         "description": "HPC job records from the hpcdb",
+        "analyze_table": false,
         "#": "job records will be duplicated for each job array",
         "#": "this hides those warnings. This will be cleaned up later.",
         "hide_sql_warning_codes": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds `"analyze_table": false` to job records/task ETL action.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This action has timed-out multiple times (`(sql: ANALYZE TABLE `modw`.`job_records`, stacktrace: [...] Ingestion failed: xdmod.hpcdb-xdw-ingest.job-records-job-tasks (ETL\Ingestor\DatabaseIngestor): Error executing Post-execute tasks  SQL Exception: 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away'`).

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
