### PR TITLE
Add missing bootstrap pipeline

### DIFF
--- a/classes/OpenXdmod/Setup/DatabaseSetup.php
+++ b/classes/OpenXdmod/Setup/DatabaseSetup.php
@@ -144,6 +144,7 @@ EOT
         Utilities::runEtlPipeline(array(
             'xdb-bootstrap',
             'jobs-xdw-bootstrap',
+            'xdw-bootstrap-storage',
             'shredder-bootstrap',
             'staging-bootstrap',
             'hpcdb-bootstrap',

--- a/configuration/etl/etl.d/storage.json
+++ b/configuration/etl/etl.d/storage.json
@@ -2,10 +2,7 @@
     "module": "xdmod",
     "#": "Storage Ingestion and Aggregation",
     "defaults": {
-        "xdw-ingest-storage": {
-            "namespace": "ETL\\Ingestor",
-            "class": "DatabaseIngestor",
-            "options_class": "IngestorOptions",
+        "global": {
             "endpoints": {
                 "source": {
                     "type": "mysql",
@@ -20,6 +17,11 @@
                     "schema": "modw"
                 }
             }
+        },
+        "xdw-ingest-storage": {
+            "namespace": "ETL\\Ingestor",
+            "class": "DatabaseIngestor",
+            "options_class": "IngestorOptions"
         }
     },
     "xdw-bootstrap-storage": [


### PR DESCRIPTION
Add a storage bootstrap pipeline to the setup process.  These tables would be automatically created, but it's preferred to create them during setup for a future manually database setup process.