### PR TITLE
Fixing timing issues in Metric Explorer UI Tests

### DIFF
--- a/tests/ui/test/specs/xdmod/metricExplorer.page.js
+++ b/tests/ui/test/specs/xdmod/metricExplorer.page.js
@@ -158,7 +158,7 @@ class MetricExplorer {
         browser.click(this.selectors.toolbar.buttonByName('New Chart'));
         browser.waitAndClick(this.selectors.newChart.topMenuByText(datasetType));
         browser.waitAndClick(this.selectors.newChart.subMenuByText(datasetType, plotType));
-        browser.waitForVisible(this.selectors.newChart.modalDialog.box);
+        browser.waitAndClick(this.selectors.newChart.modalDialog.textBox());
         browser.setValue(this.selectors.newChart.modalDialog.textBox(), chartName);
         browser.click(this.selectors.newChart.modalDialog.ok());
         browser.waitForInvisible(this.selectors.newChart.modalDialog.box);
@@ -171,8 +171,7 @@ class MetricExplorer {
         browser.waitUntilAnimEnd(this.selectors.catalog.collapseButton);
     }
     setDateRange(start, end) {
-        browser.waitForAllInvisible('.ext-el-mask');
-        browser.waitAndClick(this.selectors.startDate);
+        this.clickSelectorAndWaitForMask(this.selectors.startDate);
         browser.setValue(this.selectors.startDate, start);
         browser.waitAndClick(this.selectors.endDate);
         browser.setValue(this.selectors.endDate, end);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the way that chart title is tested in ME

## Description
<!--- Describe your changes in detail -->
I changed the way that the current test checks to make sure the HighCharts graph displays correctly.  The issue was that the test was trying to set the title of the chart too quickly, so I modified the test to wait and change the title when it was possible.

Also modified setDateRange to properly wait until the mask disappears before setting the date.

<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixed a failed test when UI tests were run

<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Created instance of XDMoD in docker container and ran the UI Tests.

<!--- Include details of your testing environment, and the tests you ran to -->
Docker container using tas-tools-ext-01.ccr.xdmod.org/centos7_6-open8.1.2:latest image.  ran "~/bin/services start", then ran UI tests

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
