### PR TITLE
Change logging of ETL SQL warnings

### DIFF
--- a/classes/ETL/aRdbmsDestinationAction.php
+++ b/classes/ETL/aRdbmsDestinationAction.php
@@ -899,9 +899,7 @@ abstract class aRdbmsDestinationAction extends aAction
             $msg .= sprintf(" (filtering codes: %s)", implode(',', $this->options->hide_sql_warning_codes));
         }
 
-        $this->logger->warning($msg);
-
-        $numWarningsLogged = 0;
+        $warningsToLog = array();
 
         foreach ( $warnings as $row ) {
             if ( null !== $this->options->hide_sql_warning_codes ) {
@@ -921,11 +919,19 @@ abstract class aRdbmsDestinationAction extends aAction
                 }
             }
 
-            $this->logger->warning(implode(' ', (is_array($row) ? $row : array($row))));
-            $numWarningsLogged++;
+            $warningsToLog[] = implode(' ', (is_array($row) ? $row : array($row)));
         }
 
-        return $numWarningsLogged;
+        if ( count($warningsToLog) > 0 ) {
+            $this->logger->warning($msg);
+            foreach ( $warningsToLog as $warning ) {
+                $this->logger->warning($warning);
+            }
+        } else {
+            $this->logger->notice($msg);
+        }
+
+        return count($warningsToLog);
 
     }  // logSqlWarnings()
 

--- a/open_xdmod/modules/xdmod/component_tests/lib/ETL/IngestorTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/ETL/IngestorTest.php
@@ -139,7 +139,7 @@ class IngestorTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertGreaterThanOrEqual(0, $numWarnings, 'Expected number of SQL warnings');
+        $this->assertEquals(0, $numWarnings, 'Expected number of SQL warnings');
         $this->assertEquals('', $result['stderr'], "Std Error");
     }
 

--- a/open_xdmod/modules/xdmod/component_tests/lib/ETL/IngestorTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/ETL/IngestorTest.php
@@ -125,6 +125,22 @@ class IngestorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertGreaterThanOrEqual(2, $numWarnings, 'Expected number of SQL warnings');
         $this->assertEquals('', $result['stderr'], "Std Error");
+
+        // Run the same action, but filter all expected warning codes.
+        $result = $this->executeOverseerAction('xdmod.ingestor-tests.test-sql-warnings', '-o "hide_sql_warning_codes=[1264,1366]"');
+
+        $this->assertEquals(0, $result['exit_status'], "Exit code");
+        $numWarnings = 0;
+
+        if ( ! empty($result['stdout']) ) {
+            foreach ( explode(PHP_EOL, trim($result['stdout'])) as $line ) {
+                $this->assertRegExp('/\[warning\]/', $line);
+                $numWarnings++;
+            }
+        }
+
+        $this->assertGreaterThanOrEqual(0, $numWarnings, 'Expected number of SQL warnings');
+        $this->assertEquals('', $result['stderr'], "Std Error");
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

If `hide_sql_warning_codes` is set and there are no unfiltered warnings log the message about SQL warnings as a notice.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, if the log level is warning and the `hide_sql_warning_codes` is used, then a warning message is displayed even when all SQL warnings have been filtered out.  It would be preferable to not display the message as a warning if it is not followed by any warnings, but to continue to display the message as a warning if it is followed by warnings.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new test to ensure no warning messages are displayed when all warnings are filtered out.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
