### PR TITLE
Added reset summary page layout UI

### DIFF
--- a/html/gui/js/modules/NoviceUser.js
+++ b/html/gui/js/modules/NoviceUser.js
@@ -188,7 +188,16 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
                     }
                 },
                 request_refresh: function () {
-                    this.needsRefresh = true;
+                    var tabPanel = Ext.getCmp('main_tab_panel');
+                    if (this === tabPanel.getActiveTab()) {
+                        // This is the case where the 'Reset to defaults' button is
+                        // clicked in the Profile dialog and the user is already on the
+                        // summary page
+                        portletStore.load();
+                    } else {
+                        // The refresh will happen the next time the tab is activated
+                        this.needsRefresh = true;
+                    }
                 }
             }
         });

--- a/html/gui/js/profile_editor/ProfileEditor.js
+++ b/html/gui/js/profile_editor/ProfileEditor.js
@@ -83,13 +83,68 @@ XDMoD.ProfileEditor = Ext.extend(Ext.Window,  {
       var self = this;
 
       this.general_settings = new XDMoD.ProfileGeneralSettings({parentWindow: self});
-      this.role_delegation = new XDMoD.ProfileRoleDelegation({parentWindow: self, id: 'tab_role_delegation' });
 
       // ------------------------------------------------
 
       this.on('beforeclose', self.handleProfileClose);
 
       // ------------------------------------------------
+
+        var tabItems = [
+            this.general_settings
+        ];
+
+        if (CCR.xdmod.ui.isCenterDirector) {
+            tabItems.push(new XDMoD.ProfileRoleDelegation({
+                parentWindow: self
+            }));
+        }
+
+        if (!CCR.xdmod.ui.tgSummaryViewer.usesToolbar) {
+            tabItems.push({
+                title: 'Settings',
+                height: 320,
+                layout: 'fit',
+                border: false,
+                frame: true,
+                items: [{
+                    items: [{
+                        title: 'User Interface',
+                        xtype: 'form',
+                        bodyStyle: 'padding:5px',
+                        labelWidth: 230,
+                        frame: true,
+                        items: [{
+                            xtype: 'compositefield',
+                            items: [{
+                                xtype: 'button',
+                                fieldLabel: 'Summary Tab Panel Layout',
+                                text: 'Reset to Default',
+                                handler: function (button) {
+                                    Ext.Ajax.request({
+                                        url: XDMoD.REST.url + '/summary/layout',
+                                        method: 'DELETE',
+                                        success: function () {
+                                            button.setDisabled(true);
+                                            CCR.xdmod.ui.tgSummaryViewer.fireEvent('request_refresh');
+                                        },
+                                        failure: function (response, opts) {
+                                            Ext.MessageBox.alert('Error', response.message);
+                                        }
+                                    });
+                                }
+                            }]
+                        }]
+                    }]
+                }],
+                bbar: {
+                    items: [
+                        '->',
+                        self.getCloseButton()
+                    ]
+                }
+            });
+        }
 
       var tabPanel = new Ext.TabPanel({
 
@@ -101,10 +156,7 @@ XDMoD.ProfileEditor = Ext.extend(Ext.Window,  {
             tabCls: 'tab-strip'
          },
 
-         items: [
-            this.general_settings,
-            this.role_delegation
-         ],
+         items: tabItems,
 
          listeners: {
             tabchange: function (thisTabPanel, tab) {
@@ -128,22 +180,6 @@ XDMoD.ProfileEditor = Ext.extend(Ext.Window,  {
          }
 
       });//tabPanel
-
-      // ------------------------------------------------
-
-      if (CCR.xdmod.ui.isCenterDirector == false) {
-
-         tabPanel.on('afterrender', function(tp) {
-
-            var role_delegation_tab = tp.id + '__tab_role_delegation';
-
-            var tab = document.getElementById(role_delegation_tab);
-
-            tab.style.display = 'none';
-
-         });//afterrender
-
-      }//if (CCR.xdmod.ui.isCenterDirector == false)
 
       // ------------------------------------------------
 


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/5342179/61503959-ab4b9280-a9a7-11e9-9b1c-1d92c6cbde1b.png" width="400">

Why the gap at the bottom?

This is the height of the first tab so that when the user selects the Settings tab the box will not resize (and hence the close button will appear to be stationary)

Then the reset button is clicked (and the reset is sucessful) the summary page will be reloaded with the defaults and the button disabled.

The button is clickable even if the user is already using the default layout. It is too much effort to grey this out in this case.