### PR TITLE
allow for timing to be recorded and fix up runtests

### DIFF
--- a/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
+++ b/open_xdmod/modules/xdmod/regression_tests/lib/Controllers/UsageExplorerTest.php
@@ -8,6 +8,7 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
     protected static $helper;
     protected static $messages = array();
     protected static $expectedEndpoint;
+    protected static $timingOutputDir;
     /*
      * These are used when testing against two different databases
      * such as when doing federation testing, this allows certain values to be
@@ -56,6 +57,11 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
             $response = self::$helper->post('/controllers/user_interface.php', null, $input);
             $csvdata = $response[0];
             $curldata = $response[1];
+            if(!empty(self::$timingOutputDir)){
+                $time_data = $fullTestName . "," . $curldata['total_time'] . "," . $curldata['starttransfer_time'] . "\n";
+                $outputCSV = self::$timingOutputDir . "timings.csv";
+                file_put_contents($outputCSV, $time_data, FILE_APPEND | LOCK_EX);
+            }
             /*
              * this temporarliy allows the "failed" tests of the public
              * user to pass, need to figure out a more robust way for
@@ -124,6 +130,12 @@ class UsageExplorerTest extends \PHPUnit_Framework_TestCase
     }
     protected function defaultSetup(){
         self::$helper = new \TestHarness\XdmodTestHelper();
+
+        $timingTestDir = getenv('REG_TIME_LOGDIR');
+        if(!empty($timingTestDir)){
+            self::$timingOutputDir = $timingTestDir;
+        }
+
         $envUserrole = getenv('REG_TEST_USER_ROLE');
         if(!empty($envUserrole)){
             self::$helper->authenticate($envUserrole);

--- a/open_xdmod/modules/xdmod/regression_tests/runtests.sh
+++ b/open_xdmod/modules/xdmod/regression_tests/runtests.sh
@@ -48,21 +48,22 @@ if [ "$REG_TEST_ALL" == "1" ]; then
     REG_TEST_USER_ROLE=cd $phpunit $CD lib/Controllers/UsageExplorerCloudTest.php
     REG_TEST_USER_ROLE=cs $phpunit $CS lib/Controllers/UsageExplorerCloudTest.php
 else
-    $phpunit $PUB lib/Controllers/UsageChartsTest.php & ucpubpid=$!
-    $phpunit $PUB lib/Controllers/UsageExplorerTest.php & pubpid=$!
-    REG_TEST_USER_ROLE=usr $phpunit $REGUSER lib/Controllers/UsageExplorerTest.php & usrpid=$!
-    REG_TEST_USER_ROLE=pi $phpunit $PI lib/Controllers/UsageExplorerTest.php & pipid=$!
-    REG_TEST_USER_ROLE=cd $phpunit $CD lib/Controllers/UsageExplorerTest.php & cdpid=$!
-    REG_TEST_USER_ROLE=cs $phpunit $CS lib/Controllers/UsageExplorerTest.php & cspid=$!
+    pids=()
+    $phpunit $PUB lib/Controllers/UsageChartsTest.php & pids+=("$!")
+    $phpunit $PUB lib/Controllers/UsageExplorerTest.php & pids+=("$!")
+    REG_TEST_USER_ROLE=usr $phpunit $REGUSER lib/Controllers/UsageExplorerTest.php & pids+=("$!")
+    REG_TEST_USER_ROLE=pi $phpunit $PI lib/Controllers/UsageExplorerTest.php & pids+=("$!")
+    REG_TEST_USER_ROLE=cd $phpunit $CD lib/Controllers/UsageExplorerTest.php & pids+=("$!")
+    REG_TEST_USER_ROLE=cs $phpunit $CS lib/Controllers/UsageExplorerTest.php & pids+=("$!")
 
-    REG_TEST_USER_ROLE=usr $phpunit $REGUSER lib/Controllers/UsageExplorerCloudTest.php & usrpid=$!
-    REG_TEST_USER_ROLE=pi $phpunit $PI lib/Controllers/UsageExplorerCloudTest.php & pipid=$!
-    REG_TEST_USER_ROLE=cd $phpunit $CD lib/Controllers/UsageExplorerCloudTest.php & cdpid=$!
-    REG_TEST_USER_ROLE=cs $phpunit $CS lib/Controllers/UsageExplorerCloudTest.php & cspid=$!
-    $phpunit $PUB lib/Controllers/UsageExplorerCloudTest.php & pubpid=$!
+    REG_TEST_USER_ROLE=usr $phpunit $REGUSER lib/Controllers/UsageExplorerCloudTest.php & pids+=("$!")
+    REG_TEST_USER_ROLE=pi $phpunit $PI lib/Controllers/UsageExplorerCloudTest.php & pids+=("$!")
+    REG_TEST_USER_ROLE=cd $phpunit $CD lib/Controllers/UsageExplorerCloudTest.php & pids+=("$!")
+    REG_TEST_USER_ROLE=cs $phpunit $CS lib/Controllers/UsageExplorerCloudTest.php & pids+=("$!")
+    $phpunit $PUB lib/Controllers/UsageExplorerCloudTest.php & pids+=("$!")
 
     EXIT_STATUS=0
-    for pid in $usrpid $pipid $cdpid $cspid $pubpid $ucpubpid;
+    for pid in "${pids[@]}";
     do
         wait "$pid"
         if [ "$?" -ne "0" ];


### PR DESCRIPTION
Add the ability to record timings of the regression tests and update runtests to be a tiny bit smarter @jtpalmer if this makes it more difficult for you to refactor as part of your storage work let me know and I will kill it.