### PR TITLE
Fix for generic cloud datetime, and openstack instance type datetime

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_generic/instance_type.json
+++ b/configuration/etl/etl_action_defs.d/cloud_generic/instance_type.json
@@ -23,7 +23,7 @@
             "num_cores": "raw.num_cores",
             "memory_mb": "raw.memory_mb",
             "disk_gb": "raw.disk_gb",
-            "start_time": "IF(existing.start_time IS NULL OR raw.start_time < existing.start_time, raw.start_time, existing.start_time)"
+            "start_time": "IF(existing.start_time IS NULL OR UNIX_TIMESTAMP(CONVERT_TZ(raw.start_time,'+00:00', @@session.time_zone)) < existing.start_time, UNIX_TIMESTAMP(CONVERT_TZ(raw.start_time,'+00:00', @@session.time_zone)), existing.start_time)"
         },
 
         "joins": [

--- a/configuration/etl/etl_action_defs.d/cloud_openstack/instance_type.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/instance_type.json
@@ -23,7 +23,7 @@
             "num_cores": "raw.num_cores",
             "memory_mb": "raw.memory_mb",
             "disk_gb": "raw.disk_gb",
-            "start_time": "IF(existing.start_time IS NULL OR raw.start_time < existing.start_time, raw.start_time, existing.start_time)"
+            "start_time": "IF(existing.start_time IS NULL OR UNIX_TIMESTAMP(CONVERT_TZ(raw.start_time,'+00:00', @@session.time_zone)) < existing.start_time, UNIX_TIMESTAMP(CONVERT_TZ(raw.start_time,'+00:00', @@session.time_zone)), existing.start_time)"
         },
 
         "joins": [

--- a/configuration/etl/etl_tables.d/cloud_generic/raw_event.json
+++ b/configuration/etl/etl_tables.d/cloud_generic/raw_event.json
@@ -24,10 +24,10 @@
             },
             {
                 "name": "event_time_utc",
-                "type": "decimal(16, 6)",
+                "type": "char(26)",
                 "nullable": false,
-                "default": 0,
-                "comment": "The time of the event as a unix timestamp to the microsecond.."
+                "default": "0000-00-00T00:00:00.000000",
+                "comment": "String representation of timestamp directly from the logs."
             },
             {
                 "name": "event_type",

--- a/configuration/etl/etl_tables.d/cloud_generic/raw_instance_type.json
+++ b/configuration/etl/etl_tables.d/cloud_generic/raw_instance_type.json
@@ -54,10 +54,10 @@
             },
             {
                 "name": "start_time",
-                "type": "decimal(16, 6)",
+                "type": "char(26)",
                 "nullable": true,
-                "default": 0,
-                "comment": "First time this configuration was encountered as a unix timestamp to the microsecond., defaults to unknown."
+                "default": "0000-00-00T00:00:00.000000",
+                "comment": "First time this configuration was encountered as a unix timestamp to the microsecond, defaults to unknown."
             }
         ],
         "indexes": [


### PR DESCRIPTION
Updates the generic tables to use string / decimal for dates in the cloud realm.

@eiffel777 said he was able to verify the changes.