### PR TITLE
Fix metric explorer metric and dimension display bug.

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1788,7 +1788,7 @@ CCR.xdmod.ui.getComboBox = function (data, fields, valueField, displayField, edi
 };
 CCR.xdmod.ui.gridComboRenderer = function (combo) {
     return function (value) {
-        var idx = combo.store.find(combo.valueField, value);
+        var idx = combo.store.findExact(combo.valueField, value);
         var rec = combo.store.getAt(idx);
         if (!rec) {
             return combo.emptyText;


### PR DESCRIPTION
The metric explorer uses a renderer to convert the internal ids to
the human readable values for many of the combo boxes. The lookup
function was incorrectly using the store.find() call which only
performs a substring match. In the observed case the defined metrics
were:

job_count_bad => 'Number of Inefficient Jobs'
job_count   => 'Number of Jobs'

so when the code looked up the text for the job_count metric
the find() function would match the job_count_bad string
and the wrong text would be displayed.

This bug has been in the system forever. Why have we not noticed
it before. Well the backend code sorts the data
so that the human readable strings appear in alphabetical order. So
for example the resource / resource_type group by ends up sorted in the
following order:

resource => 'Resource'
resource_type => 'Resource Type'

therefore resource appears in the list first and a substring lookup
for resource returns the expected value. So, by luck most of the
cases do not happen. The only one I found is the SUPREMM Requested Wall
Hours Per Job and Requested Wall Hours: Total.

An even more curious reader might ask why updates to the JobEfficiency
realm would impact the job data. Well the code in the metric explorer
ignores the realm when building the list of statistics. So if two
different realms have the same metric then the text description for the
first one wins. In this case JobEfficiency is before Jobs in the
alphabet.

Before:
![image](https://user-images.githubusercontent.com/5342179/65044930-de6cbc80-d92b-11e9-9a35-deefd11ebed3.png)

After:
![image](https://user-images.githubusercontent.com/5342179/65045000-ff351200-d92b-11e9-8e70-5eb540509a18.png)
