### PR TITLE
adding correct schema file for ingesting eucalyptus raw volume information

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_eucalyptus.json
+++ b/configuration/etl/etl.d/jobs_cloud_eucalyptus.json
@@ -102,7 +102,7 @@
                     "handler": {
                         "type": "jsonfile",
                         "record_separator": "\n",
-                        "record_schema_path": "cloud/event.schema.json",
+                        "record_schema_path": "cloud/volume.schema.json",
                         "#": "Return one record for each element in the block_devices array.",
                         "#": ".block_devices[] returns a result for each block_device array element",
                         "#": "so use this to create one object per element and then move the keys",

--- a/configuration/etl/etl_schemas.d/cloud/volume.schema.json
+++ b/configuration/etl/etl_schemas.d/cloud/volume.schema.json
@@ -1,0 +1,45 @@
+{
+    "type": "object",
+    "description": "Cloud Accounting Record",
+    "properties": {
+        "instance_id": {
+            "type": [ "string", "null" ]
+        },
+        "account_number": {
+            "type": [ "string", "null" ]
+        },
+        "event_time": {
+            "type": "string",
+            "format": "full-date",
+            "description": "Instance requested start time in RFC-3339 format (YYYY-MM-DDTHH:mm:ssZ)"
+        },
+        "account": {
+            "type": "string",
+            "description": "Account the instance was run under."
+        },
+        "backing": {
+            "type": "string",
+            "enum": [
+                "ebs",
+                "instance-store"
+            ]
+        },
+        "create_time": {
+            "type": "string",
+            "format": "full-date",
+            "description": "Disk creation time in RFC-3339 format (YYYY-MM-DDTHH:mm:ssZ)"
+        },
+        "user": {
+            "type": "string",
+            "description": "Name of user volume belongs to"
+        },
+        "id": {
+            "type": "string",
+            "description": "Volume Identifier"
+        },
+        "size": {
+            "type": "string",
+            "description": "Size in MB"
+        }
+    }
+}


### PR DESCRIPTION
The EucalyptusRawCloudVolumeIngestor action was using event.schema.json as it's schema file when ingesting eucalyptus volume information. This schema did not match he json being ingested in EucalyptusRawCloudVolumeIngestor and was causing errors. This schema should only be used for EucalyptusRawCloudEventLogIngestor. For EucalyptusRawCloudVolumeIngestor a  new schema was created to match the json being ingested

## Motivation and Context
Using the wrong schema file was preventing eucalyptus volume information from being ingested.

## Tests performed
Tested in local docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
