### PR TITLE
Updated SQL construction for `tablesExist`

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -2127,12 +2127,6 @@ function verifyDatabase()
 function tablesExist(iDatabase $db, array $tables, $schema, $all = true)
 {
     $handle = $db->handle();
-    $query = <<<SQL
-SELECT *
-FROM information_schema.tables
-WHERE table_schema = :table_schema
-AND table_name in (:table_list);
-SQL;
 
     $tables = array_reduce(
         $tables,
@@ -2145,10 +2139,18 @@ SQL;
     );
 
     $tableList = implode(',', $tables);
+
+    $query = <<<SQL
+SELECT *
+FROM information_schema.tables
+WHERE table_schema = :table_schema
+AND table_name in ($tableList);
+SQL;
+
     $params = array(
-        ':table_schema' => $schema,
-        ':table_list' => $tableList
+        ':table_schema' => $schema
     );
+
     $results = $db->query(
         $query,
         $params


### PR DESCRIPTION
## Description
So it turns out that PHP prepared statement variable binding doesn't play well
with SQL `IN` statements. Just moving things around a bit so that instead of
supplying the `IN` clause w/ a bind parameter we instead just populate it in the
base query string.

This PR is related to: https://ubccr.freshdesk.com/a/tickets/12470

## Motivation and Context
It's nice to have a `recover` mode that actually functions

## Tests performed
Manual Tests performed on a local docker instance. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
