### PR TITLE
Add primary keys to ETL source queries

### DIFF
--- a/configuration/etl/etl_action_defs.d/common/hpcdb/email-addresses.json
+++ b/configuration/etl/etl_action_defs.d/common/hpcdb/email-addresses.json
@@ -4,6 +4,7 @@
     },
     "source_query": {
         "records": {
+            "email_address_id": "uup.union_user_pi_id",
             "person_id": "uup.union_user_pi_id",
             "email_address": "''"
         },

--- a/configuration/etl/etl_action_defs.d/common/hpcdb/system-accounts.json
+++ b/configuration/etl/etl_action_defs.d/common/hpcdb/system-accounts.json
@@ -4,6 +4,7 @@
     },
     "source_query": {
         "records": {
+            "system_account_id": "uupr.union_user_pi_resource_id",
             "resource_id": "r.resource_id",
             "person_id": "uup.union_user_pi_id",
             "username": "uup.union_user_pi_name",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds additional "records" to the ETL "source_query" for ingestion into the HPCDB system accounts table.  Also adds the same for the HPCDB email addresses table which isn't used in Open XDMoD, but may as well have the proper primary keys.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is needed to prevent duplicates from being inserted during ingestion into the HPCDB.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran automated tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
