### PR TITLE
Adding index to openstack_staging_event table 

### DIFF
--- a/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
@@ -88,7 +88,7 @@
             },
             {
                 "name": "volume_id",
-                "type": "varchar(11)",
+                "type": "varchar(64)",
                 "nullable": true,
                 "default": null,
                 "comment": "Volume associated with the event."

--- a/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
@@ -88,7 +88,7 @@
             },
             {
                 "name": "volume_id",
-                "type": "varchar(64)",
+                "type": "int(11)",
                 "nullable": true,
                 "default": null,
                 "comment": "Volume associated with the event."
@@ -131,6 +131,13 @@
                 "name": "event_data",
                 "columns": [
                     "event_data"
+                ],
+                "is_unique": false
+            },
+            {
+                "name": "volume_id",
+                "columns": [
+                    "volume_id"
                 ],
                 "is_unique": false
             }

--- a/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
@@ -88,7 +88,7 @@
             },
             {
                 "name": "volume_id",
-                "type": "int(11)",
+                "type": "varchar(11)",
                 "nullable": true,
                 "default": null,
                 "comment": "Volume associated with the event."


### PR DESCRIPTION
There is a query that gets the assets for an event in configuration/etl/etl_action_defs/cloud_openstack/event_assets.json that is running slow once you have a larger set of data. This query has a where query that uses the volume_id and adding an index on that column speeds up the query

## Motivation and Context
Slow queries are bad

## Tests performed
Tested in local docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
