### PR TITLE
Performance improvements by providing caching for Configuration objects built from JSON configuration files

### DIFF
--- a/background_scripts/etl_aggregation_table_manager.php
+++ b/background_scripts/etl_aggregation_table_manager.php
@@ -167,7 +167,7 @@ if ( NULL === $scriptOptions['config-file'] ||
 // Parse the ETL configuration. We will need it for listing available ingestors, aggregators, etc.
 
 try {
-  $etlConfig = new EtlConfiguration($scriptOptions['config-file']);
+  $etlConfig = EtlConfiguration::factory($scriptOptions['config-file']);
 } catch ( Exception $e ) {
   exit($e->getMessage() . "\n");
 }

--- a/classes/CCR/Loggable.php
+++ b/classes/CCR/Loggable.php
@@ -164,4 +164,15 @@ class Loggable
     {
         return "(" . get_class($this) . ")";
     }  // __toString()
+
+    /* ------------------------------------------------------------------------------------------
+     * Do not allow serialization of the logger as it may contain a PDO resource, which cannot
+     * be serialized.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function __sleep()
+    {
+        return array();
+    }
 }  // class Loggable

--- a/classes/Configuration/CommentTransformer.php
+++ b/classes/Configuration/CommentTransformer.php
@@ -35,7 +35,7 @@ class CommentTransformer extends Loggable implements iConfigFileKeyTransformer
 
     public function keyMatches($key)
     {
-        return ( 0 === strpos($key, self::COMMENT_PREFIX) );
+        return $key[0] === self::COMMENT_PREFIX;
     }  // keyMatches()
 
     /* ------------------------------------------------------------------------------------------

--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -269,8 +269,10 @@ class Configuration extends Loggable implements \Iterator
 
         if ( self::$enableObjectCache ) {
             // The cache key must take into account the full filename as well as any options
-            // provided as this may affect the generated object.
-            $cacheKey = md5($filename . '|' . json_encode($options));
+            // provided as this may affect the generated object. We use serialize() instead of
+            // json_encode() because the latter only takes into account public member variables and
+            // we have more complex objects that can be passed as options such as VariableStore.
+            $cacheKey = md5($filename . '|' . serialize($options));
             $inCache = array_key_exists($cacheKey, self::$objectCache);
         }
 

--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -280,8 +280,9 @@ class Configuration extends Loggable implements \Iterator
             // instantiated, as well as any options provided as this may affect the generated
             // object. We use serialize() instead of json_encode() because the latter only takes
             // into account public member variables and we have more complex objects that can be
-            // passed as options such as VariableStore.
-            $cacheKey = md5($filename . '|' . get_called_class() . '|' . serialize($options));
+            // passed as options such as VariableStore. The filename and called class are maintained
+            // in clear text for debugging purposes.
+            $cacheKey = $filename . '|' . get_called_class() . '|' . md5(serialize($options));
             $inCache = array_key_exists($cacheKey, self::$objectCache);
         }
 

--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -821,6 +821,10 @@ class Configuration extends Loggable implements \Iterator
 
     protected function substituteVariables($entity)
     {
+        if ( 0 == $this->variableStore->count() ) {
+            return $entity;
+        }
+
         if ( is_string($entity) ) {
             return $this->variableStore->substitute($entity);
         } elseif ( is_array($entity) || $entity instanceof \stdClass || $entity instanceof \Traversable ) {

--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -120,7 +120,7 @@ class Configuration extends Loggable implements \Iterator
 
     /**
      * The configuration constructed from the parsed file after processing any transformers and
-     * performing manipulations. Note that this is cleared if cleanup() is called.
+     * performing manipulations.
      * @var stdClass
      */
 
@@ -820,15 +820,13 @@ class Configuration extends Loggable implements \Iterator
     }
 
     /** -----------------------------------------------------------------------------------------
-     * Clean up intermediate information that we don't need to keep around after processing. This
-     * includes parsed and constructed JSON.
+     * Clean up intermediate information that we don't need to keep around after processing.
      * ------------------------------------------------------------------------------------------
      */
 
     public function cleanup()
     {
         $this->parsedConfig = null;
-        $this->transformedConfig = null;
     }  // cleanup()
 
     /** -----------------------------------------------------------------------------------------

--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -267,7 +267,13 @@ class Configuration extends Loggable implements \Iterator
         $inCache = false;
         $cacheKey = null;
 
-        if ( self::$enableObjectCache ) {
+        // If this is a local config file, do not attempt to pull it out of the cache because its
+        // contents depend on options passed in from the global config. If the global config was
+        // retrieved from the cache we won't be processing the local configs anyway.
+
+        $skipCacheCheck = ( array_key_exists('is_local_config', $options) && $options['is_local_config'] );
+
+        if ( self::$enableObjectCache && ! $skipCacheCheck ) {
             // The cache key must take into account the full filename as well as any options
             // provided as this may affect the generated object. We use serialize() instead of
             // json_encode() because the latter only takes into account public member variables and
@@ -276,7 +282,7 @@ class Configuration extends Loggable implements \Iterator
             $inCache = array_key_exists($cacheKey, self::$objectCache);
         }
 
-        if ( ! self::$enableObjectCache || ! $inCache ) {
+        if ( ! self::$enableObjectCache || ! $inCache || $skipCacheCheck ) {
             // Let the constructor know that it was called via factory()
             $options['called_via_factory'] = true;
             $instance = new static($filename, $baseDir, $logger, $options);

--- a/classes/Configuration/StripMergePrefixTransformer.php
+++ b/classes/Configuration/StripMergePrefixTransformer.php
@@ -33,7 +33,7 @@ class StripMergePrefixTransformer extends Loggable implements iConfigFileKeyTran
      */
     public function keyMatches($key)
     {
-        return substr($key, 0, 1) === self::MERGE_PREFIX;
+        return $key[0] === self::MERGE_PREFIX;
     }
 
     /**
@@ -41,7 +41,7 @@ class StripMergePrefixTransformer extends Loggable implements iConfigFileKeyTran
      */
     public function transform(&$key, &$value, stdClass $obj, Configuration $config)
     {
-        $key = substr($key, 1, strlen($key) - 1);
+        $key = substr($key, 1);
 
         return true;
     }

--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -433,10 +433,7 @@ class EtlConfiguration extends Configuration
             'default_module_name' => $this->defaultModuleName
         );
 
-        $localConfigObj = new EtlConfiguration($localConfigFile, $this->baseDir, $this->logger, $options);
-        $localConfigObj->initialize();
-
-        return $localConfigObj;
+        return EtlConfiguration::factory($localConfigFile, $this->baseDir, $this->logger, $options);
 
     }  // processLocalConfig()
 

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -162,8 +162,12 @@ abstract class aStructuredFile extends File
         $keySource = array($this->type, $this->path, $this->mode);
         foreach ( $this->filterDefinitions as $filter )
         {
-            $keySource[] = $filter->path;
-            $keySource[] = $filter->arguments;
+            if ( isset($filter->path) ) {
+                $keySource[] = $filter->path;
+            }
+            if ( isset($filter->arguments) ) {
+                $keySource[] = $filter->arguments;
+            }
         }
         $this->key = md5(implode($this->keySeparator, $keySource));
     }

--- a/classes/ETL/DbModel/AggregationTable.php
+++ b/classes/ETL/DbModel/AggregationTable.php
@@ -171,7 +171,14 @@ class AggregationTable extends Table
 
         foreach ( $indexJson as $def ) {
             foreach ( $def as $key => &$value ) {
-                $value = $variableStore->substitute($value);
+                // The columns of an index is an array and substitution must be run on each element.
+                if ( 'columns' == $key ) {
+                    foreach ( $value as &$indexCol ) {
+                        $indexCol = $variableStore->substitute($indexCol);
+                    }
+                } else {
+                    $value = $variableStore->substitute($value);
+                }
             }
             unset($value); // Sever the reference with the last element
             $newTable->addIndex($def);

--- a/classes/ETL/DbModel/Entity.php
+++ b/classes/ETL/DbModel/Entity.php
@@ -94,8 +94,8 @@ class Entity extends Loggable
         if ( null !== $config ) {
 
             if ( is_string($config) ) {
-                $config = new \Configuration\Configuration($config);
-                $config = $config->initialize()->toStdClass();
+                $config = \Configuration\Configuration::factory($config);
+                $config = $config->toStdClass();
                 // Support the table config directly or assigned to a "table_definition" key
                 if ( isset($config->table_definition) ) {
                     $config = $config->table_definition;

--- a/classes/ETL/Maintenance/ManageTables.php
+++ b/classes/ETL/Maintenance/ManageTables.php
@@ -99,12 +99,11 @@ class ManageTables extends aRdbmsDestinationAction implements iAction
                 $defFile = \xd_utilities\qualify_path($defFile, $this->options->paths->table_definition_dir);
             }
             $this->logger->info(sprintf("Parse table definition: '%s'", $defFile));
-            $tableConfig = new Configuration(
+            $tableConfig = Configuration::factory(
                 $defFile,
                 $this->options->paths->base_dir,
                 $this->logger
             );
-            $tableConfig->initialize();
             $etlTable = new Table(
                 $tableConfig->toStdClass(),
                 $this->destinationEndpoint->getSystemQuoteChar(),

--- a/classes/ETL/Utilities.php
+++ b/classes/ETL/Utilities.php
@@ -245,13 +245,12 @@ class Utilities
             $configOptions['config_variables'] = $params['variable-overrides'];
         }
 
-        $etlConfig = new EtlConfiguration(
+        $etlConfig = EtlConfiguration::factory(
             CONFIG_DIR . '/etl/etl.json',
             null,
             $logger,
             $configOptions
         );
-        $etlConfig->initialize();
         self::setEtlConfig($etlConfig);
 
         $scriptOptions = array_merge(

--- a/classes/ETL/VariableStore.php
+++ b/classes/ETL/VariableStore.php
@@ -260,6 +260,12 @@ class VariableStore extends Loggable
             return $string;
         }
 
+        // Return if there are no variables found in the string (this is likely).
+
+        if ( false === preg_match($this->variableRegex, $string) ) {
+            return $string;
+        }
+
         $exceptionForUnusedVariables = (null !== $this->logger && null != $exceptionPrefix);
         $trackDetails = ( null !== $substitutionDetails );
 

--- a/classes/ETL/VariableStore.php
+++ b/classes/ETL/VariableStore.php
@@ -254,9 +254,9 @@ class VariableStore extends Loggable
         array &$substitutionDetails = null
     ) {
 
-        // Can't do anything with NULL or ""
+        // Can't do anything with NULL, "", or non-strings.
 
-        if ( empty($string) ) {
+        if ( ! is_string($string) || empty($string) ) {
             return $string;
         }
 

--- a/classes/ETL/VariableStore.php
+++ b/classes/ETL/VariableStore.php
@@ -78,6 +78,15 @@ class VariableStore extends Loggable
     }
 
     /**
+     * @return int The number of variables in the store.
+     */
+
+    public function count()
+    {
+        return count($this->variables);
+    }
+
+    /**
      * Set a variable in the store.  If a variable should be overwritten use overwrite() instead.
      * Setting a variable to a NULL value will unset the variable.  If the variable is already set,
      * do not overwrite and issue a warning. This is done so that variables set early in a process

--- a/classes/ETL/VariableStore.php
+++ b/classes/ETL/VariableStore.php
@@ -260,9 +260,9 @@ class VariableStore extends Loggable
             return $string;
         }
 
-        // Return if there are no variables found in the string (this is likely).
+        // Return if there is no possibility that there is a variable in the string (this is likely).
 
-        if ( false === preg_match($this->variableRegex, $string) ) {
+        if ( false === strpos($string, '${') ) {
             return $string;
         }
 

--- a/classes/ETL/aAction.php
+++ b/classes/ETL/aAction.php
@@ -172,13 +172,12 @@ abstract class aAction extends aEtlObject
                 $options = array(
                     'variable_store' => $this->variableStore
                 );
-                $this->parsedDefinitionFile = new Configuration(
+                $this->parsedDefinitionFile = Configuration::factory(
                     $this->definitionFile,
                     ( isset($this->options->paths->base_dir) ? $this->options->paths->base_dir : null ),
                     $logger,
                     $options
                 );
-                $this->parsedDefinitionFile->initialize();
                 $this->parsedDefinitionFile->cleanup();
             }
         }  // if ( null !== $this->options->definition_file )

--- a/classes/OpenXdmod/Migration/Etlv2Migration.php
+++ b/classes/OpenXdmod/Migration/Etlv2Migration.php
@@ -23,13 +23,12 @@ class Etlv2Migration extends Migration
      */
     public function execute()
     {
-        $etlConfig = new EtlConfiguration(
+        $etlConfig = EtlConfiguration::factory(
             CONFIG_DIR . '/etl/etl.json',
             null,
             $this->logger,
             array('default_module_name' => 'xdmod')
         );
-        $etlConfig->initialize();
         Utilities::setEtlConfig($etlConfig);
 
         $sectionFilter = 'migration-' . str_replace('.', '_', $this->currentVersion) . '-' . str_replace('.', '_', $this->newVersion);

--- a/classes/OpenXdmod/Migration/Migration.php
+++ b/classes/OpenXdmod/Migration/Migration.php
@@ -54,7 +54,7 @@ abstract class Migration
 
         $this->logger = \Log::singleton('null');
 
-        $this->config = new Configuration(
+        $this->config = Configuration::factory(
             ".",
             CONFIG_DIR,
             $this->logger

--- a/tests/artifacts/xdmod/etlv2/configuration/output/xdmod_etl_config_8.0.0.json
+++ b/tests/artifacts/xdmod/etlv2/configuration/output/xdmod_etl_config_8.0.0.json
@@ -651,6 +651,118 @@
         "local_config_dir": "/tmp/xdmod-etl-configuration-test/etl_8.0.0.d",
         "base_dir": "/tmp/xdmod-etl-configuration-test"
       }
+    },
+    {
+        "class": "StructuredFileIngestor",
+        "definition_file": "raw_generic_cloud_job_logs.json",
+        "description": "Loading generic cloud data",
+        "endpoints": {
+            "destination": {
+                "config": "datawarehouse",
+                "create_schema_if_not_exists": true,
+                "key": "04d8e2279be6616bc524830353c866e4",
+                "name": "Cloud DB",
+                "paths": {
+                    "action_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_action_defs_8.0.0.d",
+                    "base_dir": "/tmp/xdmod-etl-configuration-test",
+                    "data_dir": "/tmp/xdmod-etl-configuration-test/etl_data.d",
+                    "local_config_dir": "/tmp/xdmod-etl-configuration-test/etl_8.0.0.d",
+                    "macro_dir": "/tmp/xdmod-etl-configuration-test/etl_macros.d",
+                    "specs_dir": "/tmp/xdmod-etl-configuration-test/etl_specs.d",
+                    "sql_dir": "/tmp/xdmod-etl-configuration-test/etl_sql.d",
+                    "table_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_tables_8.0.0.d"
+                },
+                "schema": "modw_cloud",
+                "type": "mysql"
+            },
+            "source": {
+                "file_pattern": "/\\.json$/",
+                "handler": {
+                    "field_names": [
+                        "instance_id",
+                        "event_type",
+                        "event_data",
+                        "event_time",
+                        "record_type",
+                        "account",
+                        "node_controller",
+                        "image_type",
+                        "instance_type",
+                        "root_type",
+                        "block_devices",
+                        "public_ip",
+                        "private_ip"
+                    ],
+                    "paths": {
+                        "action_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_action_defs_8.0.0.d",
+                        "base_dir": "/tmp/xdmod-etl-configuration-test",
+                        "data_dir": "/tmp/xdmod-etl-configuration-test/etl_data.d",
+                        "local_config_dir": "/tmp/xdmod-etl-configuration-test/etl_8.0.0.d",
+                        "macro_dir": "/tmp/xdmod-etl-configuration-test/etl_macros.d",
+                        "specs_dir": "/tmp/xdmod-etl-configuration-test/etl_specs.d",
+                        "sql_dir": "/tmp/xdmod-etl-configuration-test/etl_sql.d",
+                        "table_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_tables_8.0.0.d"
+                    },
+                    "record_separator": "\n",
+                    "type": "jsonfile"
+                },
+                "key": "6e92814c53ca85ad6bdd9a7eb0111a1c",
+                "name": "Generic cloud event logs",
+                "path": "${CLOUD_EVENT_LOG_DIR}",
+                "paths": {
+                    "action_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_action_defs_8.0.0.d",
+                    "base_dir": "/tmp/xdmod-etl-configuration-test",
+                    "data_dir": "/tmp/xdmod-etl-configuration-test/etl_data.d",
+                    "local_config_dir": "/tmp/xdmod-etl-configuration-test/etl_8.0.0.d",
+                    "macro_dir": "/tmp/xdmod-etl-configuration-test/etl_macros.d",
+                    "specs_dir": "/tmp/xdmod-etl-configuration-test/etl_specs.d",
+                    "sql_dir": "/tmp/xdmod-etl-configuration-test/etl_sql.d",
+                    "table_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_tables_8.0.0.d"
+                },
+                "recursion_depth": 1,
+                "type": "directoryscanner"
+            },
+            "utility": {
+                "config": "datawarehouse",
+                "key": "ca2e6e39f463877e41347d44eca9eaaa",
+                "name": "Utility DB",
+                "paths": {
+                    "action_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_action_defs_8.0.0.d",
+                    "base_dir": "/tmp/xdmod-etl-configuration-test",
+                    "data_dir": "/tmp/xdmod-etl-configuration-test/etl_data.d",
+                    "local_config_dir": "/tmp/xdmod-etl-configuration-test/etl_8.0.0.d",
+                    "macro_dir": "/tmp/xdmod-etl-configuration-test/etl_macros.d",
+                    "specs_dir": "/tmp/xdmod-etl-configuration-test/etl_specs.d",
+                    "sql_dir": "/tmp/xdmod-etl-configuration-test/etl_sql.d",
+                    "table_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_tables_8.0.0.d"
+                },
+                "schema": "modw",
+                "type": "mysql"
+            }
+        },
+        "name": "xdmod.cloud-jobs.GenericRawCloudEventIngestor",
+        "namespace": "ETL\\Ingestor",
+        "options_class": "IngestorOptions",
+        "paths": {
+            "action_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_action_defs_8.0.0.d",
+            "base_dir": "/tmp/xdmod-etl-configuration-test",
+            "data_dir": "/tmp/xdmod-etl-configuration-test/etl_data.d",
+            "local_config_dir": "/tmp/xdmod-etl-configuration-test/etl_8.0.0.d",
+            "macro_dir": "/tmp/xdmod-etl-configuration-test/etl_macros.d",
+            "specs_dir": "/tmp/xdmod-etl-configuration-test/etl_specs.d",
+            "sql_dir": "/tmp/xdmod-etl-configuration-test/etl_sql.d",
+            "table_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_tables_8.0.0.d"
+        },
+        "variables": {
+            "action_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_action_defs_8.0.0.d",
+            "base_dir": "/tmp/xdmod-etl-configuration-test",
+            "data_dir": "/tmp/xdmod-etl-configuration-test/etl_data.d",
+            "local_config_dir": "/tmp/xdmod-etl-configuration-test/etl_8.0.0.d",
+            "macro_dir": "/tmp/xdmod-etl-configuration-test/etl_macros.d",
+            "specs_dir": "/tmp/xdmod-etl-configuration-test/etl_specs.d",
+            "sql_dir": "/tmp/xdmod-etl-configuration-test/etl_sql.d",
+            "table_definition_dir": "/tmp/xdmod-etl-configuration-test/etl_tables_8.0.0.d"
+        }
     }
   ]
 }

--- a/tests/component/lib/ETL/CloudStateReconstructorTransformIngestorTest.php
+++ b/tests/component/lib/ETL/CloudStateReconstructorTransformIngestorTest.php
@@ -101,7 +101,7 @@ class CloudStateReconstructorTransformIngestorTest extends \PHPUnit_Framework_Te
         $this->options_array["definition_file"] = BASE_DIR . "/tests/artifacts/xdmod/etlv2/configuration/input/etl_action_defs_8.0.0.d/cloud_state.json";
 
         $options = new IngestorOptions($this->options_array);
-        $conf = new ETLConfiguration($configFile);
+        $conf = EtlConfiguration::factory($configFile);
 
         $this->fsm = new CloudStateReconstructorTransformIngestor($options, $conf);
     }

--- a/tests/component/lib/ETL/DbModel/DbModelTest.php
+++ b/tests/component/lib/ETL/DbModel/DbModelTest.php
@@ -39,8 +39,7 @@ class DbModelTest extends \ComponentTests\ETL\BaseEtlTest
 
         // The modify_table.json file defines actions to create and modify the table as well was the test schema.
         $configFile = self::$testArtifactInputPath . "/xdmod_etl_config_8.0.0.json";
-        self::$etlConfig = new EtlConfiguration($configFile, self::$testArtifactInputPath);
-        self::$etlConfig->initialize();
+        self::$etlConfig = EtlConfiguration::factory($configFile, self::$testArtifactInputPath);
         self::$endpoint = self::$etlConfig->getGlobalEndpoint('utility');
 
         self::$etlOverseerOptions = new EtlOverseerOptions(array());

--- a/tests/component/lib/ETL/EtlOverseerTest.php
+++ b/tests/component/lib/ETL/EtlOverseerTest.php
@@ -34,13 +34,12 @@ class EtlOverseerTest extends \PHPUnit_Framework_TestCase
 
         // Use a pipeline with DummyIngestor and/or DummyAggregator so we can test infrastructure
         $configFile = self::$testArtifactInputPath . "/xdmod_etl_config_dummy_actions.json";
-        self::$etlConfig = new EtlConfiguration(
+        self::$etlConfig = EtlConfiguration::factory(
             $configFile,
             self::$testArtifactInputPath,
             null,
             array('default_module_name' => 'xdmod')
         );
-        self::$etlConfig->initialize();
 
         // Explicitly set the resource code map so we don't need to query the database
         self::$overseerOptions = new EtlOverseerOptions(

--- a/tests/unit/lib/ETL/Configuration/ConfigurationTest.php
+++ b/tests/unit/lib/ETL/Configuration/ConfigurationTest.php
@@ -39,7 +39,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonParseError()
     {
-        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/parse_error.json');
+        Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/parse_error.json');
     }
 
     /**
@@ -102,7 +102,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testBadFragment()
     {
-        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_bad_fragment.json');
+        Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_bad_fragment.json');
     }
 
     /**
@@ -201,9 +201,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testCallConfigurationConstructor()
     {
-        $configObj = new Configuration(
+        new Configuration(
             self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_variables.json'
         );
     }
-
 } // class ConfigurationTest

--- a/tests/unit/lib/ETL/Configuration/ConfigurationTest.php
+++ b/tests/unit/lib/ETL/Configuration/ConfigurationTest.php
@@ -26,7 +26,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'file' => false,
             'db' => false,
             'mail' => false,
-            'consoleLogLevel' => Log::DEBUG
+            'consoleLogLevel' => Log::WARNING
         );
         self::$logger = Log::factory('PHPUnit', $conf);
     }
@@ -39,8 +39,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonParseError()
     {
-        $configObj = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/parse_error.json');
-        $configObj->initialize();
+        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/parse_error.json');
     }
 
     /**
@@ -49,8 +48,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testConfiguration()
     {
-        $configObj = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json');
-        $configObj->initialize();
+        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json');
         $generated = json_decode($configObj->toJson());
         $expected = json_decode(file_get_contents(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json'));
         $this->assertEquals($generated, $expected);
@@ -62,8 +60,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testComments()
     {
-        $configObj = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/comments.json');
-        $configObj->initialize();
+        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/comments.json');
         $generated = json_decode($configObj->toJson());
         $expected = json_decode(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/comments.json'));
         $this->assertEquals($generated, $expected);
@@ -76,8 +73,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testFullPathReference()
     {
         copy(self::TEST_ARTIFACT_INPUT_PATH . '/reference_target.json', '/tmp/reference_target.json');
-        $configObj = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_full_reference.json');
-        $configObj->initialize();
+        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_full_reference.json');
         $generated = json_decode($configObj->toJson());
         $expected = json_decode(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/rfc6901_full_reference.json'));
         unlink('/tmp/reference_target.json');
@@ -91,8 +87,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testRelativePathReference()
     {
         copy(self::TEST_ARTIFACT_INPUT_PATH . '/reference_target.json', '/tmp/reference_target.json');
-        $configObj = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_relative_reference.json');
-        $configObj->initialize();
+        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_relative_reference.json');
         $generated = json_decode($configObj->toJson());
         $expected = json_decode(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/rfc6901_full_reference.json'));
         unlink('/tmp/reference_target.json');
@@ -107,8 +102,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testBadFragment()
     {
-        $configObj = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_bad_fragment.json');
-        $configObj->initialize();
+        $configObj = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/rfc6901_bad_fragment.json');
     }
 
     /**
@@ -117,13 +111,12 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigurationVariables()
     {
-        $configObj = new Configuration(
+        $configObj = Configuration::factory(
             self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_variables.json',
             null,
             null,
             array('config_variables' => array('TABLE_NAME' => 'resource_allocations', 'WIDTH' => 40))
         );
-        $configObj->initialize();
         $generated = json_decode($configObj->toJson());
         $expected = json_decode(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/sample_config.expected'));
         $this->assertEquals($generated, $expected);
@@ -142,7 +135,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         @copy(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_variables.json', '/tmp/sample_config_with_variables.json');
         @copy(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_reference.json', '/tmp/sample_config_with_reference.json');
-        $configObj = new Configuration(
+        $configObj = Configuration::factory(
             self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_transformer_keys.json',
             null,
             self::$logger,
@@ -156,11 +149,61 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
-        $configObj->initialize();
         $generated = json_decode($configObj->toJson());
         $expected = json_decode(file_get_contents(self::TEST_ARTIFACT_OUTPUT_PATH . '/sample_config_with_transformer_keys.expected'));
         @unlink('/tmp/sample_config_with_variables.json');
         @unlink('/tmp/sample_config_with_reference.json');
         $this->assertEquals($generated, $expected, "Test multiple transformer directives");
     }
+
+    /**
+     * Test the Configuration class object cache.
+     */
+
+    public function testConfigurationObjectCache()
+    {
+        // The object cache is enabled by default so objects 1 and 2 will be the same
+
+        $configObj1 = Configuration::factory(
+            self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_variables.json',
+            null,
+            null,
+            array('config_variables' => array('TABLE_NAME' => 'resource_allocations', 'WIDTH' => 40))
+        );
+
+        $configObj2 = Configuration::factory(
+            self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_variables.json',
+            null,
+            null,
+            array('config_variables' => array('TABLE_NAME' => 'resource_allocations', 'WIDTH' => 40))
+        );
+
+        $this->assertTrue($configObj1 === $configObj2, "Object cache enabled");
+
+        // Disable the cache, object 3 will be a new object
+
+        Configuration::disableObjectCache();
+        $configObj3 = Configuration::factory(
+            self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_variables.json',
+            null,
+            null,
+            array('config_variables' => array('TABLE_NAME' => 'resource_allocations', 'WIDTH' => 40))
+        );
+
+        $this->assertTrue($configObj1 !== $configObj3, "Object cache disabled");
+    }
+
+    /**
+     * Test calling Configuration::__construct() directly, which is not allowed.
+     *
+     * @expectedException Exception
+     */
+
+    public function testCallConfigurationConstructor()
+    {
+        $configObj = new Configuration(
+            self::TEST_ARTIFACT_INPUT_PATH . '/sample_config_with_variables.json'
+        );
+    }
+
 } // class ConfigurationTest

--- a/tests/unit/lib/ETL/Configuration/EtlConfigurationTest.php
+++ b/tests/unit/lib/ETL/Configuration/EtlConfigurationTest.php
@@ -63,13 +63,12 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
         copy(self::TEST_ARTIFACT_INPUT_PATH . '/etl_8.0.0.d/maintenance.json', self::TMPDIR . '/etl_8.0.0.d/maintenance.json');
         copy(self::TEST_ARTIFACT_INPUT_PATH . '/etl_8.0.0.d/jobs_cloud.json', self::TMPDIR . '/etl_8.0.0.d/jobs_cloud.json');
 
-        $configObj = new EtlConfiguration(
+        $configObj = EtlConfiguration::factory(
             self::TMPDIR . '/xdmod_etl_config_8.0.0.json',
             self::TMPDIR,
             null,
             array('default_module_name' => self::$defaultModuleName)
         );
-        $configObj->initialize();
         $generated = json_decode($configObj->toJson());
 
         $file = self::TEST_ARTIFACT_OUTPUT_PATH . '/xdmod_etl_config_8.0.0.json';
@@ -117,13 +116,12 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
             ),
             'default_module_name' => self::$defaultModuleName
         );
-        $configObj = new EtlConfiguration(
+        $configObj = EtlConfiguration::factory(
             self::TMPDIR . '/xdmod_etl_config_with_variables_8.0.0.json',
             self::TMPDIR,
             null,
             $options
         );
-        $configObj->initialize();
         $generated = json_decode($configObj->toJson());
         $this->filterKeysRecursive(array('key'), $generated);
         $file = self::TEST_ARTIFACT_OUTPUT_PATH . '/xdmod_etl_config_with_variables.json';
@@ -180,7 +178,7 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
                     'input'
                 )
             );
-            $config = new XdmodConfiguration(
+            $config = XdmodConfiguration::factory(
                 $baseFile,
                 $baseDir,
                 null,
@@ -189,13 +187,11 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
                 )
             );
         } else {
-            $config = new XdmodConfiguration(
+            $config = XdmodConfiguration::factory(
                 $baseFile,
                 $baseDir
             );
         }
-
-        $config->initialize();
 
         $actual = sprintf("%s\n", json_encode(json_decode($config->toJson()), JSON_PRETTY_PRINT));
 
@@ -252,7 +248,7 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
             )
         );
 
-        $config = new ModuleConfiguration(
+        $config = ModuleConfiguration::factory(
             $baseFile,
             $baseDir,
             null,
@@ -260,7 +256,6 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
                 'local_config_dir' => $localConfigDir
             )
         );
-        $config->initialize();
 
         $modules = $options['modules'];
         foreach($modules as $module) {
@@ -376,7 +371,7 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
             )
         );
 
-        $config = new XdmodConfiguration(
+        $config = XdmodConfiguration::factory(
             $baseFile,
             $baseDir,
             null,
@@ -384,7 +379,6 @@ class EtlConfigurationTest extends \UnitTesting\BaseTest
                 'local_config_dir' => $localConfigDir
             )
         );
-        $config->initialize();
 
         // Make sure that the actual is pretty-printed for ease of reading.
 

--- a/tests/unit/lib/ETL/Configuration/IncludeTest.php
+++ b/tests/unit/lib/ETL/Configuration/IncludeTest.php
@@ -34,7 +34,7 @@ class IncludeTest extends \PHPUnit_Framework_TestCase
         $logger = Log::factory('PHPUnit', $conf);
         
         // Configuration is used in the transformer to qualify relative paths
-        self::$config = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json');
+        self::$config = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json');
         self::$transformer = new IncludeTransformer($logger);
     }
 

--- a/tests/unit/lib/ETL/Configuration/Rfc6901Test.php
+++ b/tests/unit/lib/ETL/Configuration/Rfc6901Test.php
@@ -23,7 +23,7 @@ class Rfc6901Test extends \PHPUnit_Framework_TestCase
     public function __construct()
     {
         // Configuration is used in the transformer to qualify relative paths
-        $this->config = new Configuration(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json');
+        $this->config = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json');
         $this->transformer = new JsonReferenceTransformer();
     }
 

--- a/tests/unit/lib/ETL/SqlParser/SqlParserTest.php
+++ b/tests/unit/lib/ETL/SqlParser/SqlParserTest.php
@@ -58,7 +58,7 @@ class SqlParserTest extends \PHPUnit_Framework_TestCase
         // Rather than call the SQL parser directly, use the same methods that an ETL action would use.
         // This requires that we instantiate a class that extends aRdbmsDestinationAction.
 
-        $etlConfig = new EtlConfiguration(
+        $etlConfig = EtlConfiguration::factory(
             self::TMPDIR . '/xdmod_etl_config_8.0.0.json',
             self::TMPDIR,
             null,

--- a/tools/etl/etl_action_state_mgr.php
+++ b/tools/etl/etl_action_state_mgr.php
@@ -191,10 +191,11 @@ if ( $scriptOptions['dryrun']) {
 // Parse the ETL configuration. We will need it for listing available ingestors, aggregators, etc.
 
 try {
-    $etlConfig = new EtlConfiguration($scriptOptions['config-file'],
-                                      $scriptOptions['base-dir']);
-    $etlConfig->setLogger($logger);
-    $etlConfig->initialize();
+    $etlConfig = EtlConfiguration::factory(
+        $scriptOptions['config-file'],
+        $scriptOptions['base-dir'],
+        $logger
+    );
     $etlConfig->cleanup();
 } catch ( Exception $e ) {
     exit($e->getMessage() . "\n". $e->getTraceAsString() . "\n");

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -431,7 +431,7 @@ try {
 // Parse the ETL configuration. We will need it for listing available ingestors, aggregators, etc.
 
 try {
-    $etlConfig = new EtlConfiguration(
+    $etlConfig = EtlConfiguration::factory(
         $scriptOptions['config-file'],
         $scriptOptions['base-dir'],
         $logger,
@@ -442,7 +442,6 @@ try {
         )
     );
     $etlConfig->setLogger($logger);
-    $etlConfig->initialize();
 } catch ( Exception $e ) {
     log_error_and_exit(
         sprintf("%s%s%s", $e->getMessage(), PHP_EOL, $e->getTraceAsString())

--- a/tools/etl/etl_table_manager.php
+++ b/tools/etl/etl_table_manager.php
@@ -172,9 +172,8 @@ if ( null === $scriptOptions['config-file'] ||
 // Parse the ETL configuration. We will need it for listing available ingestors, aggregators, etc.
 
 try {
-    $etlConfig = new EtlConfiguration($scriptOptions['config-file']);
+    $etlConfig = EtlConfiguration::factory($scriptOptions['config-file']);
     $etlConfig->setLogger($logger);
-    $etlConfig->initialize();
 } catch ( Exception $e ) {
     exit($e->getMessage() . "\n");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `Configuration` and extending classes such as `EtlConfiguration` and `XdmodConfiguration` are now used to process all XDMoD configuration files and local overrides (e.g., `roles.json` and files in `roles.d`) as well as ETL configuration files. The extremely flexible nature of these files introduces significant overhead when the same configuration file is required in multiple locations throughout the code to perform a given operation.

This implements an object cache so that the same global configuration file (e.g., `roles.d`) and local configuration files (e.g., files in `roles.d`) only need to be parsed once with the resulting object stored in an object cache. Subsequent accesses are retrieved from the cache. The unique cache key is generated using the following pieces of information:
- Fully qualified path to the global configuration file. This determines the set of global defaults and the path to the local configuration directory, if any.
- Name of the class being instantiated. This is obtained using `get_called_class()` so we can distinguish between `Configuration`, `EtlConfiguration`, etc.
- Any additional options passed to the `Configuration` or child classes. Options such as substitution variables will affect the generated object.

The result is a significant reduction in the amount of times that `Configuration` related methods are called.

### Current Profile (8.5.0)

Usage Explorer get_data request: `/controllers/user_interface.php?&operation=get_data`

```
curl 'http://localhost:8080/controllers/user_interface.php' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Accept-Language: en-US,en;q=0.5' --compressed -H 'Referer: https://aristotle-hub.ccr.xdmod.org/' -H 'Content-Type: application/x-www-form-urlencoded' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Upgrade-Insecure-Requests: 1' --data 'public_user=true&scale=1&aggregation_unit=Auto&dataset_type=timeseries&thumbnail=n&query_group=tg_usage&limit=10&offset=0&log_scale=n&show_guide_lines=y&show_trend_line=n&show_error_bars=n&show_aggregate_labels=n&show_error_labels=n&hide_tooltip=false&show_title=y&legend_type=bottom_center&font_size=3&drilldowns=%5Bobject+Object%5D&none=-9999&format=png&inline=n&operation=get_data&display_type=area&combine_type=stack&realm=Cloud&width=916&height=484&group_by=resource&statistic=cloud_core_time&timeframe_label=Quarter+to+date&start_date=2016-12-01&end_date=2017-01-31&XDEBUG_PROFILE=yes' -o image.png
```
Longest Calls:

| Percent | Time  | Calls | Function |
|---------|-------|-------|----------|
| 57.54   | 46.23 |   694 | Configuration->processKeyTransformers() |
| 13.03   | 12.87 |   646 | Configuration->recursivelySubstituteVariables() |
| 5.40    | 5.33  | 1,969 | StripMergePrefixTransformer->keyMatches() |
| 5.21    | 5.15  | 1,969 | CommentTransformer->keyMatches() |

Function list: ![xdmod850-vanilla get_data_function_list](https://user-images.githubusercontent.com/2301909/58581669-1f767f00-821e-11e9-9b37-fd9c1e9fb41f.png)

Simulate a click on a Usage Tab tree node to view summary charts: `/controllers/user_interface.php?&operation=get_data?&operation=get_charts`

```
curl 'http://localhost:8080/controllers/user_interface.php' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0) Gecko/20100101 Firefox/66.0' -H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.5' --compressed -H 'Referer: http://localhost:8080/' -H 'X-Requested-With: XMLHttpRequest' -H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Cookie: PHPSESSID=6qopa2rn6p8ho7hgaqfpek5763; xdmod_token=public-1557842538.9428-5cdaca6ae6350' --data 'public_user=true&realm=Jobs&group_by=none&start_date=2016-12-01&end_date=2017-01-31&timeframe_label=Previous%20month&aggregation_unit=Auto&width=411.0197368421052&height=246.61184210526312&scale=1&dataset_type=timeseries&thumbnail=y&query_group=tg_usage&display_type=line&combine_type=side&limit=3&offset=0&log_scale=n&show_guide_lines=y&show_trend_line=n&show_error_bars=n&show_aggregate_labels=n&show_error_labels=n&hide_tooltip=false&format=session_variable&legend_type=off&font_size=0&show_title=n&operation=get_charts&controller_module=user_interface&XDEBUG_PROFILE=yes'
```

Longest Calls (no cycle detection):

| Percent | Time  | Called | Function |
|---------|-------|--------|----------|
| 58.98   | 47.46 | 10,865 | Configuration->processKeyTransformers() |
| 11.90   | 11.77 |  9,813 | Configuration->recursivelySubstituteVariables() |
| 5.42    | 5.35  | 31,872 | CommentTransformer->keyMatches() |
| 5.42    | 5.34  | 31,872 | StripMergePrefixTransformer->keyMatches() |
| 3.66    | 2.00  |  2,239 | Statistic->__construct() |
| 1.14    | 1.12  |  2,105 | Query->addStatField() |

Function list: ![xdmod850-vanilla usage_tab_tree_node_function_list](https://user-images.githubusercontent.com/2301909/58581813-65cbde00-821e-11e9-9afe-a5be90ca717a.png)

### Profile with Config Object Cache

**Note significant reduction in calls to `Configuration` related code. For example, calls to `Configuration->processKeyTransformers()` are reduced from 10,865 to 300 for Usage Tab summary charts.**

Usage Explorer get_data request: `/controllers/user_interface.php?&operation=get_data`

Longest Calls:

| Percent | Time  | Calls | Function |
|---------|-------|-------|----------|
| 41.67   | 33.64 | 300   | Configuration->processKeyTransformers() |
| 10.36   | 10.26 | 273   | Configuration->recursivelySubstituteVariables() |
| 5.40    | 3.96  | 880   | StripMergePrefixTransformer->keyMatches() |
| 5.21    | 3.57  | 880   | CommentTransformer->keyMatches() |

Function list: ![xdmod850-configcache get_data_function_list](https://user-images.githubusercontent.com/2301909/58581910-9c095d80-821e-11e9-8b9a-0a43fce2dfc5.png)

Simulate a click on a Usage Tab tree node to view summary charts: `/controllers/user_interface.php?&operation=get_data?&operation=get_charts`

Longest Calls (no cycle detection):

| Percent | Time  | Called | Function |
|---------|-------|--------|----------|
| 15.09   | 8.12  |  3,081 | Query\Statistic->__construct() |
| 5.43    | 5.36  |  8,210 | Common\Identity->__toString() |
| 4.69    | 4.61  |  2,895 | Query\Query->getStatField() |
| 5.88    | 3.82  |  3,633 | Query\Query::get_statistic_name_to_class_name() |
| 3.69    | 3.63  |  6,550 | Common\Identify->__construct() |
| ...     |       |        | |
| 4.17    | 3.34  |    300 | Configuration->processKeyTransformers() |
| 0.81    | 0.80  |    273 | Configuration->recursivelySubstituteVariables() |

Function list: ![xdmod850-configcache usage_tab_tree_node_function_list png](https://user-images.githubusercontent.com/2301909/58581925-a6c3f280-821e-11e9-99d1-f279da6786ee.png)

## Motivation and Context

Performance improvements.

## Tests performed

Ran tests locally and via shippable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
