### PR TITLE
Changing path to look for cloud event logs to use an ETL command line variable

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_eucalyptus.json
+++ b/configuration/etl/etl.d/jobs_cloud_eucalyptus.json
@@ -42,7 +42,7 @@
                     "type": "directoryscanner",
                     "name": "Eucalyptus event logs",
                     "#": "Relative paths are searched in $BASEDIR/etl_data.d",
-                    "path": "/path/to/eucalyptus/log/files",
+                    "path": "${CLOUD_EVENT_LOG_DIRECTORY}",
                     "directory_pattern": "/[0-9]{4}-[0-9]{2}-[0-9]{2}/",
                     "file_pattern": "/acct\\.json/",
                     "#": "Recursion depth is relative to the path",
@@ -93,7 +93,7 @@
                 "source": {
                     "type": "directoryscanner",
                     "name": "Eucalyptus volume logs",
-                    "path": "cloud_eucalyptus/ccr-cbls-2",
+                    "path": "${CLOUD_EVENT_LOG_DIRECTORY}",
                     "directory_pattern": "/[0-9]{4}-[0-9]{2}-[0-9]{2}/",
                     "file_pattern": "/acct\\.json/",
                     "#": "Recursion depth is relative to the path",

--- a/configuration/etl/etl.d/jobs_cloud_openstack.json
+++ b/configuration/etl/etl.d/jobs_cloud_openstack.json
@@ -42,7 +42,7 @@
                 "source": {
                     "type": "directoryscanner",
                     "name": "Open Stack event logs",
-                    "path": "/path/to/data",
+                    "path": "${CLOUD_EVENT_LOG_DIRECTORY}",
                     "file_pattern": "/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.json/",
                     "#": "Recursion depth is relative to the path",
                     "recursion_depth": 1,

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -36,12 +36,10 @@ then
     #Adding open stack resource since there is no way to automatically add a cloud resource.
     mysql -e "INSERT INTO modw.resourcefact (resourcetype_id, organization_id, name, code, resource_origin_id) VALUES (1,1,'OpenStack', 'openstack', 6);
     UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
-    #Set path to Open Stack test data in Open Stack ingestion file
-    sed -i "s%/path/to/data%$REF_DIR/openstack%" /etc/xdmod/etl/etl.d/jobs_cloud_openstack.json
     #Ingesting cloud data from references folder
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-common
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-common
-    php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack
+    php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack -d "CLOUD_EVENT_LOG_DIRECTORY=$REF_DIR/openstack"
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-extract-openstack
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p cloud-state-pipeline
     acl-import
@@ -68,12 +66,10 @@ then
     #Adding open stack resource since there is no way to automatically add a cloud resource.
     mysql -e "INSERT INTO modw.resourcefact (resourcetype_id, organization_id, name, code, resource_origin_id) VALUES (1,1,'OpenStack', 'openstack', 6);
     UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
-    #Set path to Open Stack test data in Open Stack ingestion file
-    sed -i "s%/path/to/data%$REF_DIR/openstack%" /etc/xdmod/etl/etl.d/jobs_cloud_openstack.json
     #Ingesting cloud data from references folder
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-common
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-common
-    php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack
+    php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack -d "CLOUD_EVENT_LOG_DIRECTORY=$REF_DIR/openstack"
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-extract-openstack
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p cloud-state-pipeline
     #Running acl pipelines to ensure the Cloud realm shows up


### PR DESCRIPTION
Currently, in etl.d/jobs_cloud_eucalyptus and etl.d/jobs_cloud_openstack the path to the directory containing log files is a hardcoded placeholder directory that is should be replaced manually when adding a new cloud resource. This change will allow us to use an ETL command line variable named CLOUD_EVENT_LOG_DIRECTORY specified using the -d command instead of having to manually change the directory when a new resource is added. Below is an example of the new command line argument that should be used.

```
php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack -d "CLOUD_EVENT_LOG_DIRECTORY=/path/to/openstack/data"
```
The tests were also updated to use -d flag when ingesting cloud event data.

## Motivation and Context
Using a command line variable to specify the location of the cloud logs keeps consistency with how the shredder uses the -i flag to specify the location of a file to shred

## Tests performed
Tested manually in docker and ran integration, component and regression tests in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
