### PR TITLE
Improve handling of Standard Error Marker (sem) statistics

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -194,6 +194,7 @@ function main()
             $groupBys = array_keys($realmObj->getGroupByNames());
             $statistics = array_keys($realmObj->getStatisticNames());
             $results[$module]['realms'][$realmId] = array(
+                'display_name' => $realmObj->getName(),
                 'group_bys' => json_decode(json_encode($groupBys), true),
                 'statistics' => json_decode(json_encode($statistics), true)
             );
@@ -1640,12 +1641,11 @@ SQL;
         $statistics = $realmData['statistics'];
         foreach ($statistics as $statisticId) {
 
-            $realmName = strtolower($realm);
-            $id = "[ $module, $realmName, $acl, $groupBy, $statisticId ]";
+            $id = "[ $module, $realm, $acl, $groupBy, $statisticId ]";
 
             $params = array(
                 ':module_name' => $module,
-                ':realm_name' => $realmName,
+                ':realm_name' => $realm,
                 ':acl_name' => $acl,
                 ':group_by_name' => $groupBy,
                 ':statistic_name' => $statisticId,
@@ -1714,17 +1714,17 @@ function processRealms(iDatabase $db, $moduleName, array $realms)
 {
     global $dryRun, $log;
 
-    foreach ($realms as $realm => $realmData) {
-        $log->notice("Processing Realm: $realm for Module: $moduleName");
+    foreach ($realms as $realmId => $realmData) {
+        $log->notice(sprintf("Processing Realm: %s (%s) for Module: %s", $realmId, $realmData['display_name'], $moduleName));
 
-        createRealm($db, $moduleName, $realm);
+        createRealm($db, $moduleName, $realmId, $realmData['display_name']);
 
         $groupBys = $realmData['group_bys'];
         $statistics = $realmData['statistics'];
 
-        createGroupBys($db, $moduleName, strtolower($realm), $groupBys);
-        createStatistics($db, $moduleName, strtolower($realm), $statistics);
-        updateResourceTypeRealms($db, $realm);
+        createGroupBys($db, $moduleName, $realmId, $groupBys);
+        createStatistics($db, $moduleName, $realmId, $statistics);
+        updateResourceTypeRealms($db, $realmId);
     }
 }
 
@@ -1735,19 +1735,18 @@ function processRealms(iDatabase $db, $moduleName, array $realms)
  * @param iDatabase $db            the database to be used when creating the realm
  * @param string    $moduleName    the name of the module to associate this realm
  *                                 with.
- * @param string    $realmDisplay  the name that this realm should be created with.
+ * @param string    $realmId       the id that this realm should be created with.
+ * @param string    $realmDisplay  the display name that this realm should be created with.
  *
  * @return void
  **/
-function createRealm(iDatabase $db, $moduleName, $realmDisplay)
+function createRealm(iDatabase $db, $moduleName, $realmId, $realmDisplay)
 {
     global $dryRun, $log;
 
-    $realmName = strtolower($realmDisplay);
+    $log->notice(sprintf("*** Creating Realm %s (%s)...", $realmId, $realmDisplay));
 
-    $log->notice("*** Creating Realm ($realmDisplay)...");
-
-    $successMsg = "[SUCCESS] Created Realm: $realmDisplay for Module: $moduleName";
+    $successMsg = sprintf("[SUCCESS] Created Realm: %s (%s) for Module: %s", $realmId, $realmDisplay, $moduleName);
 
     $query = <<<SQL
     INSERT INTO realms(module_id, name, display)
@@ -1766,7 +1765,7 @@ function createRealm(iDatabase $db, $moduleName, $realmDisplay)
 SQL;
 
     $params = array(
-        ':realm_name' => $realmName,
+        ':realm_name' => $realmId,
         ':realm_display' => $realmDisplay,
         ':module_name' => $moduleName
     );

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -249,7 +249,11 @@ class MetricExplorer extends Common
 
                 if ($data_description->std_err == 1) {
                     try {
-                        $query->addStat('sem_'.$data_description->metric);
+                        $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                            $data_description->realm,
+                            $data_description->metric
+                        );
+                        $query->addStat($semStatId);
                     }
                     catch (Exception $ex) {
                         $data_description->std_err = 0;

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -98,7 +98,12 @@ class Usage extends Common
                     $statUsageChartSettings['display_type'] = 'line';
                     $statUsageChartSettings['swap_xy'] = false;
                 }
-                $errorstat = 'sem_' . $userStatistic;
+
+                $errorstat = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                    $realm->getId(),
+                    $userStatistic
+                );
+
                 if (in_array($errorstat, $realm->getStatisticNames()) ) {
                     $statUsageChartSettings['enable_errors'] = 'y';
                 }
@@ -625,7 +630,11 @@ class Usage extends Common
                 // Get the statistic object used by this chart request.
                 $meRequestMetric = $realm->getStatisticObject($meRequest['data_series_unencoded'][0]['metric']);
 
-                $errorstat = 'sem_' . $meRequest['data_series_unencoded'][0]['metric'];
+                $errorstat = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                    $realm->getId(),
+                    $meRequest['data_series_unencoded'][0]['metric']
+                );
+
                 if (in_array($errorstat, $realm->getStatisticNames()) ) {
                     $usageChartSettings['enable_errors'] = 'y';
                 }

--- a/classes/DataWarehouse/Data/ComplexDataset.php
+++ b/classes/DataWarehouse/Data/ComplexDataset.php
@@ -112,7 +112,11 @@ class ComplexDataset
                 )
             ) {
                 try {
-                    $query->addStat('sem_'.$data_description->metric);
+                    $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                        $data_description->realm,
+                        $data_description->metric
+                    );
+                    $query->addStat($semStatId);
                 } catch (\Exception $ex) {
                     $data_description->std_err = 0;
                     $data_description->std_err_labels = false;
@@ -620,13 +624,12 @@ class ComplexDataset
                     $yAxisDataObject->setErrors($newErrors);
                     $yAxisDataObject->getErrorCount(true);
 
-                    $semStatisticObject
-                        = $dataDescripterAndDataset->dataset->_query->_stats[
-                            'sem_'
-                            . $dataDescripterAndDataset->data_description
-                                                       ->metric
-                        ];
+                    $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                        $dataDescripterAndDataset->dataset->_query->getRealmName(),
+                        $dataDescripterAndDataset->data_description->metric
+                    );
 
+                    $semStatisticObject = $dataDescripterAndDataset->dataset->_query->_stats[$semStatId];
                     $semDecimals = $semStatisticObject->getPrecision();
                 }
 

--- a/classes/DataWarehouse/Data/SimpleDataset.php
+++ b/classes/DataWarehouse/Data/SimpleDataset.php
@@ -211,8 +211,13 @@ class SimpleDataset
         }
         $dataObject->setUnit( $this->getColumnLabel($column_name, $is_dimension) );
 
-        if (isset($this->_query->_stats['sem_' . $column_name])) {
-            $sem_column_name = 'sem_' . $column_name;
+        $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+            $this->_query->getRealmName(),
+            $column_name
+        );
+
+        if (isset($this->_query->_stats[$semStatId])) {
+            $sem_column_name = $semStatId;
         }
 
         $columnTypes = $this->_columnTypes;

--- a/classes/DataWarehouse/Data/SimpleTimeseriesDataset.php
+++ b/classes/DataWarehouse/Data/SimpleTimeseriesDataset.php
@@ -109,8 +109,12 @@ class SimpleTimeseriesDataset extends SimpleDataset
         $start_ts_column_name  = $this->_query->getAggregationUnit()->getUnitName()
                                 . '_start_ts';
         // standard error
-        if (isset($this->_query->_stats['sem_' . $column_name])) {
-            $sem_column_name = 'sem_' . $column_name;
+        $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+            $this->_query->getGetRealmName(),
+            $column_name
+        );
+        if (isset($this->_query->_stats[$semStatId])) {
+            $sem_column_name = $semStatId;
         }
 
         // create the data object
@@ -420,7 +424,10 @@ class SimpleTimeseriesDataset extends SimpleDataset
                     );
                 }
 
-                $sem_column_name = 'sem_' . $values_column_name;
+                $sem_column_name = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                    $this->_query->getGetRealmName(),
+                    $values_column_name
+                );
 
                 if (!array_key_exists($sem_column_name, $row)) {
                     $dataErrors[] = 0;

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -338,7 +338,10 @@ class Query extends Loggable
                 // Sort the results with stat_column descending
                 array_multisort($stat_column, $sort_option, $name_column, SORT_ASC, $results);
             }
-            $sem_name = 'sem_'.$stat;
+            $sem_name = Realm::getStandardErrorStatisticFromStatistic(
+                $this->realm->getId(),
+                $stat
+            );
             if (count($results) > 0) {
                 $return[$stat] = array();
                 $return['weight'] = array();
@@ -1223,7 +1226,7 @@ SQL;
             return null;
         }
         $statistic = $this->realm->getStatisticObject($stat_name);
-        $this->_stats[$stat_name] = $statistic;
+        $this->_stats[ $statistic->getId() ] = $statistic;
         $this->addStatField($statistic);
         return $statistic;
     }

--- a/classes/DataWarehouse/Query/TimeseriesQuery.php
+++ b/classes/DataWarehouse/Query/TimeseriesQuery.php
@@ -234,7 +234,10 @@ SQL;
         $stat        = $this->_main_stat_field->getAlias();
         $stat_weight = $this->_main_stat_field->getWeightStatName();
 
-        $sem_name = 'sem_' . $stat;
+        $sem_name = Realm::getStandardErrorStatisticFromStatistic(
+            $this->realm->getId(),
+            $stat
+        );
 
         $useWeights
             =  strpos($stat, 'avg_')             !== false

--- a/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
+++ b/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
@@ -270,7 +270,11 @@ class HighChartTimeseries2 extends HighChart2
                 ) {
                     try
                     {
-                         $query->addStat('sem_'.$data_description->metric);
+                        $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                            $data_description->realm,
+                            $data_description->metric
+                        );
+                        $query->addStat($semStatId);
                     }
                     catch(\Exception $ex)
                     {
@@ -449,7 +453,11 @@ class HighChartTimeseries2 extends HighChart2
 
                 if($data_description->std_err == 1)
                 {
-                    $semStatisticObject = $query->_stats['sem_'.$data_description->metric];
+                    $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                        $data_description->realm,
+                        $data_description->metric
+                    );
+                    $semStatisticObject = $query->_stats[$semStatId];
                     $semDecimals = $semStatisticObject->getPrecision();
                 }
 

--- a/classes/Models/Services/Acls.php
+++ b/classes/Models/Services/Acls.php
@@ -579,7 +579,8 @@ FROM acl_group_bys agb
   JOIN statistics s
     ON s.statistic_id = agb.statistic_id
   LEFT JOIN statistics sem
-    ON sem.name = CONCAT('sem_', s.name)
+-- Example: Statistic id is Jobs_avg_jobs_running while SEM statistic id is Jobs_sem_avg_jobs_running
+    ON sem.name = CONCAT(r.name, '_sem_', SUBSTR(s.name, LENGTH(r.name) + 1))
 WHERE
   ua.user_id = :user_id
   AND agb.enabled = TRUE
@@ -1168,7 +1169,7 @@ SELECT DISTINCT agb.realm_id
 
     WHERE
       r.name = :realm_name AND
-      gb.name = :group_by_name 
+      gb.name = :group_by_name
 SQL;
         // Query to tell whether or not they have a 'query descriptor' and it's disabled but still
         // visible.
@@ -1185,14 +1186,12 @@ SELECT DISTINCT agb.realm_id
 
     WHERE agb.enabled = false AND
           r.name = :realm_name AND
-          gb.name = :group_by_name 
+          gb.name = :group_by_name
 
 SQL;
 
-        // NOTE: we explicitly strtolower the $realmName because it is often passed in ucfirst which
-        // will not match realms.name values.
         $params = array(
-            ':realm_name' => strtolower($realmName),
+            ':realm_name' => $realmName,
             ':group_by_name' => $groupByName,
             ':user_id' => $user->getUserID()
         );

--- a/classes/Realm/Realm.php
+++ b/classes/Realm/Realm.php
@@ -175,6 +175,15 @@ class Realm extends \CCR\Loggable implements iRealm
     }
 
     /**
+     * @see iRealm::getStandardErrorStatisticFromStatistic()
+     */
+
+    public static function getStandardErrorStatisticFromStatistic($realmId, $statisticId)
+    {
+        return sprintf('%s_sem_%s', $realmId, substr($statisticId, strlen($realmId) + 1));
+    }
+
+    /**
      * @see iRealm::factory()
      */
 
@@ -651,8 +660,8 @@ class Realm extends \CCR\Loggable implements iRealm
 
     public function getStatisticObject($shortName)
     {
-        // As a convienence, if the requested statistic does not start with the realm id, add it
-        // here.
+        // As a convienence, if the requested statistic does not start with the realm id, add
+        // it.
 
         if ( 0 !== strpos($shortName, $this->id) ) {
             $shortName = sprintf("%s_%s", $this->id, $shortName);

--- a/classes/Realm/iRealm.php
+++ b/classes/Realm/iRealm.php
@@ -82,6 +82,25 @@ interface iRealm
     public static function getRealmObjects($order = self::SORT_ON_ORDER, Logger $logger = null);
 
     /**
+     * XDMoD supports hidden meta-statistics such as standard error measurements. These are not
+     * available via the metric catalog but are available when standard error bars are enabled.
+     * Historically, they are referenced in the usage tab, metric explorer, and datasets by
+     * prefixing the statistic name with "sem_" (e.g., sem_job_count).  Now that the statistics are
+     * prefixed with the realm name we need to be able to translate between the statistic id and the
+     * standard error measurement version of that statistic id.
+     *
+     * For example, given the statistic "Jobs_job_count" the standard error measurement statisic
+     * would be "Jobs_sem_job_count".
+     *
+     * @param $realmId string The ID of the realm that the statistic belongs to
+     * @param $statisticId string The ID of the source statistic
+     *
+     * @return string The ID of the standard error measurement statistic
+     */
+
+    public static function getStandardErrorStatisticFromStatistic($realmId, $statisticId);
+
+    /**
      * @return string The short internal identifier.
      */
 

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -78,11 +78,15 @@ foreach ($roles as $activeRole) {
 
                     $statsObjects = $query_descripter->getStatisticsClasses($stats);
                     foreach ($statsObjects as $realm_group_by_statistic => $statistic_object) {
+                        $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                            $query_descripter_realm,
+                            $realm_group_by_statistic
+                        );
                         $realms[$query_descripter_realm]['metrics'][$realm_group_by_statistic] =
                             array(
                                 'text' => $statistic_object->getName(),
                                 'info' => $statistic_object->getHtmlDescription(),
-                                'std_err' => in_array('sem_' . $realm_group_by_statistic, $permittedStatistics)
+                                'std_err' => in_array($semStatId, $permittedStatistics)
                             );
                         $seenstats[] = $realm_group_by_statistic;
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Standard error marker statistics have historically been used for generating error bars for statistics that average a set of data. These statistics are not shown in the metric catalog, but are hidden from the user and used behind the scenes. They were named by prefixing the statistic name with "sem_" (e.g., sem_avg_processors). Now that the statistics include the realm name (e.g., Jobs_avg_processors) we cannot simply prefix the name with "sem_" but need to insert it after the realm (e.g., Jobs_sem_avg_processors).

In addition, the `acl-config` script stored the realm name as lowercase in the database (e.g., "Jobs" was stored as "jobs"), however in `Acls::getDescriptorsForUser()` this would prevent us from properly constructing the names of the SEM statistics and they would not match values stored in the database. The realm identifier is now stored as it is written in the datawarehouse.json/datawarehouse.d files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
