### PR TITLE
Remove deprecated code

### DIFF
--- a/classes/ETL/Maintenance/VerifyDatabase.php
+++ b/classes/ETL/Maintenance/VerifyDatabase.php
@@ -18,7 +18,7 @@ use ETL\aAction;
 use ETL\DataEndpoint\iRdbmsEndpoint;
 use ETL\DbModel\Query;
 use PDOException;
-use ETL\Utilities;
+use ETL\VariableStore;
 use Log;
 
 use PHPSQLParser\PHPSQLParser;
@@ -263,7 +263,8 @@ class VerifyDatabase extends aAction implements iAction
                 $this->logger->info(count($result) . " matches found");
                 if ( 0 != count($result) ) {
                     foreach ( $result as $row ) {
-                        $line = Utilities::substituteVariables($lineTemplate, $row);
+                        $vs = new VariableStore($row, $this->logger);
+                        $line = $vs->substitute($lineTemplate);
                         $this->logger->warning($line);
                         $lines[] = $line;
                     }

--- a/classes/ETL/VariableStore.php
+++ b/classes/ETL/VariableStore.php
@@ -69,10 +69,21 @@ class VariableStore extends Loggable
     }  // __construct()
 
     /**
+     * Clear the variables in the store
+     */
+
+    public function clear()
+    {
+        $this->variables = array();
+    }
+
+    /**
      * Set a variable in the store.  If a variable should be overwritten use overwrite() instead.
      * Setting a variable to a NULL value will unset the variable.  If the variable is already set,
-     * do not overwrite and issue a warning.  We issue a warning because it may be the case that the
-     * developer is expecting a value to be updated and want to alter them that it is not.
+     * do not overwrite and issue a warning. This is done so that variables set early in a process
+     * (such as ETL) are not blindly changed causing unexpected results.  We issue a warning because
+     * it may be the case that the developer is expecting a value to be updated and want to alert
+     * them that it is not.
      *
      * @param string $var The name of the variable to set
      * @param scalar $value The value of the variable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`ETL\Utilities::substituteVariables()` was deprecated by `ETL\VariableStore`. This removes the last remmants.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
