### PR TITLE
Fix datatype of job_id column

### DIFF
--- a/configuration/etl/etl_tables.d/jobs/xdw/jobfact_by_day_joblist.json
+++ b/configuration/etl/etl_tables.d/jobs/xdw/jobfact_by_day_joblist.json
@@ -10,7 +10,7 @@
             },
             {
                 "name": "jobid",
-                "type": "int(11)",
+                "type": "bigint(20) unsigned",
                 "nullable": false
             }
         ],


### PR DESCRIPTION
Need to ensure that the jobid column in the joblist table matches the datatype of the column it references. i.e job_tasks.job_id