### PR TITLE
update to 'working' email

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM       tas-tools-ext-01.ccr.xdmod.org/xdmod-centos7:open7.5.1-v4
+FROM       tas-tools-ext-01.ccr.xdmod.org/xdmod-centos7:open7.5.1-v5

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/input/create_users.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/input/create_users.json
@@ -6,7 +6,8 @@
         "cd": [1],
         "usr": []
       },
-      "long_name": "Auk, Great"
+      "long_name": "Auk, Great",
+      "output": "create_user-cd.one-center"
     }
   ],
   [
@@ -16,7 +17,8 @@
         "cs": [1],
         "usr": []
       },
-      "long_name": "Auk, Little"
+      "long_name": "Auk, Little",
+      "output": "create_user-cs.one-center"
     }
   ],
   [
@@ -25,7 +27,8 @@
       "acls": {
         "pi": []
       },
-      "long_name": "Flycatcher, Taiga"
+      "long_name": "Flycatcher, Taiga",
+      "output": "create_user-pi"
     }
   ],
   [
@@ -34,7 +37,8 @@
       "acls": {
         "usr": []
       },
-      "long_name": "Honey-buzzard"
+      "long_name": "Honey-buzzard",
+      "output": "create_user-normal_user"
     }
   ],
   [
@@ -78,7 +82,8 @@
         "usr": [],
         "dev": []
       },
-      "long_name": "Honey-buzzard"
+      "long_name": "Honey-buzzard",
+      "output": "create_user-usr_dev"
     }
   ],
   [
@@ -88,7 +93,8 @@
         "usr": [],
         "mgr": []
       },
-      "long_name": "Honey-buzzard"
+      "long_name": "Honey-buzzard",
+      "output": "create_user-usr_mgr"
     }
   ],
   [
@@ -99,7 +105,8 @@
         "mgr": [],
         "dev": []
       },
-      "long_name": "Honey-buzzard"
+      "long_name": "Honey-buzzard",
+      "output": "create_user-usr_mgr_dev"
     }
   ]
 ]

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-cd.one-center.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-cd.one-center.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "User <b>test.cd.one-center</b> created successfully",
+  "user_type": "3"
+}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-cs.one-center.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-cs.one-center.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "User <b>test.cs.one-center</b> created successfully",
+  "user_type": "3"
+}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-normal_user.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-normal_user.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "User <b>test.normal-user</b> created successfully",
+  "user_type": "3"
+}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-pi.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-pi.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "User <b>test.pi</b> created successfully",
+  "user_type": "3"
+}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-usr_dev.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-usr_dev.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "User <b>test.usr_dev</b> created successfully",
+  "user_type": "3"
+}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-usr_mgr.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-usr_mgr.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "User <b>test.usr_mgr</b> created successfully",
+  "user_type": "3"
+}

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-usr_mgr_dev.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/output/create_user-usr_mgr_dev.json
@@ -1,0 +1,5 @@
+{
+  "success": true,
+  "message": "User <b>test.usr_mgr_dev</b> created successfully",
+  "user_type": "3"
+}


### PR DESCRIPTION
1. Delivers all mail to /var/mail/root 
1. Prevent invalid sendmail configuration from causing errors
1. Enable future testing of email send verification
```diff
diff --git a/docker/xdmod/Dockerfile b/docker/xdmod/Dockerfile
index f9d0044..2a5804d 100644
--- a/docker/xdmod/Dockerfile
+++ b/docker/xdmod/Dockerfile
@@ -26,12 +26,13 @@ RUN yum install -y \
     google-chrome-stable \
     nodejs \
     jq \
+    postfix \
     php-mbstring \
     https://github.com/ubccr/xdmod/releases/download/v$REL/xdmod-$REL-$BUILD.el7.noarch.rpm
 
 RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 RUN yum -y install git2u
-RUN yum -y remove ius-release
+RUN yum -y remove ius-release ssmtp
 RUN yum clean all
 RUN rm -rf /var/cache/yum
 
@@ -49,6 +50,15 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
 # Fix defaults
 RUN sed -i 's/.*date.timezone[[:space:]]*=.*/date.timezone = UTC/' /etc/php.ini
 RUN sed -i 's/.*memory_limit[[:space:]]*=.*/memory_limit = -1/' /etc/php.ini
+RUN sed -ie 's/inet_interfaces = localhost/#inet_interfaces = localhost/' /etc/postfix/main.cf
+RUN sed -ie 's/smtp      inet  n       -       n       -       -       smtpd/#smtp      inet  n       -       n       -       -       smtpd/' /etc/postfix/master.cf
+RUN sed -ie 's/smtp      unix  -       -       n       -       -       smtp/smtp      unix  -       -       n       -       -       local/' /etc/postfix/master.cf
+RUN sed -ie 's/relay     unix  -       -       n       -       -       smtp/relay     unix  -       -       n       -       -       local/' /etc/postfix/master.cf
+
+RUN echo '/.*/ root' >> /etc/postfix/virtual
+RUN postmap /etc/postfix/virtual
+RUN echo 'virtual_alias_maps = regexp:/etc/postfix/virtual' >> /etc/postfix/main.cf
+RUN newaliases
 
 # Start the webserver and database and populate it
 # note that we make sure to clean shutdown the database so the data are flushed properly

```