### PR TITLE
Changing where staging action gets user id from for cloud data

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_generic.json
+++ b/configuration/etl/etl.d/jobs_cloud_generic.json
@@ -264,7 +264,7 @@
             "description": "Generic cloud instance type data",
             "class": "DatabaseIngestor",
             "definition_file": "cloud_generic/instance_type.json",
-            "#": "Because the generic format allows for a Z at the end of the timestamp",	
+            "#": "Because the generic format allows for a Z at the end of the timestamp",
             "#": "the Z gets truncated off and throws this warning",
             "hide_sql_warning_codes": [
                 1292
@@ -309,7 +309,7 @@
                 "type": "mysql",
                 "name": "Cloud DB",
                 "config": "datawarehouse",
-                "schema": "mod_shredder"
+                "schema": "modw"
               }
             },
             "#": "Because the generic format allows for a Z at the end of the timestamp",

--- a/configuration/etl/etl.d/jobs_cloud_openstack.json
+++ b/configuration/etl/etl.d/jobs_cloud_openstack.json
@@ -262,7 +262,7 @@
                 "type": "mysql",
                 "name": "Cloud DB",
                 "config": "datawarehouse",
-                "schema": "mod_shredder"
+                "schema": "modw"
               }
             }
         },

--- a/configuration/etl/etl_action_defs.d/cloud_generic/staging_event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_generic/staging_event.json
@@ -22,7 +22,7 @@
             "event_type_id": "COALESCE(etype.event_type_id, -1)",
             "record_type_id": "COALESCE(rtype.record_type_id, -1)",
             "user_name": "rv.provider_user",
-            "person_id": "su.union_user_pi_id",
+            "person_id": "sa.person_id",
             "account_id": "COALESCE(acct.account_id, -1)",
             "host_id": "COALESCE(h.host_id, -1)",
             "instance_id": "COALESCE(i.instance_id, -1)",
@@ -92,10 +92,10 @@
                 "on": "raw.provider_instance_identifier = rv.provider_instance_identifier"
             },
             {
-                "name": "staging_union_user_pi",
+                "name": "systemaccount",
                 "schema": "${UTILITY_SCHEMA}",
-                "alias": "su",
-                "on": "rv.provider_user = su.union_user_pi_name"
+                "alias": "sa",
+                "on": "rv.provider_user = sa.username AND rv.resource_id = sa.resource_id"
             },
             {
                 "name": "asset_type",
@@ -113,7 +113,7 @@
             "etype.event_type_id",
             "rtype.record_type_id",
             "acct.account_id",
-            "su.union_user_pi_id",
+            "sa.person_id",
             "h.host_id"
         ]
     }

--- a/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
@@ -17,7 +17,7 @@
             "event_type_id": "COALESCE(etype.event_type_id, -1)",
             "record_type_id": "COALESCE(rtype.record_type_id, -1)",
             "user_name": "raw.user_name",
-            "person_id": "su.union_user_pi_id",
+            "person_id": "sa.person_id",
             "account_id": "COALESCE(acct.account_id, -1)",
             "host_id": "COALESCE(h.host_id, -1)",
             "instance_id": "COALESCE(i.instance_id, -1)",
@@ -81,10 +81,10 @@
                 "type": "LEFT OUTER"
             },
             {
-                "name": "staging_union_user_pi",
+                "name": "systemaccount",
                 "schema": "${UTILITY_SCHEMA}",
-                "alias": "su",
-                "on": "raw.user_name = su.union_user_pi_name"
+                "alias": "sa",
+                "on": "raw.user_name = sa.username AND raw.resource_id = sa.resource_id"
             }
         ],
 
@@ -99,7 +99,7 @@
             "etype.event_type_id",
             "rtype.record_type_id",
             "acct.account_id",
-            "su.union_user_pi_id",
+            "sa.person_id",
             "h.host_id"
         ]
     }


### PR DESCRIPTION
Changing where cloudstaging action gets user id from. Instead of using mod_shredder which does not exist in the xsede version use modw.systemaccount instead and add resource_id to join clause.

This also fixes this error.
```
ETL\EtlOverseer: Error verifying data endpoints:
('Cloud DB', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=mod_shredder, host=tas-db1.ccr.buffalo.edu:3306, user=xdmod): Schema 'mod_shredder' does not exist for user 'xdmod'
#0 /data/www/xdmod/share/classes/ETL/EtlOverseer.php(379): ETL\EtlOverseer->verifyDataEndpoints(Object(ETL\Configuration\EtlConfiguration), true)
#1 /data/www/xdmod/share/tools/etl/etl_overseer.php(612): ETL\EtlOverseer->execute(Object(ETL\Configuration\EtlConfiguration))
#2 {main}
```

## Motivation and Context
Prevents errors with being used with XSEDE and make sure user is retrieved from the correct resource

## Tests performed
Manually verified in docker and all test pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
