### PR TITLE
Add resource_id to where clause when updating end time for instance in post ingest

### DIFF
--- a/configuration/etl/etl_sql.d/cloud_eucalyptus/post_ingest_updates.sql
+++ b/configuration/etl/etl_sql.d/cloud_eucalyptus/post_ingest_updates.sql
@@ -11,6 +11,7 @@ AS
 SELECT
   instance_type_id,
   instance_type,
+  resource_id,
   IF ( @current_instance_type = instance_type AND @prev_start IS NOT NULL, @prev_start - INTERVAL 1 SECOND, NULL) AS end_time,
   @current_instance_type := instance_type AS junk1,
   @prev_start := start_time AS junk2
@@ -25,6 +26,8 @@ SET
   a.end_time = e.end_time
 WHERE
  a.instance_type_id = e.instance_type_id
+AND 
+ a.resource_id = e.resource_id
 //
 
 -- The UpdateIngestor does not yet support queries as source data. Update the accounts table with

--- a/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
+++ b/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
@@ -54,6 +54,7 @@ AS
 SELECT
   instance_type_id,
   instance_type,
+	resource_id,
   IF ( @current_instance_type = instance_type AND @prev_start IS NOT NULL, @prev_start - INTERVAL 1 SECOND, NULL) AS end_time,
   @current_instance_type := instance_type AS junk1,
   @prev_start := start_time AS junk2
@@ -68,6 +69,8 @@ SET
   a.end_time = e.end_time
 WHERE
  a.instance_type_id = e.instance_type_id
+AND
+ a.resource_id = e.resource_id
 //
 
 -- Truncate raw and staging tables once the data is no longer needed


### PR DESCRIPTION
Add resource_id to where clause when updating end time for instance in post ingest

## Motivation and Context
Adding the resource_id to the where clause makes sure that you are getting the correct instance and resource.

## Tests performed
Tested in local docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
