### PR TITLE
allow order to be set on FOS

### DIFF
--- a/configuration/etl/etl.d/hpcdb-xdw.json
+++ b/configuration/etl/etl.d/hpcdb-xdw.json
@@ -54,7 +54,8 @@
     }, {
         "name": "field-of-science-hierarchy",
         "definition_file": "jobs/xdw/field-of-science-hierarchy.json",
-        "description": "field of science hierarchy records"
+        "description": "field of science hierarchy records",
+        "optimize_query": false
     }, {
         "name": "organization",
         "definition_file": "jobs/xdw/organization.json",


### PR DESCRIPTION
the field of science hierarchy was not getting the order set.
This will automatically set it.