### PR TITLE
Updating test users created during docker bootstrap

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -37,6 +37,10 @@ then
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack -d "CLOUD_EVENT_LOG_DIRECTORY=$REF_DIR/openstack"
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-extract-openstack
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p cloud-state-pipeline
+
+    # This will ensure that the users created in `/root/bin/createusers.php`
+    # have their organizations set correctly.
+    php /usr/share/xdmod/tools/etl/etl_overseer.php -p xdmod.acls-import
 fi
 
 if [ "$XDMOD_TEST_MODE" = "upgrade" ];

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -28,6 +28,9 @@ then
     xdmod-import-csv -t names -i $REF_DIR/names.csv
     xdmod-ingestor
     php /root/bin/createusers.php
+    # This will ensure that the users created in `/root/bin/createusers.php`
+    # have their organizations set correctly.
+    php /usr/share/xdmod/tools/etl/etl_overseer.php -p xdmod.acls-import
     #Updating minmaxdate table so data for cloud realm shows up
     mysql -e "UPDATE modw.minmaxdate SET max_job_date = '2018-07-01';"
     #Ingesting cloud data from references folder
@@ -37,10 +40,6 @@ then
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-ingest-openstack -r openstack -d "CLOUD_EVENT_LOG_DIRECTORY=$REF_DIR/openstack"
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p jobs-cloud-extract-openstack
     php /usr/share/xdmod/tools/etl/etl_overseer.php -p cloud-state-pipeline
-
-    # This will ensure that the users created in `/root/bin/createusers.php`
-    # have their organizations set correctly.
-    php /usr/share/xdmod/tools/etl/etl_overseer.php -p xdmod.acls-import
 fi
 
 if [ "$XDMOD_TEST_MODE" = "upgrade" ];


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a call to `acls-import` to the bootstrap fresh_install. 

## Motivation and Context
This will ensure that test users created during the bootstrap process have their
person / organization set appropriately. This will no longer be necessary once
we update the script that creates the users.

## Tests performed
All Automated Tests: Unit, Component, Integrated, UI

Manual Test: 
- Spin up a fresh docker w/ a fresh install
- `mysql moddb`
- `SELECT id, username, person_id, organization_id`
- Ensure that all person_id's == -1 || >= 1
- Ensure that all organization_id' == -1 || >= 1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
