### PR TITLE
Updating linker config to use Configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -415,7 +415,15 @@
     },
     "autoload": {
         "classmap": [
-            "composer.scripts.php"
+            "composer.scripts.php",
+            "classes",
+            "classes/DB",
+            "classes/DB/DBModel",
+            "classes/DB/TimePeriodGenerators",
+            "classes/ExtJS",
+            "classes/Rest",
+            "classes/User",
+            "classes/ReportTemplates"
         ]
     }
 }

--- a/configuration/autoloader.json
+++ b/configuration/autoloader.json
@@ -1,0 +1,5 @@
+{
+  "autoloaders": [
+    "vendor/autoload.php"
+  ]
+}

--- a/configuration/linker.json
+++ b/configuration/linker.json
@@ -1,22 +1,5 @@
 {
-    "autoloaders": [
-        "vendor/autoload.php"
-    ],
     "include_dirs": [
-        "classes",
-        "classes/DB",
-        "classes/DB/TACCStatsIngestors",
-        "classes/DB/TGcDBIngestors",
-        "classes/DB/POPSIngestors",
-        "classes/DB/XRASIngestors",
-        "classes/DB/Aggregators",
-        "classes/DB/DBModel",
-        "classes/DB/TimePeriodGenerators",
-        "classes/ExtJS",
-        "classes/REST",
-        "classes/User",
-        "classes/ReportTemplates",
-        "classes/AppKernel",
-        "libraries/HighRoller_1.0.5"
+
     ]
 }

--- a/configuration/linker.php
+++ b/configuration/linker.php
@@ -5,28 +5,8 @@ $baseDir = dirname($dir);
 
 require_once($dir . '/constants.php');
 
-// ---------------------------
-
-// If present, load linker configuration from linker.json and linker.d.
-require_once("$baseDir/classes/CCR/Json.php");
-
-try {
-    $linkerConfigFilePath = implode(
-        DIRECTORY_SEPARATOR,
-        array(
-            CONFIG_DIR,
-            'linker.json'
-        )
-    );
-    $linkerConfig = CCR\Json::loadFile(
-        $linkerConfigFilePath
-    );
-} catch (Exception $e) {
-    $configDir = $config->getConfigDirPath();
-    echo "Could not find valid \"linker.json\" or \"linker.d\" files in \"$configDir\".\n";
-    echo "Please set up valid linker configuration files and try again.\n";
-    exit(1);
-}
+// Read in the linker config files
+$linkerConfig = \Configuration\XdmodConfiguration::assocArrayFactory('linker.json', CONFIG_DIR);
 
 // Load configured autoloaders.
 if (isset($linkerConfig['autoloaders'])) {

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -74,6 +74,7 @@
             "configuration/etl",
             "configuration/hierarchy.json",
             "configuration/internal_dashboard.json",
+            "configuration/autoloader.json",
             "configuration/linker.json",
             "configuration/organization.json",
             "configuration/portal_settings.ini",


### PR DESCRIPTION
## Description
Replaced a section of linker.php that read in the `linker.json` config
file and replaced it with the new `XdmodConfiguration` class. This
allows it to have .d files that will be merged in.

**NOTE** This PR is per a convo with @jtpalmer about this causing problems when used in an XSEDE deployment.


## Motivation and Context
We should utilize the new `Configuration` classes where possible so that we can utilize all of the features they provide.

## Tests performed


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
