### PR TITLE
Fix test harness for javascript-based ETL code

### DIFF
--- a/etl/js/etl.js
+++ b/etl/js/etl.js
@@ -135,6 +135,7 @@ ETL.prototype.runRegressionTests = function () {
             self.emit('message', msg);
         });
         etlProfile.on('error', function (error) {
+            process.exitCode = 1;
             self.emit('error', error);
         });
         etlProfile.regressionTests();

--- a/etl/js/etl.js
+++ b/etl/js/etl.js
@@ -125,20 +125,21 @@ ETL.prototype.integrateWithXDMoD = function() {
 		etlProfile.integrateWithXDMoD();
 	});
 }
-ETL.prototype.runRegressionTests = function() {
-	var self = this;
-	self.emit('message', 'Regression Testing...');
-	config.profiles.forEach(function(etl_profile) {
-		var etlProfile = new ETLProfile(etl_profile);
-		etlProfile.on('message', function(msg) {
-			self.emit('message', msg);
-		});
-		etlProfile.on('error', function(error) {
-			self.emit('error', error);
-		});
-		etlProfile.regressionTests();
-	});
-}
+
+ETL.prototype.runRegressionTests = function () {
+    var self = this;
+    self.emit('message', 'Regression Testing...');
+    config.profiles.forEach(function (etl_profile) {
+        var etlProfile = new ETLProfile(etl_profile);
+        etlProfile.on('message', function (msg) {
+            self.emit('message', msg);
+        });
+        etlProfile.on('error', function (error) {
+            self.emit('error', error);
+        });
+        etlProfile.regressionTests();
+    });
+};
 
 ETL.prototype.processAll = function(totalCores, coreIndex, datasetNames) {
 	var self = this;

--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -786,7 +786,7 @@ ETLProfile.prototype.regressionTests = function () {
             if ( dataset.input.getQuery() == null ) {
                 throw "GetQuery returned null";
             }
-            coll = { update: function(x,y,z,a) { } };
+            var coll = { updateOne: function () { } };
             cof = { errors: null, warnings: null };
             dataset.input.markAsProcessed(coll, 1, cof, console.log);
 


### PR DESCRIPTION
The  javascript-based ETL test harness was not setting the process exit code appropriately when the tests failed. In addition the tests were failing