### PR TITLE
Fixed `getResources` authorization logic

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2627,8 +2627,7 @@ SQL;
     public function getResources($resourceNames = array())
     {
         // We need to make sure that this function is only called for Center [Director|Staff]
-        if (!$this->hasAcl(ROLE_ID_CENTER_DIRECTOR) ||
-            !$this->hasAcl(ROLE_ID_CENTER_STAFF)) {
+        if ( ! ( $this->hasAcl(ROLE_ID_CENTER_DIRECTOR) ||  $this->hasAcl(ROLE_ID_CENTER_STAFF) ) ) {
             throw new Exception('Unable to complete action. User is not authorized.');
         }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
The logic should be:

User must have one: center staff / center director

**not**

User must have both: center staff / center director

## Motivation and Context
**facepalm**

## Tests performed
Manual Testing on xdmod-dev

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
