### PR TITLE
Bug in Advanced Search change realm

### DIFF
--- a/html/gui/js/modules/job_viewer/SearchPanel.js
+++ b/html/gui/js/modules/job_viewer/SearchPanel.js
@@ -312,9 +312,7 @@ XDMoD.Module.JobViewer.SearchPanel = Ext.extend(Ext.Panel, {
             Ext.getCmp('search-add').disable();
             Ext.getCmp('job-viewer-search-search').disable();
             this.searchStore.removeAll();
-            this.valueField.store.setBaseParam({
-                realm: realm
-            });
+            this.valueField.store.setBaseParam('realm', realm);
             this.searchField.reset();
             this.searchField.store.load({
                 params: {


### PR DESCRIPTION
The store setParams function was being called with syntax error. This didn't show up in previous testing because at the time we only had one realm in use and the bug results in the realm not being updated.