### PR TITLE
add some summary charts for the cloud realm

### DIFF
--- a/templates/roles.d/cloud.json
+++ b/templates/roles.d/cloud.json
@@ -26,8 +26,77 @@
                     "group_by": "vm_size_memory"
                 },
                 {
-                  "realm": "Cloud",
-                  "group_by": "submission_venue"
+                    "realm": "Cloud",
+                    "group_by": "submission_venue"
+                }
+            ],
+            "+summary_charts": [{
+                    "data_series": {
+                        "data": [{
+                            "combine_type": "stack",
+                            "display_type": "column",
+                            "filters": {
+                                "data": [],
+                                "total": 0
+                            },
+                            "group_by": "project",
+                            "has_std_err": true,
+                            "ignore_global": false,
+                            "log_scale": false,
+                            "long_legend": true,
+                            "metric": "cloud_core_time",
+                            "realm": "Cloud",
+                            "sort_type": "value_desc",
+                            "std_err": false,
+                            "value_labels": false,
+                            "x_axis": true
+                        }],
+                        "total": 1
+                    },
+                    "global_filters": {
+                        "data": [],
+                        "total": 0
+                    },
+                    "legend_type": "off",
+                    "limit": 10,
+                    "show_filters": true,
+                    "start": 0,
+                    "timeseries": false,
+                    "title": "Cloud - Total CPU Hours by Project"
+                },
+                {
+                    "data_series": {
+                        "data": [{
+                            "combine_type": "stack",
+                            "display_type": "column",
+                            "filters": {
+                                "data": [],
+                                "total": 0
+                            },
+                            "group_by": "project",
+                            "has_std_err": true,
+                            "ignore_global": false,
+                            "log_scale": false,
+                            "long_legend": true,
+                            "metric": "cloud_num_sessions_started",
+                            "realm": "Cloud",
+                            "sort_type": "value_desc",
+                            "std_err": false,
+                            "value_labels": false,
+                            "x_axis": true
+                        }],
+                        "total": 1
+                    },
+                    "global_filters": {
+                        "data": [],
+                        "total": 0
+                    },
+                    "legend_type": "off",
+                    "limit": 10,
+                    "show_filters": true,
+                    "start": 0,
+                    "timeseries": false,
+                    "title": "Cloud - Number of Sessions Started by Project"
                 }
             ]
         },
@@ -57,8 +126,8 @@
                     "group_by": "vm_size_memory"
                 },
                 {
-                  "realm": "Cloud",
-                  "group_by": "submission_venue"
+                    "realm": "Cloud",
+                    "group_by": "submission_venue"
                 }
             ]
         }


### PR DESCRIPTION
This adds two default summary tab charts when the cloud realm is enabled.