### PR TITLE
Updated to add resource_types and resource_type_realms

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -2222,7 +2222,7 @@ function updateResourceTypeRealms(iDatabase $db, $realm)
 
     $query = <<<SQL
 INSERT INTO moddb.resource_type_realms(resource_type_id, realm_id)
-SELECT 
+SELECT
     rt.id as resource_type_id,
     r.realm_id as realm_id
 FROM $stagingSchema.staging_resource_type_realms srtr

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -718,8 +718,11 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
         array_reduce(
             $enabledResourceTypes,
             function ($carry, $item) use ($resourceTypes) {
-                $realms = $resourceTypes['resource_types'][$item]['realms'];
-                return array_merge($carry, $realms);
+                if(!isset($resourceTypes['resource_types'][$item]['disabled'])) {
+                    $realms = $resourceTypes['resource_types'][$item]['realms'];
+                    return array_merge($carry, $realms);
+                }
+                return $carry;
             },
             array()
         )
@@ -2228,7 +2231,7 @@ INSERT INTO moddb.resource_type_realms(resource_type_id, realm_id)
 SELECT 
     rt.id as resource_type_id,
     r.realm_id as realm_id
-FROM mod_shredder.staging_resource_type_realms srtr
+FROM modw.staging_resource_type_realms srtr
 JOIN modw.resourcetype rt ON rt.abbrev = srtr.abbrev
 JOIN moddb.realms r ON r.display = srtr.realm
 WHERE r.display = :realm_display;

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -33,6 +33,7 @@ $opts = array(
 $dryRun = false;
 $logLevel = Log::ERR;
 $recover = false;
+$isXSEDE = false;
 
 try {
     $options = getopt(implode('', array_keys($opts)), array_values($opts));
@@ -94,7 +95,7 @@ try {
  **/
 function main()
 {
-    global $dryRun, $log, $verify, $logLevel, $recover;
+    global $dryRun, $log, $verify, $logLevel, $recover, $isXSEDE;
 
     $log->notice("*** Beginning Acl Configuration Tool...");
     $log->info(
@@ -127,6 +128,8 @@ function main()
 
     // Module Retrieval
     $modules = Configuration::assocArrayFactory('modules.json', CONFIG_DIR, $log);
+
+    $isXSEDE = array_key_exists('XSEDE', $modules);
 
     // Remove the warning to users that this files contents are automatically
     // generated and that they modify it at their own risk.
@@ -727,7 +730,7 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
             array()
         )
     );
-    $filteredRealms = array_intersect(array_keys($realms), $enabledRealms);
+    $filteredRealms = array_diff(array_keys($realms), $enabledRealms);
     foreach($filteredRealms as $filteredRealm) {
         unset($realms[$filteredRealm]);
     }
@@ -2222,21 +2225,32 @@ function dropTables(iDatabase $db, array $tables)
 
 function updateResourceTypeRealms(iDatabase $db, $realm)
 {
-    global $dryRun, $log;
+    global $dryRun, $log, $isXSEDE;
 
     $log->info("*** Updating Resource Types -> Realm Associations");
+
+    $stagingSchema = 'mod_shredder';
+    if ($isXSEDE === true) {
+        $stagingSchema = 'modw';
+    }
 
     $query = <<<SQL
 INSERT INTO moddb.resource_type_realms(resource_type_id, realm_id)
 SELECT 
     rt.id as resource_type_id,
     r.realm_id as realm_id
-FROM modw.staging_resource_type_realms srtr
+FROM $stagingSchema.staging_resource_type_realms srtr
 JOIN modw.resourcetype rt ON rt.abbrev = srtr.abbrev
 JOIN moddb.realms r ON r.display = srtr.realm
 WHERE r.display = :realm_display;
 SQL;
-    $db->execute($query, array(':realm_display' => $realm));
+
+    if ($dryRun === true) {
+        $log->info(sprintf("Would have Executed: \n%s\n", $query));
+    } else {
+        $db->execute($query, array(':realm_display' => $realm));
+    }
+
 
     $log->info("*** Resource Types -> Realm Associated!");
 }

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -727,7 +727,7 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
             array()
         )
     );
-    $filteredRealms = array_diff(array_keys($realms), $enabledRealms);
+    $filteredRealms = array_intersect(array_keys($realms), $enabledRealms);
     foreach($filteredRealms as $filteredRealm) {
         unset($realms[$filteredRealm]);
     }

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -141,31 +141,6 @@ function main()
     // Role Retrieval
     $allRoles = Roles::getRoleNames($blacklist);
 
-    $resourceConfig = \Configuration\XdmodConfiguration::assocArrayFactory('resources.json', CONFIG_DIR, $log);
-    $resourceTypesConfig = \Configuration\XdmodConfiguration::assocArrayFactory('resource_types.json', CONFIG_DIR, $log);
-
-    $enabledResourceTypes = array_unique(
-        array_reduce(
-            $resourceConfig,
-            function ($carry, $item) {
-                $carry [] = $item['resource_type'];
-                return $carry;
-            },
-            array()
-        )
-    );
-
-    $enabledRealms = array_unique(
-        array_reduce(
-            $enabledResourceTypes,
-            function ($carry, $item) use ($resourceTypesConfig) {
-                $realms = $resourceTypesConfig['resource_types'][$item]['realms'];
-                return array_merge($carry, $realms);
-            },
-            array()
-        )
-    );
-
     // Configuration Files
     $hierarchyConfig = \Configuration\ModuleConfiguration::factory('hierarchies.json', CONFIG_DIR, $log);
     $roleConfig = \Configuration\ModuleConfiguration::factory('roles.json', CONFIG_DIR, $log);
@@ -208,14 +183,12 @@ function main()
         // Process the realms provided by this module, if any.
         if (property_exists($realms, 'realms')) {
             foreach ($realms->realms as $realm => $data) {
-                if (in_array($realm, $enabledRealms)) {
-                    $groupBys = property_exists($data, 'group_bys') ? $data->group_bys : null;
-                    $statistics = property_exists($data, 'statistics') ? $data->statistics : null;
-                    $results[$module]['realms'][$realm] = array(
-                        'group_bys' => json_decode(json_encode($groupBys), true),
-                        'statistics' => json_decode(json_encode($statistics), true)
-                    );
-                }
+                $groupBys = property_exists($data, 'group_bys') ? $data->group_bys : null;
+                $statistics = property_exists($data, 'statistics') ? $data->statistics : null;
+                $results[$module]['realms'][$realm] = array(
+                    'group_bys' => json_decode(json_encode($groupBys), true),
+                    'statistics' => json_decode(json_encode($statistics), true)
+                );
             }
         }
     }
@@ -501,7 +474,7 @@ SQL;
     if (array_key_exists(DEFAULT_MODULE_NAME, $results)) {
         $xdmod = $results[DEFAULT_MODULE_NAME];
         unset($results[DEFAULT_MODULE_NAME]);
-        processResult($db, DEFAULT_MODULE_NAME, $xdmod, $modules);
+        processResult($db, DEFAULT_MODULE_NAME, $xdmod, $modules, true);
     }
 
     foreach ($results as $module => $moduleData) {
@@ -580,7 +553,8 @@ function wipeManagedTables(iDatabase $db)
         'statistics',
         'hierarchies',
         'realms',
-        'modules'
+        'modules',
+        'resource_type_realms'
     );
 
     foreach($tables as $table) {
@@ -733,6 +707,27 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
     $realms = ( isset($moduleData['realms']) ? $moduleData['realms'] : null );
 
     $log->info("Processing Module: $module");
+
+    $db = DB::factory('database');
+    $stmt = $db->prepare('SELECT DISTINCT rt.abbrev FROM modw.resourcetype rt JOIN modw.resourcefact rf ON rt.id = rf.resourcetype_id;');
+    $stmt->execute();
+    $enabledResourceTypes = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+
+    $resourceTypes = \Configuration\XdmodConfiguration::assocArrayFactory('resource_types.json', CONFIG_DIR);
+    $enabledRealms = array_unique(
+        array_reduce(
+            $enabledResourceTypes,
+            function ($carry, $item) use ($resourceTypes) {
+                $realms = $resourceTypes['resource_types'][$item]['realms'];
+                return array_merge($carry, $realms);
+            },
+            array()
+        )
+    );
+    $filteredRealms = array_diff(array_keys($realms), $enabledRealms);
+    foreach($filteredRealms as $filteredRealm) {
+        unset($realms[$filteredRealm]);
+    }
 
     if ($modules === null) {
         $log->err("Unable to process $module, missing module information. Is there a $module.json file in CONF_DIR/datawarehouse.d?");
@@ -1744,6 +1739,7 @@ function processRealms(iDatabase $db, $moduleName, array $realms)
 
         createGroupBys($db, $moduleName, strtolower($realm), $groupBys);
         createStatistics($db, $moduleName, strtolower($realm), $statistics);
+        updateResourceTypeRealms($db, $realm);
     }
 }
 
@@ -2219,6 +2215,27 @@ function dropTables(iDatabase $db, array $tables)
     $db->execute("DROP TABLE $tableList");
 
     $log->info("*** Tables Dropped!");
+}
+
+function updateResourceTypeRealms(iDatabase $db, $realm)
+{
+    global $dryRun, $log;
+
+    $log->info("*** Updating Resource Types -> Realm Associations");
+
+    $query = <<<SQL
+INSERT INTO moddb.resource_type_realms(resource_type_id, realm_id)
+SELECT 
+    rt.id as resource_type_id,
+    r.realm_id as realm_id
+FROM mod_shredder.staging_resource_type_realms srtr
+JOIN modw.resourcetype rt ON rt.abbrev = srtr.abbrev
+JOIN moddb.realms r ON r.display = srtr.realm
+WHERE r.display = :realm_display;
+SQL;
+    $db->execute($query, array(':realm_display' => $realm));
+
+    $log->info("*** Resource Types -> Realm Associated!");
 }
 
 /**

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -129,7 +129,7 @@ function main()
     // Module Retrieval
     $modules = Configuration::assocArrayFactory('modules.json', CONFIG_DIR, $log);
 
-    $isXSEDE = array_key_exists('XSEDE', $modules);
+    $isXSEDE = array_key_exists('xsede', $modules);
 
     // Remove the warning to users that this files contents are automatically
     // generated and that they modify it at their own risk.

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -186,6 +186,7 @@ function main()
         // Process the realms provided by this module, if any.
         if (property_exists($realms, 'realms')) {
             foreach ($realms->realms as $realm => $data) {
+
                 $groupBys = property_exists($data, 'group_bys') ? $data->group_bys : null;
                 $statistics = property_exists($data, 'statistics') ? $data->statistics : null;
                 $results[$module]['realms'][$realm] = array(
@@ -711,25 +712,7 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
 
     $log->info("Processing Module: $module");
 
-    $db = DB::factory('database');
-    $stmt = $db->prepare('SELECT DISTINCT rt.abbrev FROM modw.resourcetype rt JOIN modw.resourcefact rf ON rt.id = rf.resourcetype_id;');
-    $stmt->execute();
-    $enabledResourceTypes = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
-
-    $resourceTypes = \Configuration\XdmodConfiguration::assocArrayFactory('resource_types.json', CONFIG_DIR);
-    $enabledRealms = array_unique(
-        array_reduce(
-            $enabledResourceTypes,
-            function ($carry, $item) use ($resourceTypes) {
-                if(!isset($resourceTypes['resource_types'][$item]['disabled'])) {
-                    $realms = $resourceTypes['resource_types'][$item]['realms'];
-                    return array_merge($carry, $realms);
-                }
-                return $carry;
-            },
-            array()
-        )
-    );
+    $enabledRealms = getEnabledRealms();
     $filteredRealms = array_diff(array_keys($realms), $enabledRealms);
     foreach($filteredRealms as $filteredRealm) {
         unset($realms[$filteredRealm]);
@@ -747,7 +730,7 @@ function processResult(iDatabase $db, $module, $moduleData, $modules)
     }
 
     if ($acls !== null) {
-        processAcls($db, $module, ( null !== $realms ? $realms : array() ), $acls);
+        processAcls($db, $module, ( null !== $realms ? $realms : array() ), $acls, $enabledRealms);
     } else {
         $log->info("No acl information for module $module skipping...");
     }
@@ -1044,7 +1027,7 @@ function processModules(iDatabase $db, array $modules)
  *                          db.
  * @return void
  **/
-function processAcls(iDatabase $db, $module, array $realms, array $acls)
+function processAcls(iDatabase $db, $module, array $realms, array $acls, array $enabledRealms)
 {
     global $dryRun, $log;
 
@@ -1063,7 +1046,7 @@ function processAcls(iDatabase $db, $module, array $realms, array $acls)
 
         if (null !== $permittedModules && count($permittedModules) > 0) {
             $log->info("Processing tabs for Acl [$acl]");
-            processTabs($db, $module, $acl, $permittedModules);
+            processTabs($db, $module, $acl, $permittedModules, $enabledRealms);
         } elseif (null === $permittedModules) {
             $log->info("Acl $acl has no tabs to process.");
         }
@@ -1393,11 +1376,14 @@ SQL;
  *
  * @return void
  **/
-function processTabs(iDatabase $db, $module, $acl, array $tabs)
+function processTabs(iDatabase $db, $module, $acl, array $tabs, array $enabledRealms)
 {
     global $dryRun, $log;
 
     foreach ($tabs as $tab) {
+        if (isset($tab['supported_realms']) && count(array_intersect($enabledRealms, $tab['supported_realms'])) === 0){
+            continue;
+        }
         $name = $tab['name'];
         createTab($db, $module, $name);
         relateAclAndTab($db, $acl, $name);
@@ -2253,6 +2239,29 @@ SQL;
 
 
     $log->info("*** Resource Types -> Realm Associated!");
+}
+
+function getEnabledRealms()
+{
+    $db = DB::factory('database');
+    $stmt = $db->prepare('SELECT DISTINCT rt.abbrev FROM modw.resourcetype rt JOIN modw.resourcefact rf ON rt.id = rf.resourcetype_id;');
+    $stmt->execute();
+    $enabledResourceTypes = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+
+    $resourceTypes = \Configuration\XdmodConfiguration::assocArrayFactory('resource_types.json', CONFIG_DIR);
+    return array_unique(
+        array_reduce(
+            $enabledResourceTypes,
+            function ($carry, $item) use ($resourceTypes) {
+                if(isset($resourceTypes['resource_types'][$item]) && !isset($resourceTypes['resource_types'][$item]['disabled'])) {
+                    $realms = $resourceTypes['resource_types'][$item]['realms'];
+                    return array_merge($carry, $realms);
+                }
+                return $carry;
+            },
+            array()
+        )
+    );
 }
 
 /**

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -478,7 +478,7 @@ SQL;
     if (array_key_exists(DEFAULT_MODULE_NAME, $results)) {
         $xdmod = $results[DEFAULT_MODULE_NAME];
         unset($results[DEFAULT_MODULE_NAME]);
-        processResult($db, DEFAULT_MODULE_NAME, $xdmod, $modules, true);
+        processResult($db, DEFAULT_MODULE_NAME, $xdmod, $modules);
     }
 
     foreach ($results as $module => $moduleData) {

--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -274,6 +274,8 @@ function main()
                     $dwi->ingestStorageData();
                 }
             }
+
+            passthru('acl-config');
         } catch (Exception $e) {
             $logger->crit(array(
                 'message'    => 'Ingestion failed: ' . $e->getMessage(),

--- a/classes/ETL/DataEndpoint/ConfigurationFileEndpoint.php
+++ b/classes/ETL/DataEndpoint/ConfigurationFileEndpoint.php
@@ -24,6 +24,4 @@ class ConfigurationFileEndpoint extends JsonFile implements iStructuredFile, iCo
 
         return $retVal;
     }
-
-
 }

--- a/classes/ETL/DataEndpoint/ConfigurationFileEndpoint.php
+++ b/classes/ETL/DataEndpoint/ConfigurationFileEndpoint.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ETL\DataEndpoint;
+
+use Configuration\XdmodConfiguration;
+
+class ConfigurationFileEndpoint extends JsonFile implements iStructuredFile, iComplexDataRecords
+{
+
+    const ENDPOINT_NAME = 'configurationfile';
+
+    public function parse()
+    {
+        $config = XdmodConfiguration::factory($this->path, CONFIG_DIR, $this->logger);
+        $tmpFile = tempnam(sys_get_temp_dir(), 'etl-xdmod-config-json');
+
+        @file_put_contents($tmpFile, $config->toJson());
+
+        $this->path = $tmpFile;
+
+        $retVal = parent::parse();
+
+        #unlink($tmpFile);
+
+        return $retVal;
+    }
+
+
+}

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -453,7 +453,7 @@ class DataWarehouseInitializer
             array_reduce(
                 $enabledResourceTypes,
                 function ($carry, $item) use ($resourceTypes) {
-                    if(!isset($resourceTypes['resource_types'][$item]['disabled'])) {
+                    if(isset($resourceTypes['resource_types'][$item]) && !isset($resourceTypes['resource_types'][$item]['disabled'])) {
                         $realms = $resourceTypes['resource_types'][$item]['realms'];
                         return array_merge($carry, $realms);
                     }

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -145,7 +145,7 @@ class DataWarehouseInitializer
         }
 
         $this->logger->debug('Ingesting shredded data to staging tables');
-        Utilities::runEtlPipeline(array('staging-ingest-common', 'staging-ingest-jobs'), $this->logger);
+        Utilities::runEtlPipeline(array('staging-ingest-common', 'staging-ingest-jobs', 'ingest-resource-types'), $this->logger);
     }
 
     /**

--- a/classes/OpenXdmod/Setup/DatabaseSetup.php
+++ b/classes/OpenXdmod/Setup/DatabaseSetup.php
@@ -162,5 +162,7 @@ EOT
             $tpg = TimePeriodGenerator::getGeneratorForUnit($aggUnit);
             $tpg->generateMainTable(DB::factory('datawarehouse'), new \DateTime('2000-01-01'), new \DateTime('2038-01-18'));
         }
+
+        passthru('acl-config');
     }
 }

--- a/classes/OpenXdmod/Setup/ResourcesSetup.php
+++ b/classes/OpenXdmod/Setup/ResourcesSetup.php
@@ -158,15 +158,5 @@ class ResourcesSetup extends SubMenuSetupItem
     {
         $this->saveJsonConfig($this->resources,     'resources');
         $this->saveJsonConfig($this->resourceSpecs, 'resource_specs');
-
-        $this->updateAcls();
-    }
-
-    /**
-     * Execute all ACL actions.
-     */
-    private function updateAcls()
-    {
-        passthru('acl-config');
     }
 }

--- a/configuration/etl/etl.d/acls-xdmod-management.json
+++ b/configuration/etl/etl.d/acls-xdmod-management.json
@@ -35,7 +35,8 @@
         "acls/tabs.json",
         "acls/acl_tabs.json",
         "acls/user_acl_group_by_parameters.json",
-        "acls/report_template_acls.json"
+        "acls/report_template_acls.json",
+        "common/hpcdb/resource-type-realms.json"
       ],
       "enabled": true
     },

--- a/configuration/etl/etl.d/ingest_resources.json
+++ b/configuration/etl/etl.d/ingest_resources.json
@@ -98,6 +98,83 @@
                 "schema": "mod_hpcdb"
             }
         }
+
+    },
+    {
+        "name": "IngestResourceTypeRealmRelationsStaging",
+        "description": "",
+        "definition_file": "common/staging/resource-type-realms.json",
+        "class": "StructuredFileIngestor",
+        "endpoints": {
+            "source": {
+                "type": "configurationfile",
+                "namespace": "ETL\\DataEndpoint",
+                "options_class": "IngestorOptions",
+                "name": "Resource Types configuration",
+                "path": "${base_dir}/../resource_types.json",
+                "field_names": [
+                    "abbrev",
+                    "realm"
+                ],
+                "filters": [
+                    {
+                        "#": "Reformat config file for ETLs purposes.",
+                        "type": "external",
+                        "name": "jq",
+                        "path": "jq",
+                        "arguments": "'[(.resource_types | keys) as $a | .resource_types as $rt |  $a[] | {abbrev: . , realm: $rt[.].realms[]}]'"
+                    }
+                ]
+            },
+            "destination": {
+                "type": "mysql",
+                "name": "Shredder/Staging Database",
+                "config": "database",
+                "schema": "mod_shredder",
+                "definition_file": "common/staging/resource-type-realms.json"
+            }
+        }
+    },
+        {
+            "class": "DatabaseIngestor",
+            "name": "IngestInitialRealms",
+            "definition_file": "acls/realms.json",
+            "disable_keys": true,
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "shredder",
+                    "config": "database",
+                    "schema": "mod_shredder"
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "realm",
+                    "config": "database",
+                    "schema": "moddb"
+                }
+            }
+        },
+    {
+        "class": "DatabaseIngestor",
+        "name": "IngestResourcefactRealmRelations",
+        "definition_file": "common/hpcdb/resource-type-realms.json",
+        "description": "Ingest resource information into resourcefact table. Modeled after hpcdb-xdw-ingest-common.resource",
+        "endpoints": {
+            "source": {
+                "type": "mysql",
+                "name": "HPCDB",
+                "config": "database",
+                "schema": "mod_shredder"
+            },
+            "destination": {
+                "type": "mysql",
+                "name": "MODDB",
+                "config": "database",
+                "schema": "moddb"
+            }
+        }
     }
-  ]
+
+    ]
 }

--- a/configuration/etl/etl.d/resource_types.json
+++ b/configuration/etl/etl.d/resource_types.json
@@ -27,6 +27,16 @@
 
     "ingest-resource-types": [
         {
+            "name": "ResourceTypesStagingTableManagement",
+            "description": "Manage the staging_resource_types table",
+            "namespace": "ETL\\Maintenance",
+            "class": "ManageTables",
+            "options_class": "MaintenanceOptions",
+            "definition_file_list": [
+                "common/staging/resource-type.json"
+            ]
+        },
+        {
             "name": "ResourceTypesStagingUnknown",
             "description": "Populates the resource types table w/ the Unknown resource",
             "namespace": "ETL\\Maintenance",

--- a/configuration/etl/etl.d/xdmod-migration-8_1_2-8_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-8_1_2-8_5_0.json
@@ -170,6 +170,87 @@
                 }
             },
             "truncate_destination": true
+        },
+        {
+            "name": "IngestResourceTypeRealmRelationsStaging",
+            "description": "",
+            "definition_file": "common/staging/resource-type-realms.json",
+            "namespace": "ETL\\Ingestor",
+            "options_class": "IngestorOptions",
+            "class": "StructuredFileIngestor",
+            "endpoints": {
+                "source": {
+                    "type": "configurationfile",
+                    "namespace": "ETL\\DataEndpoint",
+                    "options_class": "IngestorOptions",
+                    "name": "Resource Types configuration",
+                    "path": "${base_dir}/../resource_types.json",
+                    "field_names": [
+                        "abbrev",
+                        "realm"
+                    ],
+                    "filters": [
+                        {
+                            "#": "Reformat config file for ETLs purposes.",
+                            "type": "external",
+                            "name": "jq",
+                            "path": "jq",
+                            "arguments": "'[(.resource_types | keys) as $a | .resource_types as $rt |  $a[] | {abbrev: . , realm: $rt[.].realms[]}]'"
+                        }
+                    ]
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "Shredder/Staging Database",
+                    "config": "database",
+                    "schema": "mod_shredder",
+                    "definition_file": "common/staging/resource-type-realms.json"
+                }
+            }
+        },
+        {
+            "class": "DatabaseIngestor",
+            "name": "IngestInitialRealms",
+            "namespace": "ETL\\Ingestor",
+            "options_class": "IngestorOptions",
+            "definition_file": "acls/realms.json",
+            "disable_keys": true,
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "shredder",
+                    "config": "database",
+                    "schema": "mod_shredder"
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "realm",
+                    "config": "database",
+                    "schema": "moddb"
+                }
+            }
+        },
+        {
+            "class": "DatabaseIngestor",
+            "name": "IngestResourcefactRealmRelations",
+            "namespace": "ETL\\Ingestor",
+            "options_class": "IngestorOptions",
+            "definition_file": "common/hpcdb/resource-type-realms.json",
+            "description": "Ingest resource information into resourcefact table. Modeled after hpcdb-xdw-ingest-common.resource",
+            "endpoints": {
+                "source": {
+                    "type": "mysql",
+                    "name": "HPCDB",
+                    "config": "database",
+                    "schema": "mod_shredder"
+                },
+                "destination": {
+                    "type": "mysql",
+                    "name": "MODDB",
+                    "config": "database",
+                    "schema": "moddb"
+                }
+            }
         }
     ]
 }

--- a/configuration/etl/etl_action_defs.d/acls/realms.json
+++ b/configuration/etl/etl_action_defs.d/acls/realms.json
@@ -1,0 +1,19 @@
+{
+    "table_definition": {
+        "$ref": "${table_definition_dir}/acls/realms.json#/table_definition"
+    },
+    "source_query": {
+        "records": {
+            "display": "DISTINCT srtr.realm",
+            "name": "LOWER(srtr.realm)",
+            "module_id": 1
+        },
+        "joins": [
+            {
+                "schema": "${SOURCE_SCHEMA}",
+                "name": "staging_resource_type_realms",
+                "alias": "srtr"
+            }
+        ]
+    }
+}

--- a/configuration/etl/etl_action_defs.d/common/hpcdb/resource-type-realms.json
+++ b/configuration/etl/etl_action_defs.d/common/hpcdb/resource-type-realms.json
@@ -1,0 +1,30 @@
+{
+    "table_definition": {
+        "$ref": "${table_definition_dir}/common/hpcdb/resource-type-realms.json#/table_definition"
+    },
+    "source_query": {
+        "records": {
+            "resource_type_id": "rt.id",
+            "realm_id": "r.realm_id"
+        },
+        "joins": [
+            {
+                "schema": "${SOURCE_SCHEMA}",
+                "name": "staging_resource_type_realms",
+                "alias": "srtr"
+            },
+            {
+                "schema": "modw",
+                "name": "resourcetype",
+                "alias": "rt",
+                "on": "rt.abbrev = srtr.abbrev"
+            },
+            {
+                "schema": "moddb",
+                "name": "realms",
+                "alias": "r",
+                "on": "r.display = srtr.realm"
+            }
+        ]
+    }
+}

--- a/configuration/etl/etl_action_defs.d/common/staging/resource-type-realms.json
+++ b/configuration/etl/etl_action_defs.d/common/staging/resource-type-realms.json
@@ -1,0 +1,5 @@
+{
+    "table_definition": {
+        "$ref": "${table_definition_dir}/common/staging/resource-type-realms.json#/table_definition"
+    }
+}

--- a/configuration/etl/etl_tables.d/common/hpcdb/resource-type-realms.json
+++ b/configuration/etl/etl_tables.d/common/hpcdb/resource-type-realms.json
@@ -1,0 +1,41 @@
+{
+    "table_definition": {
+        "name": "resource_type_realms",
+        "engine": "InnoDB",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
+        "columns": [
+            {
+                "name": "resource_type_realm_id",
+                "type": "int(11)",
+                "nullable": false,
+                "extra": "auto_increment"
+            },
+            {
+                "name": "resource_type_id",
+                "type": "int(11)",
+                "nullable": false
+            },
+            {
+                "name": "realm_id",
+                "type": "int(11)",
+                "nullable": false
+            }
+        ],
+        "indexes": [
+            {
+                "name": "PRIMARY",
+                "columns": [
+                    "resource_type_realm_id"
+                ]
+            },
+            {
+                "name": "idx_resource_type_id_realm_name",
+                "columns": [
+                    "resource_type_id",
+                    "realm_id"
+                ]
+            }
+        ]
+    }
+}

--- a/configuration/etl/etl_tables.d/common/staging/resource-type-realms.json
+++ b/configuration/etl/etl_tables.d/common/staging/resource-type-realms.json
@@ -1,0 +1,34 @@
+{
+    "table_definition": {
+        "name": "staging_resource_type_realms",
+        "engine": "InnoDB",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
+        "columns": [
+            {
+                "name": "staging_resource_type_realm_id",
+                "type": "int(11)",
+                "nullable": false,
+                "extra": "auto_increment"
+            },
+            {
+                "name": "abbrev",
+                "type": "varchar(10)",
+                "nullable": false
+            },
+            {
+                "name": "realm",
+                "type": "varchar(16)",
+                "nullable": false
+            }
+        ],
+        "indexes": [
+            {
+                "name": "PRIMARY",
+                "columns": [
+                    "staging_resource_type_realm_id"
+                ]
+            }
+        ]
+    }
+}

--- a/configuration/roles.json
+++ b/configuration/roles.json
@@ -40,6 +40,7 @@
                     "tooltip": ""
                 },
                 {
+                    "supported_realms": ["Jobs", "SUPREMM"],
                     "name": "job_viewer",
                     "title": "Job Viewer",
                     "position": 5000,

--- a/tests/integration/lib/Controllers/UserAdminTest.php
+++ b/tests/integration/lib/Controllers/UserAdminTest.php
@@ -379,8 +379,11 @@ class UserAdminTest extends BaseUserAdminTest
         $this->assertArrayHasKey('tabs', $actual['data'][0], '"data" has one element with "tabs"');
 
         $expectedFileName = $this->getTestFiles()->getFile('user_admin', $user['output'], 'output');
+        if (!is_file($expectedFileName)) {
+            @file_put_contents($expectedFileName, json_encode($actual, JSON_PRETTY_PRINT) . "\n");
+            $this->markTestSkipped();
+        }
         $expected = file_get_contents($expectedFileName);
-
         $this->assertJsonStringEqualsJsonString($expected, $actual['data'][0]['tabs']);
 
         if (!$isPublicUser) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added Resource Types -> Supported Realms relations that we then use to filter what data `acl-config` processes.

## Motivation and Context
We wanted to be able to only process, in `acl-config` the realms that are currently enabled. To accomplish this we associated resource_types w/ the appropriate realms. Then we select all currently installed resources and their types and retrieve a distinct list of the realms for those types. 

There was also a few changes made to support Trevor's realm separation work ( Making it so that XDMoD doesn't need to have the Jobs realm installed to function properly. ). 

## Tests performed
- All automated tests for: Fresh Install & Upgrade
- Manually tested on xdmod-dev
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
