### PR TITLE
Explicitly cast potentiall nulls to array for array_merge()

### DIFF
--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -180,8 +180,8 @@ class EtlOverseer extends \CCR\Loggable implements iEtlOverseer
                     // Verify that specified resource codes are valid
 
                     $codeList = array_merge(
-                        $action->getOptions()->include_only_resource_codes,
-                        $action->getOptions()->exclude_resource_codes
+                        (array) $action->getOptions()->include_only_resource_codes,
+                        (array) $action->getOptions()->exclude_resource_codes
                     );
                     $this->verifyResourceCodes($codeList);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If resource codes are specified for either inclusion or exclusion the mapping between resource codes and database ids is loaded and the resource codes are verified against this mapping. If only inclusion or exclusion resources were specified, a `null` would be passed to `array_merge()` causing an error. This PR casts the value to an array to mitigate this.

## Motivation and Context

Fixes error when running ETL on XSEDE
```
Warning: array_merge(): Argument #1 is not an array in /data/www/xdmod/share/classes/ETL/EtlOverseer.php on line 185
```

## Tests performed

Manual testing on XSEDE development instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
