### PR TITLE
Update sso user retrieval

### DIFF
--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -31,13 +31,6 @@ class XDSamlAuthentication
      */
     protected $_isConfigured = false;
 
-    /**
-     * Whether or not we allow Single Sign On users local access. Defaults to true.
-     *
-     * @var boolean
-     */
-    protected $_allowLocalAccessViaSSO = true;
-
     const BASE_ADMIN_EMAIL = <<<EML
 
 Person Details -----------------------------------
@@ -72,10 +65,6 @@ EML;
         );
 
         $this->_sources = \SimpleSAML_Auth_Source::getSources();
-        try {
-            $this->_allowLocalAccessViaSSO = strtolower(\xd_utilities\getConfiguration('authentication', 'allowLocalAccessViaFederation')) === "false" ? false : true;
-        } catch (Exception $e) {
-        }
         if ($this->isSamlConfigured()) {
             try {
                 $authSource = \xd_utilities\getConfiguration('authentication', 'source');

--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -161,9 +161,7 @@ EML;
     }
 
     /**
-     * Retrieves the organization_id that this User should be associated with. There is one
-     * configuration property that affects the return value of this function,
-     * `force_default_organization`. It does so in the following ways:
+     * Retrieves the organization_id that this User should be associated with.
      *
      * - If we were able to identify which `person` this user should be associated with
      *   - then look up which organization they are associated via the `modw.person.id` column.

--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -110,72 +110,65 @@ EML;
     public function getXdmodAccount()
     {
         $samlAttrs = $this->_as->getAttributes();
-        if (!isset($samlAttrs["username"])) {
-            $thisUserName = null;
-        } else {
-            $thisUserName = !empty($samlAttrs['username'][0]) ? $samlAttrs['username'][0] : null;
-        }
-        if (!isset($samlAttrs["system_username"])) {
-            $thisSystemUserName = $thisUserName;
-        } else {
-            $thisSystemUserName = !empty($samlAttrs['system_username'][0]) ? $samlAttrs['system_username'][0] : null;
-        }
-        if ($this->_as->isAuthenticated() && !empty($thisUserName)) {
-            $xdmodUserId = \XDUser::userExistsWithUsername($thisUserName);
-            if ($xdmodUserId !== INVALID) {
-                return \XDUser::getUserByID($xdmodUserId);
-            } elseif ($this->_allowLocalAccessViaSSO && isset($samlAttrs['email_address'])) {
-                $xdmodUserId = \XDUser::userExistsWithEmailAddress($samlAttrs['email_address'][0]);
-                if ($xdmodUserId === AMBIGUOUS) {
-                    return "AMBIGUOUS";
-                }
-                if ($xdmodUserId !== INVALID) {
-                    return \XDUser::getUserByID($xdmodUserId);
-                }
-            }
-            $emailAddress = !empty($samlAttrs['email_address'][0]) ? $samlAttrs['email_address'][0] : NO_EMAIL_ADDRESS_SET;
-            $personId = \DataWarehouse::getPersonIdFromPII($thisSystemUserName, $samlAttrs['organization']);
 
+        if ($this->_as->isAuthenticated()) {
+            $userName = $samlAttrs['username'][0];
+
+            $xdmodUserId = \XDUser::userExistsWithUsername($userName);
+
+            if ($xdmodUserId !== INVALID) {
+                $user = \XDUser::getUserByID($xdmodUserId);
+                $user->setSSOAttrs($samlAttrs);
+                return $user;
+            }
+
+            // If we've gotten this far then we're creating a new user. Proceed with gathering the
+            // information we'll need to do so.
+            $emailAddress = isset($samlAttrs['email_address']) ? $samlAttrs['email_address'][0] : NO_EMAIL_ADDRESS_SET;
+            $systemUserName = isset($samlAttrs['system_username']) ? $samlAttrs['system_username'][0] : $userName;
+            $firstName = isset($samlAttrs['first_name']) ? $samlAttrs['first_name'][0] : 'UNKNOWN';
+            $middleName = isset($samlAttrs['middle_name']) ? $samlAttrs['middle_name'][0] : null;
+            $lastName = isset($samlAttrs['last_name']) ? $samlAttrs['last_name'][0] : null;
+            $personId = \DataWarehouse::getPersonIdFromPII($systemUserName, $samlAttrs['organization'][0]);
+
+            // Attempt to identify which organization this user should be associated with. Prefer
+            // using the personId if not unknown, then fall back to the saml attributes if the
+            // 'organization' property is present, and finally defaulting to the Unknown organization
+            // if none of the preceding conditions are met.
             $userOrganization = $this->getOrganizationId($samlAttrs, $personId);
 
-            if (!isset($samlAttrs["first_name"])) {
-                $samlAttrs["first_name"] = array("UNKNOWN");
-            }
-            if (!isset($samlAttrs["middle_name"])) {
-                $samlAttrs["middle_name"] = array(null);
-            }
-            if (!isset($samlAttrs["last_name"])) {
-                $samlAttrs["last_name"] = array("UNKNOWN");
-            }
             try {
                 $newUser = new \XDUser(
-                    $thisUserName,
+                    $userName,
                     null,
                     $emailAddress,
-                    $samlAttrs["first_name"][0],
-                    $samlAttrs["middle_name"][0],
-                    $samlAttrs["last_name"][0],
+                    $firstName,
+                    $middleName,
+                    $lastName,
                     array(ROLE_ID_USER),
                     ROLE_ID_USER,
                     $userOrganization,
-                    $personId
+                    $personId,
+                    $samlAttrs
                 );
             } catch (Exception $e) {
-                return "EXISTS";
+                throw new Exception('An account is currently configured with this information, please contact an administrator.');
             }
+
             $newUser->setUserType(SSO_USER_TYPE);
+
             try {
                 $newUser->saveUser();
             } catch (Exception $e) {
                 $this->logger->err('User creation failed: ' . $e->getMessage());
-                return false;
+                throw $e;
             }
 
             $this->handleNotifications($newUser, $samlAttrs, ($personId != UNKNOWN_USER_TYPE));
 
             return $newUser;
         }
-        return false;
+        throw new Exception('An unknown error has occurred.');
     }
 
     /**
@@ -183,25 +176,15 @@ EML;
      * configuration property that affects the return value of this function,
      * `force_default_organization`. It does so in the following ways:
      *
-     * - If the `force_default_organization` property in `portal_settings.ini` === 'on'
-     *   - Then the users organization is determined by the run time constant
-     *     `ORGANIZATION_NAME` ( which is derived from the `organization.json` configuration
-     *     file. ) This value will be used to find a corresponding record in the
-     *     `modw.organization` table via the `name` column.
+     * - If we were able to identify which `person` this user should be associated with
+     *   - then look up which organization they are associated via the `modw.person.id` column.
      * - If SAML has been provided with an `organization` property.
      *   - Then the users organization will be determined by attempting to find a record in
      *     the `modw.organization` table that has a `name` column that matches the provided
-     *     value.
-     *   - If unable to identify an organization in the previous step and a personId has been
-     *     supplied, attempt to retrieve the organization_id for this person via the
-     *     `modw.person.id` column.
-     * - If we were able to identify which `person` this user should be associated with
-     *   - then look up which organization they are associated via the `modw.person.id` column.
+     *     value. If no records are found then the 'Unknown' organization ( -1 ) is returned.
      * - and finally, if none of the other conditions are satisfied, return the Unknown organization
      *   ( i.e. -1 )
      *
-     * The default setting for an OpenXDMoD installation is:
-     *   - `force_default_organization="on"`
      * @param array $samlAttrs the saml attributes returned for this user
      * @param int   $personId  the id property for the Person this user has been associated with.
      * @return int the id of the organization that a new SSO user should be associated with.
@@ -209,25 +192,7 @@ EML;
      */
     public function getOrganizationId($samlAttrs, $personId)
     {
-        $techSupportRecipient = \xd_utilities\getConfiguration('general', 'tech_support_recipient');
-
-        $forceDefaultOrganization = null;
-        try {
-            $forceDefaultOrganization = \xd_utilities\getConfiguration('sso', 'force_default_organization') === 'on';
-        } catch (Exception $e) {
-            $this->notify(
-                $techSupportRecipient,
-                $techSupportRecipient,
-                '',
-                $techSupportRecipient,
-                'Error retrieving XDMoD configuration property "force_default_organization" form portal_settings.ini',
-                $e->getMessage()
-            );
-        }
-
-        if ($forceDefaultOrganization) {
-            return Organizations::getIdByName(ORGANIZATION_NAME);
-        } elseif ($personId !== -1 ) {
+        if ($personId !== -1 ) {
             return Organizations::getOrganizationIdForPerson($personId);
         } elseif(!empty($samlAttrs['organization'])) {
             return Organizations::getIdByName($samlAttrs['organization'][0]);

--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -168,7 +168,7 @@ EML;
 
             return $newUser;
         }
-        throw new Exception('An unknown error has occurred.');
+        throw new \DataWarehouse\Query\Exceptions\AccessDeniedException('Authentication failure.');
     }
 
     /**

--- a/classes/DataWarehouse.php
+++ b/classes/DataWarehouse.php
@@ -69,7 +69,7 @@ class DataWarehouse
      * @param string username
      * @return person_id or -1 if the person_id could not be determined
      */
-    public function getPersonIdFromPII($username, $organization) {
+    public static function getPersonIdFromPII($username, $organization) {
 
         $config = Config::factory();
         $query = $config['user_management']['person_mapping'];

--- a/classes/Models/Services/Organizations.php
+++ b/classes/Models/Services/Organizations.php
@@ -8,55 +8,6 @@ class Organizations
 {
 
     /**
-     * Retrieve the organization that the user identified by the $userId parameter is associated
-     * with.
-     *
-     * @param int $userId the id of the user for whom an associated organization ( if any ) is to be
-     *                    retrieved.
-     *
-     * @return int the id of the organization $userId is associated with. If one is not found then
-     *             -1 is returned.
-     *
-     * @throws \Exception if there is a problem retrieving a db connection.
-     * @throws \Exception if there is a problem executing sql statements.
-     */
-    public static function getOrganizationForUser($userId)
-    {
-        $sql = <<<SQL
-    SELECT src.organization_id
-    FROM (
-      SELECT user_org.*
-      FROM (
-      SELECT
-          u.organization_id,
-          2
-        FROM moddb.Users u
-        JOIN modw.organization o ON o.id = u.organization_id
-        WHERE u.id = :user_id
-        UNION
-        SELECT
-          o.id organization_id,
-          1
-        FROM moddb.Users u
-        JOIN modw.person p ON p.id = u.person_id
-        JOIN modw.organization o ON o.id = p.organization_id
-        WHERE u.id = :user_id
-      ) user_org
-      ORDER BY 2
-      LIMIT 1
-    ) src;
-SQL;
-        $db = DB::factory('database');
-
-        $rows = $db->query(
-            $sql,
-            array(':user_id' => $userId)
-        );
-
-        return count($rows) > 0 ? $rows[0]['organization_id'] : -1;
-    }
-
-    /**
      * Retrieve the name for the organization identified by the provided id.
      *
      * @param int $organizationId the id of the organization whose name is to be retrieved.

--- a/classes/Models/Services/Organizations.php
+++ b/classes/Models/Services/Organizations.php
@@ -94,7 +94,7 @@ SQL;
      * $organizationName.
      *
      * @param string $organizationName the name of the organization to retrieve.
-     * @return int|null null if no record is found else the organization_id as an int.
+     * @return int -1 if no record is found else the organization_id as an int.
      * @throws \Exception if there is a problem retrieving a db connection.
      * @throws \Exception if there is a problem executing the sql statement.
      */

--- a/classes/OpenXdmod/Migration/Version751To800/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version751To800/DatabasesMigration.php
@@ -21,6 +21,13 @@ class DatabasesMigration extends \OpenXdmod\Migration\DatabasesMigration
     {
         parent::execute();
 
+        // Ensure that the User table is updated.
+        $this->runEtl(
+            array(
+                'actions' => 'xdmod.xdb-bootstrap.xdb-table-create'
+            )
+        );
+
         $this->runEtl(
             array(
                 'process-sections' => array(

--- a/classes/Rest/Controllers/AuthenticationControllerProvider.php
+++ b/classes/Rest/Controllers/AuthenticationControllerProvider.php
@@ -22,58 +22,6 @@ use XDUser;
  */
 class AuthenticationControllerProvider extends BaseControllerProvider
 {
-    const ADMIN_NOTIFICATION_EMAIL = <<<EML
-
-User Organization Update --------------------------------
-Name:             %s
-Username:         %s
-E-Mail:           %s
-Old Organization: %s
-New Organization: %s
-EML;
-
-    const ACL_EMAIL_ADDITION = <<<EML
-Old Acls:         %s
-New Acls:         %s
-EML;
-
-
-    const USER_NOTIFICATION_EMAIL = <<<EML
-
-Dear %s,
-
-This email is to notify you that XDMoD has detected a change in your organization affiliation. We
-have taken steps to ensure that this is accurately reflected in our systems. If you have any questions
-or concerns please contact us @ %s.
-
-Thank You,
-
-XDMoD
-EML;
-
-    const EMAIL_EXCEPTION_MSG = <<<TXT
-
-There was an unexpected error while attempting to send an email.
-
-To:               %s
-Old Organization: %s
-New Organization: %s
-Original Acls:    %s
-New Acls:         %s
-
-Exception:
-  Code:           %s
-  Message:        %s
-  Stack Trace:
-    %s
-TXT;
-
-
-    private static $CENTER_ROLES = array('cd', 'cs');
-
-    private $emailLogger;
-
-    private $fileLogger;
 
     /**
      * AuthenticationControllerProvider constructor.
@@ -85,29 +33,6 @@ TXT;
     public function __construct(array $params = array())
     {
         parent::__construct($params);
-
-        $this->emailLogger = Log::factory(
-            'Authentication-email',
-            array(
-                'file' => false,
-                'db' => false,
-                'console' => false,
-                'mail' => true,
-                'emailTo' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
-                'emailFrom' => \xd_utilities\getConfiguration('mailer', 'sender_email'),
-                'emailSubject' => 'XDMoD SSO: Additional Actions Necessary'
-            )
-        );
-
-        $this->fileLogger = Log::factory(
-            'Authentication-exceptions-file',
-            array(
-                'file' => LOG_DIR . '/authentication-exceptions.log',
-                'db' => false,
-                'console' => false,
-                'mail' => false
-            )
-        );
     }
 
 
@@ -140,13 +65,11 @@ TXT;
     {
         $user = $this->authorize($request);
 
-        $token = \XDSessionManager::recordLogin($user);
-
-        $this->syncUserOrganization($user);
+        $user->postLogin();
 
         return $app->json(array(
             'success' => true,
-            'results' => array('token' => $token, 'name' => $user->getFormalName())
+            'results' => array('token' => $user->getSessionToken(), 'name' => $user->getFormalName())
         ));
     }
 
@@ -185,91 +108,5 @@ TXT;
         }
 
         return $app->json($redirectUrl);
-    }
-
-    /**
-     * Ensure that the provided user's organization is in sync with their person organization. If
-     * their organization has changed then remove any elevated organization related access and notify
-     * the user of the steps that have been taken. Also notify the admins so that they will have some
-     * visibility in to any additional steps that maybe required.
-     *
-     * @param XDUser $user
-     *
-     * @throws \Exception if there is a problem updating the provided users organization.
-     */
-    private function syncUserOrganization(XDUser $user)
-    {
-
-        $userProfileOrganization = $user->getOrganizationID();
-        $datawarehouseUserOrganization = Organizations::getOrganizationForUser($user->getUserID());
-
-        if ($userProfileOrganization !== $datawarehouseUserOrganization) {
-            $userOrganizationName = Organizations::getNameById($userProfileOrganization);
-            $currentOrganizationName = Organizations::getNameById($datawarehouseUserOrganization);
-
-            $originalAcls = $user->getAcls(true);
-
-            if (count(array_intersect($originalAcls, self::$CENTER_ROLES)) > 0) {
-
-                $otherAcls = array_diff($originalAcls, self::$CENTER_ROLES);
-
-                // Make sure that they at least have 'usr'
-                if (empty($otherAcls)) {
-                    $otherAcls = array('usr');
-                }
-
-                // Update the user w/ their new set of acls.
-                foreach($otherAcls as $aclName) {
-                    $acl = Acls::getAclByName($aclName);
-                    $user->addAcl($acl);
-                }
-
-                $this->emailLogger->notice(
-                    sprintf(
-                        self::ADMIN_NOTIFICATION_EMAIL . self::ACL_EMAIL_ADDITION,
-                        $user->getFormalName(),
-                        $user->getUsername(),
-                        $user->getEmailAddress(),
-                        $userOrganizationName,
-                        $currentOrganizationName,
-                        json_encode($originalAcls),
-                        json_encode($otherAcls)
-                    )
-                );
-            }
-
-            $user->setOrganizationId($datawarehouseUserOrganization);
-            $user->saveUser();
-            try {
-                MailWrapper::sendMail(
-                    array(
-                        'subject' => 'XDMoD User: Organization Update',
-                        'body' => sprintf(
-                            self::USER_NOTIFICATION_EMAIL,
-                            $user->getFormalName(),
-                            \xd_utilities\getConfiguration('mailer', 'sender_email')
-                        ),
-                        'toAddress' => $user->getEmailAddress(),
-                        'fromAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
-                        'fromName' => '',
-                        'replyAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email')
-                    )
-                );
-            } catch (\Exception $e) {
-                $this->fileLogger->err(
-                    sprintf(
-                        self::EMAIL_EXCEPTION_MSG,
-                        $user->getEmailAddress(),
-                        $userOrganizationName,
-                        $currentOrganizationName,
-                        json_encode($originalAcls),
-                        json_encode($otherAcls),
-                        $e->getCode(),
-                        $e->getMessage(),
-                        $e->getTraceAsString()
-                    )
-                );
-            }
-        }
     }
 }

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -4,8 +4,10 @@ require_once dirname(__FILE__) . '/../configuration/linker.php';
 
 use CCR\DB;
 use CCR\Log;
+use CCR\MailWrapper;
 use Models\Acl;
 use Models\Services\Acls;
+use Models\Services\Organizations;
 use User\aRole;
 use DataWarehouse\Query\Exceptions\AccessDeniedException;
 
@@ -74,6 +76,91 @@ class XDUser extends CCR\Loggable implements JsonSerializable
     const PUBLIC_USER = 1;
     const INTERNAL_USER = 2;
 
+    const ADMIN_NOTIFICATION_EMAIL = <<<EML
+
+User Organization Update --------------------------------
+Name:             %s
+Username:         %s
+E-Mail:           %s
+Old Organization: %s
+New Organization: %s
+EML;
+
+    const ACL_EMAIL_ADDITION = <<<EML
+Old Acls:         %s
+New Acls:         %s
+EML;
+
+
+    const USER_NOTIFICATION_EMAIL = <<<EML
+
+Dear %s,
+
+This email is to notify you that XDMoD has detected a change in your organization affiliation. We
+have taken steps to ensure that this is accurately reflected in our systems. If you have any questions
+or concerns please contact us @ %s.
+
+Thank You,
+
+XDMoD
+EML;
+
+    const EMAIL_EXCEPTION_MSG = <<<TXT
+
+There was an unexpected error while attempting to send an email.
+
+To:               %s
+Old Organization: %s
+New Organization: %s
+Original Acls:    %s
+New Acls:         %s
+
+Exception:
+  Code:           %s
+  Message:        %s
+  Stack Trace:
+    %s
+TXT;
+
+    /**
+     * The acls in OpenXDMoD that have a dependency on centers / organizations.
+     * NOTE: This should be pulled from a configuration file not hard coded. Explore in future
+     * commit.
+     *
+     * @var array
+     */
+    private static $CENTER_ACLS = array('cd', 'cs');
+
+    /**
+     * These are the only SSO attribtutes that should be included when setting `$this->ssoAttrs;`
+     *
+     * @var array
+     */
+    private static $INCLUDE_SSO_ATTRS = array('username', 'organization', 'system_username', 'email_address');
+
+    /**
+     * The attributes present when a user logs in via SSO. Defaults to an empty array otherwise.
+     *
+     * @var array
+     */
+    private $ssoAttrs;
+
+    /**
+     * The current session token for this user. Populated via XDSessionManager::recordLogin when
+     * XDUser::postLogin() is called.
+     *
+     * @var string
+     */
+    private $currentToken;
+
+    /**
+     * The state of this user's `sticky` bit. Corresponds to the moddb.Users.sticky column.
+     * Indicates that the organization_id and or the person_id has been manually overridden and
+     * should not be automatically updated.
+     *
+     * @var boolean
+     */
+    private $sticky;
     // ---------------------------
 
     /*
@@ -90,9 +177,19 @@ class XDUser extends CCR\Loggable implements JsonSerializable
      *
      */
 
-    function __construct($username = NULL, $password = NULL, $email_address = NO_EMAIL_ADDRESS_SET,
-        $first_name = NULL, $middle_name = NULL, $last_name = NULL,
-        $role_set = array(ROLE_ID_USER), $primary_role = ROLE_ID_USER, $organization_id = NULL, $person_id = NULL
+    function __construct(
+        $username = null,
+        $password = null,
+        $email_address = NO_EMAIL_ADDRESS_SET,
+        $first_name = null,
+        $middle_name = null,
+        $last_name = null,
+        $role_set = array(ROLE_ID_USER),
+        $primary_role = ROLE_ID_USER,
+        $organization_id = null,
+        $person_id = null,
+        array $ssoAttrs = array(),
+        $sticky = false
     ) {
 
         $this->_pdo = DB::factory('database');
@@ -164,6 +261,9 @@ class XDUser extends CCR\Loggable implements JsonSerializable
         // If you are explicitly calling 'new XDUser(...)', saveUser() must be called on the newly created XDUser object before accessing
         // these roles using getPrimaryRole() and getActiveRole()
         $this->_primary_role = $this->_active_role = \User\aRole::factory($primary_role_name);
+
+        $this->sticky = $sticky;
+
         parent::__construct(
             Log::factory(
                 'xduser.sql',
@@ -175,6 +275,8 @@ class XDUser extends CCR\Loggable implements JsonSerializable
                 )
             )
         );
+
+        $this->setSSOAttrs($ssoAttrs);
     }//construct
 
     // ---------------------------
@@ -432,7 +534,7 @@ class XDUser extends CCR\Loggable implements JsonSerializable
 
         $userCheck = $pdo->query("
          SELECT username, password, email_address, first_name, middle_name, last_name,
-         time_created, time_last_updated, password_last_updated, account_is_active, organization_id, person_id, field_of_science, token, user_type
+         time_created, time_last_updated, password_last_updated, account_is_active, organization_id, person_id, field_of_science, token, user_type, sticky
          FROM Users
          WHERE id=:id
       ", array(
@@ -477,6 +579,8 @@ class XDUser extends CCR\Loggable implements JsonSerializable
         // datatypes are not passed back unless using prepared statements so force to int
         // See: http://stackoverflow.com/questions/1197005/how-to-get-numeric-types-from-mysql-using-pdo
         $user->_user_type = (int)$userCheck[0]['user_type'];
+
+        $user->sticky = (bool)$userCheck[0]['sticky'];
 
         // We retrieve the most privileged acl for this user and use it for the
         // active / primary role.
@@ -777,13 +881,13 @@ SQL;
      */
     public function getUpdateQuery($updateToken = false, $includePassword = false)
     {
-        $result = 'UPDATE moddb.Users SET username = :username,  email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, user_type = :user_type WHERE id = :id';
+        $result = 'UPDATE moddb.Users SET username = :username,  email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, user_type = :user_type, sticky = :sticky WHERE id = :id';
         if ($updateToken && $includePassword) {
-            $result = 'UPDATE moddb.Users SET username = :username, password = :password, email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, token = :token, user_type = :user_type, password_last_updated = :password_last_updated WHERE id = :id';
+            $result = 'UPDATE moddb.Users SET username = :username, password = :password, email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, token = :token, user_type = :user_type, password_last_updated = :password_last_updated, sticky = :sticky WHERE id = :id';
         } else if (!$updateToken && $includePassword) {
-            $result = 'UPDATE moddb.Users SET username = :username, password = :password, email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, user_type = :user_type, password_last_updated = :password_last_updated WHERE id = :id';
+            $result = 'UPDATE moddb.Users SET username = :username, password = :password, email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, user_type = :user_type, password_last_updated = :password_last_updated, sticky = :sticky WHERE id = :id';
         } else if ($updateToken && !$includePassword) {
-            $result = 'UPDATE moddb.Users SET username = :usernam, email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, token = :token, user_type = :user_type WHERE id = :id';
+            $result = 'UPDATE moddb.Users SET username = :usernam, email_address = :email_address, first_name = :first_name, middle_name = :middle_name, last_name = :last_name, account_is_active = :account_is_active, person_id = :person_id, organization_id = :organization_id, field_of_science = :field_of_science, token = :token, user_type = :user_type, sticky = :sticky WHERE id = :id';
         }
         return $result;
     }
@@ -802,13 +906,13 @@ SQL;
      */
     public function getInsertQuery($updateToken = false, $includePassword = false)
     {
-        $result = 'INSERT INTO moddb.Users (username, email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, user_type) VALUES (:username, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :user_type)';
+        $result = 'INSERT INTO moddb.Users (username, email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, user_type, sticky) VALUES (:username, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :user_type, :sticky)';
         if ($updateToken && $includePassword) {
-            $result = 'INSERT INTO moddb.Users (username, password, password_last_updated, email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, token, user_type) VALUES (:username, :password, :password_last_updated, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :token, :user_type)';
+            $result = 'INSERT INTO moddb.Users (username, password, password_last_updated, email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, token, user_type, sticky) VALUES (:username, :password, :password_last_updated, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :token, :user_type, :sticky)';
         } else if (!$updateToken && $includePassword) {
-            $result = 'INSERT INTO moddb.Users (username, password, password_last_updated,  email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, user_type) VALUES (:username, :password, :password_last_updated, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :user_type)';
+            $result = 'INSERT INTO moddb.Users (username, password, password_last_updated,  email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, user_type, sticky) VALUES (:username, :password, :password_last_updated, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :user_type, :sticky)';
         } else if ($updateToken && !$includePassword) {
-            $result = 'INSERT INTO moddb.Users (username, email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, token, user_type) VALUES (:username, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :token, :user_type)';
+            $result = 'INSERT INTO moddb.Users (username, email_address, first_name, middle_name, last_name, account_is_active, person_id, organization_id, field_of_science, token, user_type, sticky) VALUES (:username, :email_address, :first_name, :middle_name, :last_name, :account_is_active, :person_id, :organization_id, :field_of_science, :token, :user_type, :sticky)';
         }
         return $result;
     }
@@ -923,6 +1027,8 @@ SQL;
             $this->_token = $update_data['token'];
         }
         $update_data['user_type'] = $this->_user_type;
+        $update_data['sticky'] = $this->sticky ? 1 : 0;
+
         /* END: Query Data Population */
         try {
             /* BEGIN: Construct the parameterized query */
@@ -3043,5 +3149,190 @@ SQL;
         }
 
         return $results;
+    }
+
+    /**
+     * Executes any actions that need to be conducted immediately after a user is logged into XDMoD.
+     *
+     * @throws Exception if there is a problem executing any of the required post logged in steps.
+     */
+    public function postLogin() {
+        if (!$this->isSticky()) {
+            $this->updatePerson();
+            $this->synchronizeOrganization();
+        }
+        $this->currentToken = XDSessionManager::recordLogin($this);
+    }
+
+    /**
+     * Attempts to synchronize this users organization. This will ensure that if the organization
+     * assigned to the user is not the same as the organization that should be assigned to the user
+     * ( i.e. the organization assigned to this users person has been updated ). They have their
+     * organization updated. If they have been associated with a 'center' related acl, center
+     * director or center staff, then they are to have these acls removed and an email notice sent
+     * to the admin / user notifying them that additional steps will need to be taken before their
+     * former level of access is restored.
+     *
+     * @throws Exception
+     */
+    public function synchronizeOrganization()
+    {
+        // This is pulled from the moddb.Users.organization_id column for this user record.
+        $actualOrganization = $this->getOrganizationID();
+
+        // Retrieve the organization associated with this users Person. This is the value we expect
+        // the user's organization to match.
+        $expectedOrganization = Organizations::getOrganizationIdForPerson($this->getPersonID());
+
+        // If we have ssoAttrs available and this user's person's organization is 'Unknown' ( -1 ).
+        // Then go ahead and lookup the organization value from sso.
+        if ($expectedOrganization == -1 && count($this->ssoAttrs) > 0) {
+            $expectedOrganization = Organizations::getIdByName($this->ssoAttrs['organization'][0]);
+        }
+
+        // If these don't match then the user's organization has been updated. Steps need to be taken.
+        if ($actualOrganization !== $expectedOrganization) {
+            $originalAcls = $this->getAcls(true);
+
+            // if the user is currently assigned an acl that interacts with XDMoD's centers ( i.e.
+            // center director, center staff etc. ) then we need to remove these acls and notify
+            // the admins that additional setup may be required for this user.
+            if (count(array_intersect($originalAcls, self::$CENTER_ACLS)) > 0) {
+                $otherAcls = array_values(array_diff($originalAcls, self::$CENTER_ACLS));
+
+                // Make sure that they at least have 'usr'
+                if (empty($otherAcls)) {
+                    $otherAcls = array('usr');
+                }
+
+                // Now we need to make sure that the user is only assigned their non-center acls so
+                // clear any existing acls they have.
+                $this->setAcls(array());
+
+                // Update the user w/ their new set of acls.
+                foreach($otherAcls as $aclName) {
+                    $acl = Acls::getAclByName($aclName);
+                    $this->addAcl($acl);
+                }
+
+                // Retrieving the names for display purposes.
+                $userOrganizationName = Organizations::getNameById($actualOrganization);
+                $currentOrganizationName = Organizations::getNameById($expectedOrganization);
+
+                // Notify the XDMoD Admin that a user has had their privileges altered due to an
+                // organization change so that they can take any further steps that may be required.
+                MailWrapper::sendMail(
+                    array(
+                        'subject' => 'XDMoD User: Organization Update',
+                        'body' => sprintf(
+                            self::ADMIN_NOTIFICATION_EMAIL . self::ACL_EMAIL_ADDITION,
+                            $this->getFormalName(),
+                            $this->getUsername(),
+                            $this->getEmailAddress(),
+                            $userOrganizationName,
+                            $currentOrganizationName,
+                            json_encode($originalAcls),
+                            json_encode($otherAcls)
+                        ),
+                        'toAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
+                        'fromAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email'),
+                        'fromName' => \xd_utilities\getConfiguration('mailer', 'sender_email'),
+                        'replyAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient')
+                    )
+                );
+            }
+
+            // Update / save the user with their new organization
+            $this->setOrganizationId($expectedOrganization);
+            $this->saveUser();
+
+            // Notify the user that there was an organization change detected.
+            MailWrapper::sendMail(
+                array(
+                    'subject' => 'XDMoD User: Organization Update',
+                    'body' => sprintf(
+                        self::USER_NOTIFICATION_EMAIL,
+                        $this->getFormalName(),
+                        \xd_utilities\getConfiguration('mailer', 'sender_email')
+                    ),
+                    'toAddress' => $this->getEmailAddress(),
+                    'fromAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
+                    'fromName' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
+                    'replyAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email')
+                )
+            );
+        }
+    }
+
+    /**
+     * Updates this Users Person / Organization if they are not currently assigned to the Unknown User && they there are
+     * ssoAttrs available ( logged in via SSO ). Also, if the person identified via ssoAttrs is not the Unknown User &&
+     * is different than the users curent Person.
+     *
+     */
+    public function updatePerson()
+    {
+        $currentPersonId = $this->getPersonID();
+        $hasSSO = count($this->ssoAttrs) > 0;
+
+        if ($currentPersonId == -1 && $hasSSO) {
+            $username = $this->ssoAttrs['username'][0];
+            $systemUserName = isset($this->ssoAttrs['system_username']) ? $this->ssoAttrs['system_username'][0] : $username;
+            $expectedPersonId = \DataWarehouse::getPersonIdFromPII($systemUserName, null);
+
+            // As long as the identified person is not Unknown and it is different than our current Person Id
+            // go ahead and update this user with the new person & that person's organization.
+            if ($expectedPersonId != -1 && $currentPersonId != $expectedPersonId) {
+                $organizationId = Organizations::getOrganizationIdForPerson($expectedPersonId);
+                $this->setPersonID($expectedPersonId);
+                $this->setOrganizationID($organizationId);
+
+                $this->saveUser();
+            }
+        }
+    }
+
+    public function setSSOAttrs($ssoAttrs)
+    {
+        $this->ssoAttrs = array_reduce(
+            array_intersect(self::$INCLUDE_SSO_ATTRS, array_keys($ssoAttrs)),
+            function ($carry, $key) use ($ssoAttrs) {
+                $carry[$key] = $ssoAttrs[$key];
+                return $carry;
+            },
+            array()
+        );
+    }
+
+    /**
+     * Retrieve this users current session token. This will only be populated if the user has had
+     * its `postLogin` function called.
+     *
+     * @return string
+     */
+    public function getSessionToken()
+    {
+        return $this->currentToken;
+    }
+
+    /**
+     * Set's the value of this user's `sticky` bit.
+     *
+     * @param $sticky
+     */
+    public function setSticky($sticky)
+    {
+        $this->sticky = $sticky;
+    }
+
+    /**
+     * Return's the value of this user's `sticky` bit. If true, then this user's person and or
+     * organization has been manually overridden, do not update unless via the admin interface.
+     *
+     * @return bool
+     */
+    public function isSticky()
+    {
+        return $this->sticky;
     }
 }//XDUser

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -84,13 +84,9 @@ Username:         %s
 E-Mail:           %s
 Old Organization: %s
 New Organization: %s
-EML;
-
-    const ACL_EMAIL_ADDITION = <<<EML
 Old Acls:         %s
 New Acls:         %s
 EML;
-
 
     const USER_NOTIFICATION_EMAIL = <<<EML
 
@@ -104,23 +100,6 @@ Thank You,
 
 XDMoD
 EML;
-
-    const EMAIL_EXCEPTION_MSG = <<<TXT
-
-There was an unexpected error while attempting to send an email.
-
-To:               %s
-Old Organization: %s
-New Organization: %s
-Original Acls:    %s
-New Acls:         %s
-
-Exception:
-  Code:           %s
-  Message:        %s
-  Stack Trace:
-    %s
-TXT;
 
     /**
      * The acls in OpenXDMoD that have a dependency on centers / organizations.
@@ -3225,7 +3204,7 @@ SQL;
                     array(
                         'subject' => 'XDMoD User: Organization Update',
                         'body' => sprintf(
-                            self::ADMIN_NOTIFICATION_EMAIL . self::ACL_EMAIL_ADDITION,
+                            self::ADMIN_NOTIFICATION_EMAIL,
                             $this->getFormalName(),
                             $this->getUsername(),
                             $this->getEmailAddress(),
@@ -3235,8 +3214,19 @@ SQL;
                             json_encode($otherAcls)
                         ),
                         'toAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
-                        'fromAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email'),
-                        'fromName' => \xd_utilities\getConfiguration('mailer', 'sender_email'),
+                    )
+                );
+
+                // Notify the user that there was an organization change detected.
+                MailWrapper::sendMail(
+                    array(
+                        'subject' => 'XDMoD User: Organization Update',
+                        'body' => sprintf(
+                            self::USER_NOTIFICATION_EMAIL,
+                            $this->getFormalName(),
+                            \xd_utilities\getConfiguration('mailer', 'sender_email')
+                        ),
+                        'toAddress' => $this->getEmailAddress(),
                         'replyAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient')
                     )
                 );
@@ -3245,22 +3235,6 @@ SQL;
             // Update / save the user with their new organization
             $this->setOrganizationId($expectedOrganization);
             $this->saveUser();
-
-            // Notify the user that there was an organization change detected.
-            MailWrapper::sendMail(
-                array(
-                    'subject' => 'XDMoD User: Organization Update',
-                    'body' => sprintf(
-                        self::USER_NOTIFICATION_EMAIL,
-                        $this->getFormalName(),
-                        \xd_utilities\getConfiguration('mailer', 'sender_email')
-                    ),
-                    'toAddress' => $this->getEmailAddress(),
-                    'fromAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
-                    'fromName' => \xd_utilities\getConfiguration('general', 'tech_support_recipient'),
-                    'replyAddress' => \xd_utilities\getConfiguration('mailer', 'sender_email')
-                )
-            );
         }
     }
 

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -3226,8 +3226,7 @@ SQL;
                             $this->getFormalName(),
                             \xd_utilities\getConfiguration('mailer', 'sender_email')
                         ),
-                        'toAddress' => $this->getEmailAddress(),
-                        'replyAddress' => \xd_utilities\getConfiguration('general', 'tech_support_recipient')
+                        'toAddress' => $this->getEmailAddress()
                     )
                 );
             }

--- a/configuration/etl/etl_tables.d/xdb/users.json
+++ b/configuration/etl/etl_tables.d/xdb/users.json
@@ -96,6 +96,13 @@
                 "name": "user_type",
                 "type": "int(11)",
                 "nullable": false
+            },
+            {
+                "name": "sticky",
+                "comment": "Set when an admin manually updates the [person|organization]_id. Indicates that further modification must be made manually by an admin.",
+                "type": "tinyint(1) unsigned",
+                "nullable": false,
+                "default": 0
             }
         ],
         "indexes": [

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -48,9 +48,6 @@ singlejobviewer = "off"
 ; set to 'off' in Open XDMoD until support has been added.
 multiple_service_providers = "off"
 
-[sso]
-force_default_organization = "on"
-
 [internal]
 dw_desc_cache = "off"
 

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -73,24 +73,16 @@ Conditionally, if your installation supports multiple organizations then you mus
 *    `organization`
      * This will be used to identify which Organization the user should be associated with via the `modw.organization.name` column
 
-There is one property in `portal_settings.ini` that supports and interacts with this SAML property.
-*    `force_default_organization`: `on`|`off`
-     * Controls how Organization association is handled when new SSO users log in to XDMoD.
-
 To get a better idea of how these properties translate into expected behavior during SSO login. Please refer to the table below:
 
-|Property Name               |Value|SAML Organization Present|Person Present|Expected Behavior |
-|:---------------------------|:---:|:-----------------------:|:------------:|:-----------------|
-| force_default_organization | on  | true                    | true         | The user is associated with the organization defined in `organization.json`|
-| force_default_organization | on  | true                    | false        | The user is associated with the organization defined in `organization.json`|
-| force_default_organization | on  | false                   | true         | The user is associated with the organization defined in `organization.json`|
-| force_default_organization | on  | false                   | false        | The user is associated with the organization defined in `organization.json`|
-| force_default_organization | off | true                    | true         | The user is associated with the the Person's organization if found, else the Unknown Organization|
-| force_default_organization | off | true                    | false        | The user is associated with the SAML Organization if found, else the Unknown organization|
-| force_default_organization | off | false                   | true         | The user is associated with the Persons organization if found, else the Unknown organization|
-| force_default_organization | off | false                   | false        | The user is associated with the Unknown organization|
+|SAML Organization Present|Person Present|Expected Behavior |
+|:-----------------------:|:------------:|:-----------------|
+| true                    | true         | The user is associated with the the Person's organization if found, else the SAML Organization if found, else the Unknown Organization|
+| true                    | false        | The user is associated with the SAML Organization if found, else the Unknown organization|
+| false                   | true         | The user is associated with the Persons organization if found, else the Unknown organization|
+| false                   | false        | The user is associated with the Unknown organization|
 
-Here is an example `authsources.php` file:
+Here is an example `authsources.php` file **note: keys 60 and 61 must be present** These check that the _mandatory_ username and organization properties are present.
 
 ```php
 <?php
@@ -116,6 +108,20 @@ $config = array(
         'orgId' => 'organization',
         'fieldOfScience' => 'field_of_science',
         'itname' => 'username'
+      ),
+      // Ensures that the 'username' property has one or more non-whitespace characters
+      60 => array(
+        'class' => 'authorize:Authorize',
+        'username' => array(
+          '/\S+/'
+        ),
+      ),
+      // Ensures that the 'organization' property has one or more non-whitespace characters
+      61 => array(
+        'class' => 'authorize:Authorize',
+        'organization' => array(
+           '/\S+/'
+        )
       )
     )
   ),

--- a/html/controllers/user_admin/get_user_details.php
+++ b/html/controllers/user_admin/get_user_details.php
@@ -49,6 +49,7 @@ use Models\Services\Acls;
    }	
 
 	$userDetails['is_active'] = $selected_user->getAccountStatus() ? 'active' : 'disabled' ;
+    $userDetails['sticky'] = $selected_user->isSticky();
 
     $acls = Acls::listUserAcls($selected_user);
     $populatedAcls = array_reduce(

--- a/html/controllers/user_admin/update_user.php
+++ b/html/controllers/user_admin/update_user.php
@@ -111,7 +111,7 @@ if (isset($_POST['user_type'])) {
 }
 
 if (isset($_POST['sticky'])) {
-    $user_to_update->setSticky($_POST['sticky'] === 'true' ? 1 : 0);
+    $user_to_update->setSticky($_POST['sticky'] === 'true');
 }
 
 // Store this users original set of acls before they are possibly modified below.

--- a/html/controllers/user_admin/update_user.php
+++ b/html/controllers/user_admin/update_user.php
@@ -110,6 +110,10 @@ if (isset($_POST['user_type'])) {
 
 }
 
+if (isset($_POST['sticky'])) {
+    $user_to_update->setSticky($_POST['sticky'] === 'true' ? 1 : 0);
+}
+
 // Store this users original set of acls before they are possibly modified below.
 $originalAcls = $user_to_update->getAcls(true);
 

--- a/html/internal_dashboard/controllers/pseudo_login.php
+++ b/html/internal_dashboard/controllers/pseudo_login.php
@@ -30,7 +30,7 @@
          exit;
       }
 
-      XDSessionManager::recordLogin($user);
+      $user->postLogin();
 
       $redirect_url = str_replace('internal_dashboard/controllers/pseudo_login.php', '', getAbsoluteURL());
    

--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -204,13 +204,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
             settingsAreDirty = true;
             saveIndicator.show();
 
-            // If the currently selected person is the Unknown person then make sure we
-            // enable the institution drop down for manual overrides.
-            if (cmbUserMapping.getValue() === '-1') {
-                cmbInstitution.setDisabled(false);
-            } else {
-                cmbInstitution.setDisabled(true);
-            }
+            stickyCheckbox.setValue(true);
             /* eslint-enable no-use-before-define */
         };
 
@@ -359,6 +353,11 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
         }, this, { single: true });
 
         // ------------------------------------------
+        var stickyCheckbox = new Ext.form.Checkbox({
+            boxLabel: 'Manually Overridden',
+            labelStyle: 'display: none; visible: none'
+        });
+
 
         var cmbInstitution = new CCR.xdmod.ui.InstitutionDropDown({
             fieldLabel: 'Institution',
@@ -369,7 +368,6 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
             allowBlank: false
         });
 
-        cmbInstitution.setDisabled(true);
 
         // ------------------------------------------
 
@@ -762,7 +760,8 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                 cmbUserType,
                 lblXSEDEUser,
                 cmbUserMapping,
-                cmbInstitution
+                cmbInstitution,
+                stickyCheckbox
             ]
         });
 
@@ -850,7 +849,8 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                         '-1' :
                         cmbUserMapping.getValue(),
                     institution: cmbInstitution.getValue(),
-                    user_type: userType
+                    user_type: userType,
+                    sticky: stickyCheckbox.getValue()
                 };
 
                 Ext.Ajax.request({
@@ -1142,9 +1142,6 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                         // We then disable / enable controls based on the information retrieved.
                         userSettings.setDisabled(false);
 
-                        // We disabled cmbInstitution because it's always disabled now.
-                        cmbInstitution.setDisabled(true);
-
                         userEditor.setTitle('User Details: ' + Ext.util.Format.htmlEncode(json.user_information.formal_name));
 
                         existingUserEmailField.setValue(json.user_information.email_address);
@@ -1170,15 +1167,8 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                             cmbUserType.setDisabled(false);
                             cmbUserType.setValue(cached_user_type);
                         }
-
+                        stickyCheckbox.setValue(Boolean(json.user_information.sticky));
                         cmbInstitution.initializeWithValue(json.user_information.institution, json.user_information.institution_name);
-
-                        // If the current person mapped is the Unknown person then make
-                        // sure to enable the institution drop down for manual override.
-                        // we don't need an else as it's already setDisabled(true) above.
-                        if (cmbUserMapping.getValue() === '-1') {
-                            cmbInstitution.setDisabled(false);
-                        }
 
                         /**
                          * acls are in the form:

--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -203,8 +203,11 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
             /* eslint-disable no-use-before-define */
             settingsAreDirty = true;
             saveIndicator.show();
-
-            stickyCheckbox.setValue(true);
+            if (cmbUserMapping.startValue !== cmbUserMapping.getValue() || cmbInstitution.startValue !== cmbInstitution.getValue()) {
+                stickyCheckbox.setValue(true);
+            } else {
+                stickyCheckbox.setValue(false);
+            }
             /* eslint-enable no-use-before-define */
         };
 
@@ -364,7 +367,11 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
             emptyText: 'No Institution Selected',
             width: 165,
             listWidth: 310,
-            listeners: { change: comboChangeHandler },
+            listeners: {
+                select: comboChangeHandler,
+                blur: comboChangeHandler,
+                change: comboChangeHandler
+            },
             allowBlank: false
         });
 
@@ -685,7 +692,9 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                 valueProperty: 'id'
             },
             listeners: {
-                change: comboChangeHandler
+                change: comboChangeHandler,
+                select: comboChangeHandler,
+                blur: comboChangeHandler
             }
         });
 

--- a/html/internal_dashboard/user_check.php
+++ b/html/internal_dashboard/user_check.php
@@ -14,8 +14,9 @@ if (isset($_POST['xdmod_username']) && isset($_POST['xdmod_password'])) {
         denyWithMessage('Invalid login');
     }
 
+    $user->postLogin();
+
     $_SESSION['xdDashboardUser'] = $user->getUserID();
-    XDSessionManager::recordLogin($user);
 }
 
 // Check that the user has been set in the session.

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/SSOLoginTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/SSOLoginTest.php
@@ -2,18 +2,174 @@
 
 namespace IntegrationTests\Controllers;
 
-class SSOLoginTest extends \PHPUnit_Framework_TestCase
+use CCR\DB;
+
+class SSOLoginTest extends BaseUserAdminTest
 {
+    /**
+     * key to use when providing / retrieving the value that controls whether or not to include the
+     * default SSO parameters when conducting an SSO login. By default these keys / values will be
+     * included which may cause problems if you're attempting to test the absence of said keys /
+     * values
+     *
+     * @var string
+     */
+    const INCLUDE_DEFAULT_SSO = 'include_default_sso';
+
+    /**
+     * Key to use when providing / retrieving the value that indicates whether or not a user is
+     * expected to be created and therefor should be removed after the test is run.
+     *
+     * @var string
+     */
+    const REMOVE_USER = 'remove_user';
+
+    /**
+     * Key to use when retrieving the username ( 'itname' ) value from SSO properties.
+     *
+     * @var string
+     */
+    const SSO_USERNAME = 'itname';
+
+    /**
+     * Key to use when providing / retrieving the value that indicates whether or not a user should
+     * have the 'sticky' bit set
+     *
+     * @var string
+     */
+    const STICKY = 'sticky';
+
+    /**
+     * Key to use when providing / retrieving the value that must match the Users organization_id.
+     *
+     * @var string
+     */
+    const EXPECTED_ORG = 'expected_org';
+
+    /**
+     * Key to use when providing / retrieving the set of acls a user is to be updated with.
+     * @var string
+     */
+    const SET_ACLS = 'acls';
+
+    /**
+     * Key to use when providing / retrieving the set of acls a user is expected to have after
+     * they have logged in.
+     * @var string
+     */
+    const EXPECTED_ACLS = 'expected_acls';
+
+    /**
+     * Key to use when providing / retrieving the info to use when creating a new person.
+     * @var string
+     */
+    const CREATE_PERSON = 'create_person';
+
+    /**
+     * Key to use when providing / retrieving the info to be used when creating a new system_account
+     * record.
+     * @var string
+     */
+    const CREATE_SYSTEM_ACCOUNT = 'create_system_account';
+
+    /**
+     * Key to use when providing / retrieving the information to be used in removing a person.
+     * aka. their 'long_name' value.
+     *
+     * @var string
+     */
+    const REMOVE_PERSON = 'remove_person';
+
+    /**
+     * Key to use when providing / retrieving information to be used in removing a system_account.
+     * aka. their 'username' value.
+     *
+     * @var string
+     */
+    const REMOVE_SYSTEM_ACCOUNT = 'remove_system_account';
+
+    /**
+     * Key to use when providing / retrieving information to be used when setting the current users
+     * organization.
+     *
+     * @var string
+     */
+    const SET_ORGANIZATION = 'set_organization';
+
     /**
      * used to test that SSO logins work correctly and the correct user information
      * is reported
      *
      * @dataProvider loginsProvider
      */
-    public function testLogin($ssoSettings, $expected)
+    public function testLogin($ssoSettings, $expected, $testOptions = array())
     {
         $helper = new \TestHarness\XdmodTestHelper();
-        $helper->authenticateSSO($ssoSettings);
+        $peopleHelper = new \TestHarness\PeopleHelper();
+
+        $includeDefault = \xd_utilities\array_get($testOptions, self::INCLUDE_DEFAULT_SSO, true);
+        $removeUser  = \xd_utilities\array_get($testOptions, self::REMOVE_USER, false);
+        $sticky = \xd_utilities\array_get($testOptions, self::STICKY, false);
+        $expectedOrg = \xd_utilities\array_get($testOptions, self::EXPECTED_ORG, null);
+        $setAcls = \xd_utilities\array_get($testOptions, self::SET_ACLS, null);
+        $setOrganization = \xd_utilities\array_get($testOptions, self::SET_ORGANIZATION, null);
+        $expectedAcls = \xd_utilities\array_get($testOptions, self::EXPECTED_ACLS, null);
+
+        $createPerson = \xd_utilities\array_get($testOptions, self::CREATE_PERSON, null);
+        $createSystemAccount = \xd_utilities\array_get($testOptions, self::CREATE_SYSTEM_ACCOUNT, null);
+
+        $removePerson = \xd_utilities\array_get($testOptions, self::REMOVE_PERSON, null);
+        $removeSystemAccount = \xd_utilities\array_get($testOptions, self::REMOVE_SYSTEM_ACCOUNT, null);
+
+        $username = \xd_utilities\array_get($ssoSettings, self::SSO_USERNAME, '');
+
+        // If we need to create a person then do it now. Person needs to be created before a system_account
+        // so that it can be associated with it.
+        if ($createPerson) {
+            $peopleHelper->createPerson(
+                $createPerson['organization_id'],
+                $createPerson['nsfstatuscode_id'],
+                $createPerson['first_name'],
+                $createPerson['last_name'],
+                $createPerson['long_name'],
+                $createPerson['short_name']
+            );
+        }
+
+        // If we need to create a system account then go ahead and do it now.
+        if ($createSystemAccount) {
+            $this->createSystemAccount(
+                $createSystemAccount['person_long_name'],
+                $createSystemAccount['resource_id'],
+                $createSystemAccount['username']
+            );
+        }
+
+        // Take care of setting the sticky bit for a user. NOTE: Can only be set for users that exist.
+        if ($sticky) {
+            $userId = $this->retrieveUserId($username, SSO_USER_TYPE);
+            $properties = $this->retrieveUserProperties(
+                $userId,
+                array(
+                    'email_address',
+                    'assigned_user_id',
+                    'institution'
+                )
+            );
+
+            $this->updateUser(
+                $userId,
+                $properties['email_address'],
+                array('usr' => array()),
+                $properties['assigned_user_id'],
+                $properties['institution'],
+                SSO_USER_TYPE,
+                'true'
+            );
+        }
+
+        // Perform the SSO login
+        $helper->authenticateSSO($ssoSettings, $includeDefault);
 
         $response = $helper->get('index.php');
         $this->assertEquals(200, $response[1]['http_code']);
@@ -22,29 +178,902 @@ class SSOLoginTest extends \PHPUnit_Framework_TestCase
         preg_match_all('/^(CCR\.xdmod.[a-zA-Z_\.]*) = ([^=;]*);?$/m', $response[0], $matches);
         $jsvariables = array_combine($matches[1], $matches[2]);
 
-        foreach($expected as $varname => $varvalue)
-        {
+        // Ensure that everything is copacetic
+        foreach ($expected as $varname => $varvalue) {
             $this->assertEquals($varvalue, $jsvariables[$varname]);
+        }
+
+        // Log the SSO User out
+        $helper->logout();
+
+        // If specified, update the users set of acls
+        if ($setAcls) {
+            $userId = $this->retrieveUserId($username, SSO_USER_TYPE);
+            $properties = $this->retrieveUserProperties(
+                $userId,
+                array(
+                    'email_address',
+                    'assigned_user_id',
+                    'institution'
+                )
+            );
+            $this->updateUser(
+                $userId,
+                $properties['email_address'],
+                $setAcls,
+                $properties['assigned_user_id'],
+                $properties['institution'],
+                SSO_USER_TYPE
+            );
+        }
+
+        // If specified, update this users organization
+        if ($setOrganization) {
+            $userId = $this->retrieveUserId($username, SSO_USER_TYPE);
+            $properties = $this->retrieveUserProperties(
+                $userId,
+                array(
+                    'email_address',
+                    'assigned_user_id',
+                    'acls'
+                )
+            );
+
+            $this->updateUser(
+                $userId,
+                $properties['email_address'],
+                $properties['acls'],
+                $properties['assigned_user_id'],
+                $setOrganization,
+                SSO_USER_TYPE,
+                false
+            );
+        }
+
+        // If specified, ensure that this user's organization is as expected.
+        if ($expectedOrg) {
+            $userId = $this->retrieveUserId($username, SSO_USER_TYPE);
+            $actualOrganization = $this->retrieveUserProperties(
+                $userId,
+                array(
+                    'institution'
+                )
+            );
+            $this->assertEquals($expectedOrg, $actualOrganization, "Expected $expectedOrg == $actualOrganization.");
+        }
+
+        // If specified, ensure that this users acls are as expected.
+        if ($expectedAcls) {
+            $userId = $this->retrieveUserId($username, SSO_USER_TYPE);
+            $actualAcls = $this->retrieveUserProperties(
+                $userId,
+                array(
+                    'acls'
+                )
+            );
+            $this->assertEquals(array_keys($expectedAcls), array_keys($actualAcls), "Expected Acls !== Actual Acls");
+        }
+
+        if ($removeSystemAccount) {
+            $this->removeSystemAccount($removeSystemAccount);
+        }
+
+        if ($removePerson) {
+            $peopleHelper->removePerson($removePerson);
+        }
+
+        if ($removeUser) {
+            $userId = $this->retrieveUserId($username, SSO_USER_TYPE);
+            $this->removeUser($userId, $username);
         }
     }
 
     public function loginsProvider()
     {
         return array(
+            // 0 NU1: New User Test 1
             array(
                 array(
-                    'itname' => 'alpsw',
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 1 NU2: New User Test 2
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::REMOVE_USER => true
+                )
+            ),
+            // 2 NU3: New User Test 3
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'UB CCR',
                     'firstName' => 'Alpine',
                     'lastName' => 'Swift',
                     'email' => 'alpsw@example.com'
                 ),
                 array(
-                    'CCR.xdmod.ui.username' => "'alpsw'",
+                    'CCR.xdmod.ui.username' => "'testy'",
                     'CCR.xdmod.ui.fullName' => '"Alpine Swift"',
                     'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
                     'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_USER => true
                 )
-            )
+            ),
+
+            // 3 EU1: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1
+                )
+            ),
+
+            // 4 EU1
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::STICKY => true,
+                    self::EXPECTED_ORG => -1,
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 5 E02: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1
+                )
+            ),
+
+            // 6 E02
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 7 E03: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::SET_ACLS => array('usr' => array(), 'cd' => array()),
+                    self::EXPECTED_ORG => -1
+                )
+            ),
+
+            // 8 E03
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'alpsw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 9 E04: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1
+                )
+            ),
+
+            // 10 E04
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'alpsw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 11 E05: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1
+                )
+            ),
+
+            // 12 E05
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'alpsw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 13 E06: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::CREATE_PERSON => array(
+                        'organization_id' => -1,
+                        'nsfstatuscode_id' => 0,
+                        'first_name' => 'Testy',
+                        'last_name' => 'Person',
+                        'long_name' => 'Person, Testy',
+                        'short_name' => 'Person, T',
+                    ),
+                    self::CREATE_SYSTEM_ACCOUNT => array(
+                        'person_long_name' => 'Person, Testy',
+                        'resource_id' => 5,
+                        'username' => 'teper'
+                    )
+                )
+            ),
+
+            // 14 E06
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'teper',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::EXPECTED_ORG => -1,
+                    self::REMOVE_PERSON => 'Person, Testy',
+                    self::REMOVE_SYSTEM_ACCOUNT => 'teper',
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 15 E07: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::SET_ACLS => array('usr' => array(), 'cd' => array()),
+
+                    self::CREATE_PERSON => array(
+                        'organization_id' => -1,
+                        'nsfstatuscode_id' => 0,
+                        'first_name' => 'Testy',
+                        'last_name' => 'Person',
+                        'long_name' => 'Person, Testy',
+                        'short_name' => 'Person, T',
+                    ),
+                    self::CREATE_SYSTEM_ACCOUNT => array(
+                        'person_long_name' => 'Person, Testy',
+                        'resource_id' => 5,
+                        'username' => 'teper'
+                    )
+                )
+            ),
+
+            // 16 E07
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'teper',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_PERSON => 'Person, Testy',
+                    self::REMOVE_SYSTEM_ACCOUNT => 'teper',
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 17 E08: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Unknown, Unknown"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::CREATE_PERSON => array(
+                        'organization_id' => -1,
+                        'nsfstatuscode_id' => 0,
+                        'first_name' => 'Testy',
+                        'last_name' => 'Person',
+                        'long_name' => 'Person, Testy',
+                        'short_name' => 'Person, T',
+                    ),
+                    self::CREATE_SYSTEM_ACCOUNT => array(
+                        'person_long_name' => 'Person, Testy',
+                        'resource_id' => 5,
+                        'username' => 'teper'
+                    )
+                )
+            ),
+
+            // 18 E08
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'teper',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_PERSON => 'Person, Testy',
+                    self::REMOVE_SYSTEM_ACCOUNT => 'teper',
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 19 E09: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'teper',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::CREATE_PERSON => array(
+                        'organization_id' => -1,
+                        'nsfstatuscode_id' => 0,
+                        'first_name' => 'Testy',
+                        'last_name' => 'Person',
+                        'long_name' => 'Person, Testy',
+                        'short_name' => 'Person, T',
+                    ),
+                    self::CREATE_SYSTEM_ACCOUNT => array(
+                        'person_long_name' => 'Person, Testy',
+                        'resource_id' => 5,
+                        'username' => 'teper'
+                    )
+                )
+            ),
+
+            // 20 E09
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'UB CCR',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::REMOVE_PERSON => 'Person, Testy',
+                    self::REMOVE_SYSTEM_ACCOUNT => 'teper',
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 21 E10: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'teper',
+                    'orgId' => 'testy',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => -1,
+                    self::SET_ACLS => array('usr' => array(), 'cd' => array()),
+                    self::CREATE_PERSON => array(
+                        'organization_id' => -1,
+                        'nsfstatuscode_id' => 0,
+                        'first_name' => 'Testy',
+                        'last_name' => 'Person',
+                        'long_name' => 'Person, Testy',
+                        'short_name' => 'Person, T',
+                    ),
+                    self::CREATE_SYSTEM_ACCOUNT => array(
+                        'person_long_name' => 'Person, Testy',
+                        'resource_id' => 5,
+                        'username' => 'teper'
+                    )
+                )
+            ),
+
+            // 22 E10
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::REMOVE_PERSON => 'Person, Testy',
+                    self::REMOVE_SYSTEM_ACCOUNT => 'teper',
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 23 E11: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'teper',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctesterson@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::CREATE_PERSON => array(
+                        'organization_id' => -1,
+                        'nsfstatuscode_id' => 0,
+                        'first_name' => 'Testy',
+                        'last_name' => 'Person',
+                        'long_name' => 'Person, Testy',
+                        'short_name' => 'Person, T',
+                    ),
+                    self::CREATE_SYSTEM_ACCOUNT => array(
+                        'person_long_name' => 'Person, Testy',
+                        'resource_id' => 5,
+                        'username' => 'teper'
+                    )
+                )
+            ),
+
+            // 24 E11
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'testy',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Testy McTesterson"',
+                    'CCR.xdmod.ui.mappedPName' => '"Person, Testy"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_PERSON => 'Person, Testy',
+                    self::REMOVE_SYSTEM_ACCOUNT => 'teper',
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 25 E12: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Alpine',
+                    'lastName' => 'Swift',
+                    'email' => 'alpsw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Alpine Swift"',
+                    'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1
+                )
+            ),
+
+            // 26 E12
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Alpine Swift"',
+                    'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 27 E13: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Alpine',
+                    'lastName' => 'Swift',
+                    'email' => 'alpsw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Alpine Swift"',
+                    'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::SET_ORGANIZATION => 2,
+                    self::SET_ACLS => array('usr' => array(), 'cd' => array()),
+                    self::EXPECTED_ORG => 2
+                )
+            ),
+
+            // 28 E13
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Alpine Swift"',
+                    'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::EXPECTED_ACLS => array('usr' => array()),
+                    self::REMOVE_USER => true
+                )
+            ),
+
+            // 29 E14: User Creation
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Alpine',
+                    'lastName' => 'Swift',
+                    'email' => 'alpsw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Alpine Swift"',
+                    'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::SET_ORGANIZATION => 2,
+                    self::EXPECTED_ORG => 2
+                )
+            ),
+
+            // 30 E14
+            array(
+                array(
+                    'itname' => 'testy',
+                    'system_username' => 'alpsw',
+                    'orgId' => 'Screwdriver',
+                    'firstName' => 'Testy',
+                    'lastName' => 'McTesterson',
+                    'email' => 'tmctestersonw@example.com'
+                ),
+                array(
+                    'CCR.xdmod.ui.username' => "'testy'",
+                    'CCR.xdmod.ui.fullName' => '"Alpine Swift"',
+                    'CCR.xdmod.ui.mappedPName' => '"Swift, Alpine"',
+                    'CCR.xdmod.org_name' => '"Screwdriver"'
+                ),
+                array(
+                    self::EXPECTED_ORG => 1,
+                    self::REMOVE_USER => true
+                )
+            ),
         );
+    }
+
+    public function createSystemAccount($personLongName, $resourceId, $username)
+    {
+        $query = <<<SQL
+INSERT INTO modw.systemaccount(person_id, resource_id, username, ts) 
+SELECT 
+    p.id ,
+    :resource_id as resource_id,
+    :username as username,
+    NOW() as ts
+FROM modw.person p WHERE p.long_name = :person_long_name
+SQL;
+        $params = array(
+            ':person_long_name' => $personLongName,
+            ':resource_id'=> $resourceId,
+            ':username' => $username
+        );
+
+        $db = DB::factory('database');
+        $db->execute($query, $params);
+    }
+
+    public function removeSystemAccount($username)
+    {
+        $query = "DELETE FROM modw.systemaccount WHERE username = :username";
+        $params = array(
+            ':username' => $username
+        );
+        $db = DB::factory('database');
+        $db->execute($query, $params);
     }
 }

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UserAdminTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UserAdminTest.php
@@ -176,7 +176,7 @@ class UserAdminTest extends BaseUserAdminTest
         // users password so that it can be used to login in future tests.
         if ($userId !== null) {
             $username = array_search($userId, self::$newUsers);
-            $this->updateUser($userId, $username);
+            $this->updateCurrentUser($userId, $username);
         }
     }
 

--- a/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/PeopleHelper.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/PeopleHelper.php
@@ -39,4 +39,56 @@ class PeopleHelper
         }
         return $people[0]['id'];
     }
+
+    /**
+     * Manually create a person with the attributes provided.
+     *
+     * @param int $organizationId
+     * @param int $nsfStatusCodeId
+     * @param string $firstName
+     * @param string $lastName
+     * @param string $longName
+     * @param string $shortName
+     */
+    public function createPerson($organizationId, $nsfStatusCodeId, $firstName, $lastName, $longName, $shortName)
+    {
+        $query = <<<SQL
+INSERT INTO modw.person(organization_id, nsfstatuscode_id, first_name, last_name, long_name, short_name, person_origin_id)
+SELECT
+:organization_id as organization_id,
+:nsfstatuscode_id as nsfstatuscode_id,
+:first_name as first_name,
+:last_name as last_name,
+:long_name as long_name,
+:short_name as short_name,
+MAX(person_origin_id) + 1 as person_origin_id
+FROM modw.person
+SQL;
+        $params = array(
+            ':organization_id' => $organizationId,
+            ':nsfstatuscode_id' => $nsfStatusCodeId,
+            ':first_name' => $firstName,
+            ':last_name' => $lastName,
+            ':long_name' => $longName,
+            ':short_name' => $shortName
+        );
+
+        $this->dbh->execute($query, $params);
+    }
+
+    /**
+     * Remove the person identified by the provided `$longName`.
+     *
+     * @param string $longName
+     */
+    public function removePerson($longName)
+    {
+        $query = <<<SQL
+DELETE FROM modw.person WHERE long_name = :long_name;
+SQL;
+        $params = array(
+            ':long_name' => $longName
+        );
+        $this->dbh->execute($query, $params);
+    }
 }

--- a/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/XdmodTestHelper.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/TestHarness/XdmodTestHelper.php
@@ -172,15 +172,19 @@ class XdmodTestHelper
      * Authenticate a user via SSO. SSO authentication requires a saml-idp
      * server. This is setup in the integration_tests/scripts/samlSetup.sh
      */
-    public function authenticateSSO($parameters)
+    public function authenticateSSO($parameters, $includeDefault = true)
     {
         $result = $this->get('rest/auth/idpredirect', array('returnTo' => '/gui/general/login.php'));
         $nextlocation = $result[0];
         $result = $this->get($nextlocation, null, true);
 
         list($action, $authSettings) = $this->getHTMLFormData($result[0]);
+        if ($includeDefault) {
+            $finalSettings = array_merge($authSettings, $parameters);
+        } else {
+            $finalSettings = $parameters;
+        }
 
-        $finalSettings = array_merge($authSettings, $parameters);
 
         $providerInfo = parse_url($result[1]['url']);
         $url = $providerInfo['scheme'] . '://' . $providerInfo['host'] . ':' . $providerInfo['port'] . $action;

--- a/open_xdmod/modules/xdmod/integration_tests/phpunit.xml.dist
+++ b/open_xdmod/modules/xdmod/integration_tests/phpunit.xml.dist
@@ -25,6 +25,7 @@
         <exclude>./lib/Controllers/SSOLoginTest.php</exclude>
     </testsuite>
     <testsuite name="sso">
+        <file>./lib/Controllers/BaseUserAdminTest.php</file>
         <file>./lib/Controllers/SSOLoginTest.php</file>
     </testsuite>
 </testsuites>

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
@@ -35,7 +35,8 @@ var profile = {
   mobilePhone: '+1-415-555-5141',
   groups: 'Simple AIdP Users, West Coast Users, Cloud Users',
   itname: 'samlj',
-  orgId: 'University At Buffalo',
+  system_username: 'samlj',
+  orgId: 'Screwdriver',
   fieldOfScience: 'Computational Research'
 }
 
@@ -57,8 +58,14 @@ var metadata = [{
 }, {
   id: "itname",
   optional:'false',
-  displayName: 'System Username',
+  displayName: 'Organization Username',
   description: 'The system user',
+  multiValue: false
+}, {
+  id: 'system_username',
+  optional: 'true',
+  displayName: 'System Username',
+  description: 'Username of account used to run jobs.',
   multiValue: false
 }, {
   id: "firstName",
@@ -147,6 +154,18 @@ cat > "$VENDOR_DIR/simplesamlphp/simplesamlphp/config/authsources.php" <<EOF
         'orgId' => 'organization',
         'fieldOfScience' => 'field_of_science',
         'itname' => 'username'
+      ),
+      60 => array(
+        'class' => 'authorize:Authorize',
+        'username' => array(
+          '/\S+/'
+        ),
+      ),
+      61 => array(
+        'class' => 'authorize:Authorize',
+        'organization' => array(
+          '/\S+/'
+        )
       )
     )
   ),

--- a/shippable.yml
+++ b/shippable.yml
@@ -25,10 +25,10 @@ build:
         - cp -f /etc/xdmod/portal_settings.ini ./configuration/portal_settings.ini
         - ./open_xdmod/modules/xdmod/integration_tests/runtests.sh --junit-output-dir `pwd`/shippable/testresults/
         - ./open_xdmod/modules/xdmod/component_tests/runtests.sh --log-junit `pwd`/shippable/testresults/xdmod-component.xml
-        - mv ./configuration/portal_settings.ini.old ./configuration/portal_settings.ini
         - ./open_xdmod/modules/xdmod/automated_tests/runtests.sh --headless --log-junit `pwd`/shippable/testresults
         - ./open_xdmod/modules/xdmod/integration_tests/scripts/samlSetup.sh
         - ./open_xdmod/modules/xdmod/automated_tests/runtests.sh --headless --log-junit `pwd`/shippable/testresults --sso
         - ./vendor/phpunit/phpunit/phpunit -c ./open_xdmod/modules/xdmod/integration_tests/phpunit.xml.dist --testsuite sso --log-junit `pwd`/shippable/testresults/xdmod-sso-integration.xml
+        - mv ./configuration/portal_settings.ini.old ./configuration/portal_settings.ini
     on_failure:
         - cat /var/log/xdmod/*

--- a/templates/portal_settings.template
+++ b/templates/portal_settings.template
@@ -48,9 +48,6 @@ singlejobviewer = "off"
 ; set to 'off' in Open XDMoD until support has been added.
 multiple_service_providers = "off"
 
-[sso]
-force_default_organization = "on"
-
 [internal]
 dw_desc_cache = "off"
 

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/input/create_users.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/user_admin/input/create_users.json
@@ -7,6 +7,7 @@
         "usr": []
       },
       "long_name": "Auk, Great",
+      "institution": 1,
       "output": "create_user-cd.one-center"
     }
   ],
@@ -18,6 +19,7 @@
         "usr": []
       },
       "long_name": "Auk, Little",
+      "institution": 1,
       "output": "create_user-cs.one-center"
     }
   ],
@@ -28,6 +30,7 @@
         "pi": []
       },
       "long_name": "Flycatcher, Taiga",
+      "institution": 1,
       "output": "create_user-pi"
     }
   ],
@@ -38,6 +41,7 @@
         "usr": []
       },
       "long_name": "Honey-buzzard",
+      "institution": 1,
       "output": "create_user-normal_user"
     }
   ],
@@ -48,6 +52,7 @@
         "dev": []
       },
       "long_name": "Albatross, Black-browed",
+      "institution": 1,
       "output": "test.only_feature_acls",
       "expected_success": false
     }
@@ -59,6 +64,7 @@
         "mgr": []
       },
       "long_name": "Albatross, Yellow-nosed",
+      "institution": 1,
       "output": "test.only_feature_acls",
       "expected_success": false
     }
@@ -71,6 +77,7 @@
         "dev": []
       },
       "long_name": "Amherst's, Lady",
+      "institution": 1,
       "output": "test.only_feature_acls",
       "expected_success": false
     }
@@ -83,6 +90,7 @@
         "dev": []
       },
       "long_name": "Honey-buzzard",
+      "institution": 1,
       "output": "create_user-usr_dev"
     }
   ],
@@ -94,6 +102,7 @@
         "mgr": []
       },
       "long_name": "Honey-buzzard",
+      "institution": 1,
       "output": "create_user-usr_mgr"
     }
   ],
@@ -106,6 +115,7 @@
         "dev": []
       },
       "long_name": "Honey-buzzard",
+      "institution": 1,
       "output": "create_user-usr_mgr_dev"
     }
   ]


### PR DESCRIPTION
## Description
Added additional functionality to both SSO & normal login path that makes sure
that the user that is authenticating has an up to date organization_id. A user's
organization can become out of date if the person they are associated with has
their organization changed. It can also occur if a User's person is updated but not their organization. 

We also do not check the organization if the user has been assigned the unknown
person or organizations.

Added a new `MailHelper` class that's a thin wrapper around
`MailWrapper::sendMail` to catch / log any exceptions that may be encountered
while sending an email.

## Motivation and Context
We need to be able to account for when a user's assigned person has their organization updated. 

## Tests performed
Manual Tests Performed:

- Manually update a centerdirector's user's person to somebody with a different organization.
- Login as the centerdirector
- Check that email(s) have been sent
- Check that the Users record has been updated w/ the new person & organization
- Check that the user no longer has the center director acl. 
- Create an SSO User
- Give them the center director acl 
- Give them a person w/ an organization != Unknown Organization
- Login via SSO
- Ensure that no email has been generated
- Manually update this users's person w/ somebody who has a different organization
- Login via SSO
- Ensure that emails are generated
- Ensure that the user has their person / organization updated
- Ensure that the user no longer has the center director acl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
