### PR TITLE
Implement path filtering for modules

### DIFF
--- a/classes/OpenXdmod/Build/Packager.php
+++ b/classes/OpenXdmod/Build/Packager.php
@@ -867,6 +867,27 @@ class Packager
        }
     }
 
+    /** Check to see if a file or directory is to be excluded from the build
+     * because of the configuration settings.
+     *
+     * @param filePath path of file to check
+     * @return true if the file is to be excluded false otherwise.
+     */
+    private function isFilePathExcluded($filePath)
+    {
+        if (array_search($filePath, $this->config->getFileExcludePaths()) !== false) {
+            return true;
+        }
+
+        foreach ($this->config->getFileExcludePatterns() as $pattern) {
+            if (preg_match($pattern, $filePath) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Copy a directory recursively.
      *
@@ -875,6 +896,10 @@ class Packager
      */
     private function copyDir($srcDir, $destDir)
     {
+        if ($this->isFilePathExcluded($srcDir)) {
+            return;
+        }
+
         if (!is_dir($srcDir)) {
             throw new Exception("Directory '$srcDir' does not exist");
         }
@@ -894,6 +919,10 @@ class Packager
 
             $srcFile  = "$srcDir/$file";
             $destFile = "$destDir/$file";
+
+            if ($this->isFilePathExcluded($srcFile)) {
+                continue;
+            }
 
             if (is_file($srcFile)) {
                 $this->copyFile($srcFile, $destFile);

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -25,11 +25,6 @@
             "#^\\/configuration\\/.+\\..+\\.template$#"
         ]
     },
-    "commands": {
-        "pre_build": [
-            "find . -type f -name .eslintrc.json -delete"
-        ]
-    },
     "file_maps": {
         "data": [
             "classes",

--- a/open_xdmod/modules/xdmod/integration_tests/scripts/validate.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/validate.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script is intended to be used to run tests that validate the correct
+# packaging / install behavour of XDMoD. For example checking the
+# file permissions are correct on the RPM packaged files.
+
+exitcode=0
+
+# Check that there are no development artifacts installed in the RPM
+if rpm -ql xdmod | fgrep .eslintrc.json; then
+    echo "Error eslintrc files found in the RPM"
+    exitcode=1
+fi
+
+for file in open_xdmod/build/*.tar.gz;
+do
+    echo "Checking $file"
+    if tar tf $file | fgrep .eslintrc.json; then
+        echo "Error eslintrc files found in build tarball $file"
+        exitcode=1
+    fi
+done
+
+exit $exitcode

--- a/shippable.yml
+++ b/shippable.yml
@@ -18,6 +18,7 @@ build:
         - composer install --no-progress
         - ~/bin/buildrpm xdmod
         - ./open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+        - ./open_xdmod/modules/xdmod/integration_tests/scripts/validate.sh
         - composer install --no-progress
         - cp ~/assets/secrets.json open_xdmod/modules/xdmod/integration_tests/.secrets.json
         - ./open_xdmod/modules/xdmod/regression_tests/runtests.sh --junit-output-dir `pwd`/shippable/testresults/


### PR DESCRIPTION
## Description
When building a module (or when copying the files under open_xdmod/*), the installer ignored the exclude_paths and exclude_patterns settings from the build.json file. This lead to work-arounds such as #715.

This change makes it so that these settings are honoured and reverts the workaround that was added in #715. Also adds a test to check that the new code works properly.