### PR TITLE
Proper Support For Multiple Cloud Resource Ingestion + Ingestion Bugfixes

### DIFF
--- a/classes/ETL/Ingestor/CloudStateReconstructorTransformIngestor.php
+++ b/classes/ETL/Ingestor/CloudStateReconstructorTransformIngestor.php
@@ -59,6 +59,7 @@ class CloudStateReconstructorTransformIngestor extends pdoIngestor implements iA
         $default_end_time = isset($this->_end_time) ? $this->_end_time : $srcRecord['event_time_utc'];
 
         $this->_instance_state = array(
+            'resource_id' => $srcRecord['resource_id'],
             'instance_id' => $srcRecord['instance_id'],
             'start_time' => $srcRecord['event_time_utc'],
             'start_event_id' => $srcRecord['event_type_id'],
@@ -105,7 +106,7 @@ class CloudStateReconstructorTransformIngestor extends pdoIngestor implements iA
 
         $transformedRecord = array();
 
-        if ($this->_instance_state['instance_id'] !== $srcRecord['instance_id']) {
+        if (($this->_instance_state['instance_id'] !== $srcRecord['instance_id']) || ($this->_instance_state['resource_id'] !== $srcRecord['resource_id'])) {
             $transformedRecord[] = $this->_instance_state;
             $this->initInstance($srcRecord);
         } elseif (in_array($srcRecord['event_type_id'], $this->_start_event_ids)) {
@@ -128,7 +129,7 @@ class CloudStateReconstructorTransformIngestor extends pdoIngestor implements iA
         $colCount = count($this->etlSourceQuery->records);
         $unionValues = array_fill(0, $colCount, 0);
 
-        $sql = "$sql \nUNION ALL\nSELECT " . implode(',', $unionValues) . "\nORDER BY 1 DESC, 2 ASC";
+        $sql = "$sql \nUNION ALL\nSELECT " . implode(',', $unionValues) . "\nORDER BY 1 DESC, 2 DESC, 3 ASC";
 
         return $sql;
     }

--- a/configuration/etl/etl_action_defs.d/cloud_common/cloud_state.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/cloud_state.json
@@ -4,6 +4,7 @@
     },
     "destination_record_map": {
         "event_reconstructed": {
+            "resource_id": "resource_id",
             "instance_id": "instance_id",
             "start_time": "start_time",
             "start_event_id": "start_event_id",
@@ -13,6 +14,7 @@
     },
     "source_query": {
         "records": {
+            "resource_id": "e.resource_id",
             "instance_id": "e.instance_id",
             "event_time_utc": "event_time_utc",
             "event_type_id": "event_type_id",
@@ -21,12 +23,10 @@
             "end_time": -1,
             "end_event_id": -1
         },
-        "joins": [
-            {
-                "name": "event",
-                "schema": "${SOURCE_SCHEMA}",
-                "alias": "e"
-            }
-        ]
+        "joins": [{
+            "name": "event",
+            "schema": "${SOURCE_SCHEMA}",
+            "alias": "e"
+        }]
     }
 }

--- a/configuration/etl/etl_action_defs.d/cloud_common/cloud_transient.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/cloud_transient.json
@@ -34,25 +34,25 @@
                 "name": "event",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "ev",
-                "on": "e.start_event_id = ev.event_type_id and e.start_time = ev.event_time_utc and e.instance_id = ev.instance_id and e.resource_id = ev.resource_id"
+                "on": "e.start_event_id = ev.event_type_id AND e.start_time = ev.event_time_utc AND e.instance_id = ev.instance_id AND e.resource_id = ev.resource_id"
             },
             {
                 "name": "instance",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "it",
-                "on": "e.instance_id = it.instance_id and e.resource_id = it.resource_id"
+                "on": "e.instance_id = it.instance_id AND e.resource_id = it.resource_id"
             },
             {
                 "name": "instance_data",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "itd",
-                "on": "itd.resource_id = it.resource_id and itd.event_id = ev.event_id"
+                "on": "itd.resource_id = it.resource_id AND itd.event_id = ev.event_id"
             },
             {
                 "name": "instance_type",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "itt",
-                "on": "itt.resource_id = it.resource_id and itt.instance_type_id = itd.instance_type_id"
+                "on": "itt.resource_id = it.resource_id AND itt.instance_type_id = itd.instance_type_id"
             }
         ],
         "orderby": [

--- a/configuration/etl/etl_action_defs.d/cloud_common/cloud_transient.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/cloud_transient.json
@@ -34,13 +34,13 @@
                 "name": "event",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "ev",
-                "on": "e.start_event_id = ev.event_type_id and e.start_time = ev.event_time_utc and e.instance_id = ev.instance_id"
+                "on": "e.start_event_id = ev.event_type_id and e.start_time = ev.event_time_utc and e.instance_id = ev.instance_id and e.resource_id = ev.resource_id"
             },
             {
                 "name": "instance",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "it",
-                "on": "e.instance_id = it.instance_id"
+                "on": "e.instance_id = it.instance_id and e.resource_id = it.resource_id"
             },
             {
                 "name": "instance_data",
@@ -56,7 +56,7 @@
             }
         ],
         "orderby": [
-            "instance_id ASC, start_time ASC"
+            "resource_id ASC, instance_id ASC, start_time ASC"
         ]
     }
 }

--- a/configuration/etl/etl_action_defs.d/cloud_common/initialize_unknown_dimension_values.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/initialize_unknown_dimension_values.json
@@ -40,7 +40,7 @@
     "source_query": {
         "records": {
             "resource_id": "rf.id",
-            "unknown_id": 1,
+            "unknown_id": -1,
             "unknown_key": "'unknown'",
             "unknown_display": "'Unknown'"
         },

--- a/configuration/etl/etl_tables.d/cloud_common/account.json
+++ b/configuration/etl/etl_tables.d/cloud_common/account.json
@@ -52,10 +52,10 @@
                 "is_unique": true
             },
             {
-                "name": "increment_key",
+                "name": "autoincrement_key",
                 "columns": [
-                    "resource_id",
-                    "account_id"
+                    "account_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             },

--- a/configuration/etl/etl_tables.d/cloud_common/account.json
+++ b/configuration/etl/etl_tables.d/cloud_common/account.json
@@ -52,6 +52,10 @@
                 "is_unique": true
             },
             {
+                "#": "The ordering of autoincrement id + resource_id is explicit and mandatory.",
+                "#": "This is because MyISAM mandates that composite keys containing an",
+                "#": "autoincrement value have said value as the first key.",
+                "#": "See the following for details: https://www.ryadel.com/en/mysql-two-columns-primary-key-with-auto-increment/",
                 "name": "autoincrement_key",
                 "columns": [
                     "account_id",

--- a/configuration/etl/etl_tables.d/cloud_common/asset.json
+++ b/configuration/etl/etl_tables.d/cloud_common/asset.json
@@ -95,8 +95,8 @@
 
                 "name": "autoincrement_key",
                 "columns": [
-                    "resource_id",
-                    "asset_id"
+                    "asset_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             }

--- a/configuration/etl/etl_tables.d/cloud_common/avail_zone.json
+++ b/configuration/etl/etl_tables.d/cloud_common/avail_zone.json
@@ -60,8 +60,8 @@
 
                 "name": "autoincrement_key",
                 "columns": [
-                    "resource_id",
-                    "avail_zone_id"
+                    "avail_zone_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             }

--- a/configuration/etl/etl_tables.d/cloud_common/avail_zone.json
+++ b/configuration/etl/etl_tables.d/cloud_common/avail_zone.json
@@ -58,6 +58,10 @@
                 "#": "useful when you want to put data into ordered groups.",
                 "#": "See [MyISAM Notes](https://dev.mysql.com/doc/refman/5.7/en/example-auto-increment.html)",
 
+                "#": "The ordering of autoincrement id + resource_id is explicit and mandatory.",
+                "#": "This is because MyISAM mandates that composite keys containing an",
+                "#": "autoincrement value have said value as the first key.",
+                "#": "See the following for details: https://www.ryadel.com/en/mysql-two-columns-primary-key-with-auto-increment/",
                 "name": "autoincrement_key",
                 "columns": [
                     "avail_zone_id",

--- a/configuration/etl/etl_tables.d/cloud_common/cloud_transient.json
+++ b/configuration/etl/etl_tables.d/cloud_common/cloud_transient.json
@@ -99,6 +99,24 @@
                 "type": "int(5)",
                 "nullable": true
             }
+        ],
+        "indexes": [
+            {
+                "name": "PRIMARY",
+                "columns": [
+                    "resource_id",
+                    "instance"
+                ],
+                "is_unique": true
+            },
+            {
+                "name": "increment_key",
+                "columns": [
+                    "instance_id",
+                    "resource_id"
+                ],
+                "is_unique": true
+            }
         ]
     }
 }

--- a/configuration/etl/etl_tables.d/cloud_common/event.json
+++ b/configuration/etl/etl_tables.d/cloud_common/event.json
@@ -80,7 +80,8 @@
             {
                 "name": "fk_instance",
                 "columns": [
-                    "instance_id"
+                    "instance_id",
+                    "resource_id"
                 ],
                 "is_unique": false
             }

--- a/configuration/etl/etl_tables.d/cloud_common/event_reconstructed.json
+++ b/configuration/etl/etl_tables.d/cloud_common/event_reconstructed.json
@@ -3,7 +3,11 @@
         "name": "event_reconstructed",
         "comment": "The start and end times for cloud instances reconstructed from event data.",
         "engine": "MyISAM",
-        "columns": [
+        "columns": [{
+                "name": "resource_id",
+                "type": "int(11)",
+                "nullable": false
+            },
             {
                 "name": "instance_id",
                 "type": "int(11)",

--- a/configuration/etl/etl_tables.d/cloud_common/host.json
+++ b/configuration/etl/etl_tables.d/cloud_common/host.json
@@ -48,8 +48,8 @@
 
                 "name": "autoincrement_key",
                 "columns": [
-                    "resource_id",
-                    "host_id"
+                    "host_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             }

--- a/configuration/etl/etl_tables.d/cloud_common/host.json
+++ b/configuration/etl/etl_tables.d/cloud_common/host.json
@@ -46,6 +46,10 @@
                 "#": "useful when you want to put data into ordered groups.",
                 "#": "See [MyISAM Notes](https://dev.mysql.com/doc/refman/5.7/en/example-auto-increment.html)",
 
+                "#": "The ordering of autoincrement id + resource_id is explicit and mandatory.",
+                "#": "This is because MyISAM mandates that composite keys containing an",
+                "#": "autoincrement value have said value as the first key.",
+                "#": "See the following for details: https://www.ryadel.com/en/mysql-two-columns-primary-key-with-auto-increment/",
                 "name": "autoincrement_key",
                 "columns": [
                     "host_id",

--- a/configuration/etl/etl_tables.d/cloud_common/image.json
+++ b/configuration/etl/etl_tables.d/cloud_common/image.json
@@ -48,8 +48,8 @@
 
                 "name": "autoincrement_key",
                 "columns": [
-                    "resource_id",
-                    "image_id"
+                    "image_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             }

--- a/configuration/etl/etl_tables.d/cloud_common/image.json
+++ b/configuration/etl/etl_tables.d/cloud_common/image.json
@@ -46,6 +46,10 @@
                 "#": "useful when you want to put data into ordered groups.",
                 "#": "See [MyISAM Notes](https://dev.mysql.com/doc/refman/5.7/en/example-auto-increment.html)",
 
+                "#": "The ordering of autoincrement id + resource_id is explicit and mandatory.",
+                "#": "This is because MyISAM mandates that composite keys containing an",
+                "#": "autoincrement value have said value as the first key.",
+                "#": "See the following for details: https://www.ryadel.com/en/mysql-two-columns-primary-key-with-auto-increment/",
                 "name": "autoincrement_key",
                 "columns": [
                     "image_id",

--- a/configuration/etl/etl_tables.d/cloud_common/instance.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance.json
@@ -60,6 +60,10 @@
                 "#": "useful when you want to put data into ordered groups.",
                 "#": "See [MyISAM Notes](https://dev.mysql.com/doc/refman/5.7/en/example-auto-increment.html)",
 
+                "#": "The ordering of autoincrement id + resource_id is explicit and mandatory.",
+                "#": "This is because MyISAM mandates that composite keys containing an",
+                "#": "autoincrement value have said value as the first key.",
+                "#": "See the following for details: https://www.ryadel.com/en/mysql-two-columns-primary-key-with-auto-increment/",
                 "name": "increment_key",
                 "columns": [
                     "instance_id",

--- a/configuration/etl/etl_tables.d/cloud_common/instance.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance.json
@@ -62,8 +62,8 @@
 
                 "name": "increment_key",
                 "columns": [
-                    "resource_id",
-                    "instance_id"
+                    "instance_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             }

--- a/configuration/etl/etl_tables.d/cloud_common/instance_type.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance_type.json
@@ -97,8 +97,8 @@
 
                 "name": "increment_key",
                 "columns": [
-                    "resource_id",
-                    "instance_type_id"
+                    "instance_type_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             }

--- a/configuration/etl/etl_tables.d/cloud_common/region.json
+++ b/configuration/etl/etl_tables.d/cloud_common/region.json
@@ -53,6 +53,10 @@
                 "#": "useful when you want to put data into ordered groups.",
                 "#": "See [MyISAM Notes](https://dev.mysql.com/doc/refman/5.7/en/example-auto-increment.html)",
 
+                "#": "The ordering of autoincrement id + resource_id is explicit and mandatory.",
+                "#": "This is because MyISAM mandates that composite keys containing an",
+                "#": "autoincrement value have said value as the first key.",
+                "#": "See the following for details: https://www.ryadel.com/en/mysql-two-columns-primary-key-with-auto-increment/",
                 "name": "autoincrement_key",
                 "columns": [
                     "region_id",

--- a/configuration/etl/etl_tables.d/cloud_common/region.json
+++ b/configuration/etl/etl_tables.d/cloud_common/region.json
@@ -55,8 +55,8 @@
 
                 "name": "autoincrement_key",
                 "columns": [
-                    "resource_id",
-                    "region_id"
+                    "region_id",
+                    "resource_id"
                 ],
                 "is_unique": true
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request enables proper support for ingestion of multiple resources. We now properly key on resource_id AND instance_id when generating cloud tables. Additionally, we address a bug in the MyISAM engine by reordering key pairs to ensure auto-incremented keys are ordered first. A logical error in event reconstruction was also addressed.

Lastly, any lingering defaults of 1 were set to -1 for consistency with the rest of XDMoD data.

## Motivation and Context
Consistency, bugfixes, and deliverable mandates.

## Tests performed
Manual tests on metrics-dev and additional unit tests to ensure proper event reconstruction.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
