### PR TITLE
Fix Organizations::getNameById

### DIFF
--- a/classes/Models/Services/Organizations.php
+++ b/classes/Models/Services/Organizations.php
@@ -70,13 +70,14 @@ SQL;
     public static function getNameById($organizationId)
     {
         $query = <<<SQL
-SELECT o.name
+SELECT o.name, o.id
 FROM modw.organization o
 WHERE o.id = :organization_id
 UNION
-SELECT unk.name
+SELECT unk.name, unk.id
 FROM modw.organization unk
 WHERE unk.id = -1
+ORDER BY id DESC
 SQL;
         $params = array(
             ':organization_id' => $organizationId


### PR DESCRIPTION
The order of rows in an SQL union is not deterministic. You need to add an explicit order by clause if you want the order to be guaranteed. The original code assumed that the results would be ordered but there was no order by clause.