### PR TITLE
Remove chart / report active role usage

### DIFF
--- a/classes/XDChartPool.php
+++ b/classes/XDChartPool.php
@@ -55,35 +55,6 @@ use CCR\DB;
                
       }//emptyCache
 
-		// --------------------------------------------
-		      
-		public function enumChartsUnderOtherRoles() {
-
-         $results = $this->_pdo->query(
-            'SELECT active_role, COUNT(*) AS num_charts FROM ChartPool WHERE user_id=:user_id AND active_role != :active_role GROUP BY active_role',
-            array(
-               'user_id' => $this->_user_id,
-               'active_role' => $this->_user->getActiveRole()->getIdentifier(true)
-            )
-         );
-			
-			$chartBreakdown = array();
-			
-			foreach ($results as $r) {
-			
-			   $chartBreakdown[] = array(
-                                 'role' => \xd_roles\getFormalRoleNameFromIdentifier($r['active_role']),
-                                 'num_charts' => $r['num_charts']
-			                       );
-			
-			}//foreach
-
-			return $chartBreakdown;
-		
-		}//enumChartsUnderOtherRoles
-		
-		// --------------------------------------------
-		
 		public function addChartToQueue($chartIdentifier, $chartTitle, $chartDrillDetails, $chartDateDesc) {
 
          if (empty($chartIdentifier)){
@@ -103,8 +74,8 @@ use CCR\DB;
             throw new Exception("chart_exists_in_queue");
          }
 	
-         $insertQuery = "INSERT INTO {$this->_table_name} (user_id, chart_id, chart_title, chart_drill_details, chart_date_description, type, active_role) VALUES " .
-                        "(:user_id, :chart_id, :chart_title, :chart_drill_details, :chart_date_description, 'image', :active_role)";
+         $insertQuery = "INSERT INTO {$this->_table_name} (user_id, chart_id, chart_title, chart_drill_details, chart_date_description, type) VALUES " .
+                        "(:user_id, :chart_id, :chart_title, :chart_drill_details, :chart_date_description, 'image')";
 	        
          $this->_pdo->execute(
             $insertQuery, 
@@ -113,8 +84,7 @@ use CCR\DB;
                'chart_id' => $chartIdentifier,
                'chart_title'=> $chartTitle, 
                'chart_date_description' => $chartDateDesc,
-               'chart_drill_details'=> $chartDrillDetails,
-               'active_role' => $this->_user->getActiveRole()->getIdentifier(true)
+               'chart_drill_details'=> $chartDrillDetails
             )
          );
 		

--- a/classes/XDReportManager.php
+++ b/classes/XDReportManager.php
@@ -15,7 +15,6 @@ class XDReportManager
     private $_user = null;
     private $_user_id = null;
     private $_charts_per_page = 1;
-    private $_active_role_id = null;
     private $_report_name = null;
     private $_report_title = null;
     private $_report_header = null;
@@ -47,7 +46,6 @@ class XDReportManager
         $this->_pdo = DB::factory('database');
         $this->_user = $user;
         $this->_user_id         = $user->getUserID();
-        $this->_active_role_id  = $user->getActiveRole()->getIdentifier(true);
     }
 
     public function emptyCache()
@@ -293,8 +291,7 @@ class XDReportManager
                     schedule,
                     delivery,
                     selected,
-                    charts_per_page,
-                    active_role
+                    charts_per_page
                 ) VALUES (
                     :report_id,
                     :user_id,
@@ -308,8 +305,7 @@ class XDReportManager
                     :report_schedule,
                     :report_delivery,
                     :selected,
-                    :charts_per_page,
-                    :active_role_id
+                    :charts_per_page
                 )
             ",
             array(
@@ -325,8 +321,7 @@ class XDReportManager
                 'report_schedule' => $this->_report_schedule,
                 'report_delivery' => $this->_report_delivery,
                 'selected'        => 0,
-                'charts_per_page' => $this->_charts_per_page,
-                'active_role_id'  => $this->_active_role_id,
+                'charts_per_page' => $this->_charts_per_page
             )
         );
     }
@@ -415,36 +410,6 @@ class XDReportManager
         }
 
         return $param_value;
-    }
-
-    public function enumReportsUnderOtherRoles()
-    {
-        $results = $this->_pdo->query(
-            '
-                SELECT active_role, COUNT(*) AS num_reports
-                FROM moddb.Reports
-                WHERE user_id = :user_id AND active_role != :active_role
-                GROUP BY active_role
-            ',
-            array(
-                'user_id'     => $this->_user_id,
-                'active_role' => $this->_active_role_id,
-            )
-        );
-
-        $reportBreakdown = array();
-
-        foreach ($results as $r) {
-
-            $reportBreakdown[] = array(
-                'role'        => \xd_roles\getFormalRoleNameFromIdentifier(
-                    $r['active_role']
-                ),
-                'num_reports' => $r['num_reports']
-            );
-        }
-
-        return $reportBreakdown;
     }
 
     public function fetchChartPool()

--- a/html/controllers/report_builder/enum_available_charts.php
+++ b/html/controllers/report_builder/enum_available_charts.php
@@ -8,12 +8,7 @@
       $cp = new XDChartPool($user);
    
    	$returnData['status'] = 'success';
-   	
-   	$charts_in_other_roles = $cp->enumChartsUnderOtherRoles();
-   	
-   	$returnData['has_charts_in_other_roles'] = (count($charts_in_other_roles) > 0);
-   	$returnData['charts_in_other_roles'] = $charts_in_other_roles;
-   		
+
    	$returnData['queue'] = $rm->fetchChartPool();
    
    	\xd_controller\returnJSON($returnData);

--- a/html/controllers/report_builder/enum_reports.php
+++ b/html/controllers/report_builder/enum_reports.php
@@ -7,12 +7,7 @@
    	$rm = new XDReportManager($user);
    
    	$returnData['status'] = 'success';
-   	
-   	$reports_in_other_roles = $rm->enumReportsUnderOtherRoles();
-   	
-   	$returnData['has_reports_in_other_roles'] = (count($reports_in_other_roles) > 0);
-   	$returnData['reports_in_other_roles'] = $reports_in_other_roles;
-   	
+
    	$returnData['queue'] = $rm->fetchReportTable();
    
    	\xd_controller\returnJSON($returnData);

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ReportBuilderTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ReportBuilderTest.php
@@ -117,7 +117,7 @@ class ReportBuilderTest extends \PHPUnit_Framework_TestCase
 
         $actual = $response[0];
 
-        $this->assertEquals($actual, $expected);
+        $this->assertEquals($expected, $actual);
 
         if ($user !== 'pub') {
             $this->helper->logout();

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cd_enum_available_charts.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cd_enum_available_charts.json
@@ -1,1 +1,1 @@
-{"status":"success","has_charts_in_other_roles":false,"charts_in_other_roles":[],"queue":[]}
+{"status":"success","queue":[]}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cd_enum_reports.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cd_enum_reports.json
@@ -1,1 +1,1 @@
-{"status":"success","has_reports_in_other_roles":false,"reports_in_other_roles":[],"queue":[]}
+{"status":"success","queue":[]}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cs_enum_available_charts.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cs_enum_available_charts.json
@@ -1,6 +1,4 @@
 {
   "status": "success",
-  "has_charts_in_other_roles": false,
-  "charts_in_other_roles": [],
   "queue": []
 }

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cs_enum_reports.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/cs_enum_reports.json
@@ -1,6 +1,4 @@
 {
   "status": "success",
-  "has_reports_in_other_roles": false,
-  "reports_in_other_roles": [],
   "queue": []
 }

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/pi_enum_available_charts.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/pi_enum_available_charts.json
@@ -1,6 +1,4 @@
 {
   "status": "success",
-  "has_charts_in_other_roles": false,
-  "charts_in_other_roles": [],
   "queue": []
 }

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/pi_enum_reports.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/pi_enum_reports.json
@@ -1,6 +1,4 @@
 {
   "status": "success",
-  "has_reports_in_other_roles": false,
-  "reports_in_other_roles": [],
   "queue": []
 }

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/usr_enum_available_charts.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/usr_enum_available_charts.json
@@ -1,6 +1,4 @@
 {
   "status": "success",
-  "has_charts_in_other_roles": false,
-  "charts_in_other_roles": [],
   "queue": []
 }

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/usr_enum_reports.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/report_builder/output/usr_enum_reports.json
@@ -1,6 +1,4 @@
 {
   "status": "success",
-  "has_reports_in_other_roles": false,
-  "reports_in_other_roles": [],
   "queue": []
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For the following controller operations:
  - `report_builder/enum_available_charts.php`
  - `report_builder/enum_reports.php`

The following values are not used:
  - `has_charts_in_other_roles`
  - `charts_in_other_roles`
  - `has_reports_in_other_roles`
  - `reports_in_other_roles`

This consequently means that the following functions are not used:
  - `XDChartPool::enumChartsUnderOtherRoles`
  - `XDReportManager::enumReportsUnderOtherRoles`

Which means we no longer need to populate / reference the `active_role` column
in:
  - `moddb.ChartPool`
  - `moddb.Reports`

And that the report_builder test output needs to be updated for:
  - [user]_enum_available_charts
  - [user]_enum_reports

## Motivation and Context
In addition to removing code that is no longer used, this also saves us from having to update / migrate these usages of `XDUser::getActiveRole` to an acl equivalent.

## Tests performed
For OpenXDMoD ( via rpm installed docker ):
  - [X] Unit Tests
  - [X] Component Tests
  - [X] Integration Tests
  - [X] UI Tests

For OpenXDMoD w/ supremm ( via rpm installed docker ):
  - [X] Unit Tests
  - [X] Component Tests
  - [X] Integration Tests
    - _NOTE: Not all tests passed, but those that did fail failed due to inclusion of `SUPREMM` related information. This is to be expected_ 
  - [X] UI Tests
  - [X] Manual Tests

For XSEDE:
  - [X] Unit Tests
  - [X] Manual Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
