### PR TITLE
Fix path to exception in TimeAggregationUnit::factory

### DIFF
--- a/classes/DataWarehouse/Query/TimeAggregationUnit.php
+++ b/classes/DataWarehouse/Query/TimeAggregationUnit.php
@@ -184,7 +184,7 @@ abstract class TimeAggregationUnit
             
             return $class;
         } else {
-            throw new Exception("TimeAggregationUnit: Time period {$time_period} is invalid.");
+            throw new \Exception("TimeAggregationUnit: Time period {$time_period} is invalid.");
         }
     } //factory
 

--- a/open_xdmod/modules/xdmod/tests/lib/DataWarehouse/Query/TimeAggregationUnitTest.php
+++ b/open_xdmod/modules/xdmod/tests/lib/DataWarehouse/Query/TimeAggregationUnitTest.php
@@ -6,6 +6,13 @@ use \UnitTesting\mock;
 
 class TimeAggregationUnitTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedException Exception
+     */
+    public function testInvalidTimePeriod()
+    {
+        $aggunit = \DataWarehouse\Query\TimeAggregationUnit::factory('era', 'Palenzoic', 'Mesoproterozoic', 'fossilfact_by');
+    }
 
     public function testGetRawTimePeriod()
     {


### PR DESCRIPTION
Found during testing of the Job Efficiency Report code. Added a new unit test to check correct behaviour. Note that if we add support for geological eras to the code then the tests will likely need updating.