### PR TITLE
Use long_name field from database

### DIFF
--- a/classes/XDWarehouse.php
+++ b/classes/XDWarehouse.php
@@ -124,7 +124,7 @@ class XDWarehouse
 
                 $usersQuery = $this->_pdo->query(
                     "
-                        SELECT p.id, p.first_name, p.last_name
+                        SELECT p.id, p.long_name
                         FROM person AS p
                         $filter
                         ORDER BY p.last_name ASC, p.first_name ASC
@@ -401,4 +401,3 @@ SQL;
         return $users;
     }
 }
-

--- a/html/controllers/sab_user/enum_tg_users.php
+++ b/html/controllers/sab_user/enum_tg_users.php
@@ -74,10 +74,7 @@ foreach ($users as $currentUser) {
     $entry_id++;
 
     if ($searchMethod == FORMAL_NAME_SEARCH) {
-        $personName
-            = $currentUser['last_name']
-            . ', '
-            . $currentUser['first_name'];
+        $personName = $currentUser['long_name'];
         $personID = $currentUser['id'];
     }
 
@@ -106,4 +103,3 @@ $returnData = array(
 );
 
 xd_controller\returnJSON($returnData);
-

--- a/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/internalDashboard.js
+++ b/open_xdmod/modules/xdmod/automated_tests/test/specs/xdmod/internalDashboard.js
@@ -47,7 +47,7 @@ describe('Internal Dashboard', function () {
             browser.waitForInvisible(page.selectors.combo.container);
 
             const mapTo = browser.getValue(page.selectors.create_manage_users.new_user.mapTo());
-            expect(mapTo).to.equal('Unknown, Unknown');
+            expect(mapTo).to.equal('Unknown');
 
             // Wait for the institution combo to be enabled / have a value.
             browser.waitForEnabled(page.selectors.create_manage_users.new_user.institution());

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ControllerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/ControllerTest.php
@@ -349,14 +349,14 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
             $found = array_filter(
                 $actualUsers,
                 function ($value) use ($expectedUser) {
-                    return $expectedUser['person_name']=== $value['person_name'];
+                    return $expectedUser['person_name'] === $value['person_name'];
                 }
             );
             if (empty($found)) {
                 $notFound []= $expectedUser;
             }
         }
-        $this->assertEmpty($notFound, "There were expected users missing in actual. \nExpected: " . json_encode($notFound) . "\nActual: " . json_encode($actualUsers));
+        $this->assertEmpty($notFound, "There were expected users missing in actual (person_id is not actually checked and may be different).\nExpected: " . json_encode($notFound) . "\nActual: " . json_encode($actualUsers));
         $this->helper->logoutDashboard();
     }
 

--- a/tests/artifacts/xdmod-test-artifacts/xdmod/controllers/output/sab_user_enum_tg_users.json
+++ b/tests/artifacts/xdmod-test-artifacts/xdmod/controllers/output/sab_user_enum_tg_users.json
@@ -6,1503 +6,1503 @@
   "users": [
     {
       "id": 1,
-      "person_id": "67",
+      "person_id": "1",
       "person_name": "Accentor, Alpine"
     },
     {
       "id": 2,
-      "person_id": "498",
+      "person_id": "526",
       "person_name": "Albatross, Black-browed"
     },
     {
       "id": 3,
-      "person_id": "603",
+      "person_id": "631",
       "person_name": "Albatross, Yellow-nosed"
     },
     {
       "id": 4,
-      "person_id": "110",
+      "person_id": "138",
       "person_name": "Amherst's, Lady"
     },
     {
       "id": 5,
-      "person_id": "181",
+      "person_id": "209",
       "person_name": "Auk, Great"
     },
     {
       "id": 6,
-      "person_id": "31",
+      "person_id": "87",
       "person_name": "Auk, Little"
     },
     {
       "id": 7,
-      "person_id": "197",
-      "person_name": "Avocet, "
+      "person_id": "225",
+      "person_name": "Avocet"
     },
     {
       "id": 8,
-      "person_id": "236",
-      "person_name": "Bee-eater, "
+      "person_id": "264",
+      "person_name": "Bee-eater"
     },
     {
       "id": 9,
-      "person_id": "261",
+      "person_id": "289",
       "person_name": "Bee-eater, Blue-cheeked"
     },
     {
       "id": 10,
-      "person_id": "69",
-      "person_name": "Bittern, "
+      "person_id": "4",
+      "person_name": "Bittern"
     },
     {
       "id": 11,
-      "person_id": "121",
+      "person_id": "149",
       "person_name": "Bittern, American"
     },
     {
       "id": 12,
-      "person_id": "526",
+      "person_id": "554",
       "person_name": "Bittern, Little"
     },
     {
       "id": 13,
-      "person_id": "431",
+      "person_id": "459",
       "person_name": "Black, White-crowned"
     },
     {
       "id": 14,
-      "person_id": "418",
+      "person_id": "446",
       "person_name": "Black, White-winged"
     },
     {
       "id": 15,
-      "person_id": "567",
+      "person_id": "595",
       "person_name": "Black-backed, Great"
     },
     {
       "id": 16,
-      "person_id": "190",
+      "person_id": "218",
       "person_name": "Black-backed, Lesser"
     },
     {
       "id": 17,
-      "person_id": "160",
+      "person_id": "188",
       "person_name": "Black-headed, Great"
     },
     {
       "id": 18,
-      "person_id": "70",
-      "person_name": "Blackbird, "
+      "person_id": "5",
+      "person_name": "Blackbird"
     },
     {
       "id": 19,
-      "person_id": "422",
-      "person_name": "Blackcap, "
+      "person_id": "450",
+      "person_name": "Blackcap"
     },
     {
       "id": 20,
-      "person_id": "568",
+      "person_id": "596",
       "person_name": "Blue, Great"
     },
     {
       "id": 21,
-      "person_id": "525",
+      "person_id": "553",
       "person_name": "Blue, Siberian"
     },
     {
       "id": 22,
-      "person_id": "93",
+      "person_id": "35",
       "person_name": "Bluetail, Red-flanked"
     },
     {
       "id": 23,
-      "person_id": "185",
-      "person_name": "Bluethroat, "
+      "person_id": "213",
+      "person_name": "Bluethroat"
     },
     {
       "id": 24,
-      "person_id": "309",
-      "person_name": "Bobolink, "
+      "person_id": "337",
+      "person_name": "Bobolink"
     },
     {
       "id": 25,
-      "person_id": "154",
+      "person_id": "182",
       "person_name": "Bonelli's, Eastern"
     },
     {
       "id": 26,
-      "person_id": "112",
+      "person_id": "140",
       "person_name": "Bonelli's, Western"
     },
     {
       "id": 27,
-      "person_id": "173",
-      "person_name": "Brambling, "
+      "person_id": "201",
+      "person_name": "Brambling"
     },
     {
       "id": 28,
-      "person_id": "72",
-      "person_name": "Bufflehead, "
+      "person_id": "7",
+      "person_name": "Bufflehead"
     },
     {
       "id": 29,
-      "person_id": "324",
-      "person_name": "Bullfinch, "
+      "person_id": "352",
+      "person_name": "Bullfinch"
     },
     {
       "id": 30,
-      "person_id": "183",
+      "person_id": "211",
       "person_name": "Bunting, Black-faced"
     },
     {
       "id": 31,
-      "person_id": "4",
+      "person_id": "66",
       "person_name": "Bunting, Black-headed"
     },
     {
       "id": 32,
-      "person_id": "175",
+      "person_id": "203",
       "person_name": "Bunting, Chestnut-eared"
     },
     {
       "id": 33,
-      "person_id": "206",
+      "person_id": "234",
       "person_name": "Bunting, Cirl"
     },
     {
       "id": 34,
-      "person_id": "155",
+      "person_id": "183",
       "person_name": "Bunting, Corn"
     },
     {
       "id": 35,
-      "person_id": "283",
+      "person_id": "311",
       "person_name": "Bunting, Cretzschmar's"
     },
     {
       "id": 36,
-      "person_id": "209",
+      "person_id": "237",
       "person_name": "Bunting, Indigo"
     },
     {
       "id": 37,
-      "person_id": "285",
+      "person_id": "313",
       "person_name": "Bunting, Lapland"
     },
     {
       "id": 38,
-      "person_id": "512",
+      "person_id": "540",
       "person_name": "Bunting, Little"
     },
     {
       "id": 39,
-      "person_id": "90",
+      "person_id": "32",
       "person_name": "Bunting, Ortolan"
     },
     {
       "id": 40,
-      "person_id": "273",
+      "person_id": "301",
       "person_name": "Bunting, Pine"
     },
     {
       "id": 41,
-      "person_id": "42",
+      "person_id": "97",
       "person_name": "Bunting, Reed"
     },
     {
       "id": 42,
-      "person_id": "106",
+      "person_id": "134",
       "person_name": "Bunting, Rock"
     },
     {
       "id": 43,
-      "person_id": "187",
+      "person_id": "215",
       "person_name": "Bunting, Rustic"
     },
     {
       "id": 44,
-      "person_id": "148",
+      "person_id": "176",
       "person_name": "Bunting, Snow"
     },
     {
       "id": 45,
-      "person_id": "63",
+      "person_id": "117",
       "person_name": "Bunting, Yellow-breasted"
     },
     {
       "id": 46,
-      "person_id": "64",
+      "person_id": "118",
       "person_name": "Bunting, Yellow-browed"
     },
     {
       "id": 47,
-      "person_id": "323",
+      "person_id": "351",
       "person_name": "Bush, Rufous"
     },
     {
       "id": 48,
-      "person_id": "310",
+      "person_id": "338",
       "person_name": "Bustard, Great"
     },
     {
       "id": 49,
-      "person_id": "514",
+      "person_id": "542",
       "person_name": "Bustard, Little"
     },
     {
       "id": 50,
-      "person_id": "109",
+      "person_id": "137",
       "person_name": "Bustard, Macqueen's"
     },
     {
       "id": 51,
-      "person_id": "251",
-      "person_name": "Buzzard, "
+      "person_id": "279",
+      "person_name": "Buzzard"
     },
     {
       "id": 52,
-      "person_id": "304",
+      "person_id": "332",
       "person_name": "Buzzard, Rough-legged"
     },
     {
       "id": 53,
-      "person_id": "587",
-      "person_name": "Canvasback, "
+      "person_id": "615",
+      "person_name": "Canvasback"
     },
     {
       "id": 54,
-      "person_id": "410",
-      "person_name": "Capercaillie, "
+      "person_id": "438",
+      "person_name": "Capercaillie"
     },
     {
       "id": 55,
-      "person_id": "493",
+      "person_id": "521",
       "person_name": "Catbird, Grey"
     },
     {
       "id": 56,
-      "person_id": "8",
-      "person_name": "Chaffinch, "
+      "person_id": "11",
+      "person_name": "Chaffinch"
     },
     {
       "id": 57,
-      "person_id": "311",
-      "person_name": "Chiffchaff, "
+      "person_id": "339",
+      "person_name": "Chiffchaff"
     },
     {
       "id": 58,
-      "person_id": "85",
+      "person_id": "25",
       "person_name": "Chiffchaff, Iberian"
     },
     {
       "id": 59,
-      "person_id": "368",
-      "person_name": "Chough, "
+      "person_id": "396",
+      "person_name": "Chough"
     },
     {
       "id": 60,
-      "person_id": "9",
-      "person_name": "Coot, "
+      "person_id": "70",
+      "person_name": "Coot"
     },
     {
       "id": 61,
-      "person_id": "511",
+      "person_id": "539",
       "person_name": "Coot, American"
     },
     {
       "id": 62,
-      "person_id": "238",
-      "person_name": "Cormorant, "
+      "person_id": "266",
+      "person_name": "Cormorant"
     },
     {
       "id": 63,
-      "person_id": "257",
+      "person_id": "285",
       "person_name": "Cormorant, Double-crested"
     },
     {
       "id": 64,
-      "person_id": "375",
-      "person_name": "Corncrake, "
+      "person_id": "403",
+      "person_name": "Corncrake"
     },
     {
       "id": 65,
-      "person_id": "119",
+      "person_id": "147",
       "person_name": "Courser, Cream-coloured"
     },
     {
       "id": 66,
-      "person_id": "240",
+      "person_id": "268",
       "person_name": "Cowbird, Brown-headed"
     },
     {
       "id": 67,
-      "person_id": "138",
+      "person_id": "166",
       "person_name": "Crake, Baillon's"
     },
     {
       "id": 68,
-      "person_id": "394",
+      "person_id": "422",
       "person_name": "Crake, Little"
     },
     {
       "id": 69,
-      "person_id": "347",
+      "person_id": "375",
       "person_name": "Crake, Spotted"
     },
     {
       "id": 70,
-      "person_id": "12",
-      "person_name": "Crane, "
+      "person_id": "73",
+      "person_name": "Crane"
     },
     {
       "id": 71,
-      "person_id": "46",
+      "person_id": "101",
       "person_name": "Crane, Sandhill"
     },
     {
       "id": 72,
-      "person_id": "548",
+      "person_id": "576",
       "person_name": "Crested, Great"
     },
     {
       "id": 73,
-      "person_id": "398",
+      "person_id": "426",
       "person_name": "Crested, Lesser"
     },
     {
       "id": 74,
-      "person_id": "531",
+      "person_id": "559",
       "person_name": "Crossbill, Common"
     },
     {
       "id": 75,
-      "person_id": "231",
+      "person_id": "259",
       "person_name": "Crossbill, Parrot"
     },
     {
       "id": 76,
-      "person_id": "445",
+      "person_id": "473",
       "person_name": "Crossbill, Scottish"
     },
     {
       "id": 77,
-      "person_id": "486",
+      "person_id": "514",
       "person_name": "Crossbill, Two-barred"
     },
     {
       "id": 78,
-      "person_id": "224",
+      "person_id": "252",
       "person_name": "Crow, Carrion"
     },
     {
       "id": 79,
-      "person_id": "326",
+      "person_id": "354",
       "person_name": "Crow, Hooded"
     },
     {
       "id": 80,
-      "person_id": "147",
+      "person_id": "175",
       "person_name": "Crowned, Eastern"
     },
     {
       "id": 81,
-      "person_id": "235",
-      "person_name": "Cuckoo, "
+      "person_id": "263",
+      "person_name": "Cuckoo"
     },
     {
       "id": 82,
-      "person_id": "230",
+      "person_id": "258",
       "person_name": "Cuckoo, Black-billed"
     },
     {
       "id": 83,
-      "person_id": "386",
+      "person_id": "414",
       "person_name": "Cuckoo, Yellow-billed"
     },
     {
       "id": 84,
-      "person_id": "276",
-      "person_name": "Curlew, "
+      "person_id": "304",
+      "person_name": "Curlew"
     },
     {
       "id": 85,
-      "person_id": "113",
+      "person_id": "141",
       "person_name": "Curlew, Eskimo"
     },
     {
       "id": 86,
-      "person_id": "537",
+      "person_id": "565",
       "person_name": "Curlew, Slender-billed"
     },
     {
       "id": 87,
-      "person_id": "467",
+      "person_id": "495",
       "person_name": "Desert, Asian"
     },
     {
       "id": 88,
-      "person_id": "355",
-      "person_name": "Dipper, "
+      "person_id": "383",
+      "person_name": "Dipper"
     },
     {
       "id": 89,
-      "person_id": "449",
+      "person_id": "477",
       "person_name": "Diver, Black-throated"
     },
     {
       "id": 90,
-      "person_id": "487",
+      "person_id": "515",
       "person_name": "Diver, Pacific"
     },
     {
       "id": 91,
-      "person_id": "566",
+      "person_id": "594",
       "person_name": "Diver, Red-throated"
     },
     {
       "id": 92,
-      "person_id": "546",
+      "person_id": "574",
       "person_name": "Diver, White-billed"
     },
     {
       "id": 93,
-      "person_id": "77",
-      "person_name": "Dotterel, "
+      "person_id": "13",
+      "person_name": "Dotterel"
     },
     {
       "id": 94,
-      "person_id": "229",
+      "person_id": "257",
       "person_name": "Dove, Collared"
     },
     {
       "id": 95,
-      "person_id": "134",
+      "person_id": "162",
       "person_name": "Dove, Mourning"
     },
     {
       "id": 96,
-      "person_id": "554",
+      "person_id": "582",
       "person_name": "Dove, Rock"
     },
     {
       "id": 97,
-      "person_id": "440",
+      "person_id": "468",
       "person_name": "Dove, Stock"
     },
     {
       "id": 98,
-      "person_id": "57",
+      "person_id": "111",
       "person_name": "Dove, Turtle"
     },
     {
       "id": 99,
-      "person_id": "284",
+      "person_id": "312",
       "person_name": "Dowitcher, Long-billed"
     },
     {
       "id": 100,
-      "person_id": "96",
+      "person_id": "38",
       "person_name": "Dowitcher, Short-billed"
     },
     {
       "id": 101,
-      "person_id": "211",
+      "person_id": "239",
       "person_name": "Duck, Black"
     },
     {
       "id": 102,
-      "person_id": "17",
+      "person_id": "77",
       "person_name": "Duck, Ferruginous"
     },
     {
       "id": 103,
-      "person_id": "180",
+      "person_id": "208",
       "person_name": "Duck, Harlequin"
     },
     {
       "id": 104,
-      "person_id": "298",
+      "person_id": "326",
       "person_name": "Duck, Long-tailed"
     },
     {
       "id": 105,
-      "person_id": "315",
+      "person_id": "343",
       "person_name": "Duck, Mandarin"
     },
     {
       "id": 106,
-      "person_id": "330",
+      "person_id": "358",
       "person_name": "Duck, Ring-necked"
     },
     {
       "id": 107,
-      "person_id": "438",
+      "person_id": "466",
       "person_name": "Duck, Ruddy"
     },
     {
       "id": 108,
-      "person_id": "228",
+      "person_id": "256",
       "person_name": "Duck, Tufted"
     },
     {
       "id": 109,
-      "person_id": "13",
-      "person_name": "Dunlin, "
+      "person_id": "14",
+      "person_name": "Dunlin"
     },
     {
       "id": 110,
-      "person_id": "331",
-      "person_name": "Dunnock, "
+      "person_id": "359",
+      "person_name": "Dunnock"
     },
     {
       "id": 111,
-      "person_id": "312",
+      "person_id": "340",
       "person_name": "Eagle, Golden"
     },
     {
       "id": 112,
-      "person_id": "335",
+      "person_id": "363",
       "person_name": "Eagle, Short-toed"
     },
     {
       "id": 113,
-      "person_id": "294",
+      "person_id": "322",
       "person_name": "Eagle, White-tailed"
     },
     {
       "id": 114,
-      "person_id": "7",
+      "person_id": "69",
       "person_name": "Egret, Cattle"
     },
     {
       "id": 115,
-      "person_id": "126",
+      "person_id": "154",
       "person_name": "Egret, Little"
     },
     {
       "id": 116,
-      "person_id": "78",
+      "person_id": "15",
       "person_name": "Egret, Snowy"
     },
     {
       "id": 117,
-      "person_id": "411",
-      "person_name": "Eider, "
+      "person_id": "439",
+      "person_name": "Eider"
     },
     {
       "id": 118,
-      "person_id": "220",
+      "person_id": "248",
       "person_name": "Eider, King"
     },
     {
       "id": 119,
-      "person_id": "365",
+      "person_id": "393",
       "person_name": "Eider, Steller's"
     },
     {
       "id": 120,
-      "person_id": "494",
+      "person_id": "522",
       "person_name": "Falcon, Amur"
     },
     {
       "id": 121,
-      "person_id": "565",
+      "person_id": "593",
       "person_name": "Falcon, Eleonora's"
     },
     {
       "id": 122,
-      "person_id": "466",
+      "person_id": "494",
       "person_name": "Falcon, Gyr"
     },
     {
       "id": 123,
-      "person_id": "547",
+      "person_id": "575",
       "person_name": "Falcon, Red-footed"
     },
     {
       "id": 124,
-      "person_id": "18",
-      "person_name": "Fieldfare, "
+      "person_id": "16",
+      "person_name": "Fieldfare"
     },
     {
       "id": 125,
-      "person_id": "424",
+      "person_id": "452",
       "person_name": "Finch, Citril"
     },
     {
       "id": 126,
-      "person_id": "136",
+      "person_id": "164",
       "person_name": "Finch, Trumpeter"
     },
     {
       "id": 127,
-      "person_id": "150",
-      "person_name": "Firecrest, "
+      "person_id": "178",
+      "person_name": "Firecrest"
     },
     {
       "id": 128,
-      "person_id": "269",
+      "person_id": "297",
       "person_name": "Flycatcher, Brown"
     },
     {
       "id": 129,
-      "person_id": "491",
+      "person_id": "519",
       "person_name": "Flycatcher, Collared"
     },
     {
       "id": 130,
-      "person_id": "191",
+      "person_id": "219",
       "person_name": "Flycatcher, Pied"
     },
     {
       "id": 131,
-      "person_id": "247",
+      "person_id": "275",
       "person_name": "Flycatcher, Red-breasted"
     },
     {
       "id": 132,
-      "person_id": "132",
+      "person_id": "160",
       "person_name": "Flycatcher, Spotted"
     },
     {
       "id": 133,
-      "person_id": "97",
+      "person_id": "40",
       "person_name": "Flycatcher, Taiga"
     },
     {
       "id": 134,
-      "person_id": "505",
+      "person_id": "533",
       "person_name": "Frigatebird, Ascension"
     },
     {
       "id": 135,
-      "person_id": "595",
+      "person_id": "623",
       "person_name": "Frigatebird, Magnificent"
     },
     {
       "id": 136,
-      "person_id": "79",
-      "person_name": "Fulmar, "
+      "person_id": "17",
+      "person_name": "Fulmar"
     },
     {
       "id": 137,
-      "person_id": "107",
-      "person_name": "Gadwall, "
+      "person_id": "135",
+      "person_name": "Gadwall"
     },
     {
       "id": 138,
-      "person_id": "1",
+      "person_id": "64",
       "person_name": "Gallinule, Allen's"
     },
     {
       "id": 139,
-      "person_id": "557",
-      "person_name": "Gannet, "
+      "person_id": "585",
+      "person_name": "Gannet"
     },
     {
       "id": 140,
-      "person_id": "252",
-      "person_name": "Garganey, "
+      "person_id": "280",
+      "person_name": "Garganey"
     },
     {
       "id": 141,
-      "person_id": "579",
+      "person_id": "607",
       "person_name": "Godwit, Bar-tailed"
     },
     {
       "id": 142,
-      "person_id": "327",
+      "person_id": "355",
       "person_name": "Godwit, Black-tailed"
     },
     {
       "id": 143,
-      "person_id": "262",
+      "person_id": "290",
       "person_name": "Godwit, Hudsonian"
     },
     {
       "id": 144,
-      "person_id": "161",
-      "person_name": "Goldcrest, "
+      "person_id": "189",
+      "person_name": "Goldcrest"
     },
     {
       "id": 145,
-      "person_id": "454",
+      "person_id": "482",
       "person_name": "Golden, American"
     },
     {
       "id": 146,
-      "person_id": "559",
+      "person_id": "587",
       "person_name": "Golden, Pacific"
     },
     {
       "id": 147,
-      "person_id": "503",
-      "person_name": "Goldeneye, "
+      "person_id": "531",
+      "person_name": "Goldeneye"
     },
     {
       "id": 148,
-      "person_id": "141",
+      "person_id": "169",
       "person_name": "Goldeneye, Barrow's"
     },
     {
       "id": 149,
-      "person_id": "162",
-      "person_name": "Goldfinch, "
+      "person_id": "190",
+      "person_name": "Goldfinch"
     },
     {
       "id": 150,
-      "person_id": "303",
-      "person_name": "Goosander, "
+      "person_id": "331",
+      "person_name": "Goosander"
     },
     {
       "id": 151,
-      "person_id": "576",
+      "person_id": "604",
       "person_name": "Goose, Barnacle"
     },
     {
       "id": 152,
-      "person_id": "317",
+      "person_id": "345",
       "person_name": "Goose, Bean"
     },
     {
       "id": 153,
-      "person_id": "592",
+      "person_id": "620",
       "person_name": "Goose, Brent"
     },
     {
       "id": 154,
-      "person_id": "577",
+      "person_id": "605",
       "person_name": "Goose, Cackling"
     },
     {
       "id": 155,
-      "person_id": "380",
+      "person_id": "408",
       "person_name": "Goose, Canada"
     },
     {
       "id": 156,
-      "person_id": "15",
+      "person_id": "75",
       "person_name": "Goose, Egyptian"
     },
     {
       "id": 157,
-      "person_id": "570",
+      "person_id": "598",
       "person_name": "Goose, Greylag"
     },
     {
       "id": 158,
-      "person_id": "332",
+      "person_id": "360",
       "person_name": "Goose, Pink-footed"
     },
     {
       "id": 159,
-      "person_id": "92",
+      "person_id": "34",
       "person_name": "Goose, Red-breasted"
     },
     {
       "id": 160,
-      "person_id": "338",
+      "person_id": "366",
       "person_name": "Goose, Snow"
     },
     {
       "id": 161,
-      "person_id": "321",
+      "person_id": "349",
       "person_name": "Goose, White-fronted"
     },
     {
       "id": 162,
-      "person_id": "210",
-      "person_name": "Goshawk, "
+      "person_id": "238",
+      "person_name": "Goshawk"
     },
     {
       "id": 163,
-      "person_id": "432",
+      "person_id": "460",
       "person_name": "Grasshopper, Pallas's"
     },
     {
       "id": 164,
-      "person_id": "192",
+      "person_id": "220",
       "person_name": "Grebe, Black-necked"
     },
     {
       "id": 165,
-      "person_id": "469",
+      "person_id": "497",
       "person_name": "Grebe, Little"
     },
     {
       "id": 166,
-      "person_id": "40",
+      "person_id": "95",
       "person_name": "Grebe, Pied-billed"
     },
     {
       "id": 167,
-      "person_id": "451",
+      "person_id": "479",
       "person_name": "Grebe, Red-necked"
     },
     {
       "id": 168,
-      "person_id": "279",
+      "person_id": "307",
       "person_name": "Grebe, Slavonian"
     },
     {
       "id": 169,
-      "person_id": "376",
-      "person_name": "Greenfinch, "
+      "person_id": "404",
+      "person_name": "Greenfinch"
     },
     {
       "id": 170,
-      "person_id": "144",
-      "person_name": "Greenshank, "
+      "person_id": "172",
+      "person_name": "Greenshank"
     },
     {
       "id": 171,
-      "person_id": "22",
+      "person_id": "81",
       "person_name": "Grey, Great"
     },
     {
       "id": 172,
-      "person_id": "29",
+      "person_id": "85",
       "person_name": "Grey, Lesser"
     },
     {
       "id": 173,
-      "person_id": "54",
+      "person_id": "108",
       "person_name": "Grey, Southern"
     },
     {
       "id": 174,
-      "person_id": "16",
+      "person_id": "76",
       "person_name": "Grosbeak, Evening"
     },
     {
       "id": 175,
-      "person_id": "585",
+      "person_id": "613",
       "person_name": "Grosbeak, Pine"
     },
     {
       "id": 176,
-      "person_id": "389",
+      "person_id": "417",
       "person_name": "Grosbeak, Rose-breasted"
     },
     {
       "id": 177,
-      "person_id": "349",
+      "person_id": "377",
       "person_name": "Grouse, Black"
     },
     {
       "id": 178,
-      "person_id": "600",
+      "person_id": "628",
       "person_name": "Grouse, Red"
     },
     {
       "id": 179,
-      "person_id": "367",
-      "person_name": "Guillemot, "
+      "person_id": "395",
+      "person_name": "Guillemot"
     },
     {
       "id": 180,
-      "person_id": "352",
+      "person_id": "380",
       "person_name": "Guillemot, Black"
     },
     {
       "id": 181,
-      "person_id": "465",
+      "person_id": "493",
       "person_name": "Guillemot, Brunnich's"
     },
     {
       "id": 182,
-      "person_id": "343",
+      "person_id": "371",
       "person_name": "Gull, Audouin's"
     },
     {
       "id": 183,
-      "person_id": "171",
+      "person_id": "199",
       "person_name": "Gull, Black-headed"
     },
     {
       "id": 184,
-      "person_id": "485",
+      "person_id": "513",
       "person_name": "Gull, Bonaparte's"
     },
     {
       "id": 185,
-      "person_id": "536",
+      "person_id": "564",
       "person_name": "Gull, Caspian"
     },
     {
       "id": 186,
-      "person_id": "212",
+      "person_id": "240",
       "person_name": "Gull, Common"
     },
     {
       "id": 187,
-      "person_id": "562",
+      "person_id": "590",
       "person_name": "Gull, Franklin's"
     },
     {
       "id": 188,
-      "person_id": "420",
+      "person_id": "448",
       "person_name": "Gull, Glaucous"
     },
     {
       "id": 189,
-      "person_id": "80",
+      "person_id": "18",
       "person_name": "Gull, Glaucous-winged"
     },
     {
       "id": 190,
-      "person_id": "412",
+      "person_id": "440",
       "person_name": "Gull, Herring"
     },
     {
       "id": 191,
-      "person_id": "342",
+      "person_id": "370",
       "person_name": "Gull, Iceland"
     },
     {
       "id": 192,
-      "person_id": "159",
+      "person_id": "187",
       "person_name": "Gull, Ivory"
     },
     {
       "id": 193,
-      "person_id": "481",
+      "person_id": "509",
       "person_name": "Gull, Laughing"
     },
     {
       "id": 194,
-      "person_id": "468",
+      "person_id": "496",
       "person_name": "Gull, Little"
     },
     {
       "id": 195,
-      "person_id": "574",
+      "person_id": "602",
       "person_name": "Gull, Mediterranean"
     },
     {
       "id": 196,
-      "person_id": "44",
+      "person_id": "99",
       "person_name": "Gull, Ring-billed"
     },
     {
       "id": 197,
-      "person_id": "421",
+      "person_id": "449",
       "person_name": "Gull, Ross's"
     },
     {
       "id": 198,
-      "person_id": "471",
+      "person_id": "499",
       "person_name": "Gull, Sabine's"
     },
     {
       "id": 199,
-      "person_id": "178",
+      "person_id": "206",
       "person_name": "Gull, Slaty-backed"
     },
     {
       "id": 200,
-      "person_id": "381",
+      "person_id": "409",
       "person_name": "Gull, Slender-billed"
     },
     {
       "id": 201,
-      "person_id": "98",
+      "person_id": "41",
       "person_name": "Gull, Yellow-legged"
     },
     {
       "id": 202,
-      "person_id": "23",
+      "person_id": "22",
       "person_name": "Harrier, Hen"
     },
     {
       "id": 203,
-      "person_id": "179",
+      "person_id": "207",
       "person_name": "Harrier, Marsh"
     },
     {
       "id": 204,
-      "person_id": "499",
+      "person_id": "527",
       "person_name": "Harrier, Montagu's"
     },
     {
       "id": 205,
-      "person_id": "522",
+      "person_id": "550",
       "person_name": "Harrier, Northern"
     },
     {
       "id": 206,
-      "person_id": "305",
+      "person_id": "333",
       "person_name": "Harrier, Pallid"
     },
     {
       "id": 207,
-      "person_id": "221",
-      "person_name": "Hawfinch, "
+      "person_id": "249",
+      "person_name": "Hawfinch"
     },
     {
       "id": 208,
-      "person_id": "442",
+      "person_id": "470",
       "person_name": "Heron, Green"
     },
     {
       "id": 209,
-      "person_id": "101",
+      "person_id": "129",
       "person_name": "Heron, Grey"
     },
     {
       "id": 210,
-      "person_id": "307",
+      "person_id": "335",
       "person_name": "Heron, Purple"
     },
     {
       "id": 211,
-      "person_id": "123",
+      "person_id": "151",
       "person_name": "Heron, Squacco"
     },
     {
       "id": 212,
-      "person_id": "413",
+      "person_id": "441",
       "person_name": "Herring, American"
     },
     {
       "id": 213,
-      "person_id": "275",
-      "person_name": "Hobby, "
+      "person_id": "303",
+      "person_name": "Hobby"
     },
     {
       "id": 214,
-      "person_id": "24",
-      "person_name": "Honey-buzzard, "
+      "person_id": "82",
+      "person_name": "Honey-buzzard"
     },
     {
       "id": 215,
-      "person_id": "157",
-      "person_name": "Hoopoe, "
+      "person_id": "185",
+      "person_name": "Hoopoe"
     },
     {
       "id": 216,
-      "person_id": "20",
+      "person_id": "79",
       "person_name": "Ibis, Glossy"
     },
     {
       "id": 217,
       "person_id": "26",
-      "person_name": "Jackdaw, "
+      "person_name": "Jackdaw"
     },
     {
       "id": 218,
-      "person_id": "202",
-      "person_name": "Jay, "
+      "person_id": "230",
+      "person_name": "Jay"
     },
     {
       "id": 219,
-      "person_id": "172",
+      "person_id": "200",
       "person_name": "Junco, Dark-eyed"
     },
     {
       "id": 220,
-      "person_id": "158",
-      "person_name": "Kestrel, "
+      "person_id": "186",
+      "person_name": "Kestrel"
     },
     {
       "id": 221,
-      "person_id": "383",
+      "person_id": "411",
       "person_name": "Kestrel, American"
     },
     {
       "id": 222,
-      "person_id": "86",
+      "person_id": "27",
       "person_name": "Kestrel, Lesser"
     },
     {
       "id": 223,
-      "person_id": "572",
-      "person_name": "Killdeer, "
+      "person_id": "600",
+      "person_name": "Killdeer"
     },
     {
       "id": 224,
-      "person_id": "195",
-      "person_name": "Kingfisher, "
+      "person_id": "223",
+      "person_name": "Kingfisher"
     },
     {
       "id": 225,
-      "person_id": "131",
+      "person_id": "159",
       "person_name": "Kingfisher, Belted"
     },
     {
       "id": 226,
-      "person_id": "270",
+      "person_id": "298",
       "person_name": "Kite, Black"
     },
     {
       "id": 227,
-      "person_id": "274",
+      "person_id": "302",
       "person_name": "Kite, Red"
     },
     {
       "id": 228,
-      "person_id": "129",
-      "person_name": "Kittiwake, "
+      "person_id": "157",
+      "person_name": "Kittiwake"
     },
     {
       "id": 229,
-      "person_id": "354",
-      "person_name": "Knot, "
+      "person_id": "382",
+      "person_name": "Knot"
     },
     {
       "id": 230,
-      "person_id": "539",
+      "person_id": "567",
       "person_name": "Knot, Great"
     },
     {
       "id": 231,
-      "person_id": "28",
-      "person_name": "Lapwing, "
+      "person_id": "84",
+      "person_name": "Lapwing"
     },
     {
       "id": 232,
-      "person_id": "364",
+      "person_id": "392",
       "person_name": "Lark, Bimaculated"
     },
     {
       "id": 233,
-      "person_id": "478",
+      "person_id": "506",
       "person_name": "Lark, Black"
     },
     {
       "id": 234,
-      "person_id": "73",
+      "person_id": "8",
       "person_name": "Lark, Calandra"
     },
     {
       "id": 235,
-      "person_id": "333",
+      "person_id": "361",
       "person_name": "Lark, Crested"
     },
     {
       "id": 236,
-      "person_id": "268",
+      "person_id": "296",
       "person_name": "Lark, Shore"
     },
     {
       "id": 237,
-      "person_id": "581",
+      "person_id": "609",
       "person_name": "Lark, Short-toed"
     },
     {
       "id": 238,
-      "person_id": "414",
+      "person_id": "442",
       "person_name": "Lark, White-winged"
     },
     {
       "id": 239,
-      "person_id": "501",
-      "person_name": "Linnet, "
+      "person_id": "529",
+      "person_name": "Linnet"
     },
     {
       "id": 240,
-      "person_id": "214",
-      "person_name": "Magpie, "
+      "person_id": "242",
+      "person_name": "Magpie"
     },
     {
       "id": 241,
-      "person_id": "513",
-      "person_name": "Mallard, "
+      "person_id": "541",
+      "person_name": "Mallard"
     },
     {
       "id": 242,
-      "person_id": "11",
+      "person_id": "72",
       "person_name": "Martin, Crag"
     },
     {
       "id": 243,
-      "person_id": "540",
+      "person_id": "568",
       "person_name": "Martin, House"
     },
     {
       "id": 244,
-      "person_id": "41",
+      "person_id": "96",
       "person_name": "Martin, Purple"
     },
     {
       "id": 245,
-      "person_id": "94",
+      "person_id": "36",
       "person_name": "Martin, Sand"
     },
     {
       "id": 246,
-      "person_id": "544",
+      "person_id": "572",
       "person_name": "May, Cape"
     },
     {
       "id": 247,
-      "person_id": "378",
+      "person_id": "406",
       "person_name": "Merganser, Hooded"
     },
     {
       "id": 248,
-      "person_id": "457",
+      "person_id": "485",
       "person_name": "Merganser, Red-breasted"
     },
     {
       "id": 249,
-      "person_id": "199",
-      "person_name": "Merlin, "
+      "person_id": "227",
+      "person_name": "Merlin"
     },
     {
       "id": 250,
-      "person_id": "399",
+      "person_id": "427",
       "person_name": "Mockingbird, Northern"
     },
     {
       "id": 251,
-      "person_id": "36",
-      "person_name": "Moorhen, "
+      "person_id": "30",
+      "person_name": "Moorhen"
     },
     {
       "id": 252,
-      "person_id": "297",
+      "person_id": "325",
       "person_name": "Murrelet, Ancient"
     },
     {
       "id": 253,
-      "person_id": "203",
+      "person_id": "231",
       "person_name": "Murrelet, Long-billed"
     },
     {
       "id": 254,
-      "person_id": "578",
+      "person_id": "606",
       "person_name": "Night, Black-crowned"
     },
     {
       "id": 255,
-      "person_id": "194",
+      "person_id": "222",
       "person_name": "Nighthawk, Common"
     },
     {
       "id": 256,
-      "person_id": "254",
-      "person_name": "Nightingale, "
+      "person_id": "282",
+      "person_name": "Nightingale"
     },
     {
       "id": 257,
-      "person_id": "400",
+      "person_id": "428",
       "person_name": "Nightingale, Thrush"
     },
     {
       "id": 258,
-      "person_id": "358",
-      "person_name": "Nightjar, "
+      "person_id": "386",
+      "person_name": "Nightjar"
     },
     {
       "id": 259,
-      "person_id": "374",
+      "person_id": "402",
       "person_name": "Nightjar, Egyptian"
     },
     {
       "id": 260,
-      "person_id": "340",
+      "person_id": "368",
       "person_name": "Nightjar, Red-necked"
     },
     {
       "id": 261,
-      "person_id": "217",
+      "person_id": "245",
       "person_name": "Northern, Great"
     },
     {
       "id": 262,
-      "person_id": "363",
-      "person_name": "Nutcracker, "
+      "person_id": "391",
+      "person_name": "Nutcracker"
     },
     {
       "id": 263,
-      "person_id": "89",
-      "person_name": "Nuthatch, "
+      "person_id": "31",
+      "person_name": "Nuthatch"
     },
     {
       "id": 264,
-      "person_id": "177",
+      "person_id": "205",
       "person_name": "Nuthatch, Red-breasted"
     },
     {
       "id": 265,
-      "person_id": "256",
+      "person_id": "284",
       "person_name": "Olivaceous, Eastern"
     },
     {
       "id": 266,
-      "person_id": "37",
+      "person_id": "92",
       "person_name": "Oriole, Baltimore"
     },
     {
       "id": 267,
-      "person_id": "115",
+      "person_id": "143",
       "person_name": "Oriole, Golden"
     },
     {
       "id": 268,
-      "person_id": "320",
+      "person_id": "348",
       "person_name": "Orphean, Western"
     },
     {
       "id": 269,
-      "person_id": "601",
-      "person_name": "Osprey, "
+      "person_id": "629",
+      "person_name": "Osprey"
     },
     {
       "id": 270,
-      "person_id": "314",
+      "person_id": "342",
       "person_name": "Ouzel, Ring"
     },
     {
       "id": 271,
-      "person_id": "38",
-      "person_name": "Ovenbird, "
+      "person_id": "93",
+      "person_name": "Ovenbird"
     },
     {
       "id": 272,
-      "person_id": "120",
+      "person_id": "148",
       "person_name": "Owl, Barn"
     },
     {
       "id": 273,
-      "person_id": "470",
+      "person_id": "498",
       "person_name": "Owl, Hawk"
     },
     {
       "id": 274,
-      "person_id": "322",
+      "person_id": "350",
       "person_name": "Owl, Little"
     },
     {
       "id": 275,
-      "person_id": "156",
+      "person_id": "184",
       "person_name": "Owl, Long-eared"
     },
     {
       "id": 276,
-      "person_id": "250",
+      "person_id": "278",
       "person_name": "Owl, Scops"
     },
     {
       "id": 277,
-      "person_id": "149",
+      "person_id": "177",
       "person_name": "Owl, Short-eared"
     },
     {
       "id": 278,
-      "person_id": "182",
+      "person_id": "210",
       "person_name": "Owl, Snowy"
     },
     {
       "id": 279,
-      "person_id": "549",
+      "person_id": "577",
       "person_name": "Owl, Tawny"
     },
     {
       "id": 280,
-      "person_id": "521",
+      "person_id": "549",
       "person_name": "Owl, Tengmalm's"
     },
     {
       "id": 281,
-      "person_id": "405",
-      "person_name": "Oystercatcher, "
+      "person_id": "433",
+      "person_name": "Oystercatcher"
     },
     {
       "id": 282,
-      "person_id": "492",
+      "person_id": "520",
       "person_name": "Parakeet, Ring-necked"
     },
     {
       "id": 283,
-      "person_id": "281",
+      "person_id": "309",
       "person_name": "Partridge, Grey"
     },
     {
       "id": 284,
-      "person_id": "43",
+      "person_id": "98",
       "person_name": "Partridge, Red-legged"
     },
     {
       "id": 285,
-      "person_id": "124",
+      "person_id": "152",
       "person_name": "Parula, Northern"
     },
     {
       "id": 286,
-      "person_id": "39",
-      "person_name": "Peregrine, "
+      "person_id": "94",
+      "person_name": "Peregrine"
     },
     {
       "id": 287,
-      "person_id": "316",
+      "person_id": "344",
       "person_name": "Petrel, Capped"
     },
     {
       "id": 288,
-      "person_id": "91",
+      "person_id": "33",
       "person_name": "Petrel, Fea's"
     },
     {
       "id": 289,
-      "person_id": "301",
+      "person_id": "329",
       "person_name": "Petrel, Leach's"
     },
     {
       "id": 290,
-      "person_id": "596",
+      "person_id": "624",
       "person_name": "Petrel, Storm"
     },
     {
       "id": 291,
-      "person_id": "397",
+      "person_id": "425",
       "person_name": "Petrel, Swinhoe's"
     },
     {
       "id": 292,
-      "person_id": "542",
+      "person_id": "570",
       "person_name": "Petrel, White-faced"
     },
     {
       "id": 293,
-      "person_id": "288",
+      "person_id": "316",
       "person_name": "Petrel, Wilson's"
     },
     {
       "id": 294,
-      "person_id": "538",
+      "person_id": "566",
       "person_name": "Phalarope, Grey"
     },
     {
       "id": 295,
-      "person_id": "216",
+      "person_id": "244",
       "person_name": "Phalarope, Red-necked"
     },
     {
       "id": 296,
-      "person_id": "286",
+      "person_id": "314",
       "person_name": "Phalarope, Wilson's"
     },
     {
       "id": 297,
-      "person_id": "226",
-      "person_name": "Pheasant, "
+      "person_id": "254",
+      "person_name": "Pheasant"
     },
     {
       "id": 298,
-      "person_id": "259",
+      "person_id": "287",
       "person_name": "Pheasant, Golden"
     },
     {
       "id": 299,
-      "person_id": "594",
+      "person_id": "622",
       "person_name": "Phoebe, Eastern"
     },
     {
       "id": 300,
-      "person_id": "213",
-      "person_name": "Pintail, "
+      "person_id": "241",
+      "person_name": "Pintail"
     }
   ]
 }


### PR DESCRIPTION
## Description

Fix display of person name to use long_name field from database instead of reconstructing on internal dashboard 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Specifically for the federation this is needed with duplicate names.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally modified and tested the federation hub to make sure things still worked

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)