### PR TITLE
Updates to Help Tips

### DIFF
--- a/html/gui/js/Portlet.js
+++ b/html/gui/js/Portlet.js
@@ -36,6 +36,10 @@ CCR.xdmod.ui.Portlet = Ext.extend(Ext.ux.Portlet, {
     helpTour: null,
     helpTourDetails: [],
     initComponent: function () {
+        this.helpTourDetails.tips.forEach( function (value, index, arr) {
+            arr[index].target = (value.target.slice(0,1) !== '/') ? '#' + this.id + ' ' + value.target : value.target.slice(1, value.target.length);
+        }, this);
+
         this.helpTour = new Ext.ux.HelpTipTour({
             title: this.helpTourDetails.title,
             items: this.helpTourDetails.tips

--- a/html/gui/js/Portlet.js
+++ b/html/gui/js/Portlet.js
@@ -36,8 +36,8 @@ CCR.xdmod.ui.Portlet = Ext.extend(Ext.ux.Portlet, {
     helpTour: null,
     helpTourDetails: [],
     initComponent: function () {
-        this.helpTourDetails.tips.forEach( function (value, index, arr) {
-            arr[index].target = (value.target.slice(0,1) !== '/') ? '#' + this.id + ' ' + value.target : value.target.slice(1, value.target.length);
+        this.helpTourDetails.tips.forEach(function (value, index, arr) {
+            arr[index].target = (value.target.slice(0, 1) !== '/') ? '#' + this.id + ' ' + value.target : value.target.slice(1, value.target.length);
         }, this);
 
         this.helpTour = new Ext.ux.HelpTipTour({

--- a/html/gui/js/modules/HelpTip.js
+++ b/html/gui/js/modules/HelpTip.js
@@ -25,6 +25,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
     closable: true,
     offset: [0, 0],
     anchorOffset: 0,
+    constrainPosition: true,
     initComponent: function () {
         var anchor = this.position.split('-');
         this.tipAnchorPos = anchor[0];
@@ -96,6 +97,41 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
                 break;
         }
         this.anchorEl.alignTo(this.el, anchorPos + '-' + this.tipAnchorPos, offset);
+    },
+
+    getWindowXY: function () {
+        var xPos = window.innerHeight / 2;
+        var yPos = window.innerWidth / 2;
+
+        return {x: xPos, y: yPos}
+    },
+
+    findScrollableParent: function (el) {
+        var elem = Ext.get(el);
+        var parentId = elem.dom.parentNode.id;
+
+        if(parentId !== null || parentId !== undefined) {
+            var p = Ext.get(parentId);
+            if(p.isScrollable() === true) {
+                return p;
+            }
+            else {
+                return this.findScrollableParent(p);
+            }
+        }
+
+        return null;
+    },
+    setTipLocation: function (el) {
+        var elem = Ext.get(el);
+        var centerXYPosition = this.getWindowXY();
+        var elPos = elem.getXY();
+
+        if (elPos[0] < 0 || elPos[1] < 0) {
+            var s = this.findScrollableParent(el);
+            elem.scrollIntoView(s);
+        }
+
     },
 
     showBy: function (el) {

--- a/html/gui/js/modules/HelpTip.js
+++ b/html/gui/js/modules/HelpTip.js
@@ -25,7 +25,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
     closable: true,
     offset: [0, 0],
     anchorOffset: 0,
-    initComponent: function() {
+    initComponent: function () {
         // Adding a question make to the end of the supplied posiion makes sure
         // the tip will show up on the viewable area of the page.
         if (this.position[this.position.length - 1] !== '?') {
@@ -35,12 +35,12 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
         Ext.ToolTip.superclass.initComponent.call(this);
     },
     listeners: {
-        hide: function() {
+        hide: function () {
             this.spotlight.hide();
             this.position = this.originalAnchorPosition;
         }
     },
-    onShow: function() {
+    onShow: function () {
         if (this.anchorEl !== undefined) {
             Ext.destroy(this.anchorEl);
         }
@@ -65,7 +65,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
 
         Ext.ToolTip.superclass.onShow.call(this);
     },
-    syncAnchor: function() {
+    syncAnchor: function () {
         var anchorPos;
         var offset;
         switch (this.tipAnchorPos) {
@@ -104,7 +104,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
         }
         this.anchorEl.alignTo(this.el, anchorPos + '-' + this.tipAnchorPos, offset);
     },
-    findScrollableParent: function(el) {
+    findScrollableParent: function (el) {
         var parentEl = el.findParentNode('', 1, true);
 
         if (parentEl !== null && parentEl !== undefined) {
@@ -113,9 +113,8 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
 
         return null;
     },
-    getElementAnchorPositions: function(el, constrainOffset) {
+    getElementAnchorPositions: function (el, constrainOffset) {
         var elementRegion = el.getRegion();
-
         var horizontalCenter = Math.round(elementRegion.left + ((elementRegion.right - elementRegion.left) / 2))
         var verticalCenter = Math.round(elementRegion.top + ((elementRegion.bottom - elementRegion.top) / 2));
 
@@ -130,7 +129,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
             elementRegion.right + ',' + verticalCenter
         ];
     },
-    getConstraintOffset: function(el) {
+    getConstraintOffset: function (el) {
         var nonConstrainedPosition = (this.position[this.position.length - 1] === '?') ? this.position.slice(0, -1) : this.position;
         var nonConstrainedXY = this.el.getAlignToXY(el, nonConstrainedPosition);
         var constrainedXY = this.el.getAlignToXY(el, this.position);
@@ -142,7 +141,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
 
         return constrainOffset;
     },
-    setAnchorPosition: function(el) {
+    setAnchorPosition: function (el) {
         var anchorPositionMap = ['tl', 'tr', 'bl', 'br', 't', 'b', 'l', 'r'];
         var targetElementXY = this.getElementAnchorPositions(Ext.Element.get(el), 0);
         var tipXY = this.getElementAnchorPositions(this.el, this.getConstraintOffset(el));
@@ -181,7 +180,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
             this.position = anchorPositionMatch[0] + '?';
         }
     },
-    getOffset: function() {
+    getOffset: function () {
         var p = this.position.split('-');
         var alignmentOffsets = {
             bl: [-10, -7],
@@ -200,7 +199,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
 
         return offset;
     },
-    showBy: function(el) {
+    showBy: function (el) {
         if (!this.rendered) {
             this.render(Ext.getBody());
         }
@@ -227,11 +226,11 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
         this.syncAnchor();
     },
 
-    hideTip: function() {
+    hideTip: function () {
         this.hide();
     },
 
-    createSpotlight: function() {
+    createSpotlight: function () {
         if (this.spotlight === null) {
             this.spotlight = new Ext.ux.Spotlight({
                 easing: 'easeOut',

--- a/html/gui/js/modules/HelpTip.js
+++ b/html/gui/js/modules/HelpTip.js
@@ -115,7 +115,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
     },
     getElementAnchorPositions: function (el, constrainOffset) {
         var elementRegion = el.getRegion();
-        var horizontalCenter = Math.round(elementRegion.left + ((elementRegion.right - elementRegion.left) / 2))
+        var horizontalCenter = Math.round(elementRegion.left + ((elementRegion.right - elementRegion.left) / 2));
         var verticalCenter = Math.round(elementRegion.top + ((elementRegion.bottom - elementRegion.top) / 2));
 
         return [
@@ -148,32 +148,32 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
 
         // Find a [x,y] that matches between the possible anchor points for the
         // HelpTip and the target element it is being anchored to
-        var anchorPositionMatch = targetElementXY.map(function(value, key) {
+        var anchorPositionMatch = targetElementXY.map( function(value, key) {
             return (tipXY.includes(value)) ? anchorPositionMap[tipXY.indexOf(value)] + '-' + anchorPositionMap[key] : false;
-        }).filter(function(el) {
-            return el !== false;
+        }).filter( function(element) {
+            return element !== false;
         });
 
         // If no matching [x,y] pair is found in the statement above look for a matching
         // point between the two elements and use that point as an anchor position
-        if (anchorPositionMatch.length == 0) {
+        if (anchorPositionMatch.length === 0) {
             var tipElementRegions = this.el.getRegion();
             var targetElementRegions = Ext.Element.get(el).getRegion();
-            if (tipElementRegions.top == targetElementRegions.top) {
+            if (tipElementRegions.top === targetElementRegions.top) {
                 this.position = 't-t?';
-            } else if (tipElementRegions.top == targetElementRegions.bottom) {
+            } else if (tipElementRegions.top === targetElementRegions.bottom) {
                 this.position = 't-b?';
-            } else if (tipElementRegions.bottom == targetElementRegions.top) {
+            } else if (tipElementRegions.bottom === targetElementRegions.top) {
                 this.position = 'b-t?';
-            } else if (tipElementRegions.bottom == targetElementRegions.bottom) {
+            } else if (tipElementRegions.bottom === targetElementRegions.bottom) {
                 this.position = 'b-b?';
-            } else if (tipElementRegions.right == targetElementRegions.right) {
+            } else if (tipElementRegions.right === targetElementRegions.right) {
                 this.position = 'r-r?';
-            } else if (tipElementRegions.right == targetElementRegions.left) {
+            } else if (tipElementRegions.right === targetElementRegions.left) {
                 this.position = 'r-l?';
-            } else if (tipElementRegions.left == targetElementRegions.left) {
+            } else if (tipElementRegions.left === targetElementRegions.left) {
                 this.position = 'l-l?';
-            } else if (tipElementRegions.left == targetElementRegions.right) {
+            } else if (tipElementRegions.left === targetElementRegions.right) {
                 this.position = 'l-r?';
             }
         } else {
@@ -193,7 +193,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
             r: [-7, 0]
         };
 
-        var offset = alignmentOffsets[p[0]].map(function(v, k) {
+        var offset = alignmentOffsets[p[0]].map( function(v, k) {
             return v + this.offset[k];
         }, this);
 
@@ -215,10 +215,15 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
 
         // Help tips are aligned to the specified target element relative to specific
         // anchor points. In order to correctly anchor the help tip, the help tip must
-        // has a height and width which it does not have until iti si rendered on the
+        // have a height and width which it does not have until it is rendered on the
         // page. The help tip is first shown off the screen with the statement below so
-        // it has a height and width and then the showAt() function is called again
-        // to show it in the correct location relative to its target element.
+        // it has a height and width. The Help Tip is shown a second time without any
+        // offsets so that we can see what position the Help Tip aligns to in case it
+        // is shown in a different location than specified because the original location
+        // would have show the tip outside of the viewing area. After that we are able
+        // to get the correct offsets to for the Help tip and then the showAt() function
+        // is called again to show the tip in the correct location relative to its
+        // target element.
         this.showAt([-1000, -1000]);
         this.showAt(this.el.getAlignToXY(el, this.position));
         this.setAnchorPosition(el);

--- a/html/gui/js/modules/HelpTip.js
+++ b/html/gui/js/modules/HelpTip.js
@@ -148,9 +148,9 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
 
         // Find a [x,y] that matches between the possible anchor points for the
         // HelpTip and the target element it is being anchored to
-        var anchorPositionMatch = targetElementXY.map( function(value, key) {
+        var anchorPositionMatch = targetElementXY.map(function (value, key) {
             return (tipXY.includes(value)) ? anchorPositionMap[tipXY.indexOf(value)] + '-' + anchorPositionMap[key] : false;
-        }).filter( function(element) {
+        }).filter(function (element) {
             return element !== false;
         });
 
@@ -193,7 +193,7 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
             r: [-7, 0]
         };
 
-        var offset = alignmentOffsets[p[0]].map( function(v, k) {
+        var offset = alignmentOffsets[p[0]].map(function (v, k) {
             return v + this.offset[k];
         }, this);
 

--- a/html/gui/js/modules/HelpTip.js
+++ b/html/gui/js/modules/HelpTip.js
@@ -25,21 +25,30 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
     closable: true,
     offset: [0, 0],
     anchorOffset: 0,
-    constrainPosition: true,
-    initComponent: function () {
-        var anchor = this.position.split('-');
-        this.tipAnchorPos = anchor[0];
-        this.targetAnchorPos = anchor[1];
+    initComponent: function() {
+        // Adding a question make to the end of the supplied posiion makes sure
+        // the tip will show up on the viewable area of the page.
+        if (this.position[this.position.length - 1] !== '?') {
+            this.position = this.position + '?';
+        }
+        this.originalAnchorPosition = this.position;
         Ext.ToolTip.superclass.initComponent.call(this);
     },
     listeners: {
-        hide: function () {
+        hide: function() {
             this.spotlight.hide();
+            this.position = this.originalAnchorPosition;
         }
     },
-    // private
-    onRender: function (ct, position) {
-        Ext.ToolTip.superclass.onRender.call(this, ct, position);
+    onShow: function() {
+        if (this.anchorEl !== undefined) {
+            Ext.destroy(this.anchorEl);
+        }
+
+        var anchor = this.position.split('-');
+        this.tipAnchorPos = anchor[0];
+        this.targetAnchorPos = anchor[1];
+
         var anchorCls = {
             t: 'x-tip-anchor-top',
             b: 'x-tip-anchor-bottom',
@@ -51,15 +60,12 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
         this.anchorEl = this.el.createChild({
             cls: 'x-tip-anchor ' + this.anchorCls
         });
-    },
 
-    // private
-    afterRender: function () {
-        Ext.ToolTip.superclass.afterRender.call(this);
         this.anchorEl.setStyle('z-index', this.el.getZIndex() + 1).setVisibilityMode(Ext.Element.DISPLAY);
-    },
 
-    syncAnchor: function () {
+        Ext.ToolTip.superclass.onShow.call(this);
+    },
+    syncAnchor: function() {
         var anchorPos;
         var offset;
         switch (this.tipAnchorPos) {
@@ -98,49 +104,87 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
         }
         this.anchorEl.alignTo(this.el, anchorPos + '-' + this.tipAnchorPos, offset);
     },
+    findScrollableParent: function(el) {
+        var parentEl = el.findParentNode('', 1, true);
 
-    getWindowXY: function () {
-        var xPos = window.innerHeight / 2;
-        var yPos = window.innerWidth / 2;
-
-        return {x: xPos, y: yPos}
-    },
-
-    findScrollableParent: function (el) {
-        var elem = Ext.get(el);
-        var parentId = elem.dom.parentNode.id;
-
-        if(parentId !== null || parentId !== undefined) {
-            var p = Ext.get(parentId);
-            if(p.isScrollable() === true) {
-                return p;
-            }
-            else {
-                return this.findScrollableParent(p);
-            }
+        if (parentEl !== null && parentEl !== undefined) {
+            return (parentEl.isScrollable() === true) ? parentEl : this.findScrollableParent(parentEl);
         }
 
         return null;
     },
-    setTipLocation: function (el) {
-        var elem = Ext.get(el);
-        var centerXYPosition = this.getWindowXY();
-        var elPos = elem.getXY();
+    getElementAnchorPositions: function(el, constrainOffset) {
+        var elementRegion = el.getRegion();
 
-        if (elPos[0] < 0 || elPos[1] < 0) {
-            var s = this.findScrollableParent(el);
-            elem.scrollIntoView(s);
-        }
+        var horizontalCenter = Math.round(elementRegion.left + ((elementRegion.right - elementRegion.left) / 2))
+        var verticalCenter = Math.round(elementRegion.top + ((elementRegion.bottom - elementRegion.top) / 2));
 
+        return [
+            (elementRegion.left - constrainOffset) + ',' + elementRegion.top,
+            elementRegion.right + ',' + elementRegion.top,
+            (elementRegion.left - constrainOffset) + ',' + elementRegion.bottom,
+            elementRegion.right + ',' + elementRegion.bottom,
+            (horizontalCenter - constrainOffset) + ',' + elementRegion.top,
+            (horizontalCenter - constrainOffset) + ',' + elementRegion.bottom,
+            (elementRegion.left - constrainOffset) + ',' + verticalCenter,
+            elementRegion.right + ',' + verticalCenter
+        ];
     },
+    getConstraintOffset: function(el) {
+        var nonConstrainedPosition = (this.position[this.position.length - 1] === '?') ? this.position.slice(0, -1) : this.position;
+        var nonConstrainedXY = this.el.getAlignToXY(el, nonConstrainedPosition);
+        var constrainedXY = this.el.getAlignToXY(el, this.position);
+        var constrainOffset = 0;
 
-    showBy: function (el) {
-        if (!this.rendered) {
-            this.render(Ext.getBody());
+        if (nonConstrainedXY[0] < constrainedXY[0]) {
+            constrainOffset = (nonConstrainedXY[0] >= 0) ? this.el.getConstrainOffset() : -this.el.getConstrainOffset();
         }
 
+        return constrainOffset;
+    },
+    setAnchorPosition: function(el) {
+        var anchorPositionMap = ['tl', 'tr', 'bl', 'br', 't', 'b', 'l', 'r'];
+        var targetElementXY = this.getElementAnchorPositions(Ext.Element.get(el), 0);
+        var tipXY = this.getElementAnchorPositions(this.el, this.getConstraintOffset(el));
+
+        // Find a [x,y] that matches between the possible anchor points for the
+        // HelpTip and the target element it is being anchored to
+        var anchorPositionMatch = targetElementXY.map(function(value, key) {
+            return (tipXY.includes(value)) ? anchorPositionMap[tipXY.indexOf(value)] + '-' + anchorPositionMap[key] : false;
+        }).filter(function(el) {
+            return el !== false;
+        });
+
+        // If no matching [x,y] pair is found in the statement above look for a matching
+        // point between the two elements and use that point as an anchor position
+        if (anchorPositionMatch.length == 0) {
+            var tipElementRegions = this.el.getRegion();
+            var targetElementRegions = Ext.Element.get(el).getRegion();
+            if (tipElementRegions.top == targetElementRegions.top) {
+                this.position = 't-t?';
+            } else if (tipElementRegions.top == targetElementRegions.bottom) {
+                this.position = 't-b?';
+            } else if (tipElementRegions.bottom == targetElementRegions.top) {
+                this.position = 'b-t?';
+            } else if (tipElementRegions.bottom == targetElementRegions.bottom) {
+                this.position = 'b-b?';
+            } else if (tipElementRegions.right == targetElementRegions.right) {
+                this.position = 'r-r?';
+            } else if (tipElementRegions.right == targetElementRegions.left) {
+                this.position = 'r-l?';
+            } else if (tipElementRegions.left == targetElementRegions.left) {
+                this.position = 'l-l?';
+            } else if (tipElementRegions.left == targetElementRegions.right) {
+                this.position = 'l-r?';
+            }
+        } else {
+            this.position = anchorPositionMatch[0] + '?';
+        }
+    },
+    getOffset: function() {
+        var p = this.position.split('-');
         var alignmentOffsets = {
-            bl: [0, -7],
+            bl: [-10, -7],
             tl: [-10, 7],
             t: [0, 7],
             b: [0, -7],
@@ -150,10 +194,23 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
             r: [-7, 0]
         };
 
-        var offset = alignmentOffsets[this.tipAnchorPos].map(function (v, k) {
+        var offset = alignmentOffsets[p[0]].map(function(v, k) {
             return v + this.offset[k];
         }, this);
 
+        return offset;
+    },
+    showBy: function(el) {
+        if (!this.rendered) {
+            this.render(Ext.getBody());
+        }
+
+        var element = Ext.get(el);
+
+        // Find a parent element of the element you are anchoring the Help Tip to
+        // that can be scrolled and use that element to scroll the page to make
+        // sure the target element can be seen
+        element.scrollIntoView(this.findScrollableParent(element));
         this.createSpotlight();
         this.spotlight.show(el);
 
@@ -164,16 +221,17 @@ Ext.ux.HelpTip = Ext.extend(Ext.Tip, {
         // it has a height and width and then the showAt() function is called again
         // to show it in the correct location relative to its target element.
         this.showAt([-1000, -1000]);
-        this.showAt(this.el.getAlignToXY(el, this.position, offset));
-
+        this.showAt(this.el.getAlignToXY(el, this.position));
+        this.setAnchorPosition(el);
+        this.showAt(this.el.getAlignToXY(el, this.position, this.getOffset()));
         this.syncAnchor();
     },
 
-    hideTip: function () {
+    hideTip: function() {
         this.hide();
     },
 
-    createSpotlight: function () {
+    createSpotlight: function() {
         if (this.spotlight === null) {
             this.spotlight = new Ext.ux.Spotlight({
                 easing: 'easeOut',


### PR DESCRIPTION
This PR has three updates for related to Help Tips.

1. Scroll target element into view. When showing a Help Tip the target element the tip is being shown next to may be outside the viewable area. To make sure the target is in the viewable area the help tip will look through all of the parent elements of the target element and find a parent element that is scrollable and then scroll the element into view. 

2. For Portlets, by default css selector are searched only within the portlet. Since a majority of portlet help tips will target elements within their portlet by default the ID of the portlet will be added to the target element. To search for an element globally, place a backslash ("/") at the beginning of the css selector you are using. 

3. Display help tips within viewable areas. Adding a '?' to the end of the position attribute ensures that the help tip is displayed within the viewable area of the page. This will be automatically be added to any target attribute that doesn't have one at the end. Once the help tip is placed in its new position, new offsets and a new tip anchor class is selected based on this new position and its relation to target element. 

The new offsets and anchor tip class for the help tip is finding an [x,y] position that matches between the possible anchor points for the Help Tip and the target element it is being anchored to. If no matching [x,y] pair is found then look for a matching point between the two elements and use that point to determine the new offsets and anchor tip class.

## Tests performed
Tested manually and in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
