### PR TITLE
Unify the no data error messages.

### DIFF
--- a/html/gui/css/viewer.css
+++ b/html/gui/css/viewer.css
@@ -768,6 +768,20 @@ div.chart_thumb a {
     background-repeat: no-repeat;
 }
 
+div.no-data-alert {
+    height: 32px;
+    padding-left: 42px;
+    padding-top: 6px;
+    font-size: 14px;
+    background-image: url(../lib/extjs/resources/images/gray/window/icon-info.gif);
+    background-repeat: no-repeat;
+}
+
+div.no-data-info {
+    font-size: 12px;
+    text-align: justify;
+}
+
 .jobviewer_helpcontent {
     font-family: arial, "Times New Roman",Times,serif;
     font-size: 14px;

--- a/html/gui/js/modules/summary/JobPortlet.js
+++ b/html/gui/js/modules/summary/JobPortlet.js
@@ -176,7 +176,7 @@ XDMoD.Modules.SummaryPortlets.JobPortlet = Ext.extend(Ext.ux.Portlet, {
                 columns: columns
             }),
             viewConfig: {
-                emptyText: 'No Job Records found for the specified time range',
+                emptyText: '<div class="no-data-alert">No Job Records Found</div><div class="no-data-info">Job information only shows in XDMoD once the job has finished and there is a short delay between a job finishing and the job&apos;s data being available in XDMoD.</div>',
                 forceFit: true
             },
             bbar: new Ext.PagingToolbar({


### PR DESCRIPTION
Create a standard style for the grid "no data" messages. The various
portlets that could have no data available should use these css classes
for consistency.

<img width="597" alt="image" src="https://user-images.githubusercontent.com/5342179/61921702-09d6ba80-af2c-11e9-87c0-0f1644b47b9e.png">
