### PR TITLE
Fix for user organization not populating

### DIFF
--- a/html/controllers/user_admin/enum_institutions.php
+++ b/html/controllers/user_admin/enum_institutions.php
@@ -6,7 +6,13 @@ $xda = new XDAdmin();
 
 $name_filter = (isset($_POST['query'])) ? $_POST['query'] : NULL;
 
-$institutions = $xda->enumerateInstitutions($name_filter);
+$query = $xda->enumerateInstitutions($name_filter);
+
+if (count($query) > 0) {
+    $institutions = $query;
+} else {
+    $institutions = $xda->enumerateInstitutions(null);
+}
 
 $returnData['status'] = 'success';
 $returnData['success'] = true;

--- a/html/controllers/user_admin/enum_institutions.php
+++ b/html/controllers/user_admin/enum_institutions.php
@@ -8,6 +8,8 @@ $name_filter = (isset($_POST['query'])) ? $_POST['query'] : NULL;
 
 $query = $xda->enumerateInstitutions($name_filter);
 
+// If there were records found based on the free-form `query` parameter -> organization name then go
+// ahead and return them. If not, then by default retrieve / return the full list of organizations.
 if (count($query) > 0) {
     $institutions = $query;
 } else {


### PR DESCRIPTION
## Description
Per testing by @plessbd. When initializing more than one new user account from
requests, unless the user's 'Organization' was found by name in the db, then
when a person was selected to map the new user to the organization id would be
displayed not the organization name. The steps to re-produce are:

  - Start with at least 2 user account requests
  - Select the first user account request
  - Click 'Initialize New User Dialog'
  - Assign a Person to this User.
  - click 'cancel'
  - Select the next user account request
  - Click 'Initialize New User Dialog'
  - Assign a Person to this User.
  - Notice that the 'Institution' box displays a number instead of a name.

The reason this was occurring is that the data store used to populate the
Institution drop down was only being refreshed ( without a filter ) the first
time the dialog opened. Each time after that it was being filtered with the
organization value from the account request. So, when a Person would be chosen
to map the user to, the code would attempt to automatically set the Institution
value ( via id ). but, because the data had been pre-filtered there would be no associated
value and it would default to displaying the numeric id instead.

This change makes `enum_institutions` a little smarter in that if no filtered
records are found it instead retrieves / returns all the organizations.

**NOTE:** The controller that is being updated is only used by one component `InstitutionDropDown.js`.

## Motivation and Context
We should be able to handle more than one account request per page load.

## Tests performed
Manual Testing:
  - Start with at least 2 user account requests
  - Select the first user account request
  - Click 'Initialize New User Dialog'
  - Assign a Person to this User.
  - click 'cancel'
  - Select the next user account request
  - Click 'Initialize New User Dialog'
  - Assign a Person to this User.
  - Notice that the 'Institution' box displays a number instead of a name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
