### PR TITLE
Update dashboard chart display algorithm

### DIFF
--- a/configuration/roles.d/dashboard.json
+++ b/configuration/roles.d/dashboard.json
@@ -67,7 +67,7 @@
                     }
                 },
                 {
-                    "name": "summary_0",
+                    "name": "DashBoardChart_PiWallHoursByPerson",
                     "type": "xdmod-dash-chart-cmp",
                     "config": {
                         "chart": {
@@ -171,7 +171,7 @@
                     }
                 },
                 {
-                    "name": "summary_1",
+                    "name": "DashBoardChart_PiWaitHoursByJobSize",
                     "type": "xdmod-dash-chart-cmp",
                     "config": {
                         "chart": {
@@ -223,7 +223,7 @@
                                         "category": "Jobs",
                                         "color": "8BBC21",
                                         "combine_type": "side",
-                                        "display_type": "bar",
+                                        "display_type": "column",
                                         "enabled": true,
                                         "filters": {
                                             "data": [],
@@ -254,17 +254,6 @@
                             },
                             "font_size": 2,
                             "hide_tooltip": false,
-                            "legend": {
-                                "Std Err: Wait Hours: Per Job": {
-                                    "title": "Std Err"
-                                },
-                                "Std Err: Wait Hours: Per Job {User =  ${PERSON_NAME}}": {
-                                    "title": "Std Err"
-                                },
-                                "Wait Hours: Per Job {User =  ${PERSON_NAME}}": {
-                                    "title": "My Wait Hours: Per Job"
-                                }
-                            },
                             "legend_type": "top_center",
                             "limit": 20,
                             "share_y_axis": false,
@@ -361,7 +350,7 @@
                                         "category": "Jobs",
                                         "color": "8BBC21",
                                         "combine_type": "side",
-                                        "display_type": "bar",
+                                        "display_type": "column",
                                         "enabled": true,
                                         "filters": {
                                             "data": [],
@@ -392,17 +381,6 @@
                             },
                             "font_size": 2,
                             "hide_tooltip": false,
-                            "legend": {
-                                "Std Err: Wait Hours: Per Job": {
-                                    "title": "Std Err"
-                                },
-                                "Std Err: Wait Hours: Per Job {User =  ${PERSON_NAME}}": {
-                                    "title": "Std Err"
-                                },
-                                "Wait Hours: Per Job {User =  ${PERSON_NAME}}": {
-                                    "title": "My Wait Hours: Per Job"
-                                }
-                            },
                             "legend_type": "top_center",
                             "limit": 20,
                             "share_y_axis": false,
@@ -420,7 +398,7 @@
                         "column": 1,
                         "row": 0
                     },
-                    "name": "summary_0",
+                    "name": "DashBoardChart_WaitHoursByJobSize",
                     "type": "xdmod-dash-chart-cmp"
                 },
                 {
@@ -461,22 +439,6 @@
                                 "total": 1
                             },
                             "font_size": 3,
-                            "global_filters": {
-                                "data": [
-                                    {
-                                        "categories": "",
-                                        "checked": true,
-                                        "dimension_id": "resource",
-                                        "id": "resource=13",
-                                        "realms": [
-                                            "Jobs"
-                                        ],
-                                        "value_id": "13",
-                                        "value_name": "ub hpc"
-                                    }
-                                ],
-                                "total": 1
-                            },
                             "hide_tooltip": false,
                             "legend_type": "off",
                             "limit": 10,
@@ -501,7 +463,7 @@
                         "column": 0,
                         "row": 1
                     },
-                    "name": "summary_1",
+                    "name": "DashBoardChart_WaitHoursByQueue",
                     "type": "xdmod-dash-chart-cmp"
                 }
             ]

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -2,6 +2,17 @@
 title: User Dashboard (Beta)
 ---
 
+Known Issues
+------------
+
+* Edit In Metric Explorer for Dashboard Charts
+
+The "Edit In Metric Explorer" button on a dashboard chart will not load the
+dashboard chart if there already exists a chart with an identical name saved in
+the metric explorer.  The workaround for this is to change the name of
+ the existing saved chart in the metric explorer so that it does not
+match the dashboard chart name.
+
 Developer Guide
 ---------------
 


### PR DESCRIPTION
The "summary_charts" configuration setting in the roles configuration is not used in the new dashboard.

The summary_0(X) nonsense is removed.

Remove some unused setting in the chart config and change the chart names to be more descriptive.