### PR TITLE
Allow search panel scroll bars on small displays

### DIFF
--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -216,7 +216,9 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             modal: true,
             title: 'Search',
             layout: 'fit',
-            resizable: false,
+            resizable: true,
+            boxMaxHeight: 641,
+            boxMaxWidth: 1014,
             items: [searchPanel]
         });
         searchPanel.relayEvents(self.searchWindow, ['show', 'hide', 'move']);

--- a/html/gui/js/modules/job_viewer/SearchPanel.js
+++ b/html/gui/js/modules/job_viewer/SearchPanel.js
@@ -65,6 +65,7 @@ XDMoD.Module.JobViewer.SearchPanel = Ext.extend(Ext.Panel, {
             Ext.apply(this, {
                     layout: 'table',
                     width: 1000,
+                autoScroll: true,
                     border: false,
                     layoutConfig: {
                         columns: 2


### PR DESCRIPTION
The job viewer search panel is hardcoded to ~1000 x 600 px and cannot be resized and scrollbars are disabled. It gets aligned to the top left so is unusable on a screen that is shorter than ~600px since the buttons at the bottom are not displayed. 

This change makes it so that the panel window will show scrollbars if necessary so that the ui component is usable on small displays. 
