### PR TITLE
More fixing for datetime changes

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_generic.json
+++ b/configuration/etl/etl.d/jobs_cloud_generic.json
@@ -148,7 +148,12 @@
             "name": "GenericCloudInstanceTypeIngestor",
             "description": "Generic cloud instance type data",
             "class": "DatabaseIngestor",
-            "definition_file": "cloud_generic/instance_type.json"
+            "definition_file": "cloud_generic/instance_type.json",
+            "#": "Because the generic format allows for a Z at the end of the timestamp",
+            "#": "the Z gets truncated off and throws this warning",
+            "hide_sql_warning_codes": [
+                1292
+            ]
         },
         {
             "name": "GenericCloudInstanceIngestor",
@@ -160,7 +165,12 @@
             "name": "GenericCloudVolumeAssetIngestor",
             "description": "Generic cloud attachable volume (block device) data from raw logs",
             "class": "DatabaseIngestor",
-            "definition_file": "cloud_generic/volume.json"
+            "definition_file": "cloud_generic/volume.json",
+            "#": "Because the generic format allows for a Z at the end of the timestamp",
+            "#": "the Z gets truncated off and throws this warning",
+            "hide_sql_warning_codes": [
+                1292
+            ]
         },
         {
             "name": "GenericCloudPostIngestUpdates",
@@ -178,7 +188,12 @@
             "description": "Generic staging data for cloud events",
             "class": "DatabaseIngestor",
             "truncate_destination": "true",
-            "definition_file": "cloud_generic/staging_event.json"
+            "definition_file": "cloud_generic/staging_event.json",
+            "#": "Because the generic format allows for a Z at the end of the timestamp",
+            "#": "the Z gets truncated off and throws this warning",
+            "hide_sql_warning_codes": [
+                1292
+            ]
         },
         {
             "#": "Instance data must be ingested after staging events",

--- a/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
+++ b/configuration/etl/etl_sql.d/cloud_openstack/post_ingest_update.sql
@@ -5,39 +5,39 @@ CREATE TEMPORARY TABLE ${DESTINATION_SCHEMA}.tmp_volume_delete
 (INDEX resource_id_openstack_resource_key (`resource_id`, `openstack_resource_id`))
 AS
 SELECT
-	event_time_utc,
-	openstack_resource_id,
-	resource_id
+    event_time_utc,
+    openstack_resource_id,
+    resource_id
 FROM
-	${DESTINATION_SCHEMA}.openstack_raw_event
+    ${DESTINATION_SCHEMA}.openstack_raw_event
 WHERE
-	event_type = "volume.delete.end";
+    event_type = "volume.delete.end";
 //
 
 UPDATE
-	${DESTINATION_SCHEMA}.asset AS a
+    ${DESTINATION_SCHEMA}.asset AS a
 LEFT JOIN
-	${DESTINATION_SCHEMA}.tmp_volume_delete AS raw
+    ${DESTINATION_SCHEMA}.tmp_volume_delete AS raw
 ON
-  raw.resource_id = a.resource_id AND raw.openstack_resource_id = a.provider_identifier
+    raw.resource_id = a.resource_id AND raw.openstack_resource_id = a.provider_identifier
 SET
-	a.destroy_time_utc = raw.event_time_utc;
+    a.destroy_time_utc = UNIX_TIMESTAMP(CONVERT_TZ(raw.event_time_utc,'+00:00', @@session.time_zone));
 //
 
 UPDATE
-	${DESTINATION_SCHEMA}.asset AS a
+    ${DESTINATION_SCHEMA}.asset AS a
 LEFT JOIN
-	${DESTINATION_SCHEMA}.instance AS i
+    ${DESTINATION_SCHEMA}.instance AS i
 ON
-	i.resource_id = a.resource_id AND CONCAT('root-vol-', i.provider_identifier) = a.provider_identifier
+    i.resource_id = a.resource_id AND CONCAT('root-vol-', i.provider_identifier) = a.provider_identifier
 LEFT JOIN
-	${DESTINATION_SCHEMA}.openstack_staging_event AS staging
+    ${DESTINATION_SCHEMA}.openstack_staging_event AS staging
 ON
-	staging.resource_id = i.resource_id AND staging.instance_id = i.instance_id
+    staging.resource_id = i.resource_id AND staging.instance_id = i.instance_id
 SET
-	a.destroy_time_utc = staging.event_time_utc
+    a.destroy_time_utc = staging.event_time_utc
 WHERE
-	staging.event_type_id = 4;
+    staging.event_type_id = 4;
 //
 
 -- Determine the end time for each instance in a post-processing step. To properly calculate the end
@@ -56,25 +56,25 @@ DROP TEMPORARY TABLE IF EXISTS ${DESTINATION_SCHEMA}.tmp_end_times;
 CREATE TEMPORARY TABLE ${DESTINATION_SCHEMA}.tmp_end_times
 AS
 SELECT
-  instance_type_id,
-  instance_type,
-	resource_id,
-  IF ( @current_instance_type = instance_type AND @prev_start IS NOT NULL, @prev_start - INTERVAL 1 SECOND, NULL) AS end_time,
-  @current_instance_type := instance_type AS junk1,
-  @prev_start := start_time AS junk2
+    instance_type_id,
+    instance_type,
+    resource_id,
+    IF ( @current_instance_type = instance_type AND @prev_start IS NOT NULL, @prev_start - INTERVAL 1 SECOND, NULL) AS end_time,
+    @current_instance_type := instance_type AS junk1,
+    @prev_start := start_time AS junk2
 FROM ${DESTINATION_SCHEMA}.instance_type
 ORDER BY instance_type, start_time DESC
 //
 
 UPDATE
-  ${DESTINATION_SCHEMA}.instance_type a
-  JOIN ${DESTINATION_SCHEMA}.tmp_end_times e
+    ${DESTINATION_SCHEMA}.instance_type a
+    JOIN ${DESTINATION_SCHEMA}.tmp_end_times e
 SET
-  a.end_time = e.end_time
+    a.end_time = e.end_time
 WHERE
- a.instance_type_id = e.instance_type_id
+    a.instance_type_id = e.instance_type_id
 AND
- a.resource_id = e.resource_id
+    a.resource_id = e.resource_id
 //
 
 -- Truncate raw and staging tables once the data is no longer needed

--- a/configuration/etl/etl_tables.d/cloud_common/event.json
+++ b/configuration/etl/etl_tables.d/cloud_common/event.json
@@ -27,9 +27,9 @@
             },
             {
                 "name": "event_time_utc",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false,
-                "default": 0
+                "default": "0.000000"
             },
             {
                 "name": "event_type_id",

--- a/configuration/etl/etl_tables.d/cloud_common/event_reconstructed.json
+++ b/configuration/etl/etl_tables.d/cloud_common/event_reconstructed.json
@@ -15,7 +15,7 @@
             },
             {
                 "name": "start_time",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false
             },
             {
@@ -25,7 +25,7 @@
             },
             {
                 "name": "end_time",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false
             },
             {

--- a/configuration/etl/etl_tables.d/cloud_common/instance_type.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance_type.json
@@ -58,14 +58,14 @@
             },
             {
                 "name": "start_time",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false,
-                "default": 0,
+                "default": "0.000000",
                 "comment": "First time that this configuration was seen as a unix timestamp to the microsecond. defaults to unknown."
             },
             {
                 "name": "end_time",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": true,
                 "default": null,
                 "comment": "End time for this configuration as a unix timestamp to the microsecond., NULL if it is still in effect."

--- a/configuration/etl/etl_tables.d/cloud_generic/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_generic/staging_event.json
@@ -18,9 +18,9 @@
             },
             {
                 "name": "event_time_utc",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false,
-                "default": 0,
+                "default": "0.000000",
                 "comment": "The time of the event as a unix timestamp to the microsecond.."
             },
             {

--- a/configuration/etl/etl_tables.d/cloud_openstack/raw_volume.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/raw_volume.json
@@ -34,23 +34,23 @@
             },
             {
                 "name": "event_time_utc",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false,
-                "default": 0,
+                "default": "0.000000",
                 "comment": "A unix timestamp to the microsecond."
             },
             {
                 "name": "attach_time_utc",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false,
-                "default": 0,
+                "default": "0.000000",
                 "comment": "The time that the volume was attached to an instance as a unix timestamp to the microsecond."
             },
             {
                 "name": "create_time_utc",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false,
-                "default": 0,
+                "default": "0.000000",
                 "comment": "The time that the volume was created as a unix timestamp to the microsecond."
             },
             {

--- a/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
@@ -18,9 +18,9 @@
             },
             {
                 "name": "event_time_utc",
-                "type": "decimal(16, 6)",
+                "type": "decimal(16,6)",
                 "nullable": false,
-                "default": "0",
+                "default": "0.000000",
                 "comment": "Unix timestamp to the microsecond."
             },
             {


### PR DESCRIPTION
Found some more places where the generic and openstack datetimes needed to be fixed.

Whitespace changes from `(16, 3)` to `(16,3)` is required so that the ETL does not do an alter table

Travis will have to be overridden.