### PR TITLE
Disable storage "Group By None" default trend line

### DIFF
--- a/classes/DataWarehouse/Query/Storage/GroupBys/GroupByNone.php
+++ b/classes/DataWarehouse/Query/Storage/GroupBys/GroupByNone.php
@@ -45,11 +45,6 @@ class GroupByNone extends GroupBy
         return 'stack';
     }
 
-    public function getDefaultShowTrendLine()
-    {
-        return 'y';
-    }
-
     public function addOrder(
         Query &$query,
         $multiGroup = false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Disables the trend line displayed by default on the storage summary charts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These trend lines were not consistent with defaults for other realms.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually on development server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
