### PR TITLE
Move the postprocessing SQL to the aggregation pipeline

### DIFF
--- a/etl/js/.eslintrc.json
+++ b/etl/js/.eslintrc.json
@@ -6,6 +6,8 @@
       "ecmaVersion": 6
   },
   "rules": {
+      "no-underscore-dangle": 0,
+      "no-param-reassign": 0,
       "no-template-curly-in-string": 0
   }
 }

--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -128,10 +128,11 @@ ETLProfile.prototype.processDatasets = function (datasetNames, totalCores, coreI
 	}
 }
 ETLProfile.prototype.processDataset = function (dataset, totalCores, coreIndex, markProcessedRecords) {
-	this.emit('message', 'ETLProfile: processDataset: ' + dataset.name+ '[totalCores: '+totalCores+', coreIndex: ' + coreIndex + ']' );
+    this.emit('message', 'ETLProfile: processDataset: ' + dataset.name + '[totalCores: ' + totalCores + ', coreIndex: ' + coreIndex + ']');
     var self = this;
+    var datasetProcessor;
     try {
-        var datasetProcessor = new DatasetProcessor(this, dataset, markProcessedRecords);
+        datasetProcessor = new DatasetProcessor(this, dataset, markProcessedRecords);
     } catch (ex) {
         self.emit('error', ex);
         return;
@@ -142,85 +143,80 @@ ETLProfile.prototype.processDataset = function (dataset, totalCores, coreIndex, 
     datasetProcessor.on('error', function (error) {
         self.emit('error', error);
     });
-	datasetProcessor.on('afterprocess', function (processingDetails, etlLog) {
-       	self.emit('message', dataset.name + ': afterprocess: \n' + util.inspect(processingDetails));
+    datasetProcessor.on('afterprocess', function (processingDetails, etlLog) {
+        self.emit('message', dataset.name + ': afterprocess: \n' + util.inspect(processingDetails));
 
-		self.emit('message', 'Loggin ETL run');
-		var etlLogHeader = {
-			etlProfileName: "etlProfile.name",
-			etlProfileVersion: "etlProfile.version", 
-			dataset: "etlProfile.dataset[i].name",
-			start_ts: "etl start time",
-			end_ts: "etl end time",
-			min_index: "min record etld",
-			max_index: "max record etld",
-			processed: "number of docs processed",
-			good: "number of processed that were good",
-			details: "any extras"
-		};
+        self.emit('message', 'Loggin ETL run');
+        var etlLogHeader = {
+            etlProfileName: 'etlProfile.name',
+            etlProfileVersion: 'etlProfile.version',
+            dataset: 'etlProfile.dataset[i].name',
+            start_ts: 'etl start time',
+            end_ts: 'etl end time',
+            min_index: 'min record etld',
+            max_index: 'max record etld',
+            processed: 'number of docs processed',
+            good: 'number of processed that were good',
+            details: 'any extras'
+        };
 
-		for(var key in etlLog) {
-			if(! (key in etlLogHeader)) {
-				
-				throw Error ('The etlLog must conform to the etlLogHeader. key: ' + key + '\netLogHeader: ' + util.inspect(etlLogHeader) + '\nGiven etlLog: ' +util.inspect(etlLog));
-			}
-		}
-		
-		var etlLogKeys = Object.keys(etlLog);
-		var mysqlConfig = util._extend({
-			multipleStatements: true,
-			}, config.etlLogging.config); 
-		var mysqlConnection = mysql.createConnection(mysqlConfig);
-		var insertLog = 'insert into ' + config.etlLogging.config.database + '.log (' + etlLogKeys.join(',') + ') values (:' + etlLogKeys.join(',:') + ')';
-		insertLog = queryFormat(insertLog,etlLog);
-		//console.log(insertLog);
-		mysqlConnection.query(insertLog, function (err, result) {
-			mysqlConnection.end();
-			if (err) {
-				self.emit('error', err);
-				return;
-			}
-			
-			dataset._processed = true;
-			dataset._processingDetails = processingDetails;
-			
-			var allProcessed = true;
-			for(var ds = 0; ds < self.datasets.length && allProcessed; ds++) {
-				allProcessed = allProcessed && (self.datasets[ds]._processed === true);
-			}
-			if(allProcessed === true) {
-				//combine all processing details and send as one
-				var allProcessingDetails = DatasetProcessor.initBaseStats();
-				for(var ds = 0; ds < self.datasets.length; ds++) {
-					DatasetProcessor.addStats(allProcessingDetails, self.datasets[ds]._processingDetails);
-				}
+        for (var key in etlLog) {
+            if (!(key in etlLogHeader)) {
+                throw Error('The etlLog must conform to the etlLogHeader. key: ' + key + '\netLogHeader: ' + util.inspect(etlLogHeader) + '\nGiven etlLog: ' + util.inspect(etlLog));
+            }
+        }
 
-				if( self.schema.postprocess ) {
-					var mysqlConfig = util._extend({
-						multipleStatements: true
-					}, self.output.config);
-					var myhandle = mysql.createConnection(mysqlConfig);
-					var postProcessingStatements = self.schema.postprocess.join(";");
-					myhandle.query(postProcessingStatements, function(err, result) {
-						myhandle.end();
-						if (err) {
-							self.emit('error', err + ': ' + postProcessingStatements);
-						}
-						self.emit('message', "Ran post-process statements. Results: " + JSON.stringify(result, null, 4) );
-						self.emit('afterprocessall', allProcessingDetails);
-					});
-				} else {
-					self.emit('afterprocessall', allProcessingDetails);
-				}
+        var etlLogKeys = Object.keys(etlLog);
+        var mysqlConfig = util._extend({
+            multipleStatements: true
+        }, config.etlLogging.config);
+        var mysqlConnection = mysql.createConnection(mysqlConfig);
+        var insertLog = 'insert into ' + config.etlLogging.config.database + '.log (' + etlLogKeys.join(',') + ') values (:' + etlLogKeys.join(',:') + ')';
+        insertLog = queryFormat(insertLog, etlLog);
 
-			}
-		});
-		
+        mysqlConnection.query(insertLog, function (err, result) {
+            mysqlConnection.end();
+            if (err) {
+                self.emit('error', err);
+                return;
+            }
 
-		
+            dataset._processed = true;
+            dataset._processingDetails = processingDetails;
+
+            var allProcessed = true;
+            for (let ds = 0; ds < self.datasets.length && allProcessed; ds++) {
+                allProcessed = allProcessed && (self.datasets[ds]._processed === true);
+            }
+            if (allProcessed === true) {
+                // combine all processing details and send as one
+                var allProcessingDetails = DatasetProcessor.initBaseStats();
+                for (let ds = 0; ds < self.datasets.length; ds++) {
+                    DatasetProcessor.addStats(allProcessingDetails, self.datasets[ds]._processingDetails);
+                }
+
+                if (self.schema.postprocess) {
+                    var mysqlConfig = util._extend({
+                        multipleStatements: true
+                    }, self.output.config);
+                    var myhandle = mysql.createConnection(mysqlConfig);
+                    var postProcessingStatements = self.schema.postprocess.join(";");
+                    myhandle.query(postProcessingStatements, function(err, result) {
+                        myhandle.end();
+                        if (err) {
+                            self.emit('error', err + ': ' + postProcessingStatements);
+                        }
+                        self.emit('message', "Ran post-process statements. Results: " + JSON.stringify(result, null, 4) );
+                        self.emit('afterprocessall', allProcessingDetails);
+                    });
+                } else {
+                    self.emit('afterprocessall', allProcessingDetails);
+                }
+            }
+        });
     });
     datasetProcessor.process(totalCores, coreIndex);
-}
+};
 
 /*
 * @returns the dynamic tables for the etl profile. 

--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -194,24 +194,7 @@ ETLProfile.prototype.processDataset = function (dataset, totalCores, coreIndex, 
                 for (let ds = 0; ds < self.datasets.length; ds++) {
                     DatasetProcessor.addStats(allProcessingDetails, self.datasets[ds]._processingDetails);
                 }
-
-                if (self.schema.postprocess) {
-                    var mysqlConfig = util._extend({
-                        multipleStatements: true
-                    }, self.output.config);
-                    var myhandle = mysql.createConnection(mysqlConfig);
-                    var postProcessingStatements = self.schema.postprocess.join(";");
-                    myhandle.query(postProcessingStatements, function(err, result) {
-                        myhandle.end();
-                        if (err) {
-                            self.emit('error', err + ': ' + postProcessingStatements);
-                        }
-                        self.emit('message', "Ran post-process statements. Results: " + JSON.stringify(result, null, 4) );
-                        self.emit('afterprocessall', allProcessingDetails);
-                    });
-                } else {
-                    self.emit('afterprocessall', allProcessingDetails);
-                }
+                self.emit('afterprocessall', allProcessingDetails);
             }
         });
     });

--- a/etl/js/lib/etlv2.js
+++ b/etl/js/lib/etlv2.js
@@ -28,7 +28,7 @@ var remapSql = function (sql) {
     return output;
 };
 
-var mkdirAndWrite = function (dirname, filename, data) {
+var mkdirAndWrite = function (dirname, filename, data, type = 'json') {
     try {
         fs.mkdirSync(dirname);
     } catch (exception) {
@@ -37,7 +37,11 @@ var mkdirAndWrite = function (dirname, filename, data) {
             throw exception;
         }
     }
-    fs.writeFileSync(dirname + '/' + filename + '.json', JSON.stringify(data, null, 4));
+    if (type === 'json') {
+        fs.writeFileSync(dirname + '/' + filename + '.json', JSON.stringify(data, null, 4));
+    } else {
+        fs.writeFileSync(dirname + '/' + filename, data);
+    }
 };
 
 var generateAggTableIdentifier = function (table, hasJobList) {
@@ -390,6 +394,11 @@ module.exports = {
     generateDefinitionFiles: function (profile, xdmodConfigDirectory) {
         var etlv2ConfigDir = xdmodConfigDirectory + '/etl';
         var tables = profile.getAggregationTables();
+
+        if (profile.schema.postprocess) {
+            let sqlDefnDir = etlv2ConfigDir + '/etl_sql.d/' + profile.name.toLowerCase().split(' ')[0];
+            mkdirAndWrite(sqlDefnDir, 'postprocess.sql', profile.schema.postprocess.join('//\n'), 'sql');
+        }
 
         for (let t in tables) {
             if (tables.hasOwnProperty(t)) {


### PR DESCRIPTION
The postprocessing SQL statements were previously executed after the end of data for each resource. This meant that the same statement was executed multiple times on systems that had multiple resources. When the query is executing the database is locked so no ingestion can happen. On our staging system (that has a slow database) the postprocessing query took so long to run that it ended up hitting the mongo connection timeouts for some of the resources.

This changes the framework to not execute the SQL in the ingestion process at all. Instead it is written to an ETLv2 config file and must be executed in the etlv2 pipeline before aggregation.

Note that there are two commits - the first one fixes up the style. The actual code changes are in the second commit.