### PR TITLE
Add support for campus champion parameters

### DIFF
--- a/classes/Models/Services/Parameters.php
+++ b/classes/Models/Services/Parameters.php
@@ -38,6 +38,9 @@ class Parameters
                 case 'provider':
                     $parameters['provider'] = (string)$user->getOrganizationID();
                     break;
+                case 'institution':
+                    $parameters['institution'] = (string)$user->getOrganizationID();
+                    break;
                 case 'person':
                     $parameters['person'] = (string)$user->getPersonID();
                     break;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
`Parameters::getParameters` needed to have a case `institution` to support
Campus Champions users.

**NOTE: For a future PR, this should be redone in a way so as to allow modules to configure which acls require additional information and where to get it.** 

## Motivation and Context
Campus Champions in an XSEDE install should work.

## Tests performed
Manual Testing was performed: 
- Assign a user the 'Campus Champion' acl
- Log in as that user
- Ensure that all of the charts etc. show up as expected on the 'Summary' tab.
  - Previously, no data was shown as `Parameters::getParameters` didn't know how to handle a request for `institution` parameters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
