### PR TITLE
Fix typo in Eucalyptus Cloud action

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_eucalyptus/staging_event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_eucalyptus/staging_event.json
@@ -59,7 +59,7 @@
                 "name": "host",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "h",
-                "on": "h.hostname = h.hostname = raw.hostname AND h.resource_id = raw.resource_id",
+                "on": "h.hostname = raw.hostname AND h.resource_id = raw.resource_id",
                 "type": "LEFT OUTER"
             },
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Fixes typo in join conditions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current action is producing error messages:

```
2018-09-11 05:41:33 [warning] Exception thrown by xdmod.jobs-cloud-eucalyptus.EucalyptusRawCloudVolumeIngestor (ETL\Ingestor\StructuredFileIngestor) but stop_on_execution=false, continuing
2018-09-11 05:41:44 [warning] SQL warnings on table '`modw_cloud`.`eucalyptus_staging_event`' generated by action xdmod.jobs-cloud-eucalyptus.EucalyptusCloudStagingEventIngestor
2018-09-11 05:41:44 [warning] Warning 1292 Truncated incorrect DOUBLE value: '172.17.0.31'
```

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
