### PR TITLE
Don't automatically rewind DirectoryScanner file handle

### DIFF
--- a/classes/ETL/DataEndpoint/DirectoryScanner.php
+++ b/classes/ETL/DataEndpoint/DirectoryScanner.php
@@ -611,9 +611,6 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
 
         $this->handle = $iterator;
 
-        // Rewind the handle so it is ready to use.
-        $this->handle->rewind();
-
         return $this->handle;
 
     }  // connect()
@@ -781,9 +778,10 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
             // By default the key is the path and the value is an SplFileInfo object.
             // http://php.net/manual/en/class.splfileinfo.php
 
-            $this->logger->debug("Initializing first file iterator");
+            $key = $this->handle->key();
+            $this->logger->debug(sprintf("Initializing first file iterator: %s", $key));
 
-            $this->initializeCurrentFileIterator($this->handle->key());
+            $this->initializeCurrentFileIterator($key);
 
             // Save the first file iterator so we don't need to re-parse the first file on rewind
 
@@ -1035,6 +1033,7 @@ class DirectoryScanner extends aDataEndpoint implements iStructuredFile, iComple
         // If current file iterator is NULL then initialize it
 
         if ( null === $this->currentFileIterator ) {
+            $this->rewind();
             $this->valid();
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When running the DirectoryScanner ETL DataEndpoint in docker using the latest overlay2 storage driver and PHP 5.4, the `DirectoryScannerTest::testPatternFilters()` automated tests would fail because an incorrect number of files (exactly 2 times the expected number) was returned from a directory scan. When using the aufs driver (as shippable.com does) this did not manifest.

The error occurs when the `CallbackFilterIterator::rewind()` method is called twice in a row. The set of records returned by the iterator is duplicated. Since we iterate over the set using `foreach` and a `rewind()` is called under the hood by PHP it is not necessary to explicitly call it ourselves.

**Note that this bug does not manifest in PHP7 running in docker.**

## Motivation and Context

Rescue developers from insanity wondering why tests that have been working for years are now failing.

## Tests performed

Manual docker testing and automated testing in docker.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
