### PR TITLE
update path in creat_xdmod_users.php to be relative

### DIFF
--- a/tests/ci/scripts/create_xdmod_users.php
+++ b/tests/ci/scripts/create_xdmod_users.php
@@ -6,7 +6,7 @@
 // Open XDMoD and 476 (TACC) for XSEDE XDMoD.
 
 define('SERVICE_PROVIDER_ID', 1);
-define('DEFAULT_SECRETS_FILE', '/root/src/github.com/ubccr/xdmod/tests/ci/testing.json');
+define('DEFAULT_SECRETS_FILE', __DIR__ . '/../testing.json');
 define('DEFAULT_XDMOD_PATH', '/usr/share/xdmod');
 
 $scriptOptions = array(


### PR DESCRIPTION
the `create_xdmod_users.php` script had default file with user and passwords hard coded to the path that shippable checks the repo out to

Lets just make it relative to the script itself.