### PR TITLE
Addressing problem found by @jtpalmer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -416,14 +416,7 @@
     "autoload": {
         "classmap": [
             "composer.scripts.php",
-            "classes",
-            "classes/DB",
-            "classes/DB/DBModel",
-            "classes/DB/TimePeriodGenerators",
-            "classes/ExtJS",
-            "classes/Rest",
-            "classes/User",
-            "classes/ReportTemplates"
+            "classes"
         ]
     }
 }

--- a/configuration/linker.json
+++ b/configuration/linker.json
@@ -1,5 +1,12 @@
 {
     "include_dirs": [
-        "classes"
+        "classes",
+        "classes/DB",
+        "classes/DB/DBModel",
+        "classes/DB/TimePeriodGenerators",
+        "classes/ExtJS",
+        "classes/Rest",
+        "classes/User",
+        "classes/ReportTemplates"
     ]
 }


### PR DESCRIPTION
**NOTE:** The Travis tests will fail because we changed `composer.json` but there is no accompanying change to `composer.lock`. This is expected. 

## Description
The problem is that when these entries were only in `composer.json` the
classpath was determined prior to run time, aka. before any other modules are
installed. So, if a module has code installed to any of these paths they will
not be found at round time. By moving them back into `linker.json` we resolve
this problem.

## Motivation and Context
runtime exceptions bad

## Tests performed
All automated tests on OpenXDMoD docker ( upgrade / install ) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
