### PR TITLE
Replacing shell_exec w/ proc_open

### DIFF
--- a/classes/OpenXdmod/Setup/AclEtl.php
+++ b/classes/OpenXdmod/Setup/AclEtl.php
@@ -66,7 +66,7 @@ class AclEtl
             $pipes
         );
 
-        if (!is_resource($process)) {
+        if ( false === is_resource($process) ) {
             throw new \Exception("Failed to create subprocess: %s", $cmd);
         }
 

--- a/classes/OpenXdmod/Setup/AclEtl.php
+++ b/classes/OpenXdmod/Setup/AclEtl.php
@@ -67,7 +67,9 @@ class AclEtl
         );
 
         if ( false === is_resource($process) ) {
-            throw new \Exception("Failed to create subprocess: %s", $cmd);
+            throw new \Exception(
+                sprintf("Failed to create subprocess '%s': %s", $cmd, (null !== error_get_last() ? error_get_last() : "") )
+            );
         }
 
         $stdOut = stream_get_contents($pipes[1]);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Unable to differentiate between a command that has no output and an command that
errors out when using `shell_exec`. By replacing this with `proc_open` we're
able to retain STDOUT and STDERR but we also get access to the commands
return value. We make sure to not swallow when a command errors out by throwing
an exception when this is detected.

## Motivation and Context
This PR is the result of addressing the concerns brought up in support ticket:
https://help.xdmod.org/a/tickets/11402

## Tests performed
Manual Testing in XDMoD standard docker container.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
