### PR TITLE
Revert workaround for thumbnail slowness.

### DIFF
--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -962,34 +962,10 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
                 if (child) {
 
-                    tree.expandPath(child.getPath(), null, function (success) {
-                        // If the summary node was successfully expanded...
-                        if (success) {
-                            // If available, open the default statistic.
-                            //
-                            // Open XDMoD Default: CPU Hours: Total
-                            // XDMoD Default: XD SUs Charged: Total
-                            var defaultStatistic = CCR.xdmod.features.xsede ? "total_su" : "total_cpu_hours";
-                            var jobCountNode = child.findChild("statistic", defaultStatistic);
-                            if (jobCountNode && !jobCountNode.disabled) {
-                                tree.getSelectionModel().select(jobCountNode);
-                                return;
-                            }
+                    tree.getSelectionModel().select(child);
 
-                            // Otherwise, open the first available statistic,
-                            // if any.
-                            var firstAvailableStatisticNode = child.findChildBy(function (n) {
-                                return !n.disabled;
-                            });
-                            if (firstAvailableStatisticNode) {
-                                tree.getSelectionModel().select(firstAvailableStatisticNode);
-                                return;
-                            }
-                        }
+                    tree.expandPath(child.getPath(), null, function () {
 
-                        // If none of the summary node's children could be
-                        // opened, select the summary node.
-                        tree.getSelectionModel().select(child);
                     });
 
                 } //if(child)


### PR DESCRIPTION
This patch reverts commit 43fa0377154e35ec639968ffefe95c88f38186b4
from Wed Nov 25 10:12:49 2015 -0500 (note this predates github).

Prior to commit 43fa0377154, the Usage tab in XDMoD displayed a thumbnail view
by default. The thumbnail view showed multiple charts, one for each of
the statistics of the first node in the catalog.

The XDMoD code was changed to use the metric explorer backend to generate
the data for the Usage tab. Unfortunately, the changes resulted in terrible load
performance for the thumbnail view. A short term workaround was
implemented in commit 43fa0377154. This
workaround loaded one of the charts by default rather than the thunmbnail
chart view.

The changes in https://github.com/ubccr/xdmod/pull/750 mitigate
the slowness so this pull request reverts the workaround.