### PR TITLE
Updating quickfilters to not automatically select for the Unknown Person

### DIFF
--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -879,6 +879,9 @@ class WarehouseControllerProvider extends BaseControllerProvider
             $mostPrivilegedRoleIdentifier = $user->getMostPrivilegedRole()->getIdentifier(true);
             foreach ($roles as $role) {
                 $roleIdentifier = $role->getIdentifier(true);
+
+                // the $personId !== -1 has been added so that people mapped ot the Unknown Person
+                // do not have their quick filters automatically set.
                 $isMostPrivilegedRole = ($roleIdentifier === $mostPrivilegedRoleIdentifier) && $personId !== -1;
 
                 $parameters = Parameters::getParameters($user, $role->getIdentifier());

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -874,11 +874,12 @@ class WarehouseControllerProvider extends BaseControllerProvider
 
         // Generate user-specific quick filters if logged in.
         if (!$user->isPublicUser()) {
+            $personId = (int)$user->getPersonID();
             $roles = $user->getAllRoles();
             $mostPrivilegedRoleIdentifier = $user->getMostPrivilegedRole()->getIdentifier(true);
             foreach ($roles as $role) {
                 $roleIdentifier = $role->getIdentifier(true);
-                $isMostPrivilegedRole = $roleIdentifier === $mostPrivilegedRoleIdentifier;
+                $isMostPrivilegedRole = ($roleIdentifier === $mostPrivilegedRoleIdentifier) && $personId !== -1;
 
                 $parameters = Parameters::getParameters($user, $role->getIdentifier());
                 foreach ($parameters as $dimensionId => $valueId) {

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -880,7 +880,7 @@ class WarehouseControllerProvider extends BaseControllerProvider
             foreach ($roles as $role) {
                 $roleIdentifier = $role->getIdentifier(true);
 
-                // the $personId !== -1 has been added so that people mapped ot the Unknown Person
+                // the $personId !== -1 has been added so that people mapped to the Unknown Person
                 // do not have their quick filters automatically set.
                 $isMostPrivilegedRole = ($roleIdentifier === $mostPrivilegedRoleIdentifier) && $personId !== -1;
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the mostPrivilegedRole check to include a test for `$user->getPersonId() !== -1`. The mostPrivilegedRole property is what controls the automatic setting of quick filters on the front end.

## Motivation and Context
If the user is assigned to the Unknown Person than the person filter will
not be automatically selected.

## Tests performed
Manual Tests
  - Create / find a user that's associated with the Uknown person.
  - Log in as the user and ensure that there are no quick filters automatically selected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
