### PR TITLE
Use Configuration class to parse table definition rather than JsonFile

### DIFF
--- a/classes/ETL/Maintenance/ManageTables.php
+++ b/classes/ETL/Maintenance/ManageTables.php
@@ -14,6 +14,7 @@
 namespace ETL\Maintenance;
 
 use ETL\Configuration\EtlConfiguration;
+use ETL\Configuration\Configuration;
 use ETL\EtlOverseerOptions;
 use ETL\DbModel\Table;
 use ETL\aOptions;
@@ -98,8 +99,14 @@ class ManageTables extends aRdbmsDestinationAction implements iAction
                 $defFile = \xd_utilities\qualify_path($defFile, $this->options->paths->table_definition_dir);
             }
             $this->logger->info(sprintf("Parse table definition: '%s'", $defFile));
-            $etlTable = new Table(
+            $tableConfig = new Configuration(
                 $defFile,
+                $this->options->paths->base_dir,
+                $this->logger
+            );
+            $tableConfig->initialize();
+            $etlTable = new Table(
+                $tableConfig->getTransformedConfig(),
                 $this->destinationEndpoint->getSystemQuoteChar(),
                 $this->logger
             );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the `ManageTables` action to use the `Configuration` class to parse the table definition file. This will eliminate warnings such as `[warning] ETL\DbModel\Table: Attempt to set unsupported property: '#'`. The current `ManageTables` action uses the `Table` class to parse the table definition file, which uses the `JsonFile` class under the hood. This does not take advantage of the transformers such as comment filtering and RFC6901 JSON references available in the `Configuration` class. 

## Motivation and Context

Reduce unnecessary warnings and take advantage of existing functionality.

## Tests performed

Ran existing tests and tested manually to verify that warnings are no longer thrown.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
