### PR TITLE
Ingest resource names from `resources.json`

### DIFF
--- a/configuration/etl/etl.d/staging.json
+++ b/configuration/etl/etl.d/staging.json
@@ -74,7 +74,7 @@
             }
         },
         {
-            "name": "resources",
+            "name": "resource-config",
             "description": "Ingest resource configuration file",
             "definition_file": "common/staging/resource-config.json",
             "endpoints": {
@@ -94,6 +94,13 @@
                     ]
                 }
             }
+        },
+        {
+            "class": "DatabaseIngestor",
+            "name": "resources",
+            "truncate_destination": false,
+            "description": "Ingest resource names from resource config",
+            "definition_file": "common/staging/resource.json"
         },
         {
             "name": "resource-specs",

--- a/configuration/etl/etl_action_defs.d/common/staging/resource.json
+++ b/configuration/etl/etl_action_defs.d/common/staging/resource.json
@@ -1,0 +1,21 @@
+{
+    "#": "Ingest resource names from resource config data.  This is needed for",
+    "#": "cloud resources since a primary key must be assigned to the resource",
+    "#": "before the data for that resource is ingested and the cloud data",
+    "#": "does not contain the name of the resource.",
+    "table_definition": {
+        "$ref": "${table_definition_dir}/common/staging/resource.json#/table_definition"
+    },
+    "source_query": {
+        "records": {
+            "resource_name": "DISTINCT rc.resource"
+        },
+        "joins": [
+            {
+                "schema": "${SOURCE_SCHEMA}",
+                "name": "staging_resource_config",
+                "alias": "rc"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Creates resource records for all resources in `resources.json` (even if they are not present in `mod_shredder.staging_resource`).  This assigns a primary key to the resource that is used throughout the ETL process.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Cloud resources don't include the resource name in their data.  Since the `resource_id` must be known before the data is inserted into the relevant tables this value must be present in `modw.resourcefact` before the cloud data is ingested.  These changes provide a mechanism to add records to `modw.resourcefact` when no other data for that resource exists in the database.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a record to `resources.json` and ran:

```
/usr/share/xdmod/tools/etl/etl_overseer.php \
    -a xdmod.staging-ingest-common.resource-config \
    -a xdmod.staging-ingest-common.resources \
    -a xdmod.hpcdb-ingest-common.resources \
    -a xdmod.hpcdb-xdw-ingest.resource
```

Then checked `modw.resourcefact`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
