### PR TITLE
Added the -p flag to mkdir in bootstrap

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -29,7 +29,7 @@ then
     xdmod-ingestor
     php /root/bin/createusers.php
     #Copying roles file so Cloud realm shows up
-    mkdir /etc/xdmod/roles.d
+    mkdir -p /etc/xdmod/roles.d
     cp $BASEDIR/../../../../../templates/roles.d/cloud.json /etc/xdmod/roles.d/
     #Adding open stack resource since there is no way to automatically add a cloud resource.
     mysql -e "INSERT INTO modw.resourcefact (resourcetype_id, organization_id, name, code, resource_origin_id) VALUES (1,1,'OpenStack', 'openstack', 6);
@@ -57,7 +57,7 @@ then
     FLUSH PRIVILEGES;"
     expect $BASEDIR/xdmod-upgrade.tcl | col -b
     #Copying roles file so Cloud realm shows up
-    mkdir /etc/xdmod/roles.d
+    mkdir -p /etc/xdmod/roles.d
     cp $BASEDIR/../../../../../templates/roles.d/cloud.json /etc/xdmod/roles.d/
     #Adding open stack resource since there is no way to automatically add a cloud resource.
     mysql -e "INSERT INTO modw.resourcefact (resourcetype_id, organization_id, name, code, resource_origin_id) VALUES (1,1,'OpenStack', 'openstack', 6);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
This command is causing the shippable builds in the supremm module to fail due
to the directory already existing. I just added -p so that it will continue
on if it already exists.

## Motivation and Context
It's nice when Shippable passes

## Tests performed
Tested w/ the docker image / process used in the xdmod-supremm shippable process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
