### PR TITLE
Ignore having no XDMoD rpms to remove in bootstrap on fresh install

### DIFF
--- a/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/scripts/bootstrap.sh
@@ -15,7 +15,7 @@ set -o pipefail
 
 if [ "$XDMOD_TEST_MODE" = "fresh_install" ];
 then
-    rpm -qa | grep ^xdmod | xargs yum -y remove
+    rpm -qa | grep ^xdmod | xargs yum -y remove || true
     rm -rf /etc/xdmod
     rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql
     yum -y install ~/rpmbuild/RPMS/*/*.rpm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In order to leverage the `bootstrap.sh` script while building a docker image from the current git repo, we need to ignore the exit status of 1 that `rpm -qa | grep ^xdmod` returns when there are no XDMoD rpms installed. Otherwise, `set -e` and `set -o pipefail` will cause the script to abort.

## Motivation and Context

Need to be able to leverage existing bootstrap commands rather than maintain them separately in the Dockerfile.

## Tests performed

Built a dockerfile.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
