### PR TITLE
Add support for dumping chart config objects as JSON

### DIFF
--- a/tools/dev/manage_saved_charts.php
+++ b/tools/dev/manage_saved_charts.php
@@ -169,11 +169,25 @@ if ( $scriptOptions['verbose'] ) {
     print sprintf("Found %d saved charts", count($charts['data'])) . PHP_EOL;
 }
 
-$chartInfoList = array();
+// If requested, dump the chart config objects as JSON
+
+if (
+    isset($scriptOptions['list'])
+    && ! isset($scriptOptions['source'])
+    && 'chart-config-as-json' == $scriptOptions['list']
+   ) {
+    $parts = array();
+    foreach ( $charts['data'] as $chart ) {
+        $parts[] = sprintf("\"%s\": %s", $chart['name'], $chart['config']);
+    }
+    print sprintf("{%s}\n", implode(",\n", $parts));
+    exit();
+}
 
 // Loop over all of the charts and extract any information that we will need to perform operations.
 // Wile we are looping, display any requested information.
 
+$chartInfoList = array();
 foreach ( $charts['data'] as $chartIndex => $chart ) {
     if ( ! isset($chart['name']) ) {
         print sprintf("Chart name not set for index %s, skipping.", $chartIndex) . PHP_EOL;
@@ -244,6 +258,9 @@ foreach ( $charts['data'] as $chartIndex => $chart ) {
                         ) . PHP_EOL;
                     }
                 }
+                break;
+            case 'chart-config-as-json':
+                print sprintf("{\"%s\": %s}\n", $chart['name'], $chart['config']);
                 break;
             default:
                 usage_and_exit(sprintf("Unsupported option for --list: '%s'", $scriptOptions['list']));
@@ -508,7 +525,7 @@ function usage_and_exit($msg = null)
         -l <item>, --list <item>
         Display a list of the various items. If a source chart id was specified list only values
         for that chart.
-        Supported items are: chart-names, series, global-filters, local-filters
+        Supported items are: chart-names, chart-config-as-json, global-filters, local-filters, series
 
         -o <operation>, --operation <operation>
         Operation to perform. Supported operations are:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While checking the likely impact of changing statistic identifier strings, I found it useful to be able to dump the JSON representation of chart objects stored in the database.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed

Used during code examination.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
