### PR TITLE
Update `isRealmEnabled` sql

### DIFF
--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -416,7 +416,19 @@ class DataWarehouseInitializer
      */
     public function isRealmEnabled($realm)
     {
-        $realms = $this->warehouseDb->query("SELECT * FROM moddb.realms WHERE display = :realm", [':realm' => $realm]);
+        $sql = <<<SQL
+        SELECT 1
+        FROM moddb.acl_group_bys agb
+            JOIN moddb.realms r on agb.realm_id = r.realm_id
+        WHERE r.display = :realm AND
+              agb.enabled = TRUE AND
+              agb.visible = TRUE
+        LIMIT 1;
+SQL;
+        $params = array(
+            ':realm' => $realm
+        );
+        $realms = $this->warehouseDb->query($sql, $params);
         return (count($realms) > 0);
     }
 }

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -413,6 +413,7 @@ class DataWarehouseInitializer
      * Check to see if a realm exists in the realms table
      *
      * @param string $realm The realm you are checking to see if exists
+     * @return bool
      */
     public function isRealmEnabled($realm)
     {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The previous SQL statement answered the question, Is there a $realm that has
been installed. This updated version answers the question, Is there an acl that
grants access to this realm. This corresponds w/ having an entry in
`roles.json#<role>#query_descripters` w/ a `realm` property = $realm, that is
both enabled and visible.


## Motivation and Context
Get things working 

## Tests performed
Modified the `bootstrap.sh` file to only install the `Jobs` realm then ran the integration tests. The `getDWDescripters` tests failed as expected. 

Did a fresh_install and nothing borked, weee. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
