### PR TITLE
Decouple the metric and summary tabs

### DIFF
--- a/html/gui/js/modules/Summary.js
+++ b/html/gui/js/modules/Summary.js
@@ -28,6 +28,8 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
 
     },
 
+    refreshRequested: false,
+
   // ------------------------------------------------------------------
 
     initComponent: function () {
@@ -49,7 +51,16 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
             self.toolbar.doLayout();
         });
 
-        self.on('activate', self.checkForUpdates);
+        self.on('request_refresh', function () {
+            this.refreshRequested = true;
+        });
+
+        self.on('activate', function () {
+            if (this.refreshRequested) {
+                this.refreshRequested = false;
+                this.reload();
+            }
+        });
 
     // ----------------------------------------
 
@@ -415,12 +426,6 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
     }, // updateUsageSummary
 
   // ------------------------------------------------------------------
-    checkForUpdates: function () {
-        if (CCR.xdmod.ui.metricExplorer && CCR.xdmod.ui.metricExplorer.summaryDirty === true) {
-            CCR.xdmod.ui.metricExplorer.summaryDirty = false;
-            this.reload();
-        }
-    },
 
     reload: function () {
         if (!this.getDurationSelector().validate()) {

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -2250,7 +2250,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
 
         if (config.featured === JSON.parse(this.currentQueryRecord.data.config).featured &&
           !this.currentQueryRecord.stack.isMarked()) {
-            this.summaryDirty = true;
+            CCR.xdmod.ui.tgSummaryViewer.fireEvent('request_refresh');
         }
 
         var recordUpdated = false;


### PR DESCRIPTION
This change removes some of the coupling of the Summary tab and the Metric Explorer tab. The Summary tab no longer modifies a private member variable of the metric explorer. Instead the Metric
Explorer just fires an event at the Summary tab and does not have its internal state modified by an external class.

This de-coupling will lead to cleaner code in the upcoming novice user tab.