### PR TITLE
Updating the person organization route to accept negative numbers

### DIFF
--- a/classes/Rest/Controllers/PersonControllerProvider.php
+++ b/classes/Rest/Controllers/PersonControllerProvider.php
@@ -27,7 +27,7 @@ class PersonControllerProvider extends BaseControllerProvider
 
         $controller
             ->get("$root/{id}/organization", "$class::getOrganizationForPerson")
-            ->assert('id', '\d+')
+            ->assert('id', '(-)?\d+')
             ->convert('id', "$conversions::toInt");
     }
 


### PR DESCRIPTION
## Description
Updated the person organization rest path to accept negative numbers

## Motivation and Context
We now have the Unknown Person who will always have an id of -1. To support the
lookup of this person's organization we need to update this route to accept
negative numbers.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
Manual Tests:
  - Create a new user and attempt to assign the 'Unknown User' Person to them.
  - Modify an existing user and attempt to assign the 'Unknown User' Person to them.
  - Initialize a user account request and attempt to assign the 'Unknown User' Person to them
  - Initialize a user account request and attempt to assign the 'Unknown User' Person to them

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
