### PR TITLE
Bump up expect timeouts to account for slow acl-config program

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-setup.tcl
@@ -20,7 +20,7 @@ source [file join [file dirname [info script]] helper-functions.tcl]
 # they should typically not be changed as they need to match up with the
 # settings in the docker container
 
-set timeout 10
+set timeout 240
 spawn "xdmod-setup"
 
 selectMenuOption 1
@@ -42,11 +42,9 @@ answerQuestion {DB Admin Username} root
 providePassword {DB Admin Password:} {}
 confirmFileWrite yes
 enterToContinue
-set timeout 240
 provideInput {Do you want to see the output*} {no}
 provideInput {Do you want to see the output*} {no}
 provideInput {Do you want to see the output*} {no}
-set timeout 10
 
 selectMenuOption 3
 provideInput {Organization Name:} Screwdriver

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade-add-cloud-resource.tcl
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/xdmod-upgrade-add-cloud-resource.tcl
@@ -5,7 +5,7 @@
 # Load helper functions from helper-functions.tcl
 source [file join [file dirname [info script]] helper-functions.tcl]
 
-set timeout 10
+set timeout 240
 spawn "xdmod-setup"
 
 selectMenuOption 4


### PR DESCRIPTION
Longer timeouts needed to allow for acl-config to run. It takes ~40 seconds to run in the supremm module CI process. 

Also simplify timeout settings