### PR TITLE
Change cloud person username fields to be not null

### DIFF
--- a/configuration/etl/etl_tables.d/cloud_generic/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_generic/staging_event.json
@@ -7,8 +7,7 @@
             {
                 "name": "resource_id",
                 "type": "int(11)",
-                "nullable": false,
-                "default": -1
+                "nullable": false
             },
             {
                 "name": "instance_id",
@@ -41,8 +40,8 @@
             {
                 "name": "person_id",
                 "type": "int(11)",
-                "nullable": true,
-                "default": null,
+                "nullable": false,
+                "default": -1,
                 "comment": "Person ID associated with event"
             },
             {

--- a/configuration/etl/etl_tables.d/cloud_generic/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_generic/staging_event.json
@@ -7,7 +7,8 @@
             {
                 "name": "resource_id",
                 "type": "int(11)",
-                "nullable": false
+                "nullable": false,
+                "default": -1
             },
             {
                 "name": "instance_id",

--- a/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
@@ -33,15 +33,15 @@
             {
                 "name": "user_name",
                 "type": "varchar(32)",
-                "nullable": true,
-                "default": null,
+                "nullable": false,
+                "default": -1,
                 "comment": "Username associated with event"
             },
             {
                 "name": "person_id",
                 "type": "int(11)",
-                "nullable": true,
-                "default": null,
+                "nullable": false,
+                "default": -1,
                 "comment": "Person ID associated with event"
             },
             {

--- a/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/staging_event.json
@@ -33,8 +33,8 @@
             {
                 "name": "user_name",
                 "type": "varchar(32)",
-                "nullable": false,
-                "default": -1,
+                "nullable": true,
+                "default": null,
                 "comment": "Username associated with event"
             },
             {


### PR DESCRIPTION
In PR #797  the Person and System Account group bys were added to the Cloud realm. In that PR the person_id field was added to the staging tables with a default of NULL and was added to the Primary Key on that table. This caused the error below on the xdmod-dev database.
```
xdmod.jobs-cloud-extract-openstack.OpenStackCloudStagingEventIngestor (ETL\Ingestor\DatabaseIngestor): 
Error managing ETL table for 'xdmod.jobs-cloud-extract-openstack.OpenStackCloudStagingEventIngestor': 
SQLSTATE[42000]: Syntax error or access violation: 1171 All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
```
This error doesn't show up on metrics-dev or in the my docker but does on xdmod-dev and it seems to be because metrics-dev and my docker run MySQL 5.5 and xdmod-dev runs MySQL 5.7. It seems MySQL is stricter about errors in 5.7.

Changing the person_id definition to NOT NULL with a default of -1 fixes this.

## Tests performed
Manually tested in docker and on xdmod-dev. All tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
