### PR TITLE
Removing statement that truncates openstack_staging_event table

### DIFF
--- a/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
+++ b/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
@@ -78,5 +78,3 @@ AND
 TRUNCATE ${DESTINATION_SCHEMA}.openstack_raw_event;
 
 TRUNCATE ${DESTINATION_SCHEMA}.openstack_raw_instance_type;
-
-TRUNCATE ${DESTINATION_SCHEMA}.openstack_staging_event;


### PR DESCRIPTION
## Description
Removing sql statement that truncates modw_cloud.openstack_staging_event

## Motivation and Context
The modw_cloud.openstack_staging_event table is the source of uniqueness for the event_id values that are loaded in the event table. Since this table is truncated every time the jobs-cloud-extract-openstack the autoincrement key gets reset and the rows used to prevent duplicates being added are removed causing duplicate data to be loaded into he event table and be aggregated on. Removing the truncate table statement fixes this problem.

## Tests performed
Tested locally in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
