### PR TITLE
Only process extends for non local config files in `ModuleConfiguration`

### DIFF
--- a/classes/Configuration/ModuleConfiguration.php
+++ b/classes/Configuration/ModuleConfiguration.php
@@ -209,7 +209,9 @@ class ModuleConfiguration extends XdmodConfiguration
         parent::processExtends();
 
         // We need to make sure that we extend our annotatedConfig
-        $this->handleExtendsFor($this->annotatedConfig);
+        if (!$this->isLocalConfig) {
+            $this->handleExtendsFor($this->annotatedConfig);
+        }
     } // processExtends
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Made sure that the handling of the `extends` keyword only occurs if the current Configuration is for a local config file.

## Motivation and Contex
If `extends` is processed for a local config file, it is entirely possible ( really probable ) that the target will not be present. This will cause the code to throw an exception as it won't be able to properly resolve the configuration data.

## Tests performed
Manually verified that I was able to re-produce the error within an xsede docker & the refactored configuration files. Applied the required `if` statement and re-verified that `acl-config` now finishes without a problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
