### PR TITLE
Set end time to start time + walltime if the elapsed time is shorter …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Open XDMoD Change Log
 =====================
+
+- Features
+    - Set end time to start time + walltime if the elapsed time is shorter than end - start. This situatin indicates that job was suspended or gang scheduled and using end and time dates from scheduler will lead to overestimated utilization of the cluster.
+
 ## 2018-10-30 v8.0.0
 
 - Features

--- a/classes/OpenXdmod/Shredder.php
+++ b/classes/OpenXdmod/Shredder.php
@@ -810,6 +810,14 @@ class Shredder
             $errorMessages[] = 'Job start time as after job end time.';
             $valid = false;
         }
+        elseif ( $startTime !== null
+                 && $endTime != null
+                 && $walltime != null
+                 && ($endTime - $startTime) > $walltime ) {
+            $this->logger->debug('Found difference between end time and start time ('.$endTime-$startTime.') bigger than walltime ('.$walltime.') reported by scheduler. Probably job was suspended or gang scheduled');
+            $errorMessages[] = 'Difference between job end and start times is bigger than wall time reported by scheduler. Probably job was suspended or gang scheduled.';
+            $valid = false;
+        }
 
         return array($valid, $errorMessages);
     }
@@ -871,6 +879,14 @@ class Shredder
             // Assume the end time is correct.
             $startTime = $endTime - $walltime;
             $this->logger->debug("Setting start time to $startTime");
+        }
+        elseif ( ($endTime - $startTime) > $walltime)
+        {
+            // Fix end time to startTime + walltime.
+            //If those doesn't match duratin is probably overestimated -
+            //because of job suspention or gang scheduling mechanisms
+            $endTime = $startTime + $walltime;
+            $this->logger->debug("Setting end time to $endTime");
         }
 
         return array($startTime, $endTime, $walltime);


### PR DESCRIPTION
…than end - start. This situation indicates that job was suspended or gang scheduled and using

end and time dates from scheduler will lead to overestimated utilization of the cluster. Please advice if this makes sense for you - if yes I can work on unit tests and other requirements.


## Description
Add time checking and timeFix functions of Shredder the capability to overwrite endTime in case when endTime-startTime is larger than walltime reported by queuing system. In case of Slurm this means that the job was suspended and we shouldn't use endTime and startTime as the estimate for utiliation and number of hours spend in this job. Better solution would be to calculate "cpu" factor as a fraction, which will require more changes. 

## Motivation and Context
Specifically for Slurm scheduler (but probably for all with similar features) start and endtime of the job is not a real measure of time spent on job.  Since xdmod relies on end - start for job time estimate end time in case of suspended/gang scheduled jobs should be estimated based on start+walltime.
## Tests performed
Tested data shredder for my production clusters. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
