### PR TITLE
adding check to make sure Help Tips exist before making a help tour for a portlet

### DIFF
--- a/html/gui/js/Portlet.js
+++ b/html/gui/js/Portlet.js
@@ -34,7 +34,7 @@
  */
 CCR.xdmod.ui.Portlet = Ext.extend(Ext.ux.Portlet, {
     helpTour: null,
-    helpTourDetails: [],
+    helpTourDetails: {},
     initComponent: function () {
         if (this.helpTourDetails.tips !== undefined && this.helpTourDetails.tips.length > 0) {
             this.helpTourDetails.tips.forEach(function (value, index, arr) {


### PR DESCRIPTION
This PR adds a check in Portlet.js to make sure Help Tips exist before making a help tour for a portlet

## Tests performed
Tested in XSEDE and XDMoD dockers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
