### PR TITLE
Disabling the User group by for the Cloud realm

### DIFF
--- a/configuration/roles.d/cloud.json
+++ b/configuration/roles.d/cloud.json
@@ -7,7 +7,8 @@
                 },
                 {
                     "realm": "Cloud",
-                    "group_by": "person"
+                    "group_by": "person",
+                    "disable": true
                 },
                 {
                     "realm": "Cloud",

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/acls/output/roles.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/acls/output/roles.json
@@ -110,7 +110,8 @@
                 },
                 {
                     "realm": "Cloud",
-                    "group_by": "person"
+                    "group_by": "person",
+                    "disable": true
                 },
                 {
                     "realm": "Cloud",


### PR DESCRIPTION
This changes disables the User group by in the Cloud realm

## Motivation and Context
The User group by in the Cloud realm joins the the modw.systemaccount table to get user information and rows are only added to this table if the have run a job on a resource. Since the cloud realm is not tracking jobs but instead events there in no existing mechanism to load the users listed on these events into the systemaccount table. 

In the next release after 8.0 a way to ingest users listed in the cloud logs will be created so that the User group by can be enabled.

## Tests performed
Tested in local docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
