### PR TITLE
Support for ingesting job records modified in the past N days

### DIFF
--- a/classes/ETL/EtlOverseerOptions.php
+++ b/classes/ETL/EtlOverseerOptions.php
@@ -87,6 +87,7 @@ class EtlOverseerOptions extends \CCR\Loggable
 
     const RESTRICT_START_DATE = 'start_date';
     const RESTRICT_END_DATE = 'end_date';
+    const RESTRICT_NUMBER_OF_DAYS = 'number_of_days';
     const RESTRICT_LAST_MODIFIED_START_DATE = 'last_modified_start_date';
     const RESTRICT_LAST_MODIFIED_END_DATE = 'last_modified_end_date';
     const RESTRICT_INCLUDE_ONLY_RESOURCES = 'include_only_resource_codes';
@@ -250,6 +251,11 @@ class EtlOverseerOptions extends \CCR\Loggable
                 case self::RESTRICT_LAST_MODIFIED_END_DATE:
                     if ( null !== ($value = $this->getLastModifiedEndDate()) ) {
                         $replacement = $endpoint->quote($value);
+                    }
+                    break;
+                case self::RESTRICT_NUMBER_OF_DAYS:
+                    if ( null !== ($value = $this->getNumberOfDays()) ) {
+                        $replacement = $value;
                     }
                     break;
                 case self::RESTRICT_INCLUDE_ONLY_RESOURCES:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## See also ubccr/xdmod-xsede#117.

## Description

Add support for `number_of_days` as an overseer restriction in ETL queries. This will be used to query jobs that were modified in the past N days. We can now ingest using 2 methods:
- use `--number-of-days | -n` to ingest job records modified in the past N days (the proposed default)
- use `--start-date | -s` and/or `--end-date | -e` to ingest jobs that ended between the specified start and end dates (good for historical re-ingestion)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed

Manual ingest using docker.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
