### PR TITLE
Fixing Center Syncing w/ SSO Users

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -3245,6 +3245,12 @@ SQL;
             // Update / save the user with their new organization
             $this->setOrganizationId($expectedOrganization);
             $this->saveUser();
+
+            // Since we've removed this users relation to center acls we need to make sure that
+            // user_acl_group_by_parameters stays in sync.
+            foreach(self::$CENTER_ACLS as $acl) {
+                $this->setOrganizations(array(), $acl);
+            }
         }
     }
 
@@ -3272,6 +3278,21 @@ SQL;
                 $this->setOrganizationID($organizationId);
 
                 $this->saveUser();
+
+                // We need to make sure that we preserve this users center related information
+                // in user_acl_group_by_parameters.
+                $centerAcls = array_intersect($this->getAcls(true), array('cd', 'cs'));
+                foreach ($centerAcls as $acl) {
+                    $this->setOrganizations(
+                        array(
+                            $this->getOrganizationID() => array(
+                                'primary' => 1,
+                                'active' => 1
+                            )
+                        ),
+                        $acl
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While we were updating a Users's organization during `XDUser::postLogin` we were
not keeping `user_acl_group_by_parameters` in sync. This caused their old
organization to be shown when viewing the `Top Role` section of `My Profile`.

## Motivation and Context
Consistency is good.

## Tests performed
Manual Tests were performed
- Update an SSO User's person to 'Unknown, Unknown' and their organization to 'Unk' 
  - Make a note of their original organization if it's different than their SSO organization.
- Assign either: `Center Director` or `Center Staff` if they do not already have one of these acls.
- Login as that user ( via SSO )
- Click the 'My Profile' button
- Ensure that the 'Top Role' is displayed as expected.
  - ex. Center Staff - SUNY Buffalo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
