### PR TITLE
add temporary table that contains volume delete event information and join against it to get the time a volume was deleted

### DIFF
--- a/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
+++ b/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
@@ -2,16 +2,26 @@
 -- in volume.delete.end events and also root volumes which are inferred from compute.instance.create
 -- events.
 
+CREATE TEMPORARY TABLE ${DESTINATION_SCHEMA}.tmp_volume_delete
+AS
+SELECT
+	event_time_utc,
+	openstack_resource_id,
+	resource_id
+FROM
+	${DESTINATION_SCHEMA}.openstack_raw_event
+WHERE
+	event_type = "volume.delete.end";
+//
+
 UPDATE
 	${DESTINATION_SCHEMA}.asset AS a
 LEFT JOIN
-	${DESTINATION_SCHEMA}.openstack_raw_event AS raw
+	${DESTINATION_SCHEMA}.tmp_volume_delete AS raw
 ON
   raw.resource_id = a.resource_id AND raw.openstack_resource_id = a.provider_identifier
 SET
-	a.destroy_time_utc = raw.event_time_utc
-WHERE
-	raw.event_type = "volume.delete.end";
+	a.destroy_time_utc = raw.event_time_utc;
 //
 
 UPDATE

--- a/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
+++ b/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
@@ -3,6 +3,7 @@
 -- events.
 
 CREATE TEMPORARY TABLE ${DESTINATION_SCHEMA}.tmp_volume_delete
+(INDEX resource_id_openstack_resource_key (`resource_id`, `openstack_resource_id`))
 AS
 SELECT
 	event_time_utc,


### PR DESCRIPTION
Currently, the sql query that updates a volume asset with an end time joins against the openstack_raw_event table and uses a where clause to find all volume.delete.end events to find the end time. When testing on metrics-dev it became apparent that this was taking far too long to complete. 

To reduce the query time we can create a temporary table with all the necessary volume.delete.end information and join against that table which is a significantly smaller dataset to join against.

## Motivation and Context
Sql statement to update volume asset end times is taking too long

## Tests performed
Tested in local docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
