### PR TITLE
General code cleanup

### DIFF
--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -281,6 +281,8 @@ class Configuration extends Loggable implements \Iterator
      *
      * @param boolean $force TRUE to force re-initialization of the configuration even if it has
      *   previously been initialized.
+     *
+     * @return Configuration This object to support method chaining.
      * ------------------------------------------------------------------------------------------
      */
 
@@ -364,6 +366,8 @@ class Configuration extends Loggable implements \Iterator
         $this->postMergeTasks();
 
         $this->initialized = true;
+
+        return $this;
 
     }  // initialize()
 
@@ -546,7 +550,7 @@ class Configuration extends Loggable implements \Iterator
     {
         $this->transformedConfig = $this->mergeLocal(
             $this->transformedConfig,
-            $localConfigObj->getTransformedConfig(),
+            $localConfigObj->toStdClass(),
             $localConfigObj->getFilename(),
             $overwrite
         );
@@ -1066,18 +1070,6 @@ class Configuration extends Loggable implements \Iterator
     }  // getVariableStore()
 
     /** -----------------------------------------------------------------------------------------
-     * Get the configuration after applying transforms.
-     *
-     * @return stdClass The transformed configuration.
-     * ------------------------------------------------------------------------------------------
-     */
-
-    public function getTransformedConfig()
-    {
-        return $this->transformedConfig;
-    }  // getTransformedConfig()
-
-    /** -----------------------------------------------------------------------------------------
      * Getter method for accessing data keys using object notation.
      *
      * NOTE: When querying for existance we can't use isset() and must use NULL === $options->key
@@ -1162,6 +1154,19 @@ class Configuration extends Loggable implements \Iterator
         $instance->initialize();
         return $instance;
     }
+
+    /** -----------------------------------------------------------------------------------------
+     * Get the configuration after applying transforms. Note that NULL will be returned if
+     * initialize() has not been called or if cleanup() has been called.
+     *
+     * @return stdClass|null A stdClass representing the transformed configuration.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function toStdClass()
+    {
+        return $this->transformedConfig;
+    }  // toStdClass()
 
     /** -----------------------------------------------------------------------------------------
      * Return the JSON representation of the parsed and translated Configuration.

--- a/classes/ETL/DbModel/Entity.php
+++ b/classes/ETL/DbModel/Entity.php
@@ -94,7 +94,8 @@ class Entity extends Loggable
         if ( null !== $config ) {
 
             if ( is_string($config) ) {
-                $config = $this->parseJsonFile($config, "Table Definition");
+                $config = new \Configuration\Configuration($config);
+                $config = $config->initialize()->toStdClass();
                 // Support the table config directly or assigned to a "table_definition" key
                 if ( isset($config->table_definition) ) {
                     $config = $config->table_definition;
@@ -276,29 +277,6 @@ class Entity extends Loggable
         }
 
     }  // quote()
-
-    /* ------------------------------------------------------------------------------------------
-     * Parse a JSON table configuration file.
-     *
-     * @param $filename The file containing the table configuration
-     * @param $name Optional name for the file. Useful for error reporting.
-     *
-     * @return This object to support method chaining.
-     *
-     * @throw Exception If the file is does not exist or is not readable
-     * @throw Exception If there is an error parsing the file
-     * ------------------------------------------------------------------------------------------
-     */
-
-    protected function parseJsonFile($filename, $name = null)
-    {
-        $name = ( null === $name ? "JSON file" : $name );
-        $opt = new DataEndpointOptions(array('name' => $name,
-                                             'path' => $filename,
-                                             'type' => "jsonfile"));
-        $jsonFile = DataEndpoint::factory($opt, $this->logger);
-        return $jsonFile->parse();
-    }  // parseJsonFile()
 
     /* ------------------------------------------------------------------------------------------
      * @see iEntity::toStdClass()

--- a/classes/ETL/Maintenance/ManageTables.php
+++ b/classes/ETL/Maintenance/ManageTables.php
@@ -106,7 +106,7 @@ class ManageTables extends aRdbmsDestinationAction implements iAction
             );
             $tableConfig->initialize();
             $etlTable = new Table(
-                $tableConfig->getTransformedConfig(),
+                $tableConfig->toStdClass(),
                 $this->destinationEndpoint->getSystemQuoteChar(),
                 $this->logger
             );

--- a/classes/ETL/aEtlObject.php
+++ b/classes/ETL/aEtlObject.php
@@ -126,29 +126,6 @@ abstract class aEtlObject extends \CCR\Loggable
     }  // verifyRequiredConfigKeys()
 
     /* ------------------------------------------------------------------------------------------
-     * Parse a JSON table configuration file.
-     *
-     * @param $filename The file containing the table configuration
-     * @param $name Optional name for the file. Useful for error reporting.
-     *
-     * @return This object to support method chaining.
-     *
-     * @throw Exception If the file is does not exist or is not readable
-     * @throw Exception If there is an error parsing the file
-     * ------------------------------------------------------------------------------------------
-     */
-
-    protected function parseJsonFile($filename, $name = null)
-    {
-        $name = ( null === $name ? "JSON file" : $name );
-        $opt = new DataEndpointOptions(array('name' => $name,
-                                             'path' => $filename,
-                                             'type' => "jsonfile"));
-        $jsonFile = DataEndpoint::factory($opt, $this->logger);
-        return $jsonFile->parse();
-    }  // parseJsonFile()
-
-    /* ------------------------------------------------------------------------------------------
      * Generate a string representation of the endpoint. Typically the name, plus other pertinant
      * information as appropriate.
      *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

General code cleanup and consistency update:
- Change `Configuration::getTransformedConfig()` to `toStdClass()` for consistency with other code.
- `Configuration::initialize()` now returns `$this` to support method chaining.
- Use `Configuration` in the ETL `DbModel` rather than `parseJsonFile` to enable support for comments, inclusion, and references.
- Remove deprecated `aEtlObject::parseJsonFile()`

## Motivation and Context
General improvements and cleanup

## Tests performed

Yes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
