### PR TITLE
Exclude dev files from production build

### DIFF
--- a/open_xdmod/modules/xdmod/assets/setup.sh
+++ b/open_xdmod/modules/xdmod/assets/setup.sh
@@ -9,7 +9,7 @@ xdmod_dir="$module_dir/../../.."
 
 echo Installing composer managed dependencies
 cd $xdmod_dir
-composer install --no-dev
+composer install --no-dev --prefer-dist
 
 echo Compiling report builder code
 cd "$xdmod_dir/reporting/jasper_builder"

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -21,13 +21,9 @@
         "exclude_patterns": [
             "#/\\.#",
             "#xdmod-.*\\.rpm$#",
+            "#\\.eslintrc\\.json$#",
             "#xdmod-.*\\.tar\\.gz$#",
             "#^\\/configuration\\/.+\\..+\\.template$#"
-        ]
-    },
-    "commands": {
-        "pre_build": [
-            "find . -type f -name .eslintrc.json -delete"
         ]
     },
     "file_maps": {

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/validate.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/validate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# This script is intended to be used to run tests that validate the correct
+# packaging / install behavour of XDMoD. For example checking the
+# file permissions are correct on the RPM packaged files.
+
+exitcode=0
+
+# Check that there are no development artifacts installed in the RPM
+if rpm -ql xdmod | fgrep .eslintrc.json;
+then
+    echo "Error eslintrc files found in the RPM";
+    exitcode=1
+fi
+
+exit $exitcode

--- a/shippable.yml
+++ b/shippable.yml
@@ -18,6 +18,7 @@ build:
         - composer install --no-progress
         - ~/bin/buildrpm xdmod
         - ./open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+        - ./open_xdmod/modules/xdmod/integration_tests/scripts/validate.sh
         - composer install --no-progress
         - cp ~/assets/secrets.json open_xdmod/modules/xdmod/integration_tests/.secrets.json
         - ./open_xdmod/modules/xdmod/regression_tests/runtests.sh --junit-output-dir `pwd`/shippable/testresults/


### PR DESCRIPTION
This change excludes development files from the production RPM. This reduces the installed footprint by about 10MB. Also updated the build script so that it correctly excludes the eslintrc files from the build without messing with the development tree.

Also added tests.