### PR TITLE
Update user emails to address by name.

### DIFF
--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -61,7 +61,7 @@ EML;
 
     const USER_EMAIL_BODY = <<<EML
 
-Greetings,
+Dear %s,
 
 This email is notify you that XDMoD was unable to determine which organization to associate you with.
 Administrative Users have been notified that additional setup will be required. You may not have full
@@ -366,7 +366,7 @@ EML;
                 '',
                 $senderEmail,
                 self::USER_EMAIL_SUBJECT,
-                self::USER_EMAIL_BODY
+                sprintf(self::USER_EMAIL_BODY, $user->getFormalName())
             );
         } elseif (empty($userEmail)) {
             $title = 'Unable to determine email address for new SSO User.';

--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -232,9 +232,7 @@ EML;
         } catch (Exception $e) {
             $this->notify(
                 $techSupportRecipient,
-                $techSupportRecipient,
-                '',
-                $techSupportRecipient,
+                null,
                 'Error retrieving XDMoD configuration property "force_default_organization" form portal_settings.ini',
                 $e->getMessage()
             );
@@ -312,7 +310,6 @@ EML;
     private function handleNotifications(XDUser $user, $samlAttributes, $linked)
     {
         $techSupportRecipient = \xd_utilities\getConfiguration('general', 'tech_support_recipient');
-        $senderEmail = \xd_utilities\getConfiguration('mailer', 'sender_email');
 
         $userEmail = $user->getEmailAddress()
             ? $user->getEmailAddress()
@@ -327,9 +324,7 @@ EML;
         } catch (Exception $e) {
             $this->notify(
                 $techSupportRecipient,
-                $techSupportRecipient,
-                '',
-                $techSupportRecipient,
+                null,
                 'Error retrieving XDMoD configuration property "email_admin_sso_unknown_org" form portal_settings.ini',
                 $e->getMessage()
             );
@@ -353,9 +348,7 @@ EML;
 
             $this->notify(
                 $techSupportRecipient,
-                $techSupportRecipient,
-                '',
-                $senderEmail,
+                null,
                 $subject,
                 $emailBody
             );
@@ -363,8 +356,6 @@ EML;
             $this->notify(
                 $userEmail,
                 $techSupportRecipient,
-                '',
-                $senderEmail,
                 self::USER_EMAIL_SUBJECT,
                 sprintf(self::USER_EMAIL_BODY, $user->getFormalName())
             );
@@ -386,19 +377,18 @@ EML;
      *
      * @throws Exception if there is a problem sending the notification email.
      */
-    public function notify($toAddress, $fromAddress, $fromName, $replyAddress, $subject, $body)
+    public function notify($toAddress, $replyAddress, $subject, $body)
     {
+        $settings = array(
+            'subject' => $subject,
+            'body' => $body,
+            'toAddress' => $toAddress
+        );
+        if ($replyAddress !== null) {
+            $settings['replyAddress'] = $replyAddress;
+        }
         try {
-            MailWrapper::sendMail(
-                array(
-                    'subject' => $subject,
-                    'body' => $body,
-                    'toAddress' => $toAddress,
-                    'fromAddress' => $fromAddress,
-                    'fromName' => $fromName,
-                    'replyAddress' => $replyAddress
-                )
-            );
+            MailWrapper::sendMail($settings);
         } catch (Exception $e) {
             // log the exception so we have some persistent visibility into the problem.
             $errorMsgFormat = "[%s] %s\n%s";

--- a/classes/Rest/Controllers/AuthenticationControllerProvider.php
+++ b/classes/Rest/Controllers/AuthenticationControllerProvider.php
@@ -40,7 +40,7 @@ EML;
 
     const USER_NOTIFICATION_EMAIL = <<<EML
 
-Greetings,
+Dear %s,
 
 This email is to notify you that XDMoD has detected a change in your organization affiliation. We
 have taken steps to ensure that this is accurately reflected in our systems. If you have any questions
@@ -246,6 +246,7 @@ TXT;
                         'subject' => 'XDMoD User: Organization Update',
                         'body' => sprintf(
                             self::USER_NOTIFICATION_EMAIL,
+                            $user->getFormalName(),
                             \xd_utilities\getConfiguration('mailer', 'sender_email')
                         ),
                         'toAddress' => $user->getEmailAddress(),

--- a/classes/Rest/Controllers/AuthenticationControllerProvider.php
+++ b/classes/Rest/Controllers/AuthenticationControllerProvider.php
@@ -247,12 +247,10 @@ TXT;
                         'body' => sprintf(
                             self::USER_NOTIFICATION_EMAIL,
                             $user->getFormalName(),
-                            \xd_utilities\getConfiguration('mailer', 'sender_email')
+                            \xd_utilities\getConfiguration('general', 'tech_support_recipient')
                         ),
                         'toAddress' => $user->getEmailAddress(),
-                        'fromAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
-                        'fromName' => '',
-                        'replyAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email')
+                        'replyAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient')
                     )
                 );
             } catch (\Exception $e) {


### PR DESCRIPTION
The use of the word "Greetings" to start notification emails increases
the spam filtering score and makes it look like a phishing email. It
also, to my mind is a bit unprofessional. This changes it to address the
user directly with their name.

The 'greetings' also reminds me of the catchphrase of the Joey character from the mid 80s
sitcom Bread. https://www.youtube.com/watch?v=GSGWnzzRgT0
