### PR TITLE
Added Locale Specific Password Expiration Times in Forgot Password Email

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2978,7 +2978,8 @@ SQL;
         $userSecret = $this->_password;
 
         if ($expiration === null) {
-            $expiration = time() + $expiresIn;
+            // set default expiration time of 10 minutes if we don't get one from configuration
+            $expiration = !empty($expiresIn) && is_numeric($expiresIn) ? time() + $expiresIn : time() + 600;
         }
 
         $hash = hash_hmac("sha256", "$userId $expiration $userSecret", $appSecret);

--- a/email_templates/password_reset.template
+++ b/email_templates/password_reset.template
@@ -6,6 +6,8 @@ To reset your password, please navigate to the following link:
 
     [:reset_url:]
 
+This link will expire at: [:expiration:].
+
 (Please note that once you update your password, the above link will no
 longer be valid)
 

--- a/html/controllers/user_admin/pass_reset.php
+++ b/html/controllers/user_admin/pass_reset.php
@@ -45,6 +45,7 @@ try {
             'first_name'           => $user_to_email->getFirstName(),
             'username'             => $userName,
             'reset_url'            => $resetUrl,
+            'expiration'           => strftime("%c %Z", explode('|', $rid)[1]),
             'maintainer_signature' => MailWrapper::getMaintainerSignature(),
             'subject'              => "$page_title: Password Reset",
             'toAddress'            => $user_to_email->getEmailAddress()

--- a/html/controllers/user_auth/pass_reset.php
+++ b/html/controllers/user_auth/pass_reset.php
@@ -46,6 +46,7 @@ try {
             'first_name'           => $user_to_email->getFirstName(),
             'username'             => $user_to_email->getUsername(),
             'reset_url'            => $resetUrl,
+            'expiration'           => strftime("%c %Z", explode('|', $rid)[1]),
             'maintainer_signature' => MailWrapper::getMaintainerSignature(),
             'subject'              => "$page_title: Password Reset",
             'toAddress'            => $user_to_email->getEmailAddress()


### PR DESCRIPTION
… template.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Addresses one of my gripes in Asana about our forgot password emails not explicitly stating when the reset link expires.

## Motivation and Context
Minimizes support questions, user friendliness.

## Tests performed
Sent a bunch of emails to myself in Docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
