### PR TITLE
Add email subject prefix

### DIFF
--- a/classes/CCR/MailWrapper.php
+++ b/classes/CCR/MailWrapper.php
@@ -17,7 +17,15 @@ class MailWrapper
         $mail->Body = $properties['body'];
 
         if(!empty($properties['subject'])) {
-            $mail->Subject = $properties['subject'];
+            $prefix = '';
+            try {
+                $prefix = \xd_utilities\getConfiguration('mailer', 'subject_prefix');
+            }
+            catch(\Exception $e){
+                // Do nothing, the configuration option
+                // does not exist;
+            }
+            $mail->Subject = !empty($prefix) ? $prefix . ': ' . $properties['subject']: $properties['subject'];
         } else {
             throw new \Exception('There is no subject');
         }

--- a/classes/CCR/MailWrapper.php
+++ b/classes/CCR/MailWrapper.php
@@ -20,12 +20,15 @@ class MailWrapper
             $prefix = '';
             try {
                 $prefix = \xd_utilities\getConfiguration('mailer', 'subject_prefix');
+                if(!empty($prefix)){
+                    $prefix = $prefix . ': ';
+                }
             }
             catch(\Exception $e){
                 // Do nothing, the configuration option
                 // does not exist;
             }
-            $mail->Subject = !empty($prefix) ? $prefix . ': ' . $properties['subject']: $properties['subject'];
+            $mail->Subject = $prefix . $properties['subject'];
         } else {
             throw new \Exception('There is no subject');
         }

--- a/classes/OpenXdmod/Migration/Version800To810/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version800To810/ConfigFilesMigration.php
@@ -31,6 +31,11 @@ class ConfigFilesMigration extends AbstractConfigFilesMigration
         if (file_exists($this->cloudRolesFilePath)) {
             $this->addCloudRolesGroupBy();
         }
+        $this->assertPortalSettingsIsWritable();
+        // Set new options in portal_settings.ini.
+        $this->writePortalSettingsFile(array(
+            'mailer_subject_prefix' => ''
+        ));
     }
 
     /**

--- a/classes/OpenXdmod/Migration/Version800To810/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version800To810/ConfigFilesMigration.php
@@ -32,6 +32,7 @@ class ConfigFilesMigration extends AbstractConfigFilesMigration
             $this->addCloudRolesGroupBy();
         }
         $this->assertPortalSettingsIsWritable();
+
         // Set new options in portal_settings.ini.
         $this->writePortalSettingsFile(array(
             'mailer_subject_prefix' => ''

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -74,6 +74,10 @@ basic_auth = "on"
 [mailer]
 sender_name = "Open XDMoD Mailer"
 sender_email = ""
+
+; Add a prefix to all outbound emails
+subject_prefix = ""
+
 ; To use a captcha on Signup and Contact by no logged in users XDMoD loadSupportScripts
 ; google recaptcha, to get the following information you must login to
 ; https://www.google.com/recaptcha/admin

--- a/open_xdmod/modules/xdmod/integration_tests/email-subject-test.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/email-subject-test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 sed -i -- 's/subject_prefix = ""/subject_prefix = "SEND BEN MONEY"/' /etc/xdmod/portal_settings.ini
-
-curl 'http://localhost:8080/controllers/mailer.php' --compressed -H 'X-Requested-With: XMLHttpRequest' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data 'operation=contact&username=__public__&token=public&timestamp=1&reason=contact&name=Contact%20Test&email=test%40example.com&message=test%40example.com' -s > /dev/null
+host=`jq -r .url -- .secrets.json`
+curl "${host}controllers/mailer.php" --compressed -H 'X-Requested-With: XMLHttpRequest' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data 'operation=contact&username=__public__&token=public&timestamp=1&reason=contact&name=Contact%20Test&email=test%40example.com&message=test%40example.com' -s > /dev/null
 
 sed -i -- 's/subject_prefix = "SEND BEN MONEY"/subject_prefix = ""/' /etc/xdmod/portal_settings.ini
 
-emailsubjects=`grep 'SEND BEN MONEY' /var/mail/root | wc -l`
+emailsubjects=`grep 'SEND BEN MONEY' /var/mail/root -c`
 
 if [ $emailsubjects != 2 ]; then
     echo "Email Subject Test returned bad results.  Mail contents:"

--- a/open_xdmod/modules/xdmod/integration_tests/email-subject-test.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/email-subject-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+sed -i -- 's/subject_prefix = ""/subject_prefix = "SEND BEN MONEY"/' /etc/xdmod/portal_settings.ini
+
+curl 'http://localhost:8080/controllers/mailer.php' --compressed -H 'X-Requested-With: XMLHttpRequest' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' --data 'operation=contact&username=__public__&token=public&timestamp=1&reason=contact&name=Contact%20Test&email=test%40example.com&message=test%40example.com' -s > /dev/null
+
+sed -i -- 's/subject_prefix = "SEND BEN MONEY"/subject_prefix = ""/' /etc/xdmod/portal_settings.ini
+
+emailsubjects=`grep 'SEND BEN MONEY' /var/mail/root | wc -l`
+
+if [ $emailsubjects != 2 ]; then
+    echo "Email Subject Test returned bad results.  Mail contents:"
+    cat /var/mail/root
+    exit 123
+fi

--- a/open_xdmod/modules/xdmod/integration_tests/runtests.sh
+++ b/open_xdmod/modules/xdmod/integration_tests/runtests.sh
@@ -23,3 +23,5 @@ $phpunit --testsuite default --group UserAdminTest.createUsers $UATCU
 
 # Run everything else
 $phpunit --testsuite default --exclude-group UserAdminTest.createUsers $UATXCU
+
+./email-subject-test.sh

--- a/templates/portal_settings.template
+++ b/templates/portal_settings.template
@@ -76,7 +76,7 @@ sender_name = "[:mailer_sender_name:]"
 sender_email = "[:mailer_sender_email:]"
 
 ; Add a prefix to all outbound emails
-subject_prefix = ""
+subject_prefix = "[:mailer_subject_prefix:]"
 
 ; To use a captcha on Signup and Contact by no logged in users XDMoD loadSupportScripts
 ; google recaptcha, to get the following information you must login to

--- a/templates/portal_settings.template
+++ b/templates/portal_settings.template
@@ -74,6 +74,10 @@ basic_auth = "[:rest_basic_auth:]"
 [mailer]
 sender_name = "[:mailer_sender_name:]"
 sender_email = "[:mailer_sender_email:]"
+
+; Add a prefix to all outbound emails
+subject_prefix = ""
+
 ; To use a captcha on Signup and Contact by no logged in users XDMoD loadSupportScripts
 ; google recaptcha, to get the following information you must login to
 ; https://www.google.com/recaptcha/admin


### PR DESCRIPTION
Add an email subject prefix to all outbound emails.

This was tested in a docker by looking at `/var/mail/root` and sending some test emails.