### PR TITLE
Active, Primary, Most Privileged Role Consolidation

### DIFF
--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -618,8 +618,12 @@ class MetricExplorer extends Common
         } else {
             $activeRoleComponents = explode(':', $activeRoleId);
             $activeRoleComponents = array_pad($activeRoleComponents, 2, null);
-            $activeRoleName = XDUser::_getFormalRoleName($activeRoleComponents[0], false);
-            $activeRoleParameters = Parameters::getParameters($user, $activeRoleName);
+            $activeRoleId = $activeRoleComponents[0];
+            $activeRole = Acls::getAclByName($activeRoleId);
+            if ($activeRole === null) {
+                $activeRoleId = ROLE_ID_PUBLIC;
+            }
+            $activeRoleParameters = Parameters::getParameters($user, $activeRoleId);
         }
 
         // For each set of filter parameters the role has, create an

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -585,7 +585,7 @@ class MetricExplorer extends Common
                 $realm_name,
                 $group_by_name,
                 $statistic_name,
-                $userRole->getIdentifier()
+                $userRole
             );
             if ($accessPermitted) {
                 $authorizedRoles[] = $userRole;
@@ -618,11 +618,8 @@ class MetricExplorer extends Common
         } else {
             $activeRoleComponents = explode(':', $activeRoleId);
             $activeRoleComponents = array_pad($activeRoleComponents, 2, null);
-            $activeRole = $user->assumeActiveRole(
-                $activeRoleComponents[0],
-                $activeRoleComponents[1]
-            );
-            $activeRoleParameters = Parameters::getParameters($user, $activeRole->getIdentifier());
+            $activeRoleName = XDUser::_getFormalRoleName($activeRoleComponents[0], false);
+            $activeRoleParameters = Parameters::getParameters($user, $activeRoleName);
         }
 
         // For each set of filter parameters the role has, create an

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -617,7 +617,6 @@ class MetricExplorer extends Common
             );
         } else {
             $activeRoleComponents = explode(':', $activeRoleId);
-            $activeRoleComponents = array_pad($activeRoleComponents, 2, null);
             $activeRoleId = $activeRoleComponents[0];
             $activeRole = Acls::getAclByName($activeRoleId);
             if ($activeRole === null) {

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -5,6 +5,7 @@ namespace DataWarehouse\Access;
 use Exception;
 use Models\Services\Parameters;
 use Models\Services\Acls;
+use Models\Services\Realms;
 use PDOException;
 use stdClass;
 
@@ -1010,7 +1011,7 @@ class MetricExplorer extends Common
      * @return array              The realms available to the user.
      */
     public static function getRealmsFromUser(XDUser $user, $queryGroup = 'tg_usage') {
-        return array_keys($user->getMostPrivilegedRole()->getAllQueryRealms($queryGroup));
+        return Realms::getRealmsForUser($user);
     }
 
     /**

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -1536,7 +1536,8 @@ class Query
 
     /**
      * This function checks to see if the stats have been initialized for the provided $realm and if
-     * not, it calls `registerStatistics` and `registerGroupBys`.
+     * not, it calls `registerStatistics`. It also checks if the group bys have been initialized and
+     * if not calls`registerGroupBys`.
      *
      * Note: This is required because of the public static functions above. Since they are
      * `public static` they can be called without having to instantiate Query ( or calling
@@ -1549,6 +1550,10 @@ class Query
     {
         if (!self::$_stats_initialized[$realm]) {
             self::registerStatistics();
+
+        }
+
+        if (!self::$_group_bys_initialized[$realm]) {
             self::registerGroupBys();
         }
     }

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -1130,7 +1130,7 @@ class Query
 
         foreach($rolearray as $role) {
 
-            $roleparams = Parameters::getParameters($user, $role->getIdentifier());
+            $roleparams = Parameters::getParameters($user, $role);
 
             if(count($roleparams) == 0 ) {
                 // Empty where condition translates to a "WHERE 1". There is no need to add the other
@@ -1497,6 +1497,7 @@ class Query
 	public static function &get_group_by_name_to_instance()
     {
         $realm = static::getRealm();
+        self::initData($realm);
 
         if (!isset(self::$_group_by_name_to_instance[$realm])) {
             self::$_group_by_name_to_instance[$realm] = array();
@@ -1510,6 +1511,7 @@ class Query
     public static function &get_group_by_name_to_class_name()
     {
         $realm = static::getRealm();
+        self::initData($realm);
 
         if (!isset(self::$_group_by_name_to_class_name[$realm])) {
             self::$_group_by_name_to_class_name[$realm] = array();
@@ -1523,12 +1525,32 @@ class Query
     public static function &get_statistic_name_to_class_name()
     {
         $realm = static::getRealm();
+        self::initData($realm);
 
         if (!isset(self::$_statistic_name_to_class_name[$realm])) {
             self::$_statistic_name_to_class_name[$realm] = array();
         }
 
         return self::$_statistic_name_to_class_name[$realm];
+    }
+
+    /**
+     * This function checks to see if the stats have been initialized for the provided $realm and if
+     * not, it calls `registerStatistics` and `registerGroupBys`.
+     *
+     * Note: This is required because of the public static functions above. Since they are
+     * `public static` they can be called without having to instantiate Query ( or calling
+     * `Query::getGroupBy` ). So this function provides an easy method of ensuring that the
+     * statistics / groupBys data structures are populated before use.
+     *
+     * @param string $realm
+     */
+    private static function initData($realm)
+    {
+        if (!self::$_stats_initialized[$realm]) {
+            self::registerStatistics();
+            self::registerGroupBys();
+        }
     }
 
     /*

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -1497,11 +1497,8 @@ class Query
 	public static function &get_group_by_name_to_instance()
     {
         $realm = static::getRealm();
-        self::initData($realm);
 
-        if (!isset(self::$_group_by_name_to_instance[$realm])) {
-            self::$_group_by_name_to_instance[$realm] = array();
-        }
+        self::initData($realm);
 
         return self::$_group_by_name_to_instance[$realm];
     }
@@ -1511,11 +1508,8 @@ class Query
     public static function &get_group_by_name_to_class_name()
     {
         $realm = static::getRealm();
-        self::initData($realm);
 
-        if (!isset(self::$_group_by_name_to_class_name[$realm])) {
-            self::$_group_by_name_to_class_name[$realm] = array();
-        }
+        self::initData($realm);
 
         return self::$_group_by_name_to_class_name[$realm];
     }
@@ -1525,11 +1519,8 @@ class Query
     public static function &get_statistic_name_to_class_name()
     {
         $realm = static::getRealm();
-        self::initData($realm);
 
-        if (!isset(self::$_statistic_name_to_class_name[$realm])) {
-            self::$_statistic_name_to_class_name[$realm] = array();
-        }
+        self::initData($realm);
 
         return self::$_statistic_name_to_class_name[$realm];
     }

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -1548,12 +1548,12 @@ class Query
      */
     private static function initData($realm)
     {
-        if (!self::$_stats_initialized[$realm]) {
+        if (!isset(self::$_stats_initialized[$realm])) {
             self::registerStatistics();
 
         }
 
-        if (!self::$_group_bys_initialized[$realm]) {
+        if (!isset(self::$_group_bys_initialized[$realm])) {
             self::registerGroupBys();
         }
     }

--- a/classes/DataWarehouse/QueryBuilder.php
+++ b/classes/DataWarehouse/QueryBuilder.php
@@ -223,7 +223,6 @@ class QueryBuilder
                     substr($query_group, 0, strpos($query_group, $suffix))
                 );
 
-                $role_data = array_pad($role_data, 2, NULL);
                 $activeRole = XDUser::_getFormalRoleName($role_data[0], true);
 
                 $role_parameters = Parameters::getParameters($user, $activeRole);
@@ -344,7 +343,6 @@ class QueryBuilder
                     substr($query_group, 0, strpos($query_group, $suffix))
                 );
 
-                $role_data = array_pad($role_data, 2, NULL);
                 $activeRole = XDUser::_getFormalRoleName($role_data[0], true);
 
                 $role_parameters = Parameters::getParameters($user, $activeRole);

--- a/classes/DataWarehouse/QueryBuilder.php
+++ b/classes/DataWarehouse/QueryBuilder.php
@@ -237,8 +237,6 @@ class QueryBuilder
             }
         }
 
-        $user->setCachedActiveRole($activeRole);
-
         if (!isset($request['start_date'])) {
             throw new \Exception(
                 'Parameter start_date (yyyy-mm-dd) is not set'
@@ -365,8 +363,6 @@ class QueryBuilder
                 $query_group = 'tg' . $suffix;
             }
         }
-
-        $user->setCachedActiveRole($activeRole);
 
         $query_descripter = Acls::getQueryDescripters(
             $user,

--- a/classes/DataWarehouse/QueryBuilder.php
+++ b/classes/DataWarehouse/QueryBuilder.php
@@ -4,6 +4,7 @@ namespace DataWarehouse;
 
 use Models\Services\Acls;
 use Models\Services\Parameters;
+use XDUser;
 
 /**
  * Singleton class for helping guide the creation of a Query object.
@@ -190,8 +191,6 @@ class QueryBuilder
         $rp_usage_regex   = '/rp_(?P<rp_id>[0-9]+)_usage/';
         $rp_summary_regex = '/rp_(?P<rp_id>[0-9]+)_summary/';
 
-        $activeRole = $user->getMostPrivilegedRole();
-
         if (
                $query_group === 'my_usage'
             || $query_group === 'my_summary'
@@ -225,13 +224,9 @@ class QueryBuilder
                 );
 
                 $role_data = array_pad($role_data, 2, NULL);
+                $activeRole = XDUser::_getFormalRoleName($role_data[0], true);
 
-                $activeRole = $user->assumeActiveRole(
-                    $role_data[0],
-                    $role_data[1]
-                );
-
-                $role_parameters = Parameters::getParameters($user, $activeRole->getIdentifier());
+                $role_parameters = Parameters::getParameters($user, $activeRole);
                 $request = array_merge($request, $role_parameters);
                 $query_group = 'tg' . $suffix;
             }
@@ -325,8 +320,6 @@ class QueryBuilder
         $rp_usage_regex   = '/rp_(?P<rp_id>[0-9]+)_usage/';
         $rp_summary_regex = '/rp_(?P<rp_id>[0-9]+)_summary/';
 
-        $activeRole = $user->getMostPrivilegedRole();
-
         if (preg_match($rp_usage_regex, $query_group, $matches) > 0) {
             $request['provider'] = $matches['rp_id'];
             $query_group         = 'tg_usage';
@@ -352,13 +345,9 @@ class QueryBuilder
                 );
 
                 $role_data = array_pad($role_data, 2, NULL);
+                $activeRole = XDUser::_getFormalRoleName($role_data[0], true);
 
-                $activeRole = $user->assumeActiveRole(
-                    $role_data[0],
-                    $role_data[1]
-                );
-
-                $role_parameters = Parameters::getParameters($user, $activeRole->getIdentifier());
+                $role_parameters = Parameters::getParameters($user, $activeRole);
                 $request = array_merge($request, $role_parameters);
                 $query_group = 'tg' . $suffix;
             }

--- a/classes/Models/Services/Acls.php
+++ b/classes/Models/Services/Acls.php
@@ -529,6 +529,24 @@ SQL;
     }
 
     /**
+     * Attempt to retrieve an Acl via it's `display` value. This corresponds to `moddb.acls.display`
+     * If an acl is not found then null will be returned.
+     *
+     * @param string $display
+     * @return Acl|null
+     * @throws Exception
+     */
+    public static function getAclByDisplay($display)
+    {
+        $db = DB::factory('database');
+        $rows = $db->query('SELECT * FROM acls a WHERE a.display = :display', array(':display' => $display));
+        if (count($rows) > 0) {
+            return new Acl($rows[0]);
+        }
+        return null;
+    }
+
+    /**
      * Attempt to retrieve all descriptors for the provided user.
      *
      * @param XDUser $user the user to use when retrieving the descriptors.

--- a/classes/Models/Services/Organizations.php
+++ b/classes/Models/Services/Organizations.php
@@ -60,6 +60,17 @@ SQL;
         return !empty($rows) ? $rows[0]['id'] : -1;
     }
 
+    public static function getAbbrevById($organizationId)
+    {
+        $db = DB::factory('database');
+        $rows = $db->query(
+            "SELECT o.abbrev FROM modw.organization o WHERE o.id = :organization_id",
+            array(':organization_id' => $organizationId)
+        );
+
+        return $rows[0]['abbrev'];
+    }
+
     /**
      * Attempt to retrieve the organization_id for the specified person_id.
      *

--- a/classes/Models/Services/Organizations.php
+++ b/classes/Models/Services/Organizations.php
@@ -60,6 +60,13 @@ SQL;
         return !empty($rows) ? $rows[0]['id'] : -1;
     }
 
+    /**
+     * Retrieve an organizations `abbrev` value based on the provided `$organizationId`.
+     *
+     * @param integer $organizationId
+     * @return string
+     * @throws \Exception
+     */
     public static function getAbbrevById($organizationId)
     {
         $db = DB::factory('database');

--- a/classes/Models/Services/Parameters.php
+++ b/classes/Models/Services/Parameters.php
@@ -38,6 +38,9 @@ class Parameters
                 case 'provider':
                     $parameters['provider'] = (string)$user->getOrganizationID();
                     break;
+                case 'institution':
+                    $parameters['institution'] = (string)$user->getOrganizationID();
+                    break;
                 case 'person':
                     $parameters['person'] = (string)$user->getPersonID();
                     break;

--- a/classes/Rest/Controllers/MetricExplorerControllerProvider.php
+++ b/classes/Rest/Controllers/MetricExplorerControllerProvider.php
@@ -388,7 +388,7 @@ class MetricExplorerControllerProvider extends BaseControllerProvider
         unset($queryConfig->active_role);
 
         // Check whether or not $activeRoleId is an acl name or acl display value.
-        // ( Old queries may acl display ).
+        // ( Old queries may utilize the `display` property).
         $activeRole = Acls::getAclByName($activeRoleId);
         if ($activeRole === null) {
             $activeRole = Acls::getAclByDisplay($activeRoleId);

--- a/classes/Rest/Controllers/MetricExplorerControllerProvider.php
+++ b/classes/Rest/Controllers/MetricExplorerControllerProvider.php
@@ -2,6 +2,7 @@
 
 namespace Rest\Controllers;
 
+use Models\Services\Acls;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -386,6 +387,15 @@ class MetricExplorerControllerProvider extends BaseControllerProvider
         $activeRoleId = $queryConfig->active_role;
         unset($queryConfig->active_role);
 
+        // Check whether or not $activeRoleId is an acl name or acl display value.
+        // ( Old queries may acl display ).
+        $activeRole = Acls::getAclByName($activeRoleId);
+        if ($activeRole === null) {
+            $activeRole = Acls::getAclByDisplay($activeRoleId);
+            if ($activeRole !== null) {
+                $activeRoleId = $activeRole->getName();
+            }
+        }
         // Convert the active role into global filters.
         MetricExplorer::convertActiveRoleToGlobalFilters($user, $activeRoleId, $queryConfig->global_filters);
 

--- a/classes/Rest/Controllers/UserControllerProvider.php
+++ b/classes/Rest/Controllers/UserControllerProvider.php
@@ -2,6 +2,7 @@
 
 namespace Rest\Controllers;
 
+use Models\Services\Organizations;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -126,7 +127,12 @@ class UserControllerProvider extends BaseControllerProvider
         if ($emailAddress == NO_EMAIL_ADDRESS_SET) {
             $emailAddress = '';
         }
-
+        $mostPrivileged = $user->getMostPrivilegedRole();
+        $mostPrivilegedFormalName = $mostPrivileged->getFormalName();
+        if (count(array_intersect(XDUser::$CENTER_ACLS, $user->getAcls(true))) > 0) {
+            $organization = Organizations::getAbbrevById($user->getOrganizationID());
+            $mostPrivilegedFormalName = "$mostPrivilegedFormalName - $organization";
+        }
         return array(
             'first_name' => $user->getFirstName(),
             'last_name' => $user->getLastName(),
@@ -135,8 +141,8 @@ class UserControllerProvider extends BaseControllerProvider
             'first_time_login' => $user->getCreationTimestamp() == $user->getLastLoginTimestamp(),
             'autoload_suppression' => isset($_SESSION['suppress_profile_autoload']),
             'field_of_science' => $user->getFieldOfScience(),
-            'active_role' => $user->getActiveRole()->getFormalName(),
-            'most_privileged_role' => $user->getMostPrivilegedRole()->getFormalName(),
+            'active_role' => $mostPrivilegedFormalName,
+            'most_privileged_role' => $mostPrivilegedFormalName,
         );
     }
 

--- a/classes/Rest/Controllers/UserControllerProvider.php
+++ b/classes/Rest/Controllers/UserControllerProvider.php
@@ -128,7 +128,7 @@ class UserControllerProvider extends BaseControllerProvider
             $emailAddress = '';
         }
         $mostPrivileged = $user->getMostPrivilegedRole();
-        $mostPrivilegedFormalName = $mostPrivileged->getFormalName();
+        $mostPrivilegedFormalName = $mostPrivileged->getDisplay();
         if (count(array_intersect(XDUser::$CENTER_ACLS, $user->getAcls(true))) > 0) {
             $organization = Organizations::getAbbrevById($user->getOrganizationID());
             $mostPrivilegedFormalName = "$mostPrivilegedFormalName - $organization";

--- a/classes/Rest/Controllers/UserControllerProvider.php
+++ b/classes/Rest/Controllers/UserControllerProvider.php
@@ -142,7 +142,7 @@ class UserControllerProvider extends BaseControllerProvider
             'autoload_suppression' => isset($_SESSION['suppress_profile_autoload']),
             'field_of_science' => $user->getFieldOfScience(),
             'active_role' => $mostPrivilegedFormalName,
-            'most_privileged_role' => $mostPrivilegedFormalName,
+            'most_privileged_role' => $mostPrivilegedFormalName
         );
     }
 

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -732,6 +732,7 @@ class WarehouseControllerProvider extends BaseControllerProvider
                     $dimensionsToReturn[] = array(
                         'id' => $queryDescriptor->getGroupByName(),
                         'name' => $queryDescriptor->getGroupByLabel(),
+                        // NOTE: 'Category' is capitalized for historical reasons.
                         'Category' => $queryDescriptor->getGroupByCategory(),
                         'description' => $queryDescriptor->getGroupByDescription()
                     );

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -1157,12 +1157,12 @@ class WarehouseControllerProvider extends BaseControllerProvider
 
     public function processJobSearch(Request $request, Application $app, XDUser $user, $realm, $startDate, $endDate, $action)
     {
-        $queryRealms = Acls::getQueryDescripters($user, $realm);
+        $queryDescripters = Acls::getQueryDescripters($user, $realm);
 
         $offset = $this->getIntParam($request, 'start', true);
         $limit = $this->getIntParam($request, 'limit', true);
 
-        $allowableDimensions = array_keys($queryRealms);
+        $allowableDimensions = array_keys($queryDescripters);
 
         $params = $this->parseRestArguments($request, $allowableDimensions, false, 'params');
 

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2153,22 +2153,17 @@ SQL;
      *
      * @function getMostPrivilegedRole
      *
-     * @return aRole subclass instance
+     * @return Acl
      *
      */
 
     public function getMostPrivilegedRole()
     {
+        if (!isset($this->_mostPrivilegedAcl)) {
+            $this->_mostPrivilegedAcl = Acls::getMostPrivilegedAcl($this);
+        }
 
-        // XDUser::enumAllAvailableRoles already orders the roles in terms of 'visibility' / 'highest privilege'
-        // so just acquire the first item in the set.
-        $mostPrivilegedAcl = Acls::getMostPrivilegedAcl($this);
-        $roleName = self::_getFormalRoleName($mostPrivilegedAcl->getName());
-        $role = aRole::factory($roleName);
-
-        $role->configure($this, $mostPrivilegedAcl->getOrganizationId());
-
-        return $role;
+        return $this->_mostPrivilegedAcl;
     }//getMostPrivilegedRole
 
     /* @function getAllRoles
@@ -2524,6 +2519,16 @@ SQL;
             ? $this->_acls
             : array_keys($this->_acls);
     } // getAcls
+
+    /**
+     * Retrieve an array of names for this user's currently assigned Acls.
+     *
+     * @return String[]
+     */
+    public function getAclNames()
+    {
+        return array_keys($this->_acls);
+    }
 
     /**
      * Overwrite this users current set of acls with the provided ones.

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -37,8 +37,6 @@ class XDUser extends CCR\Loggable implements JsonSerializable
     private $_timePasswordUpdated;
 
     private $_roles;
-    private $_primary_role;             // Instance of class \User\aRole
-    private $_active_role;              // Instance of class \User\aRole
 
     private $_field_of_science = 0;
 
@@ -50,14 +48,17 @@ class XDUser extends CCR\Loggable implements JsonSerializable
     private $_update_token = false;
     private $_token;
 
-    private $_cachedActiveRole;
-
     /**
      * An array that is assumed to be stored in the following manner:
      *   _acls[$acl->name] = $acl;
      * @var Acl[]
      */
     private $_acls;
+
+    /**
+     * @var Acl
+     */
+    private $_mostPrivilegedAcl;
 
     /**
      * A static reference to the public user. That is used as a singleton so
@@ -108,7 +109,7 @@ EML;
      *
      * @var array
      */
-    private static $CENTER_ACLS = array('cd', 'cs');
+    public static $CENTER_ACLS = array('cd', 'cs', 'cc');
 
     /**
      * These are the only SSO attribtutes that should be included when setting `$this->ssoAttrs;`
@@ -231,15 +232,6 @@ EML;
 
         $this->_update_token = true;
         $this->_token = NULL;
-
-        // =================================
-
-        $primary_role_name = self::_getFormalRoleName($primary_role);
-
-        // These roles cannot be used immediately after constructing a new XDUser (since a user id has not been defined at this point).
-        // If you are explicitly calling 'new XDUser(...)', saveUser() must be called on the newly created XDUser object before accessing
-        // these roles using getPrimaryRole() and getActiveRole()
-        $this->_primary_role = $this->_active_role = \User\aRole::factory($primary_role_name);
 
         $this->sticky = $sticky;
 
@@ -561,13 +553,7 @@ EML;
 
         $user->sticky = (bool)$userCheck[0]['sticky'];
 
-        // We retrieve the most privileged acl for this user and use it for the
-        // active / primary role.
-        $mostPrivilegedAcl = Acls::getMostPrivilegedAcl($user);
-        $activeRoleFormalName = self::_getFormalRoleName($mostPrivilegedAcl->getName());
-
-        $user->_primary_role = $user->_active_role = aRole::factory($activeRoleFormalName);
-        $user->_active_role->configure($user);
+        $user->_mostPrivilegedAcl = Acls::getMostPrivilegedAcl($user);
 
         // BEGIN: ACL population
         $query = <<<SQL
@@ -1092,19 +1078,16 @@ SQL;
             throw new Exception('Unable to determine this users most privileged acl. There may be a problem with the state of the database.');
         }
 
-        $activeRoleName = self::_getFormalRoleName($mostPrivilegedAcl->getName());
-        $this->_primary_role = $this->_active_role = aRole::factory($activeRoleName);
+        $mostPrivilegedRoleId = $this->_getRoleID($mostPrivilegedAcl->getName());
 
-        $active_role_id = $this->_getRoleID($this->_active_role->getIdentifier());
         $this->_pdo->execute(
             "UPDATE UserRoles SET is_active='1' WHERE user_id=:id AND role_id=:roleId",
-            array('id' => $this->_id, 'roleId' => $active_role_id)
+            array('id' => $this->_id, 'roleId' => $mostPrivilegedRoleId)
         );
-        $this->_active_role->configure($this);
 
         $this->_pdo->execute(
             "UPDATE UserRoles SET is_primary='1' WHERE user_id = :id AND role_id=:roleId",
-            array(':id' => $this->_id, ':roleId' => $active_role_id)
+            array(':id' => $this->_id, ':roleId' => $mostPrivilegedRoleId)
         );
 
         $timestampData = $this->_pdo->query(
@@ -1770,12 +1753,6 @@ SQL
                 ':acl_id' => $acl->getAclId()
             )
         );
-        // =======================================
-
-        $active_is_in_set = false;
-        $primary_is_in_set = false;
-
-        $active_organization = NULL;
 
         foreach ($organization_ids as $organization_id => $config) {
 
@@ -1784,23 +1761,16 @@ SQL
 
             if (($config['active'] == true) && ($reassignActiveToPrimary == false)) {
                 $active_flag = 1;
-                $active_is_in_set = true;
             }
 
             if ($config['primary'] == true) {
 
                 $primary_flag = 1;
-                $primary_is_in_set = true;
 
                 if ($reassignActiveToPrimary == true) {
                     $active_flag = 1;
-                    $active_is_in_set = true;
                 }
 
-            }
-
-            if ($active_flag == 1) {
-                $active_organization = $organization_id;
             }
 
             $insertStatement = "INSERT INTO UserRoleParameters " .
@@ -1842,17 +1812,6 @@ SQL
                 )
             );
         }//foreach
-
-        // =======================================
-
-        if ($active_is_in_set == true) {
-            $this->setActiveRole($role, $active_organization);
-        }
-
-        if ($primary_is_in_set == true) {
-            $this->setPrimaryRole($role);
-        }
-
     }//setOrganizations
 
     // ---------------------------
@@ -2189,81 +2148,6 @@ SQL;
         $this->setAcls($acls);
     }
 
-    // ---------------------------
-
-    /*
-     *
-     * @function getPrimaryRole
-     *
-     * @return string
-     *
-     */
-
-    public function getPrimaryRole()
-    {
-
-        if ($this->_id == NULL) {
-            throw new Exception('You must call saveUser() on this newly created XDUser prior to using getPrimaryRole()');
-        }
-
-        return $this->_primary_role;
-
-    }//getPrimaryRole
-
-    // ---------------------------
-
-    /*
-     *
-     * @function setPrimaryRole
-     *
-     * @param string $primary_role
-     *
-     */
-
-    public function setPrimaryRole($primary_role)
-    {
-
-        $primary_role_name = self::_getFormalRoleName($primary_role);
-
-        if ($primary_role_name == NULL) {
-            throw new Exception("Attempting to set an invalid primary role");
-        }
-
-        $this->_primary_role = \User\aRole::factory($primary_role_name);
-
-        if ($this->_id != NULL) {
-            $this->_primary_role->configure($this);
-        }
-
-    }//setPrimaryRole
-
-    // ---------------------------
-
-    /*
-     *
-     * @function getActiveRole
-     *
-     * @return aRole subclass instance
-     *
-     */
-
-    public function getActiveRole()
-    {
-        if ($this->_id == NULL) {
-            throw new Exception('You must call saveUser() on this newly created XDUser prior to using getActiveRole()');
-        }
-
-        return $this->_active_role;
-
-    }//getActiveRole
-
-
-    public function setCachedActiveRole($role)
-    {
-
-        $this->_cachedActiveRole = $role;
-
-    }
 
     /*
      *
@@ -2394,101 +2278,6 @@ SQL;
         return $virtual_active_role;
 
     }//assumeActiveRole
-
-    // ---------------------------
-
-    /*
-     *
-     * @function setActiveRole  (NOTE: When using setActiveRole(), ensure that a subsequent call to saveUser() is made)
-     *
-     * @param int $active_role (see constants.php, ROLE_ID_... constants)
-     * @param int $role_param [required depending on what role is being set as active]
-     *
-     */
-
-    public function setActiveRole($active_role, $role_param = NULL)
-    {
-
-        $active_role_name = self::_getFormalRoleName($active_role);
-
-        if ($active_role_name == NULL) {
-            throw new Exception("Attempting to set an invalid active role");
-        }
-
-        $role_id = $this->_getRoleIDFromIdentifier($active_role);
-
-        $campus_champion_role_id = $this->_getRoleIDFromIdentifier(ROLE_ID_CAMPUS_CHAMPION);
-
-        if ($active_role == ROLE_ID_CENTER_DIRECTOR || $active_role == ROLE_ID_CENTER_STAFF) {
-
-            if ($role_param === NULL) {
-                throw new Exception("An additional parameter must be passed for this role (organization id)");
-            }
-
-            if ($this->_isValidOrganizationID($role_id, $role_param) == true) {
-
-                $this->_pdo->execute("UPDATE moddb.UserRoleParameters SET is_active=0 WHERE user_id=:user_id AND role_id != :role_id", array(
-                    ':user_id' => $this->_id,
-                    ':role_id' => $campus_champion_role_id,
-                ));
-                $this->_pdo->execute("UPDATE moddb.UserRoleParameters SET is_active=1 WHERE user_id=:user_id AND role_id=:role_id AND param_value=:param_value", array(
-                    ':user_id' => $this->_id,
-                    ':role_id' => $role_id,
-                    ':param_value' => $role_param,
-                ));
-
-            } else {
-
-                throw new Exception("An invalid organization id has been specified for the role you are attempting to make active");
-
-            }
-
-        } else {
-
-            $this->_pdo->execute("UPDATE moddb.UserRoleParameters SET is_active=0 WHERE user_id=:user_id AND role_id != :role_id", array(
-                ':user_id' => $this->_id,
-                ':role_id' => $campus_champion_role_id,
-            ));
-
-        }
-
-        $this->_pdo->execute("UPDATE moddb.UserRoles SET is_active=0 WHERE user_id=:user_id", array(
-            ':user_id' => $this->_id,
-        ));
-        $this->_pdo->execute("UPDATE moddb.UserRoles SET is_active=1 WHERE user_id=:user_id AND role_id=:role_id", array(
-            ':user_id' => $this->_id,
-            ':role_id' => $role_id,
-        ));
-
-        $this->_active_role = \User\aRole::factory($active_role_name);
-
-        if ($this->_id != NULL) {
-            $this->_active_role->configure($this);
-        }
-
-    }//setActiveRole
-
-
-    // ---------------------------
-
-    /*
-     *
-     * @function assignActiveRoleToPrimary (Re-assigns the user's active role to their primary role (failover))
-     *
-     */
-
-    public function assignActiveRoleToPrimary()
-    {
-
-        $this->_pdo->execute("UPDATE moddb.UserRoles SET is_active=is_primary WHERE user_id=:user_id", array(
-            ':user_id' => $this->_id,
-        ));
-        $this->_pdo->execute("UPDATE moddb.UserRoleParameters SET is_active=is_primary WHERE user_id=:user_id", array(
-            ':user_id' => $this->_id,
-        ));
-
-    }//assignActiveRoleToPrimary
-
 
     // ---------------------------
 

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -1725,74 +1725,6 @@ SQL
 
     }//disassociateWithInstitution
 
-    // ---------------------------
-
-    /*
-     *
-     * @function getActiveRoleID
-     *
-     * @returns string (the id of the active role) (see ROLES section in constants.php)
-     *
-     */
-
-    public function getActiveRoleID()
-    {
-
-        return $this->_active_role->getIdentifier();
-
-    }//getActiveRoleID
-
-    // ---------------------------
-
-    private function _getActiveProvider($role_id)
-    {
-
-        $active_provider = $this->_pdo->query("SELECT param_value FROM UserRoleParameters " .
-            "WHERE user_id=:user_id AND role_id=:role_id AND param_name='provider' AND is_active=1", array(
-            ':user_id' => $this->_id,
-            ':role_id' => $role_id,
-        ));
-
-        if (count($active_provider) > 0) {
-            return $active_provider[0]['param_value'];
-        } else {
-            return NULL;
-        }
-
-    }//_getActiveProvider
-
-    public function getActiveRoleSettings()
-    {
-
-        $mainRole = $this->_pdo->query("SELECT r.abbrev, r.role_id FROM Roles AS r, UserRoles AS ur WHERE r.role_id = ur.role_id AND ur.user_id=:user_id AND ur.is_active=1", array(
-            ':user_id' => $this->_id,
-        ));
-
-        $mainRoleID = $mainRole[0]['role_id'];
-        $mainRole = $mainRole[0]['abbrev'];
-
-        $activeCenter = -1;
-
-        if ($mainRole == ROLE_ID_CENTER_DIRECTOR || $mainRole == ROLE_ID_CENTER_STAFF) {
-
-            $activeCenter = $this->_pdo->query("SELECT param_value FROM UserRoleParameters WHERE user_id=:user_id AND role_id=:role_id AND is_active=1", array(
-                ':user_id' => $this->_id,
-                ':role_id' => $mainRoleID,
-            ));
-
-            if (count($activeCenter) > 0)
-                $activeCenter = $activeCenter[0]['param_value'];
-            else
-                $activeCenter = -1;
-
-        }
-
-        return array('main_role' => $mainRole, 'active_center' => $activeCenter);
-
-    }//getActiveRoleSettings
-
-    // ---------------------------
-
     /*
      *
      * @function setOrganizations
@@ -2332,15 +2264,6 @@ SQL;
         $this->_cachedActiveRole = $role;
 
     }
-
-    public function getCachedActiveRole()
-    {
-
-        return $this->_cachedActiveRole;
-
-    }
-
-    // ---------------------------
 
     /*
      *

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -9,7 +9,7 @@ $roles = $user->getAllRoles(true);
 
 $roleDescriptors = array();
 foreach ($roles as $activeRole) {
-    $shortRole = $activeRole->getIdentifier();
+    $shortRole = $activeRole;
     $us_pos = strpos($shortRole, '_');
     if ($us_pos > 0)
     {

--- a/html/controllers/user_interface/get_menus.php
+++ b/html/controllers/user_interface/get_menus.php
@@ -10,8 +10,6 @@ $returnData = array();
 try {
    $user = \xd_security\detectUser(array(XDUser::PUBLIC_USER));
 
-    $activeRole = $user->getMostPrivilegedRole();
-
     if (isset($_REQUEST['node']) && $_REQUEST['node'] == 'realms') {
         $query_group_name = 'tg_usage';
 

--- a/html/index.php
+++ b/html/index.php
@@ -248,7 +248,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
     <script type='text/javascript'>
 
         <?php
-        print "CCR.xdmod.publicUser = " . json_encode($userLoggedIn) . ";\n";
+        print "CCR.xdmod.publicUser = " . json_encode(!$userLoggedIn) . ";\n";
 
         $tech_support_recipient = xd_utilities\getConfiguration('general', 'tech_support_recipient');
         print "CCR.xdmod.tech_support_recipient = CCR.xdmod.support_email = '$tech_support_recipient';\n";

--- a/html/index.php
+++ b/html/index.php
@@ -245,7 +245,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
 
     $primary_center_director = (
         $user->hasAcl(ROLE_ID_CENTER_DIRECTOR) &&
-        true //($user->getPromoter(ROLE_ID_CENTER_DIRECTOR, $user->getActiveRole()->getActiveCenter()) == -1)
+        true
     ) ? 'true' : 'false';
     $realms = array_reduce(Realms::getRealms(), function ($carry, Realm $item) {
         $carry [] = $item->getName();

--- a/html/index.php
+++ b/html/index.php
@@ -239,14 +239,6 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
     <?php endif; ?>
 
     <?php
-
-    $manager = $user->isManager() ? 'true' : 'false';
-    $developer = $user->isDeveloper() ? 'true' : 'false';
-
-    $primary_center_director = (
-        $user->hasAcl(ROLE_ID_CENTER_DIRECTOR) &&
-        true
-    ) ? 'true' : 'false';
     $realms = array_reduce(Realms::getRealms(), function ($carry, Realm $item) {
         $carry [] = $item->getName();
         return $carry;
@@ -256,7 +248,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
     <script type='text/javascript'>
 
         <?php
-        print "CCR.xdmod.publicUser = " . ($userLoggedIn ? 'false' : 'true') . ";\n";
+        print "CCR.xdmod.publicUser = " . json_encode($userLoggedIn) . ";\n";
 
         $tech_support_recipient = xd_utilities\getConfiguration('general', 'tech_support_recipient');
         print "CCR.xdmod.tech_support_recipient = CCR.xdmod.support_email = '$tech_support_recipient';\n";
@@ -270,16 +262,15 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
             print "CCR.xdmod.ui.fullName = " . json_encode($user->getFormalName()) . ";\n";
             $userType = $user->getUserType();
             print "CCR.xdmod.ui.usertype = '$userType';\n";
-            $userIsSSO = ($userType === SSO_USER_TYPE) ? "true" : "false";
-            print "CCR.xdmod.ui.userIsSSO = $userIsSSO;\n";
+            print "CCR.xdmod.ui.userIsSSO = " . json_encode(($userType === SSO_USER_TYPE)) . ";\n";
             print "CCR.xdmod.ui.mappedPID = '{$user->getPersonID(TRUE)}';\n";
 
             $obj_warehouse = new XDWarehouse();
             print 'CCR.xdmod.ui.mappedPName = ' . json_encode($obj_warehouse->resolveName($user->getPersonID(true))) . ";\n";
 
-            print "CCR.xdmod.ui.isManager = $manager;\n";
-            print "CCR.xdmod.ui.isDeveloper = $developer;\n";
-            print "CCR.xdmod.ui.isCenterDirector = $primary_center_director;\n";
+            print "CCR.xdmod.ui.isManager = " . json_encode($user->isManager()) . ";\n";
+            print "CCR.xdmod.ui.isDeveloper = " . json_encode($user->isDeveloper()) . ";\n";
+            print "CCR.xdmod.ui.isCenterDirector = " . json_encode($user->hasAcl(ROLE_ID_CENTER_DIRECTOR)) . ";\n";
         }
 
         $config = \Xdmod\Config::factory();

--- a/libraries/roles.php
+++ b/libraries/roles.php
@@ -86,50 +86,5 @@
       return $role_label;
 
    }//getFormalRoleNameFromIdentifier
-   
-   // ----------------------------------------------------------
 
-   /*
-    *
-    * @function determineActiveRoleForUser
-    *
-    * Determines what active role this user should take on (if 'active_role' is supplied in a URL that triggers this
-    * function, then the active role will be derived from the value associated with the 'active_role' param in the URL)
-    *
-    * @param XDUser $user
-    *
-    * @return an instance of a role class (e.g. any of which extends aRole -- CenterDirector, CampusChampion, etc..)
-    *
-    */
-       
-   function determineActiveRoleForUser($user) {
-   
-   	if (isset($_REQUEST['active_role'])) {
-   	  
-   	  $role_data = explode(';', $_REQUEST['active_role']);
-   	  $role_data = array_pad($role_data, 2, NULL);
-   	  
-   	  return $user->assumeActiveRole($role_data[0], $role_data[1]);
-   	  
-   	}
-   
-   	return $user->getActiveRole();
-   
-   }//determineActiveRoleForUser
-   
-   function determineActiveRoleForUser2($user, $active_role) {
-   
-   	if (isset($active_role)) {
-   	  
-   	  $role_data = explode(':', $active_roles);
-   	  $role_data = array_pad($role_data, 2, NULL);
-   	  
-   	  return $user->assumeActiveRole($role_data[0], $role_data[1]);
-   	  
-   	}
-   
-   	return $user->getActiveRole();
-   
-   }//determineActiveRoleForUser2
-      
 ?>

--- a/open_xdmod/modules/xdmod/component_tests/lib/AclsTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/AclsTest.php
@@ -80,14 +80,12 @@ TXT;
         $allRoles = $user->getAllRoles();
 
         foreach ($allRoles as $role) {
-            $roleName = $role->getIdentifier();
-
             $actual = Acls::hasDataAccess(
                 $user,
                 $realm,
                 $groupBy,
                 $statistic,
-                $roleName
+                $role
             );
 
             // We also check the MetricExplorer::checkDataAccess function as it's
@@ -126,7 +124,7 @@ TXT;
                     $realm,
                     $groupBy,
                     $statistic,
-                    $roleName,
+                    $role,
                     self::HAS_DATA_ACCESS,
                     json_encode($expected),
                     self::HAS_DATA_ACCESS,
@@ -139,7 +137,7 @@ TXT;
                 $actual,
                 sprintf(
                     "[%s] Expected does not match Actual: %s => %s",
-                    $roleName,
+                    $role,
                     $expected ? 'true' : "false",
                     $actual ? 'true' : 'false'
                 )
@@ -230,7 +228,7 @@ TXT;
                     $realm,
                     $groupBy,
                     $statistic,
-                    $role->getIdentifier(),
+                    $role,
                     self::GET_QUERY_DESCRIPTERS,
                     print_r($expected, true),
                     self::GET_QUERY_DESCRIPTERS,

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -979,7 +979,7 @@ class XDUserTest extends BaseTest
         $user = XDUser::getUserByUserName($userName);
         $mostPrivilegedRole = $user->getMostPrivilegedRole();
         $this->assertNotNull($mostPrivilegedRole);
-        $this->assertEquals($mostPrivilegedRole->getIdentifier(), $expected);
+        $this->assertEquals($mostPrivilegedRole->getName(), $expected);
 
     }
 

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -1004,15 +1004,7 @@ class XDUserTest extends BaseTest
     {
 
         $user = XDUser::getUserByUserName($userName);
-        $allRoles = $user->getAllRoles();
-        $actual = array_reduce(
-            $allRoles,
-            function ($carry, $item) {
-                $carry[] = $item->getIdentifier();
-                return $carry;
-            },
-            array()
-        );
+        $actual = $user->getAllRoles();
         $expected = Json::loadFile(
             $this->getTestFiles()->getFile('acls', $output)
         );

--- a/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
+++ b/open_xdmod/modules/xdmod/component_tests/lib/XDUserTest.php
@@ -605,47 +605,6 @@ class XDUserTest extends BaseTest
     }
 
     /**
-     * @throws Exception
-     */
-    public function testGetPrimaryRoleWithPublicUser()
-    {
-        $user = XDUser::getPublicUser();
-        $primaryRole = $user->getPrimaryRole();
-
-        $this->assertNotNull($primaryRole);
-    }
-
-    /**
-     * @expectedException Exception
-     **/
-    public function testGetPrimaryRoleWithNewUser()
-    {
-        $user = self::getUser(null, 'test', 'a', 'user');
-
-        $user->getPrimaryRole();
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testGetActiveRoleWithPublicUser()
-    {
-        $user = XDUser::getPublicUser();
-        $activeRole = $user->getActiveRole();
-
-        $this->assertNotNull($activeRole);
-    }
-
-    /**
-     * @expectedException Exception
-     **/
-    public function testGetActiveRoleWithNewUserShouldFail()
-    {
-        $user = self::getUser(null, 'test', 'a', 'user');
-        $user->getActiveRole();
-    }
-
-    /**
      * Expect that it should complain about not having a valid user type.
      *
      * @expectedException Exception
@@ -690,28 +649,6 @@ class XDUserTest extends BaseTest
 
         $user->saveUser();
         $this->assertNotNull($user->getUserID());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testCreateUserWithNonStandardPrimaryRole()
-    {
-        $user = self::getUser(null, 'test', 'a', 'user', array(ROLE_ID_USER, ROLE_ID_MANAGER), ROLE_ID_MANAGER);
-
-        $this->assertEquals('0', $user->getUserID());
-
-        $user->setUserType(DEMO_USER_TYPE);
-
-        $user->saveUser();
-
-        $actual = $user->getActiveRole()->getIdentifier();
-
-        // This is due to the way 'most privileged' works. It prefers acls that
-        // take part in a hierarchy as opposed to those that do not. Since 'usr'
-        // is a part of a hierarchy ( 'mgr' just enables access to certain
-        // features ) then that is what is returned.
-        $this->assertEquals(ROLE_ID_USER, $actual);
     }
 
     /**
@@ -807,106 +744,6 @@ class XDUserTest extends BaseTest
     {
         $user = XDUser::getUserByID(null);
         $this->assertNull($user);
-    }
-
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage You must call saveUser() on this newly created XDUser prior to using getActiveRole()
-     */
-    public function testGetActiveRoleOnUnSavedUserFails()
-    {
-        $anotherUser = self::getUser(null, 'public', 'a', 'user');
-        $anotherUser->getActiveRole();
-    }
-
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage An additional parameter must be passed for this role (organization id)
-     */
-    public function testSetActiveRoleForCenterDirectorWithNoRoleParamShouldFail()
-    {
-        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
-
-        $user->setActiveRole(self::CENTER_DIRECTOR_ACL_NAME);
-    }
-
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage An invalid organization id has been specified for the role you are attempting to make active
-     */
-    public function testSetActiveRoleForCenterDirectorWithInvalidOrgIDShouldFail()
-    {
-        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
-
-        $user->setActiveRole(self::CENTER_DIRECTOR_ACL_NAME, self::INVALID_ID);
-    }
-
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage An additional parameter must be passed for this role (organization id)
-     */
-    public function testSetActiveRoleForCenterStaffWithNoRoleParamShouldFail()
-    {
-        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
-
-        $user->setActiveRole(self::CENTER_STAFF_ACL_NAME);
-    }
-
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage An invalid organization id has been specified for the role you are attempting to make active
-     */
-    public function testSetActiveRoleForCenterStaffWithInvalidOrgIDShouldFail()
-    {
-        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
-
-        $user->setActiveRole(self::CENTER_STAFF_ACL_NAME, self::INVALID_ID);
-    }
-
-    /**
-     * @dataProvider provideSetActiveRoleForCenterDirectorWithValidOrgID
-     * @param $validServiceProviderId
-     * @throws Exception
-     */
-    public function testSetActiveRoleForCenterDirectorWithValidOrgID($validServiceProviderId)
-    {
-        $user = XDUser::getUserByUserName(self::CENTER_DIRECTOR_USER_NAME);
-
-        $user->setActiveRole(self::CENTER_DIRECTOR_ACL_NAME, $validServiceProviderId);
-
-        $activeRole = $user->getActiveRole();
-        $this->assertNotNull($activeRole);
-
-        $activeRoleName = $activeRole->getIdentifier();
-        $this->assertEquals(self::CENTER_DIRECTOR_ACL_NAME, $activeRoleName);
-    }
-
-    /**
-     * @return array|object
-     * @throws Exception
-     */
-    public function provideSetActiveRoleForCenterDirectorWithValidOrgID()
-    {
-        return Json::loadFile(
-            $this->getTestFiles()->getFile('acls', 'center_director_valid_organization_ids')
-        );
-    }
-
-    /**
-     * @dataProvider provideSetActiveRoleForCenterDirectorWithValidOrgID
-     * @throws Exception
-     */
-    public function testSetActiveRoleForCenterStaffWithValidOrgID($validServiceProviderId)
-    {
-        $user = XDUser::getUserByUserName(self::CENTER_STAFF_USER_NAME);
-
-        $user->setActiveRole(self::CENTER_STAFF_ACL_NAME, $validServiceProviderId);
-
-        $activeRole = $user->getActiveRole();
-        $this->assertNotNull($activeRole);
-
-        $activeRoleName = $activeRole->getIdentifier();
-        $this->assertEquals(self::CENTER_STAFF_ACL_NAME, $activeRoleName);
     }
 
     /**

--- a/open_xdmod/modules/xdmod/tests/lib/NewRest/Controllers/BaseControllerTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/NewRest/Controllers/BaseControllerTest.php
@@ -82,12 +82,12 @@ class BaseControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function generateUserDataSet()
     {
-        $mgr = $this->createUser(array('mgr', 'usr'), 'mgr');
-        $cd = $this->createUser(array('cd', 'usr'), 'cd');
-        $pi = $this->createUser(array('pi', 'usr'), 'pi');
+        $mgr = $this->createUser(array('mgr', 'usr'));
+        $cd = $this->createUser(array('cd', 'usr'));
+        $pi = $this->createUser(array('pi', 'usr'));
         $usr = $this->createUser(array('usr'), 'usr');
-        $sab = $this->createUser(array('usr', 'sab'), 'sab');
-        $pub = $this->createUser(array('pub'), 'pub');
+        $sab = $this->createUser(array('usr', 'sab'));
+        $pub = $this->createUser(array('pub'));
 
         $accessDeniedException = 'Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException';
         $unauthorizedException = 'Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException';
@@ -138,19 +138,10 @@ class BaseControllerTest extends \PHPUnit_Framework_TestCase
      *
      * @param array $roles an array of strings representing the
      *                              roles / acls this user is assigned
-     * @param string $activeRole this is used by the old version of
-     *                              isAuthorized only and represents the users
-     *                              currently active role.
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function createUser(array $roles, $activeRole)
+    protected function createUser(array $roles)
     {
-        $activeRoleBuilder = $this->getMockBuilder('\User\aRole')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getIdentifier'));
-        $mockActiveRole = $activeRoleBuilder->getMockForAbstractClass();
-        $mockActiveRole->method('getIdentifier')->willReturn($activeRole);
-
         $builder = $this->getMockBuilder('\XDUser')
             ->disableOriginalConstructor()
             ->setMethods(
@@ -158,7 +149,6 @@ class BaseControllerTest extends \PHPUnit_Framework_TestCase
                     'getRoles',
                     'isManager',
                     'isPublicUser',
-                    'getActiveRole',
                     'hasAcl',
                     '__toString'
                 )
@@ -171,7 +161,6 @@ class BaseControllerTest extends \PHPUnit_Framework_TestCase
         $stub->method('isPublicUser')->willReturnCallback(function () use ($roles) {
             return in_array(ROLE_ID_PUBLIC, $roles);
         });
-        $stub->method('getActiveRole')->willReturn($mockActiveRole);
         $stub->method('hasAcl')->willReturnCallback(function () use ($roles) {
             $args = func_get_args();
             if (count($args) >= 1) {
@@ -183,8 +172,7 @@ class BaseControllerTest extends \PHPUnit_Framework_TestCase
         $stub->method('__toString')->willReturn(json_encode(array(
             'roles' => $roles,
             'is_manager' => in_array(ROLE_ID_MANAGER, $roles),
-            'is_public_user' => in_array(ROLE_ID_PUBLIC, $roles),
-            'active_role' => $activeRole
+            'is_public_user' => in_array(ROLE_ID_PUBLIC, $roles)
         )));
         $stub->method('hasAcls')->willreturnCallback(
             function () use ($roles) {


### PR DESCRIPTION
## Description
This is it, the last PR before being able to remove the Role* classes. 

Active / Primary Role, as a concept, no longer applies to XDMoD Users. Instead we have replaced it with Most Privileged Role. This PR implements those changes by doing the following:
- Remove usage of the last function that instantiates roles: `XDUser::assumeActiveRole`
- Migrate function that utilized `User::assumeActiveRole`, `XDUser::getAllRoles` to return an array of strings ( acl names: 'cd', 'cs', 'usr' etc. ) as opposed to an array of Role objects. 
- This change necessitated updating code that operated on the results of `XDUser::getAllRoles` to account for the change in type. Mainly replacing: `$role->getIdentifier()` -> `$role`. 
- Since we are no longer instantiating Roles this means that, oddly enough, a realms Query object would no longer have its statistics / group bys pre-poplated. This necessitated adding a helper function `Query::initData` and calling it from three of its functions ( each function is called by the other `public static` functions provided by `Query`): 
    - `&get_group_by_name_to_instance`
    - `&get_group_by_name_to_class_name`
    - `&get_statistic_name_to_class_name`


I know this sounds weird ( and it is ), so I'll explain:
  - When a Role was instantiated it retrieved all of its query descriptors
  - When a query descripter is instantiated it calls it's Realm's `Aggregate::registerGroupBys` and `Aggregate::registerStatistics`.
  - So no role / query descripter instantiation meant no registering of group bys / statistics for a Realm.

And finally:
- Also, any call of `XDUser::getActiveRole` or `XDUser::getPrimaryRole` was replaced with either `XDUser::getMostPrivilegedRole` or a suitable alternative.
- Tests were removed / updated to take all of these changes into account.

## Motivation and Context
We're free! We're free!

## Tests performed
All tests on docker fresh install / upgrade: 
- unit
- component
- integration
- REG_TEST_ALL=1 regression
- UI 
- Manual Testing of things like Metric Explorer, Usage charts etc. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code Refactoring / Cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
