### PR TITLE
Added support for creating a full width top panel.

### DIFF
--- a/classes/CCR/ColumnLayout.php
+++ b/classes/CCR/ColumnLayout.php
@@ -70,4 +70,14 @@ class ColumnLayout
             $this->settings[$itemId][1]
         );
     }
+
+    /**
+     * return whether an item has configured layout settings
+     * @param $itemId the identifier for the item
+     * @return boolean whether the item has a layout setting
+     */
+    public function hasLayout($itemId)
+    {
+        return isset($this->settings[$itemId]);
+    }
 }

--- a/classes/Rest/Controllers/SummaryControllerProvider.php
+++ b/classes/Rest/Controllers/SummaryControllerProvider.php
@@ -68,7 +68,14 @@ class SummaryControllerProvider extends BaseControllerProvider
         }
 
         foreach ($presetPortlets as $portlet) {
-            list($chartLocation, $column) = $layout->getLocation('PP' . $portlet['name']);
+
+            if (isset($portlet['region']) && $portlet['region'] === 'top') {
+                $chartLocation = 'FW' . $portlet['name'];
+                $column = -1;
+            } else {
+                list($chartLocation, $column) = $layout->getLocation('PP' . $portlet['name']);
+            }
+
             $summaryPortlets[$chartLocation] = array(
                 'name' => 'PP' . $portlet['name'],
                 'type' => $portlet['type'],
@@ -110,7 +117,7 @@ class SummaryControllerProvider extends BaseControllerProvider
                     $name = 'UC' . $query['name'];
 
                     if (preg_match('/summary_(?P<index>\S+)/', $query['name'], $matches) > 0) {
-                        if (isset($summaryPortlets[$matches['index']])) {
+                        if ($layout->hasLayout('PC' . $matches['index'])) {
                             $name = 'PC' . $matches['index'];
                         }
                     }
@@ -132,7 +139,7 @@ class SummaryControllerProvider extends BaseControllerProvider
         return $app->json(array(
             'success' => true,
             'total' => count($summaryPortlets),
-            'portalConfig' => array('columns' => $layout->getColumnCount(), 'layoutstyle' => 'portal'),
+            'portalConfig' => array('columns' => $layout->getColumnCount()),
             'data' => array_values($summaryPortlets)
         ));
     }

--- a/html/gui/js/modules/NoviceUser.js
+++ b/html/gui/js/modules/NoviceUser.js
@@ -25,93 +25,106 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
                 token: XDMoD.REST.token
             },
             root: 'data',
-            fields: ['name', 'type', 'config', 'column']
+            fields: ['name', 'type', 'config', 'column'],
+            listeners: {
+                load: function () {
+                    var i;
+
+                    var portletWidth = 600;
+                    var portalColumns = this.reader.jsonData.portalConfig.columns;
+
+                    var portal = new Ext.ux.Portal({
+                        items: [],
+                        width: Math.max(portletWidth * portalColumns, self.getWidth()),
+                        border: false,
+                        listeners: {
+                            drop: function () {
+                                var row;
+                                var column;
+                                var portalCol;
+                                var layout = {};
+
+                                for (column = 0; column < this.items.getCount(); column++) {
+                                    portalCol = this.items.get(column);
+                                    for (row = 0; row < portalCol.items.getCount(); row++) {
+                                        layout[portalCol.items.get(row).name] = [row, column];
+                                    }
+                                }
+                                Ext.Ajax.request({
+                                    url: XDMoD.REST.url + '/summary/layout',
+                                    params: {
+                                        data: Ext.encode({
+                                            columns: this.items.getCount(),
+                                            layout: layout
+                                        })
+                                    }
+                                });
+                            }
+                        }
+                    });
+
+                    var portalColumnsCount = Math.max(portalColumns, Math.floor(self.getWidth() / portletWidth));
+                    for (i = 0; i < portalColumnsCount; i++) {
+                        portal.add(new Ext.ux.PortalColumn({
+                            width: portletWidth,
+                            style: 'padding: 1px'
+                        }));
+                    }
+
+                    var durationSelector = self.getDurationSelector();
+
+                    var portalwindow = self.getComponent('portalwindow');
+                    portalwindow.removeAll();
+
+                    this.each(function (record) {
+                        var config = record.get('config');
+
+                        config.start_date = durationSelector.getStartDate().format('Y-m-d');
+                        config.end_date = durationSelector.getEndDate().format('Y-m-d');
+                        config.aggregation_unit = durationSelector.getAggregationUnit();
+                        config.timeframe_label = durationSelector.getDurationLabel();
+
+                        try {
+                            var portlet = Ext.ComponentMgr.create({
+                                xtype: record.get('type'),
+                                name: record.get('name'),
+                                config: config,
+                                width: portletWidth
+                            });
+                            portlet.relayEvents(self, ['duration_change']);
+
+                            if (record.get('column') === -1) {
+                                // The -1 columm is the full width panel above the portal
+                                portlet.setWidth(portletWidth * portalColumns);
+                                portalwindow.add(portlet);
+                            } else {
+                                // All others go in the column based portlet view.
+                                portal.items.itemAt(record.get('column')).add(portlet);
+                            }
+                        } catch (e) {
+                            Ext.Msg.alert(
+                                'Error loading portlets',
+                                'The portlet ' + record.get('name') + ' (' + record.get('type') + ')<br />could not be loaded.'
+                            );
+                        }
+                    });
+
+                    portalwindow.add(portal);
+                    portalwindow.doLayout();
+                }
+            }
         });
 
         Ext.apply(this, {
             items: [{
                 region: 'center',
                 itemId: 'portalwindow',
-                autoScroll: true,
-                items: [
-                ]
-            }]
-        });
-
-        portletStore.load({
-            callback: function () {
-                var i;
-
-                var portletWidth = 600;
-                var portalColumns = this.reader.jsonData.portalConfig.columns;
-
-                var portal = new Ext.ux.Portal({
-                    items: [],
-                    width: Math.max(portletWidth * portalColumns, self.getWidth()),
-                    border: false,
-                    listeners: {
-                        drop: function () {
-                            var row;
-                            var column;
-                            var portalCol;
-                            var layout = {};
-
-                            for (column = 0; column < this.items.getCount(); column++) {
-                                portalCol = this.items.get(column);
-                                for (row = 0; row < portalCol.items.getCount(); row++) {
-                                    layout[portalCol.items.get(row).name] = [row, column];
-                                }
-                            }
-                            Ext.Ajax.request({
-                                url: XDMoD.REST.url + '/summary/layout',
-                                params: {
-                                    data: Ext.encode({
-                                        columns: this.items.getCount(),
-                                        layout: layout
-                                    })
-                                }
-                            });
-                        }
-                    }
-                });
-
-                var portalColumnsCount = Math.max(portalColumns, Math.floor(self.getWidth() / portletWidth));
-                for (i = 0; i < portalColumnsCount; i++) {
-                    portal.add(new Ext.ux.PortalColumn({
-                        width: portletWidth,
-                        style: 'padding: 1px'
-                    }));
+                autoScroll: true
+            }],
+            listeners: {
+                afterrender: function () {
+                    portletStore.load();
                 }
-
-                var durationSelector = self.getDurationSelector();
-
-                this.each(function (record) {
-                    var config = record.get('config');
-
-                    config.start_date = durationSelector.getStartDate().format('Y-m-d');
-                    config.end_date = durationSelector.getEndDate().format('Y-m-d');
-                    config.aggregation_unit = durationSelector.getAggregationUnit();
-                    config.timeframe_label = durationSelector.getDurationLabel();
-
-                    try {
-                        var portlet = Ext.ComponentMgr.create({
-                            xtype: record.get('type'),
-                            name: record.get('name'),
-                            config: config,
-                            width: portletWidth
-                        });
-                        portlet.relayEvents(self, ['duration_change']);
-
-                        portal.items.itemAt(record.get('column')).add(portlet);
-                    } catch (e) {
-                        Ext.Msg.alert('Error loading portlets', 'The portlet ' + record.get('name') + ' (' + record.get('type') + ')<br />could not be loaded.');
-                    }
-                });
-
-                var portalwindow = self.getComponent('portalwindow');
-                portalwindow.removeAll();
-                portalwindow.add(portal);
-                portalwindow.doLayout();
             }
         });
 


### PR DESCRIPTION
This is needed for the Center Director and Center Staff views. To
configure a panel as a top panel set "region" to "top" in the
portlet configuration for the role.

Also added support for overriding preset charts (this is setup to
match the existing summary tab behavior).

Also fixed a bug where the summary page didn't render correctly if you loaded the interface with a different tab first.