### PR TITLE
fixing new user tour so duplicate tours are not made when the summary tab is refreshed

### DIFF
--- a/html/gui/js/modules/NoviceUser.js
+++ b/html/gui/js/modules/NoviceUser.js
@@ -208,7 +208,12 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
     },
 
     createNewUserTour: function () {
-        var userTour = new Ext.ux.HelpTipTour({
+        var self = this;
+        if(self.userTour) {
+          return self.userTour;
+        }
+
+        self.userTour = new Ext.ux.HelpTipTour({
             title: 'New User Tour',
             items: [
                 {
@@ -314,12 +319,12 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
                 Ext.get('global-toolbar-help-new-user-tour').on('click', function () {
                     Ext.History.add('main_tab_panel:tg_summary');
                     new Ext.util.DelayedTask(function () {
-                        userTour.startTour();
+                        self.userTour.startTour();
                     }).delay(10);
                 });
             });
         }
 
-        return userTour;
+        return self.userTour;
     }
 });

--- a/html/gui/js/modules/NoviceUser.js
+++ b/html/gui/js/modules/NoviceUser.js
@@ -209,8 +209,8 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
 
     createNewUserTour: function () {
         var self = this;
-        if(self.userTour) {
-          return self.userTour;
+        if (self.userTour) {
+            return self.userTour;
         }
 
         self.userTour = new Ext.ux.HelpTipTour({


### PR DESCRIPTION
This PR fixes a bug in the User Tour creating that was causing multiple User Tours to be created when the summary tab is refreshed and then shown at the same time.

## Tests performed
Tested in docker 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
