### PR TITLE
Add new functionality to Usage chart requests

### DIFF
--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1160,8 +1160,7 @@ class Usage extends Common
 
             $stmt = $db->prepare($query);
             $stmt->execute(array(':value' => $usageFilterValue));
-
-            return implode(',', $stmt->fetchAll(PDO::FETCH_COLUMN, 0));
+            return $stmt->fetch()[0];
         }
 
         return $usageFilterValue;

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1174,7 +1174,7 @@ class Usage extends Common
             }
 
             // If a string was provided but no id(s) were found then exception out.
-            throw new Exception(sprintf("Invalid filter value detected: %s", $usageFilterValue));
+            throw new Exception(sprintf("Invalid value detected for filter '%s': %s", $usageFilterType, $usageFilterValue));
         }
 
         return array($usageFilterValue);

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1174,7 +1174,7 @@ class Usage extends Common
             }
 
             // If a string was provided but no id(s) were found then exception out.
-            throw new Exception(sprintf("Invalid filter value detected: %s", $usageFilterType));
+            throw new Exception(sprintf("Invalid filter value detected: %s", $usageFilterValue));
         }
 
         return array($usageFilterValue);

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1158,7 +1158,7 @@ class Usage extends Common
                 ',',
                 array_reduce(
                     $rows,
-                    function($carry, $item) {
+                    function ($carry, $item) {
                         $carry[] = $item['value'];
                         return $carry;
                     },

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1174,7 +1174,7 @@ class Usage extends Common
             }
 
             // If a string was provided but no id(s) were found then exception out.
-            throw new Exception("Invalid filter value detected");
+            throw new Exception(sprintf("Invalid filter value detected: %s", $usageFilterType));
         }
 
         return array($usageFilterValue);

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1137,16 +1137,15 @@ class Usage extends Common
          * Anonymous function to prevent code duplication. $query is expected to minimally fulfill
          * the following:
          *   - contain one column in the select clause called 'value'
-         *   - utilize at least one parameter named ':param'
          *
-         * This function will execute the provided $query with $value as it's only parameter. If any
-         * records are found then the the first record's 'value' column is returned. If no records
-         * are found then $value is returned.
+         * This function will execute the provided $query with $values as the set of parameters. If
+         * any records are found then their 'value' columns are returned.
          *
          * @param string $query the sql query to be executed
          * @param array $values the one parameter that will be provided to $query.
-         * @return int|string all current queries return an int id value. If no rows are found then
-         * the string $value is returned.
+         *
+         * @return int[]|array all current queries return an int array. If no rows are found then
+         * an empty array is returned.
          */
         $lookupValue = function ($query, array $values) {
             $db = DB::factory('database');

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
@@ -694,7 +694,7 @@ EOF;
              */
             return array_reduce(
                 $results,
-                function($carry, $item) {
+                function ($carry, $item) {
                     $results = array();
                     foreach($item as $subItem) {
                         foreach($subItem as $key => $value) {

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
@@ -714,7 +714,7 @@ EOF;
                         'totalCount'=> 0,
                         'results' => array(),
                         'data' => array(),
-                        'message' => 'Invalid filter value detected',
+                        'message' => 'Invalid filter value detected: resource',
                         'code' => 0
                     )
                 ),

--- a/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/integration_tests/lib/Controllers/UsageExplorerTest.php
@@ -525,7 +525,15 @@ EOF;
         } else {
             $actual = $results[0];
 
-            $this->assertEquals($expectedValue, $actual);
+            foreach($expectedValue as $key => $value) {
+                $this->assertArrayHasKey($key, $actual);
+
+                if (is_array($value)) {
+                    // If we have an array value just make sure that the keys from the expected ==
+                    // the keys from the actual
+                    $this->assertEquals(array_keys($value), array_keys($actual[$key]));
+                }
+            }
         }
 
         if ($user !== 'pub') {
@@ -714,7 +722,7 @@ EOF;
                         'totalCount'=> 0,
                         'results' => array(),
                         'data' => array(),
-                        'message' => 'Invalid filter value detected: resource',
+                        'message' => 'Invalid filter value detected: %s',
                         'code' => 0
                     )
                 ),


### PR DESCRIPTION
# Note: This is for 8.1

## Description
Added the ability for Usage chart requests to provide non-numeric values for
'_filter' parameters. The new feature will attempt to translate these
non-numeric values into appropriate id values that can be used during chart
generation. Specifically this new feature is to support integration w/
Coldfront.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
