### PR TITLE
Wait for loading mask to disappear on SSO logout

### DIFF
--- a/tests/ui/test/specs/xdmod/SSOLogin.js
+++ b/tests/ui/test/specs/xdmod/SSOLogin.js
@@ -19,6 +19,7 @@ describe('Single Sign On Login', () => {
     it('Logout', () => {
         browser.waitForInvisible('.ext-el-mask-msg');
         browser.waitAndClick('#logout_link');
+        browser.waitForInvisible('.ext-el-mask-msg');
         $('a[href*=actionLogin]').waitForVisible();
         $('#main_tab_panel__about_xdmod').waitForVisible();
     });

--- a/tests/ui/test/specs/xdmod/SSOLogin.js
+++ b/tests/ui/test/specs/xdmod/SSOLogin.js
@@ -17,8 +17,8 @@ describe('Single Sign On Login', () => {
         $('#main_tab_panel__about_xdmod').waitForVisible();
     });
     it('Logout', () => {
-        browser.waitAndClick('#logout_link');
         browser.waitForInvisible('.ext-el-mask-msg');
+        browser.waitAndClick('#logout_link');
         $('a[href*=actionLogin]').waitForVisible();
         $('#main_tab_panel__about_xdmod').waitForVisible();
     });


### PR DESCRIPTION
the sso logout ui tests are sometimes failing with
```
Element <a href="javascript:CCR.xdmod.ui.actionLogout()" id="..._link">logout</a> is not clickable at point (223, 20). Other element would receive the click: <div class="ext-el-mask" id="ext-gen452" style="display: block; width: 2560px; height: 1600px; z-index: 9000;"></div>
```
this should help that