### PR TITLE
Fix chart time display when the system timezone has a positive offset from UTC

### DIFF
--- a/html/gui/js/HighChartPanel.js
+++ b/html/gui/js/HighChartPanel.js
@@ -19,6 +19,9 @@ Highcharts.setOptions ({
     lang: {
         // commas for thousands separators
         thousandsSep: '\u002c' // the humble comma
+    },
+    global: {
+        timezone: CCR.xdmod.timezone
     }
 });
 

--- a/html/index.php
+++ b/html/index.php
@@ -340,6 +340,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
         });
 
         print "CCR.xdmod.features = " . json_encode($features) . ";\n";
+        print "CCR.xdmod.timezone = " . json_encode(date_default_timezone_get()) . ";\n";
         ?>
 
     </script>
@@ -383,10 +384,8 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
         <script type="text/javascript" src="gui/js/report_builder/ReportPreview.js"></script>
     <?php endif; ?>
 
-    <?php if ($userLoggedIn): ?>
-        <script type="text/javascript" src="gui/lib/moment/moment.min.js"></script>
-        <script type="text/javascript" src="gui/lib/moment-timezone/moment-timezone-with-data.min.js"></script>
-    <?php endif; ?>
+    <script type="text/javascript" src="gui/lib/moment/moment.min.js"></script>
+    <script type="text/javascript" src="gui/lib/moment-timezone/moment-timezone-with-data.min.js"></script>
 
     <script type="text/javascript" src="gui/lib/highcharts/js/highcharts.src.js"></script>
     <script type="text/javascript" src="gui/lib/highcharts/js/highcharts-more.js"></script>

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -151,11 +151,12 @@
    
       $template = str_replace('_html_dir_', $html_dir, $template);
       $template = str_replace('_chartOptions_', json_encode($chartConfig), $template);
+
+      $globalChartOptions = array('timezone' => date_default_timezone_get());
       if ($globalChartConfig !== null) {
-          $template = str_replace('_globalChartOptions_', json_encode($globalChartConfig), $template);
-      } else {
-          $template = str_replace('_globalChartOptions_', 'null', $template);
+          $globalChartOptions = array_merge($globalChartOptions, $globalChartConfig);
       }
+      $template = str_replace('_globalChartOptions_', json_encode($globalChartOptions), $template);
       $template = str_replace('_width_',$effectiveWidth, $template);
       $template = str_replace('_height_',$effectiveHeight, $template);
       file_put_contents($tmp_html_filename,$template);


### PR DESCRIPTION
Fix issue with the chart tooltip displaying the wrong date when
the system timezone is a negative offset from UTC. That is countries
located east of the prime meridian.

See https://help.xdmod.org/a/tickets/14165

