### PR TITLE
Enforce javascript unit tests

### DIFF
--- a/html/unit_tests/Array.prototype.includes.js
+++ b/html/unit_tests/Array.prototype.includes.js
@@ -1,0 +1,37 @@
+/* eslint no-extend-native: "off", no-bitwise: "off" */
+// Any copyright is dedicated to the Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
+// Source https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Polyfill
+if (!Array.prototype.includes) {
+    Object.defineProperty(Array.prototype, 'includes', {
+        value: function (valueToFind, fromIndex) {
+            if (this == null) {
+                throw new TypeError('"this" is null or not defined');
+            }
+
+            var o = Object(this);
+
+            var len = o.length >>> 0;
+
+            if (len === 0) {
+                return false;
+            }
+
+            var n = fromIndex | 0;
+
+            var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+            function sameValueZero(x, y) {
+                return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+            }
+
+            while (k < len) {
+                if (sameValueZero(o[k], valueToFind)) {
+                    return true;
+                }
+                k++;
+            }
+
+            return false;
+        }
+    });
+}

--- a/html/unit_tests/index.html
+++ b/html/unit_tests/index.html
@@ -10,6 +10,9 @@
   <div id="messages"></div>
   <div id="fixtures"></div>
 
+  <!-- Array.prototype.includes polyfill -->
+  <script src="./Array.prototype.includes.js"></script>
+
   <!-- Test harness scripts pulled from github CDN -->
   <script src="https://cdn.rawgit.com/jquery/jquery/2.1.4/dist/jquery.min.js"></script>
   <script src="https://cdn.rawgit.com/Automattic/expect.js/0.3.1/index.js"></script>
@@ -39,10 +42,12 @@
   <!-- Files to test -->
   <script>
 Ext.ns('CCR', 'CCR.xdmod', 'CCR.xdmod.ui', 'XDMoD.REST');
+CCR.xdmod.ui.rawDataAllowedRealms = ['Jobs'];
   </script>
   <script data-cover src="../gui/js/ChangeStack.js"></script>
   <script data-cover src="../gui/js/CCR.js"></script>
 
+  <script type="text/javascript" src="../gui/js/ExportPanel.js"></script>
   <script type="text/javascript" src="../gui/js/PortalModule.js"></script>
   <script type="text/javascript" src="../gui/js/RealTimeValidatingTextField.js"></script>
   <script type="text/javascript" src="../gui/js/plugins/CollapsedPanelTitlePlugin.js"></script>

--- a/html/unit_tests/phantom.js
+++ b/html/unit_tests/phantom.js
@@ -1,4 +1,22 @@
+/* eslint no-console: "off" */
 var page = require('webpage').create();
+
+page.onError = function (msg, trace) {
+    var msgStack = ['PHANTOM ERROR: ' + msg];
+    if (trace && trace.length) {
+        msgStack.push('TRACE:');
+        trace.forEach(function (t) {
+            msgStack.push(' -> ' + (t.file || t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function + ')' : ''));
+        });
+    }
+    console.log(msgStack.join('\n'));
+    phantom.exit(1);
+};
+
+page.onConsoleMessage = function (msg) {
+    console.log(msg);
+};
+
 page.open('file://' + phantom.libraryPath + '/index.html', function (status) {
     var failures = -1;
     if (status === 'success') {


### PR DESCRIPTION
The test harness was not correctly reporting when the javascript unit tests failed. This change
ensures that the test failures are properly reported to the CI infrastructure.

Also the tests were failing to run. This pull request includes the updates needed to get the tests running again:
- polyfill for Array.prototype.includes() (which is missing from phantomjs but used in the code
- script includes for the ExportPanel (needed by the job viewer)
- populate the rawDataAllowedRealms variable.