### PR TITLE
Increase size of system username column

### DIFF
--- a/configuration/etl/etl_tables.d/cloud_openstack/raw_event.json
+++ b/configuration/etl/etl_tables.d/cloud_openstack/raw_event.json
@@ -1,6 +1,5 @@
 {
     "#": "Raw event information from the Open Stack log files.",
-
     "#": "Note that almost any field in the raw event logs can be NULL so most fields are nullable.",
     "#": "These will be stored here and filtered out later. For example, several events with type",
     "table_definition": {
@@ -51,12 +50,14 @@
                 "default": null
             },
             {
+                "#": "human readable name at the time the log is written",
                 "name": "user_name",
-                "type": "varchar(64)",
+                "type": "varchar(255)",
                 "nullable": true,
                 "default": null
             },
             {
+                "#": "GUID for user",
                 "name": "user_id",
                 "type": "varchar(64)",
                 "nullable": true,

--- a/configuration/etl/etl_tables.d/common/hpcdb/system-accounts.json
+++ b/configuration/etl/etl_tables.d/common/hpcdb/system-accounts.json
@@ -23,7 +23,7 @@
             },
             {
                 "name": "username",
-                "type": "varchar(30)",
+                "type": "varchar(255)",
                 "charset": "utf8",
                 "collation": "utf8_unicode_ci",
                 "nullable": false

--- a/configuration/etl/etl_tables.d/jobs/xdw/system-account.json
+++ b/configuration/etl/etl_tables.d/jobs/xdw/system-account.json
@@ -30,7 +30,7 @@
             },
             {
                 "name": "username",
-                "type": "varchar(30)",
+                "type": "varchar(255)",
                 "nullable": false,
                 "comment": "The username to log on to the resource."
             },

--- a/configuration/etl/etl_tables.d/storage/staging/usage.json
+++ b/configuration/etl/etl_tables.d/storage/staging/usage.json
@@ -24,13 +24,13 @@
             },
             {
                 "name": "user_name",
-                "type": "varchar(30)",
+                "type": "varchar(255)",
                 "nullable": false,
                 "comment": "User's system username"
             },
             {
                 "name": "pi_name",
-                "type": "varchar(30)",
+                "type": "varchar(255)",
                 "nullable": false,
                 "comment": "PI's system username"
             },


### PR DESCRIPTION
Cloud usernames can be whole email addresses, up the system username to be able to support this
