### PR TITLE
Fix statistic name to include unit if not already in name

### DIFF
--- a/classes/Realm/Statistic.php
+++ b/classes/Realm/Statistic.php
@@ -278,7 +278,8 @@ class Statistic extends \CCR\Loggable implements iStatistic
 
     public function getName($includeUnit = true)
     {
-        if ( $includeUnit && strpos($this->name, $this->unit) ) {
+        // Include the unit if the unit is not found in the statistic name
+        if ( $includeUnit && false === strpos($this->name, $this->unit) ) {
             return $this->realm->getVariableStore()->substitute(sprintf("%s (%s)", $this->name, $this->unit));
         } else {
             return $this->realm->getVariableStore()->substitute($this->name);

--- a/tests/unit/lib/Realm/StatisticTest.php
+++ b/tests/unit/lib/Realm/StatisticTest.php
@@ -103,7 +103,11 @@ class StatisticTest extends \PHPUnit_Framework_TestCase
         $realm = Realm::factory('Cloud', self::$logger);
         $obj = $realm->getStatisticObject('Cloud_num_sessions_running');
 
-        $this->assertEquals($obj->getName(), sprintf('%s Number of Active Sessions', ORGANIZATION_NAME), 'getName()');
+        $this->assertEquals(
+            sprintf('%s Number of Active Sessions (Number of Sessions)', ORGANIZATION_NAME),
+            $obj->getName(),
+            'getName()'
+        );
     }
 
     /**
@@ -139,8 +143,10 @@ class StatisticTest extends \PHPUnit_Framework_TestCase
         $expected = 'Jobs_job_count';
         $this->assertEquals($expected, $generated, "getId(false)");
 
+        // Note that the unit "Number of Jobs" is found in the statistic name so it will not be
+        // appended.
         $generated = $obj->getName();
-        $expected = sprintf('%s Number of Jobs Ended (Number of Jobs)', ORGANIZATION_NAME);
+        $expected = sprintf('%s Number of Jobs Ended', ORGANIZATION_NAME);
         $this->assertEquals($expected, $generated, "getName()");
 
         $generated = $obj->getName(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If the unit name is not already included in the statistic name, include it at the end in parenthesis. This mirrors existing functionality in v8.5.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
