### PR TITLE
Updated GroupByProvider id column

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByProvider.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByProvider.php
@@ -84,7 +84,7 @@ class GroupByProvider extends \DataWarehouse\Query\Jobs\GroupBy
         $query->addTable($this->organization_table);
 
         $id_field = new \DataWarehouse\Query\Model\TableField($this->organization_table, $this->_id_field_name);
-        $datatable_organization_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'organization_id');
+        $datatable_organization_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'resource_organization_id');
 
         // the where condition that specifies the join of the tables
         $query->addWhereCondition(


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
**NOTE: This GroupBy is only used by XSEDE but resides at `classes/DataWarehouse/Jobs/GroupBys/GroupByProvider.php` i.e. not in the XSEDE module. Hence needing to open this PR against 8.1 as opposed to for the XSEDE module.**

## Description
the `organization_id` column no longer exists in the `modw.serviceprovider`
table. This commit replaces it with the `resource_organization_id` column.

This was causing SQL exceptions to be thrown when viewing the `Jobs - By
Provider` section of the Usage tab on xdmod-dev.

## Motivation and Context
When navigating the Usage tab on xdmod-dev and viewing the data in `Jobs - By Provider` a sql exception would be thrown due to the `organization_id` not being present. 

## Tests performed
Manual testing was performed. 

- Navigate to xdmod-dev ( do not log in )
- Click the `Usage` tab.
- Select the `Jobs - By Provider` tree item. 
- Notice that sql exceptions are thrown that mention `jf.resource_id` not being present.

Update line 87 of `GroupByProvider.php` from: 
`$datatable_organization_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'organization_id');`
to
`$datatable_organization_id_field = new \DataWarehouse\Query\Model\TableField($data_table, 'resource_organization_id');`

- Navigate to xdmod-dev ( do not log in )
- Click the `Usage` tab
- Select the  `Jobs - By Provider ` tree item.
- Notice that no sql exceptions are thrown. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
