### PR TITLE
Update xdmod setup tcl script

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_common.json
+++ b/configuration/etl/etl.d/jobs_cloud_common.json
@@ -131,7 +131,7 @@
         },
         {
             "name": "IngestResourceConfig",
-            "description": "Ingest resource configuration file",
+            "description": "Ingest resource configuration file. Modeled after action in staging-ingest-common.resource-config",
             "definition_file": "common/staging/resource-config.json",
             "class": "StructuredFileIngestor",
             "endpoints": {
@@ -162,7 +162,7 @@
             "class": "DatabaseIngestor",
             "name": "IngestResourcesStaging",
             "truncate_destination": false,
-            "description": "Ingest resource names from resource config",
+            "description": "Ingest resource names from staging table. Modeled after action in staging-ingest-common.resources",
             "definition_file": "common/staging/resource.json",
             "endpoints": {
                 "source": {
@@ -182,7 +182,7 @@
         {
             "class": "DatabaseIngestor",
             "name": "HpcdbIngestResources",
-            "description": "Ingest resources",
+            "description": "Ingest resources from staging table to table in modw_hpcdb. Modeled after action in hpcdb-ingest-common.resources",
             "definition_file": "common/hpcdb/resources.json",
             "endpoints": {
                 "source": {
@@ -203,7 +203,7 @@
             "class": "DatabaseIngestor",
             "name": "IngestResourcefact",
             "definition_file": "jobs/xdw/resource-fact.json",
-            "description": "resource records",
+            "description": "Ingest resource information into resourcefact table. Modeled after hpcdb-xdw-ingest.resource",
             "endpoints": {
                 "source": {
                     "type": "mysql",

--- a/configuration/etl/etl.d/jobs_cloud_common.json
+++ b/configuration/etl/etl.d/jobs_cloud_common.json
@@ -128,6 +128,98 @@
                     "path": "cloud_common/processor_buckets.json"
                 }
             }
+        },
+        {
+            "name": "IngestResourceConfig",
+            "description": "Ingest resource configuration file",
+            "definition_file": "common/staging/resource-config.json",
+            "class": "StructuredFileIngestor",
+            "endpoints": {
+                "source": {
+                    "type": "jsonfile",
+                    "name": "Resources configuration",
+                    "path": "${base_dir}/../resources.json",
+                    "record_schema_path": "common/resources.schema.json",
+                    "field_names": [
+                        "resource",
+                        "name",
+                        "description",
+                        "resource_type_id",
+                        "pi_column",
+                        "shared_jobs",
+                        "timezone"
+                    ]
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "Shredder/Staging Database",
+                    "config": "database",
+                    "schema": "mod_shredder"
+                }
+            }
+        },
+        {
+            "class": "DatabaseIngestor",
+            "name": "IngestResourcesStaging",
+            "truncate_destination": false,
+            "description": "Ingest resource names from resource config",
+            "definition_file": "common/staging/resource.json",
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "Shredder/Staging Database",
+                    "config": "database",
+                    "schema": "mod_shredder"
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "Shredder/Staging Database",
+                    "config": "database",
+                    "schema": "mod_shredder"
+                }
+            }
+        },
+        {
+            "class": "DatabaseIngestor",
+            "name": "HpcdbIngestResources",
+            "description": "Ingest resources",
+            "definition_file": "common/hpcdb/resources.json",
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "Shredder/Staging Database",
+                    "config": "database",
+                    "schema": "mod_shredder"
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "HPCDB Database",
+                    "config": "database",
+                    "schema": "mod_hpcdb"
+                }
+            }
+        },
+        {
+            "class": "DatabaseIngestor",
+            "name": "IngestResourcefact",
+            "definition_file": "jobs/xdw/resource-fact.json",
+            "description": "resource records",
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "HPCDB",
+                    "config": "datawarehouse",
+                    "schema": "mod_hpcdb",
+                    "create_schema_if_not_exists": true
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "Datawarehouse",
+                    "config": "datawarehouse",
+                    "schema": "modw",
+                    "create_schema_if_not_exists": true
+                }
+            }
         }
     ]
 }

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -28,7 +28,7 @@ then
     xdmod-import-csv -t names -i $REF_DIR/names.csv
     xdmod-ingestor
     php /root/bin/createusers.php
-    #Adding open stack resource since there is no way to automatically add a cloud resource.
+    #Updating minmaxdate table so data for cloud realm shows up
     mysql -e "UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
     #Ingesting cloud data from references folder
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-common
@@ -49,7 +49,7 @@ then
     FLUSH PRIVILEGES;"
     expect $BASEDIR/xdmod-upgrade.tcl | col -b
     expect $BASEDIR/xdmod-upgrade-add-cloud-resource.tcl | col -b
-    #Adding open stack resource since there is no way to automatically add a cloud resource.
+    #Updating minmaxdate table so data for cloud realm shows up
     mysql -e "UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
     #Ingesting cloud data from references folder
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-common

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -49,9 +49,6 @@ then
     FLUSH PRIVILEGES;"
     expect $BASEDIR/xdmod-upgrade.tcl | col -b
     expect $BASEDIR/xdmod-upgrade-add-cloud-resource.tcl | col -b
-    #Copying roles file so Cloud realm shows up
-    #mkdir -p /etc/xdmod/roles.d
-    #cp $BASEDIR/../../../../../templates/roles.d/cloud.json /etc/xdmod/roles.d/
     #Adding open stack resource since there is no way to automatically add a cloud resource.
     mysql -e "UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
     #Ingesting cloud data from references folder

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -28,12 +28,8 @@ then
     xdmod-import-csv -t names -i $REF_DIR/names.csv
     xdmod-ingestor
     php /root/bin/createusers.php
-    #Copying roles file so Cloud realm shows up
-    mkdir -p /etc/xdmod/roles.d
-    cp $BASEDIR/../../../../../templates/roles.d/cloud.json /etc/xdmod/roles.d/
     #Adding open stack resource since there is no way to automatically add a cloud resource.
-    mysql -e "INSERT INTO modw.resourcefact (resourcetype_id, organization_id, name, code, resource_origin_id) VALUES (1,1,'OpenStack', 'openstack', 6);
-    UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
+    mysql -e "UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
     #Ingesting cloud data from references folder
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-common
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-common
@@ -41,10 +37,6 @@ then
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-extract-openstack
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p cloud-state-pipeline
     acl-import
-    #Running acl pipelines to ensure the Cloud realm shows up
-    php /usr/share/xdmod/tools/etl/etl_overseer.php -p acls-xdmod-management
-    acl-config
-    php /usr/share/xdmod/tools/etl/etl_overseer.php -p acls-import
 fi
 
 if [ "$XDMOD_TEST_MODE" = "upgrade" ];
@@ -56,20 +48,16 @@ then
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'gateway' WITH GRANT OPTION;
     FLUSH PRIVILEGES;"
     expect $BASEDIR/xdmod-upgrade.tcl | col -b
+    expect $BASEDIR/xdmod-upgrade-add-cloud-resource.tcl | col -b
     #Copying roles file so Cloud realm shows up
-    mkdir -p /etc/xdmod/roles.d
-    cp $BASEDIR/../../../../../templates/roles.d/cloud.json /etc/xdmod/roles.d/
+    #mkdir -p /etc/xdmod/roles.d
+    #cp $BASEDIR/../../../../../templates/roles.d/cloud.json /etc/xdmod/roles.d/
     #Adding open stack resource since there is no way to automatically add a cloud resource.
-    mysql -e "INSERT INTO modw.resourcefact (resourcetype_id, organization_id, name, code, resource_origin_id) VALUES (1,1,'OpenStack', 'openstack', 6);
-    UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
+    mysql -e "UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
     #Ingesting cloud data from references folder
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-common
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-common
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack -d "CLOUD_EVENT_LOG_DIRECTORY=$REF_DIR/openstack"
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-extract-openstack
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p cloud-state-pipeline
-    #Running acl pipelines to ensure the Cloud realm shows up
-    php /usr/share/xdmod/tools/etl/etl_overseer.php -p acls-xdmod-management
-    acl-config
-    php /usr/share/xdmod/tools/etl/etl_overseer.php -p acls-import
 fi

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/helper-functions.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/helper-functions.tcl
@@ -1,0 +1,48 @@
+#-------------------------------------------------------------------------------
+# Helper functions
+
+proc selectMenuOption { option } {
+
+	expect {
+		-re "\nSelect an option .*: "
+	}
+	send $option\n
+}
+
+proc answerQuestion { question response } {
+	expect {
+		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+		-re "\n$question: \\\[.*\\\] "
+	}
+	send $response\n
+}
+
+proc provideInput { prompt response } {
+	expect {
+		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+		"\n$prompt "
+	}
+	send $response\n
+}
+
+proc providePassword { prompt password } {
+	provideInput $prompt $password
+	provideInput "(confirm) $prompt" $password
+
+}
+
+proc enterToContinue { } {
+	expect {
+		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+		"\nPress ENTER to continue. "
+	}
+	send \n
+}
+
+proc confirmFileWrite { response } {
+	expect {
+		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+		-re "\nOverwrite config file .*\\\[.*\\\] "
+	}
+	send $response\n
+}

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
@@ -12,54 +12,8 @@ lappend resources [list phillips Phillips 400 4000]
 lappend resources [list pozidriv Posidriv 400 4000]
 lappend resources [list robertson Robertson 400 4000]
 
-#-------------------------------------------------------------------------------
-# Helper functions
-
-proc selectMenuOption { option } {
-
-	expect {
-		-re "\nSelect an option .*: "
-	}
-	send $option\n
-}
-
-proc answerQuestion { question response } {
-	expect {
-		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
-		-re "\n$question: \\\[.*\\\] "
-	}
-	send $response\n
-}
-
-proc provideInput { prompt response } {
-	expect {
-		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
-		"\n$prompt "
-	}
-	send $response\n
-}
-
-proc providePassword { prompt password } {
-	provideInput $prompt $password
-	provideInput "(confirm) $prompt" $password
-
-}
-
-proc enterToContinue { } {
-	expect {
-		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
-		"\nPress ENTER to continue. "
-	}
-	send \n
-}
-
-proc confirmFileWrite { response } {
-	expect {
-		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
-		-re "\nOverwrite config file .*\\\[.*\\\] "
-	}
-	send $response\n
-}
+# Load helper functions from helper-functions.tcl
+source [file join [file dirname [info script]] helper-functions.tcl]
 
 #-------------------------------------------------------------------------------
 # main body - note there are some hardcoded addresses, usernames and passwords here

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
@@ -109,6 +109,14 @@ foreach resource $resources {
 	provideInput {How many nodes does this resource have?} [lindex $resource 2]
 	provideInput {How many total processors (cpu cores) does this resource have?} [lindex $resource 3]
 }
+
+selectMenuOption 1
+provideInput {Resource Name:} openstack
+provideInput {Formal Name:} OpenStack
+provideInput {Resource Type*} cloud
+provideInput {How many nodes does this resource have?} 123
+provideInput {How many total processors (cpu cores) does this resource have?} 234
+
 selectMenuOption s
 confirmFileWrite yes
 enterToContinue

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade-add-cloud-resource.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade-add-cloud-resource.tcl
@@ -2,42 +2,8 @@
 # Expect script that runs xdmod-upgrade to upgrade an already installed Open
 # XDMoD instance.
 
-#-------------------------------------------------------------------------------
-
-# Helper functions
-proc provideInput { prompt response } {
-	expect {
-		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
-		"\n$prompt "
-	}
-	send $response\n
-}
-
-proc selectMenuOption { option } {
-
-	expect {
-		-re "\nSelect an option .*: "
-	}
-	send $option\n
-}
-
-proc enterToContinue { } {
-	expect {
-		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
-		"\nPress ENTER to continue. "
-	}
-	send \n
-}
-
-proc confirmFileWrite { response } {
-	expect {
-		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
-		-re "\nOverwrite config file .*\\\[.*\\\] "
-	}
-	send $response\n
-}
-
-#-------------------------------------------------------------------------------
+# Load helper functions from helper-functions.tcl
+source [file join [file dirname [info script]] helper-functions.tcl]
 
 set timeout 10
 spawn "xdmod-setup"

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade-add-cloud-resource.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade-add-cloud-resource.tcl
@@ -1,0 +1,60 @@
+#!/usr/bin/env expect
+# Expect script that runs xdmod-upgrade to upgrade an already installed Open
+# XDMoD instance.
+
+#-------------------------------------------------------------------------------
+
+# Helper functions
+proc provideInput { prompt response } {
+	expect {
+		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+		"\n$prompt "
+	}
+	send $response\n
+}
+
+proc selectMenuOption { option } {
+
+	expect {
+		-re "\nSelect an option .*: "
+	}
+	send $option\n
+}
+
+proc enterToContinue { } {
+	expect {
+		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+		"\nPress ENTER to continue. "
+	}
+	send \n
+}
+
+proc confirmFileWrite { response } {
+	expect {
+		timeout { send_user "\nFailed to get prompt\n"; exit 1 }
+		-re "\nOverwrite config file .*\\\[.*\\\] "
+	}
+	send $response\n
+}
+
+#-------------------------------------------------------------------------------
+
+set timeout 10
+spawn "xdmod-setup"
+
+selectMenuOption 4
+selectMenuOption 1
+provideInput {Resource Name:} openstack
+provideInput {Formal Name:} OpenStack
+provideInput {Resource Type*} cloud
+provideInput {How many nodes does this resource have?} 123
+provideInput {How many total processors (cpu cores) does this resource have?} 234
+selectMenuOption s
+confirmFileWrite yes
+enterToContinue
+confirmFileWrite yes
+enterToContinue
+selectMenuOption q
+
+lassign [wait] pid spawnid os_error_flag value
+exit $value


### PR DESCRIPTION
Updating the xdmod-setup.tcl and adding xdmod-upgrade-add-cloud-resource.tcl file to programmatically create cloud resources for testing instead of manually add a resource to the database. Also adding etl actions to jobs-cloud-common.json to ingest resources from the resources.json config file.

## Description
In xdmod-setup.tcl a series of prompts were added so that a cloud resource can be added for testing the same way that regular HPC resources are added in that file. When the upgrade tests are run a file called xdmod-upgrade-add-cloud-resource.tcl was added to add a cloud resource for running the upgrade tests.

Once the resources are added in using the .tcl files they then need to be imported into the database. To do this 4 actions where added to the jobs-cloud-common.json file based off the information in #651 on which actions need to be run to import resources from the resources.json file.

## Tests performed
Tested in local docker manually and ran all component, integration and regression tests for both a fresh install and an upgrade

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
