### PR TITLE
Add migration for Metric Explorer query store.

### DIFF
--- a/html/controllers/ui_data/summary3.php
+++ b/html/controllers/ui_data/summary3.php
@@ -86,20 +86,8 @@ try {
 
     if (!isset($_REQUEST['public_user']) || $_REQUEST['public_user'] != 'true')
     {
-        $userProfile = $logged_in_user->getProfile();
-
-        // Attempt to retrieve the queries from the new location, falling back
-        // to the old location. In either case normalize the results so that
-        // the proceeding code can be standardized.
-        $queries = $userProfile->fetchValue('queries_store');
-        if (!isset($queries)) {
-            $queries = $userProfile->fetchValue('queries');
-            if ($queries != null) {
-                $queries = array_values(json_decode($queries, true));
-            }
-        } else if (isset($queries['data'])) {
-            $queries = $queries['data'];
-        }
+        $queryStore = new \UserStorage($logged_in_user, 'queries_store');
+        $queries = $queryStore->get();
 
         if ($queries != NULL) {
             foreach ($queries as $i => $query) {

--- a/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Migration/Version800To810/DatabasesMigrationTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/OpenXdmod/Tests/Migration/Version800To810/DatabasesMigrationTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace UnitTesting\OpenXdmod\Tests\Migration\Version800To810;
+
+use TestHelpers\mock\MockXDUserProfile;
+
+class DatabasesMigrationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider migrationDataProvider
+     */
+    public function testMetricExplorerQueryMigrations($input, $expected) {
+
+        // Note - the profile may be modifed by the call to migrateMetricExplorerQueries
+        // so create a fresh one for each test case
+        $profile = new MockXDUserProfile;
+        
+        foreach($input as $key => $value) {
+            $profile->setValue($key, $value);
+        }
+
+        $mockuser = $this->getMockBuilder('\XDUser')
+                    ->disableOriginalConstructor()
+                    ->getMock();
+
+        $mockuser->method('getProfile')->willReturn($profile);
+
+        $migration = new \OpenXdmod\Migration\Version800To810\DatabasesMigration('800', '810');
+        $pubmeth = \TestHelpers\TestHelper::unlockMethod($migration, 'migrateMetricExplorerQueries');
+
+        $pubmeth->invokeArgs($migration, array($mockuser));
+
+        $this->assertEquals($expected, $profile);
+    }
+
+    /**
+     * Generate some test blobs that will be used in the various test
+     * scenarios
+     */
+    private static function generateChartBlobs()
+    {
+        $pseudoChartData = array(
+            array(
+                'ts' => 123123433,
+                'name' => 'chart1',
+                'config' => 'Config for Chart 1'
+            ),
+            array(
+                'ts' => 15675546,
+                'name' => 'chart2',
+                'config' => 'Config for Chart 2'
+            )
+        );
+
+        $legacyData = array();
+
+        $newData = array();
+        $oldData = array(
+            array(
+                'recordid' => 0,
+                'ts' => 156755846,
+                'name' => 'Existing New Style Chart',
+                'config' => 'Config for Existing New Style Chart'
+            )
+        );
+
+        $newStyleSingleChart = array('maxid' => 0, 'data' => $oldData);
+
+        $chartCount = 0;
+        foreach ($pseudoChartData as $chartData) {
+            $legacyData[$chartData['name']] = $chartData;
+            $newData[] = array_merge(array('recordid' => $chartCount), $chartData);
+            $oldData[] = array_merge(array('recordid' => $chartCount + 1), $chartData);
+                
+            $chartCount += 1;
+        }
+
+        $newStyleThreeCharts = array('maxid' => $chartCount, 'data' => $oldData);
+        $newStyleTwoCharts = array('maxid' => $chartCount - 1, 'data' => $newData);
+        $oldStyleTwoCharts = json_encode($legacyData);
+
+        return array(
+            $oldStyleTwoCharts,
+            $newStyleSingleChart,
+            $newStyleTwoCharts,
+            $newStyleThreeCharts
+        );
+    }
+
+    /**
+     * Data sources for the tests
+     */
+    public function migrationDataProvider()
+    {
+        list($oldStyleTwoCharts, $newStyleSingleChart, $newStyleTwoCharts, $newStyleThreeCharts) = self::generateChartBlobs();
+
+        $tests = array();
+
+        $emptyProfile = new MockXDUserProfile();
+
+        $singleChartProfile = new MockXDUserProfile();
+        $singleChartProfile->setValue('queries_store', $newStyleSingleChart);
+
+        $twoChartProfile = new MockXDUserProfile();
+        $twoChartProfile->setValue('queries_store', $newStyleTwoCharts);
+
+        $threeChartProfile = new MockXDUserProfile();
+        $threeChartProfile->setValue('queries_store', $newStyleThreeCharts);
+
+        $migrationMetadata = array(
+            'maxid' => 0,
+            'data' => array(
+                array('queries_migrated' => true, 'recordid' => 0)
+            )
+        );
+            
+        // Check that the straight migration works
+        $tests[] = array(
+            array('queries' => $oldStyleTwoCharts),
+            $twoChartProfile
+        );
+
+        // Check that migration metadata is removed correctly
+        $tests[] = array(
+            array('query_metadata' => $migrationMetadata),
+            $emptyProfile
+        );
+
+        // Check that migration metadata is checked and no migration occurs
+        $tests[] = array(
+            array(
+                'query_metadata' => $migrationMetadata,
+                'queries' => $oldStyleTwoCharts
+            ),
+            $emptyProfile
+        );
+
+        // Check that no migration occurs when metadata is set even if
+        // there is old data in the system.
+
+        $tests[] = array(
+            array(
+                'query_metadata' => $migrationMetadata,
+                'queries' => $oldStyleTwoCharts,
+                'queries_store' => $newStyleSingleChart
+            ),
+            $singleChartProfile
+        );
+
+        // Check old and new data merge works ok
+        $tests[] = array(
+            array(
+                'queries' => $oldStyleTwoCharts,
+                'queries_store' => $newStyleSingleChart
+            ),
+            $threeChartProfile
+        );
+        return $tests;
+    }
+}


### PR DESCRIPTION
The current code had paths in both the summary controller and metric explorer rest stack that tried to handle the case where metric explorer saved chart data was stored in the pre-XDMoD 5.5 format. Needless to say it is a bit wastefull to run these checks every time and it also has an impact on code maintenance. 

This change runs the migration once in the upgrade so that any pre XDMoD 5.5 save charts will be converted to the current format. The code that handles the old format is removed.

<ESC>:wq