### PR TITLE
Make lastLogin time be floored to the second instead of microtime

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -1133,9 +1133,20 @@ SQL;
     public function getLastLoginTimestamp()
     {
 
-        $results = $this->_pdo->query("SELECT FROM_UNIXTIME(init_time) as lastLogin FROM SessionManager WHERE user_id=:user_id ORDER BY init_time DESC LIMIT 1", array(
-            ':user_id' => $this->_id,
-        ));
+        $results = $this->_pdo->query(
+            "SELECT
+                FROM_UNIXTIME(FLOOR(init_time)) AS lastLogin
+            FROM
+                SessionManager
+            WHERE
+                user_id = :user_id
+            ORDER BY
+                init_time DESC
+            LIMIT 1",
+            array(
+                ':user_id' => $this->_id,
+            )
+        );
 
         if (count($results) == 0) {
             return "Never logged in";


### PR DESCRIPTION
This specifically removes the microtime from lastLoginTimestamp, but will also effect this line: https://github.com/ubccr/xdmod/blob/xdmod8.1/html/index.php#L520

Which will now show the ProfileEditor for Single Sign On (SSO) users that just so happen to have their account created and their login happen within the same second.

This maintains the previous functionality.

This does not address the following issues:
User is created and the first login does not happen in the same second (all non SSO users)
User refreshes the page / leaves and comes back without logging out will continue to see the profile editor dialog.

This might be fixed at a later date.