### PR TITLE
Make person lookup configurable

### DIFF
--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -134,7 +134,7 @@ EML;
                 }
             }
             $emailAddress = !empty($samlAttrs['email_address'][0]) ? $samlAttrs['email_address'][0] : NO_EMAIL_ADDRESS_SET;
-            $personId = \DataWarehouse::getPersonIdByUsername($thisSystemUserName);
+            $personId = \DataWarehouse::getPersonIdFromPII($thisSystemUserName, $samlAttrs['organization']);
 
             $userOrganization = $this->getOrganizationId($samlAttrs, $personId);
 

--- a/classes/DataWarehouse.php
+++ b/classes/DataWarehouse.php
@@ -61,32 +61,28 @@ class DataWarehouse
         destroy();
     }
 
-    /************************************************************
-	 * @function getPersonIdByUsername
-	 * @access public
-	 *
-	 * @param string username
-	 *
-	 * @return person_id or UNKNOWN_USER_TYPE (-1)
-	 ************************************************************/
-    public function getPersonIdByUsername($username = null){
-        if(!empty($username)){
-            $dbh = self::connect();
-            $personId = $dbh->query(
-                " SELECT person_id
-				FROM modw.systemaccount
-				WHERE username = :username
-				LIMIT 1",
-                array(
-                ':username' => $username,
-                )
-            );
-            if(count($personId) > 0){
-                return $personId[0]['person_id'];
-            }
+    /**
+     * @function getPersonIdByUsername
+     *
+     * Return the person_id of a user based on the username if available and
+     * unique.
+     *
+     * @param string username
+     * @return person_id or -1 if the person_id could not be determined
+     */
+    public function getPersonIdByUsername($username) {
+
+        $config = Config::factory();
+        $query = $config['user_management']['person_mapping'];
+
+        $dbh = self::connect();
+        $personId = $dbh->query($query, array(':username' => $username));
+        if(count($personId) === 1){
+            return $personId[0]['person_id'];
         }
-        return UNKNOWN_USER_TYPE;
+        return -1;
     }
+
     /************************************************************
 	 * @function getAllocations()
 	 * @access public

--- a/configuration/user_management.json
+++ b/configuration/user_management.json
@@ -1,0 +1,3 @@
+{
+    "person_mapping": "SELECT DISTINCT(person_id) AS person_id FROM `modw`.`systemaccount` WHERE username = :username"
+}

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -72,6 +72,7 @@
             "configuration/rest.d",
             "configuration/setup.json",
             "configuration/update_check.json",
+            "configuration/user_management.json",
             "configuration/assets.json",
             "configuration/modules.json",
             "configuration/hierarchies.json",


### PR DESCRIPTION
The sql query to identify a person from a username is now defined in a config file. This allows us to override the configuration for the XSEDE module (which uses a different lookup).

The code has also been updated to only map a username to a person if a unique mapping exists. Sites that have multiple different people with the same usernames on different resources will have to update the configuration file to define how to find the user properly.