### PR TITLE
Prompt for resource type in xdmod-setup

### DIFF
--- a/classes/OpenXdmod/Setup/AddResourceSetup.php
+++ b/classes/OpenXdmod/Setup/AddResourceSetup.php
@@ -33,6 +33,26 @@ class AddResourceSetup extends SetupItem
      */
     public function handle()
     {
+        $typeOptions = array();
+        $typeDescriptionText = "";
+        $availableTypes = json_decode(file_get_contents(CONFIG_DIR . '/resource_types.json'), true);
+
+        usort(
+            $availableTypes,
+            function ($a, $b) {
+                return strcmp($a['abbrev'], $b['abbrev']);
+            }
+        );
+
+        foreach ( $availableTypes as $type ) {
+            if ( 'UNK' == $type['abbrev'] ) {
+                continue;
+            }
+            // Note that Console::prompt() expects lowercase values for options
+            $typeOptions[] = strtolower($type['abbrev']);
+            $typeDescriptionText .= sprintf("%-10s - %s", $type['abbrev'], $type['description']) . PHP_EOL;
+        }
+
         $this->console->displaySectionHeader('Add A New Resource');
 
         $this->console->displayMessage(<<<"EOT"
@@ -40,13 +60,16 @@ The resource name you enter should match the name used by your resource
 manager.  This is the resource name that you will need to specify during
 the shredding process.  If you are using Slurm this must match the
 cluster name used by Slurm.
+
+Available resource types are:
+$typeDescriptionText
 EOT
         );
         $this->console->displayBlankLine();
 
         $resource = $this->console->prompt('Resource Name:');
         $name     = $this->console->prompt('Formal Name:');
-        $type     = $this->console->prompt('Resource Type:', 'hpc', array('cloud', 'hpc'));
+        $type     = $this->console->prompt('Resource Type:', 'hpc', $typeOptions);
 
         $this->console->displayBlankLine();
         $this->console->displayMessage(<<<"EOT"

--- a/classes/OpenXdmod/Setup/AddResourceSetup.php
+++ b/classes/OpenXdmod/Setup/AddResourceSetup.php
@@ -46,6 +46,7 @@ EOT
 
         $resource = $this->console->prompt('Resource Name:');
         $name     = $this->console->prompt('Formal Name:');
+        $type     = $this->console->prompt('Resource Type:', 'hpc', array('cloud', 'hpc'));
 
         $this->console->displayBlankLine();
         $this->console->displayMessage(<<<"EOT"
@@ -67,6 +68,7 @@ EOT
             array(
                 'resource'   => $resource,
                 'name'       => $name,
+                'type'       => $type,
                 'processors' => (int)$cpus,
                 'nodes'      => (int)$nodes,
                 'ppn'        => (int)$ppn,

--- a/classes/OpenXdmod/Setup/AdminUserSetup.php
+++ b/classes/OpenXdmod/Setup/AdminUserSetup.php
@@ -5,7 +5,6 @@
 
 namespace OpenXdmod\Setup;
 
-use Exception;
 use XDUser;
 
 /**
@@ -48,7 +47,7 @@ class AdminUserSetup extends SetupItem
             $user->setUserType(2);
 
             $user->saveUser();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->console->displayBlankLine();
             $this->console->displayMessage('Failed to create admin user:');
 

--- a/classes/OpenXdmod/Setup/Console.php
+++ b/classes/OpenXdmod/Setup/Console.php
@@ -111,7 +111,7 @@ class Console
 
         if (count($options) > 0) {
             if ($default != '' && !in_array(strtolower($default), $options)) {
-                throw new Exception('Default value is not an option');
+                throw new \Exception('Default value is not an option');
             }
 
             $lastChar = substr($prompt, -1, 1);

--- a/classes/OpenXdmod/Setup/DatabaseSetup.php
+++ b/classes/OpenXdmod/Setup/DatabaseSetup.php
@@ -105,7 +105,7 @@ EOT
                 $settings,
                 $databases
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->console->displayBlankLine();
             $this->console->displayMessage('Failed to create databases:');
             $this->console->displayBlankLine();

--- a/classes/OpenXdmod/Setup/ListResourcesSetup.php
+++ b/classes/OpenXdmod/Setup/ListResourcesSetup.php
@@ -50,7 +50,7 @@ class ListResourcesSetup extends SetupItem
 
             // Look up the resource type in the list of available types
 
-            $resourceType = 'Unknown';
+            $resourceType = 'UNK';
             foreach ( $availableTypes as $type ) {
                 if ( $type->id == $resource['resource_type_id'] ) {
                     // Note that Console::prompt() expects lowercase values for options

--- a/classes/OpenXdmod/Setup/ListResourcesSetup.php
+++ b/classes/OpenXdmod/Setup/ListResourcesSetup.php
@@ -43,11 +43,25 @@ class ListResourcesSetup extends SetupItem
             $this->console->displayBlankLine();
         }
 
+        $availableTypes = json_decode(file_get_contents(CONFIG_DIR . '/resource_types.json'));
+
         foreach ($resources as $resource) {
             $specs = $this->getSpecsForResource($resource['resource']);
 
+            // Look up the resource type in the list of available types
+
+            $resourceType = 'Unknown';
+            foreach ( $availableTypes as $type ) {
+                if ( $type->id == $resource['resource_type_id'] ) {
+                    // Note that Console::prompt() expects lowercase values for options
+                    $resourceType = strtolower($type->abbrev);
+                    break;
+                }
+            }
+
             $this->console->displayMessage('Resource: ' . $resource['resource']);
             $this->console->displayMessage('Name: ' . $resource['name']);
+            $this->console->displayMessage('Type: ' . $resourceType);
             $this->console->displayMessage('Node count: ' . $specs['nodes']);
             $this->console->displayMessage('Processor count: ' . $specs['processors']);
             $this->console->displayMessage(str_repeat('-', 72));

--- a/classes/OpenXdmod/Setup/Menu.php
+++ b/classes/OpenXdmod/Setup/Menu.php
@@ -80,6 +80,6 @@ class Menu
             }
         }
 
-        throw new Exception("No handler found for trigger '$trigger'");
+        throw new \Exception("No handler found for trigger '$trigger'");
     }
 }

--- a/classes/OpenXdmod/Setup/ResourcesSetup.php
+++ b/classes/OpenXdmod/Setup/ResourcesSetup.php
@@ -117,9 +117,22 @@ class ResourcesSetup extends SubMenuSetupItem
      */
     public function addResource(array $resource)
     {
+        // Look up the resource type id for the string that was entered
+
+        $availableTypes = json_decode(file_get_contents(CONFIG_DIR . '/resource_types.json'));
+
+        $resourceTypeId = 0; // Unknown
+        foreach ( $availableTypes as $type ) {
+            // Note that Console::prompt() expects lowercase values for options
+            if ( strtolower($type->abbrev) == $resource['type'] ) {
+                $resourceTypeId = $type->id;
+                break;
+            }
+        }
+
         $this->resources[] = array(
             'resource'         => $resource['resource'],
-            'resource_type_id' => 1,
+            'resource_type_id' => $resourceTypeId,
             'name'             => $resource['name'],
         );
 

--- a/classes/OpenXdmod/Setup/SetupItem.php
+++ b/classes/OpenXdmod/Setup/SetupItem.php
@@ -5,7 +5,6 @@
 
 namespace OpenXdmod\Setup;
 
-use Exception;
 use xd_utilities;
 use CCR\Json;
 use Xdmod\Template;
@@ -105,7 +104,7 @@ abstract class SetupItem
     {
         try {
             $data = Json::loadFile($path);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return array();
         }
 
@@ -260,7 +259,7 @@ abstract class SetupItem
         if ($returnVar != 0) {
             $msg = "Command exited with non-zero return status:\n"
                 . "command = $command\noutput =\n" . implode("\n", $output);
-            throw new Exception($msg);
+            throw new \Exception($msg);
         }
 
         return $output;

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
@@ -105,6 +105,7 @@ foreach resource $resources {
 	selectMenuOption 1
 	provideInput {Resource Name:} [lindex $resource 0]
 	provideInput {Formal Name:} [lindex $resource 1]
+	provideInput {Resource Type*} {}
 	provideInput {How many nodes does this resource have?} [lindex $resource 2]
 	provideInput {How many total processors (cpu cores) does this resource have?} [lindex $resource 3]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`xdmod-setup` add resource menu hard-codes a resource type of 1 (HPC). Prompt the user for the resource type, defaulting to HPC. Allowable types are currently HPC and Cloud. Use the `etc/resource_types.json` file to map from the string to `resouce_type_id`.

## Motivation and Context

Needed by @chakrabortyr and @eiffel777 for adding cloud resources during testing.

## Tests performed

Manual and shippable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
