### PR TITLE
Asynchronous loading of Usage tab thumbnail charts 

### DIFF
--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -1428,7 +1428,6 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                             var chart_params = Ext.apply({}, Ext.util.JSON.decode(r.get('chart_settings')), menuParams);
 
                             var deferStore = new Ext.data.JsonStore({
-                                storeId: 'chart_store_' + id,
                                 autoDestroy: true,
                                 root: 'data',
                                 totalProperty: 'totalCount',

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -431,6 +431,8 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
         var self = this;
 
+        var handleDataException;
+
         var public_user = this.public_user || CCR.xdmod.publicUser;
 
         /*
@@ -1185,6 +1187,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
         // ---------------------------------------------------------
 
         function onSelectNode(model, n) {
+            var parameters;
 
             if (!n || !n.text) return;
             if (!self.getDurationSelector().validate()) return;
@@ -1246,7 +1249,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                 this.legendTypeComboBox.disable();
 
 
-                var parameters = [];
+                parameters = [];
 
                 if (n.attributes.node_type == 'statistic') {
                     parameters = getChartParameters(n);
@@ -1321,7 +1324,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                 } else if (n.attributes.node_type == 'statistic') {
 
                     view.tpl = largeChartTemplate;
-                    var parameters = getChartParameters(n);
+                    parameters = getChartParameters(n);
                     this.legendTypeComboBox.enable();
                     this.chartTitleField.enable();
 
@@ -1344,7 +1347,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                 } else if (n.attributes.node_type == 'group_by') {
 
                     view.tpl = thumbnailChartTemplate;
-                    var parameters = getMenuParameters(n);
+                    parameters = getMenuParameters(n);
                     chartStore.removeAll(true);
                     maximizeScale.call(this);
                     this.legendTypeComboBox.disable();
@@ -1538,7 +1541,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
         // ---------------------------------------------------------
 
-        var handleDataException = function (response, exceptionType) {
+        handleDataException = function (response, exceptionType) {
             var viewer = CCR.xdmod.ui.Viewer.getViewer();
 
             if (exceptionType === 'response') {

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -1353,6 +1353,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                     this.legendTypeComboBox.disable();
                     this.chartTitleField.disable();
 
+                    parameters.summary = true;
                     parameters.operation = 'get_charts';
                     chartStore.load({
                         params: parameters
@@ -1408,17 +1409,56 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
                         this.charts = [];
 
-                        var ind = 0;
+                        var menuParams = getMenuParameters(n);
 
                         chartStore.each(function (r) {
 
                             var id = r.get('random_id');
 
-                            var task = new Ext.util.DelayedTask(function () {
+                            var chartContainer = Ext.get(id);
 
+                            if (!chartContainer) {
+                                return;
+                            }
+
+                            chartContainer.setWidth(CCR.xdmod.ui.thumbWidth * chartThumbScale);
+                            chartContainer.setHeight(CCR.xdmod.ui.thumbHeight * chartThumbScale);
+                            chartContainer.mask('Loading...');
+
+                            var chart_params = Ext.apply({}, Ext.util.JSON.decode(r.get('chart_settings')), menuParams);
+
+                            var deferStore = new Ext.data.JsonStore({
+                                storeId: 'chart_store_' + id,
+                                autoDestroy: true,
+                                root: 'data',
+                                totalProperty: 'totalCount',
+                                successProperty: 'success',
+                                messageProperty: 'message',
+                                fields: self.chartDataFields,
+                                baseParams: {
+                                    operation: 'get_charts',
+                                    public_user: public_user,
+                                    controller_module: self.module_id
+                                },
+                                proxy: new Ext.data.HttpProxy({
+                                    method: 'POST',
+                                    url: this.chartDataURL
+                                }),
+                                listeners: {
+                                    exception: function (reader, type, action, opt, response) {
+                                        handleDataException(response, type);
+                                    }
+                                }
+                            });
+
+                            var chartBuilder = function (chartRecords, options, success) {
                                 // If the rendering target no longer
                                 // exists, don't create the chart.
                                 if (!Ext.get(id)) {
+                                    return;
+                                }
+
+                                if (!success) {
                                     return;
                                 }
 
@@ -1466,20 +1506,23 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
                                 }; //baseChartOptions
 
-                                var chartOptions = r.get('hc_jsonstore');
+                                var chartOptions = {};
+                                if (chartRecords.length > 0) {
+                                    chartOptions = chartRecords[0].get('hc_jsonstore');
+                                }
                                 jQuery.extend(true, chartOptions, baseChartOptions);
 
                                 chartOptions.exporting.enabled = false;
                                 chartOptions.credits.enabled = false;
 
                                 this.charts.push(new Highcharts.Chart(chartOptions));
+                            };
 
-                            }, this); //task
-
-                            task.delay(0);
-
-                            return true;
-
+                            deferStore.load({
+                                params: chart_params,
+                                callback: chartBuilder,
+                                scope: self
+                            });
                         }, this); //chartStore.each(function(r)
 
                         self.getDurationSelector().enable();


### PR DESCRIPTION
The thumbnail charts view in the Usage tab has been painfully slow since the usage backend was replaced by a shim layer that uses the metric explorer backend. 

This pull request does not fix the poor performance of the backend code. Instead it makes the thumbnail charts load asynchronously. The user interface is still responsive while the charts are loading and the charts are loaded from top to bottom so the visible ones are likely to be rendered first (although this is not guaranteed due to the async nature).

Changing the loader code to only load the visible charts is left as an exercise for Ben.