### PR TITLE
Improve error message for ETL action

### DIFF
--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -761,7 +761,7 @@ class EtlConfiguration extends Configuration
         // the action configuration.
 
         if ( ! isset($config->options_class) ) {
-            $this->logAndThrowException("Options class not defined for $actionName");
+            $this->logAndThrowException("Key 'options_class' not defined for $actionName");
         }
 
         $optionsClassName = $config->options_class;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per discussion with @ryanrath improve error message clarity when `options_class` key is not defined for an ETL action.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
