### PR TITLE
Fix deprecation warning

### DIFF
--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -70,9 +70,9 @@ EML;
                 $authSource = null;
             }
             if (!is_null($authSource) && array_search($authSource, $this->_sources) !== false) {
-                $this->_as = new \SimpleSAML_Auth_Simple($authSource);
+                $this->_as = new \SimpleSAML\Auth\Simple($authSource);
             } else {
-                $this->_as = new \SimpleSAML_Auth_Simple($this->_sources[0]);
+                $this->_as = new \SimpleSAML\Auth\Simple($this->_sources[0]);
             }
         }
     }


### PR DESCRIPTION
as reported by @treydock 

```
Dec 19 12:24:17 xdmod-test simplesamlphp[88861]: 4 [TR5d8c0783] The class or interface 'SimpleSAML_Auth_Simple' is now using namespaces, please use 'SimpleSAML\Auth\Simple'.
```