### PR TITLE
Updating who is notified when SSO unknown org occurs

### DIFF
--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -50,7 +50,6 @@ multiple_service_providers = "off"
 
 [sso]
 force_default_organization = "on"
-email_admin_sso_unknown_org = "on"
 
 [internal]
 dw_desc_cache = "off"

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -89,8 +89,6 @@ To get a better idea of how these properties translate into expected behavior du
 | force_default_organization | off | true                    | false        | The user is associated with the SAML Organization if found, else the Unknown organization|
 | force_default_organization | off | false                   | true         | The user is associated with the Persons organization if found, else the Unknown organization|
 | force_default_organization | off | false                   | false        | The user is associated with the Unknown organization|
-| email_admin_sso_unknown_org| on  | *                       | *            | If an organization cannot be identified with the provided information then the admins will be notified|
-
 
 Here is an example `authsources.php` file:
 

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -73,7 +73,7 @@ Conditionally, if your installation supports multiple organizations then you mus
 *    `organization`
      * This will be used to identify which Organization the user should be associated with via the `modw.organization.name` column
 
-There are two configuration properties in `portal_settings.ini` that support and interact with this SAML property.
+There is one property in `portal_settings.ini` that supports and interacts with this SAML property.
 *    `force_default_organization`: `on`|`off`
      * Controls how Organization association is handled when new SSO users log in to XDMoD.
 

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -76,8 +76,6 @@ Conditionally, if your installation supports multiple organizations then you mus
 There are two configuration properties in `portal_settings.ini` that support and interact with this SAML property.
 *    `force_default_organization`: `on`|`off`
      * Controls how Organization association is handled when new SSO users log in to XDMoD.
-*    `email_admin_sso_unknown_org` : `on`|`off`
-     * Controls whether or not XDMoD Admins are emailed when the system is unable to determine which organization to associate with a new SSO User.
 
 To get a better idea of how these properties translate into expected behavior during SSO login. Please refer to the table below:
 

--- a/templates/portal_settings.template
+++ b/templates/portal_settings.template
@@ -50,7 +50,6 @@ multiple_service_providers = "off"
 
 [sso]
 force_default_organization = "on"
-email_admin_sso_unknown_org = "on"
 
 [internal]
 dw_desc_cache = "off"


### PR DESCRIPTION
## Description
- We are no longer notifying the user when we are unable to identify which
  organization they are associated with.
- We are now **always** notifying the admin when we assign a user the unknown
  organization.
  - Since we're always notifying the admin we no longer need the
  `email_admin_sso_unknown_org` property.

## Motivation and Context
We should make sure to only notify the people who can do something about a particular situation. 

## Tests performed
Manual Tests were performed: 
- Sign in via SSO with:
  - A User that has an organization that will not be identified
- Check that an email was sent correctly to the admin address

- Sign in via SSO with:
  - A User that has an organization that will be identified
  - Check that no email was sent

- Sign in via SSO with:
  - A User that will be matched with a valid person 
  - Check that no email was sent.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
