### PR TITLE
Adding cloud raw tables to cloud manage tables action

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_common.json
+++ b/configuration/etl/etl.d/jobs_cloud_common.json
@@ -43,7 +43,13 @@
                 "cloud_common/event.json",
                 "cloud_common/asset.json",
                 "cloud_common/instance_data.json",
-                "cloud_common/event_asset.json"
+                "cloud_common/event_asset.json",
+                "cloud_openstack/raw_event.json",
+                "cloud_openstack/raw_instance_type.json",
+                "cloud_openstack/raw_volume.json",
+                "cloud_generic/raw_event.json",
+                "cloud_generic/raw_instance_type.json",
+                "cloud_generic/raw_volume.json"
             ]
         },
         {


### PR DESCRIPTION
When `xdmod-ingestor` is run with no options it tries to ingest data from both the openstack and generic raw cloud tables. If no data has ever been shredded in one of the two formats the error below will occur. Adding both the openstack and generic raw tables to the CloudTableManagement action prevents this error from occurring.

```
2019-01-16 04:15:19 [error] xdmod.jobs-cloud-extract-generic.GenericCloudInstanceTypeIngestor (ETL\Ingestor\DatabaseIngestor): SQLSTATE[42S02]: Base table or view not found: 1146 Table 'modw_cloud.generic_cloud_raw_instance_type' doesn't exist Exception: 'SQLSTATE[42S02]: Base table or view not found: 1146 Table 'modw_cloud.generic_cloud_raw_instance_type' doesn't exist'
2019-01-16 04:15:19 [warning] Stopping ETL due to exception in xdmod.jobs-cloud-extract-generic.GenericCloudInstanceTypeIngestor (ETL\Ingestor\DatabaseIngestor)
```

## Motivation and Context
Fewer error messages

## Tests performed
Tested manually in docker and ran all tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
