### PR TITLE
removing duplicate join statement that was causing 1066 Not unique table/alias error

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_generic/event_asset.json
+++ b/configuration/etl/etl_action_defs.d/cloud_generic/event_asset.json
@@ -29,12 +29,6 @@
                 "on": "ev.resource_id = staging.resource_id AND ev.instance_id = staging.instance_id AND ev.event_time_ts = staging.event_time_ts AND ev.event_type_id = staging.event_type_id"
             },
             {
-                "name": "event",
-                "schema": "${SOURCE_SCHEMA}",
-                "alias": "ev",
-                "on": "ev.resource_id = staging.resource_id AND ev.instance_id = staging.instance_id AND ev.event_time_utc = staging.event_time_utc AND ev.event_type_id = staging.event_type_id"
-            },
-            {
                 "name": "asset",
                 "schema": "${SOURCE_SCHEMA}",
                 "alias": "a",


### PR DESCRIPTION
removing duplicate join statement that was causing 1066 Not unique table/alias error when ingesting data in the generic cloud format

## Tests performed
Tested manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
