### PR TITLE
Prevent null usernames being added when ingestion cloud data

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_generic/union_user_pi_resource.json
+++ b/configuration/etl/etl_action_defs.d/cloud_generic/union_user_pi_resource.json
@@ -21,7 +21,7 @@
             }
         ],
         "where": [
-          "raw.provider_user IS NOT NULL"
+            "raw.provider_user IS NOT NULL"
         ]
     }
 }

--- a/configuration/etl/etl_action_defs.d/cloud_generic/union_user_pi_resource.json
+++ b/configuration/etl/etl_action_defs.d/cloud_generic/union_user_pi_resource.json
@@ -19,6 +19,9 @@
                 "alias": "r",
                 "on": "r.id = raw.resource_id"
             }
+        ],
+        "where": [
+          "raw.provider_user IS NOT NULL"
         ]
     }
 }

--- a/configuration/etl/etl_action_defs.d/cloud_openstack/union_user_pi_resource.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/union_user_pi_resource.json
@@ -21,7 +21,7 @@
             }
         ],
         "where": [
-          "raw.user_name IS NOT NULL"
+            "raw.user_name IS NOT NULL"
         ]
     }
 }

--- a/configuration/etl/etl_action_defs.d/cloud_openstack/union_user_pi_resource.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/union_user_pi_resource.json
@@ -19,6 +19,9 @@
                 "alias": "r",
                 "on": "r.id = raw.resource_id"
             }
+        ],
+        "where": [
+          "raw.user_name IS NOT NULL"
         ]
     }
 }


### PR DESCRIPTION
This prevents the usernames that are null for a cloud event from being ingested and causing an error when running the cloud ingestor pipelines

## Tests performed
Manually tested in docker and passed existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
