### PR TITLE
Add support for hiding Realms and Statistics in the Metric Cata…

### DIFF
--- a/classes/DataWarehouse.php
+++ b/classes/DataWarehouse.php
@@ -354,44 +354,40 @@ class DataWarehouse
     }   //getAllocations()
 
     /**
-     * Get a mapping of categories to realms.
+     * Get a mapping of categories to realms. If a realm does not explicitly declare a category, its
+     * id is used as the category.  If a realm has the show_in_catalog property set to false then it
+     * does not appear in the list of categories.
      *
-     * If a realm does not explicitly declare a category, its name is used
-     * as the category.
-     *
-     * @return array An associative array mapping categories to the realms
-     *               they contain.
-     * @throws Exception if there is a problem reading / processing `datawarehouse.json`
+     * @return array An associative array mapping categories to realm ids.
      */
+
     public static function getCategories()
     {
-        $realmNames = \Realm\Realm::getRealmNames();
+        $realmObjects = \Realm\Realm::getRealmObjects();
         $categories = array();
-        foreach ( $realmNames as $realmId => $realmName ) {
-            $categories[$realmId] = array($realmId);
+
+        foreach ( $realmObjects as $realmId => $obj ) {
+            if ( ! $obj->showInMetricCatalog() ) {
+                continue;
+            }
+            $categories[$obj->getCategory()][] = $realmId;
         }
 
         return $categories;
     }
 
     /**
-     * Get the category for a given realm.
+     * Get the category for a given realm.  If a realm does not explicitly declare a category, its
+     * name is used as the category.
      *
-     * If a realm does not explicitly declare a category, its name is used
-     * as the category.
-     *
-     * @param  string $realmName The name of the realm to get
-     *                           the category for.
-     * @return string            The category the realm belongs to.
+     * @param  string $realmId The id of the realm to get the category for.
+     * @return string          The category the realm belongs to or null if the realm has the
+     *                         show_in_catalog flag set to false.
      */
-    public static function getCategoryForRealm($realmName)
+
+    public static function getCategoryForRealm($realmId)
     {
-        $dwConfig = \Configuration\XdmodConfiguration::assocArrayFactory('datawarehouse.json', CONFIG_DIR);
-
-        if (isset($dwConfig['realms'][$realmName]['category'])) {
-            return $dwConfig['realms'][$realmName]['category'];
-        }
-
-        return $realmName;
+        $realmObj = \Realm\Realm::factory($realmId);
+        return ( $realmObj->showInMetricCatalog() ? $realmObj->getCategory() : null );
     }
 } // class DataWarehouse

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -91,6 +91,10 @@ class Usage extends Common
 
                 $statsClass = $realm->getStatisticObject($userStatistic);
 
+                if ( ! $statsClass->showInMetricCatalog() ) {
+                    continue;
+                }
+
                 $statUsageChartSettings = $usageChartSettings;
 
                 if(!$statsClass->usesTimePeriodTablesForAggregate()){
@@ -275,6 +279,10 @@ class Usage extends Common
             } else {
                 foreach ($userStatistics as $userStatistic) {
                     $userStatisticObject = $realm->getStatisticObject($userStatistic);
+
+                    if ( ! $userStatisticObject->showInMetricCatalog() ) {
+                        continue;
+                    }
 
                     $statisticRequest = $this->request;
                     $statisticRequest['statistic'] = $userStatistic;

--- a/classes/Realm/Realm.php
+++ b/classes/Realm/Realm.php
@@ -78,6 +78,22 @@ class Realm extends \CCR\Loggable implements iRealm
     protected $disabled = false;
 
     /**
+     * @var boolean Set to false if this realm should not be shown to the user in the metric
+     * catalog.
+     */
+
+    protected $showInCatalog = true;
+
+    /**
+     * @var string A category that the realm will be placed into. This is used for grouping multiple
+     *   realms under a single category and was used for Value Analytics to present multiple realms
+     *   as a single entry in the user interface. If a category is not provided, the realm id is
+     *   used instead effectively placing each realm is in its own categoty.
+     */
+
+    protected $category = null;
+
+    /**
      * @var stdClass|null An associative array of group by configuration objects where the key is
      *   the short identifier and the value is a stdClass containing the configuration. These are
      *   used to create GroupBy objects on demand.
@@ -109,6 +125,7 @@ class Realm extends \CCR\Loggable implements iRealm
      */
 
     protected $statistics = array();
+
     /**
      * @var Configuration Parsed Configuration object for datawarehouse.json
      */
@@ -407,11 +424,12 @@ class Realm extends \CCR\Loggable implements iRealm
 
         $optionalConfigTypes = array(
             'aggregate_table_alias' => 'string',
-            'class' => 'string',
+            'category' => 'string',
             'disabled' => 'bool',
             'min_aggregation_unit' => 'string',
             'module' => 'string',
-            'order' => 'int'
+            'order' => 'int',
+            'show_in_catalog' => 'bool'
         );
 
         if ( ! \xd_utilities\verify_object_property_types($specification, $optionalConfigTypes, $messages, true) ) {
@@ -421,6 +439,7 @@ class Realm extends \CCR\Loggable implements iRealm
         }
 
         $this->id = $shortName;
+        $this->category = $shortName;
 
         foreach ( $specification as $key => $value ) {
             switch ($key) {
@@ -432,6 +451,9 @@ class Realm extends \CCR\Loggable implements iRealm
                     break;
                 case 'aggregate_table_alias':
                     $this->aggregateTableAlias = trim($value);
+                    break;
+                case 'category':
+                    $this->category = trim($value);
                     break;
                 case 'datasource':
                     $this->datasource = trim($value);
@@ -453,6 +475,9 @@ class Realm extends \CCR\Loggable implements iRealm
                     break;
                 case 'name':
                     $this->name = trim($value);
+                    break;
+                case 'show_in_catalog':
+                    $this->showInCatalog = filter_var($value, FILTER_VALIDATE_BOOLEAN);
                     break;
                 case 'statistics':
                     $this->statisticConfigs = $value;
@@ -705,6 +730,24 @@ class Realm extends \CCR\Loggable implements iRealm
     public function getMinimumAggregationUnit()
     {
         return $this->minAggregationUnit;
+    }
+
+    /**
+     * @see iRealm::showInMetricCatalog()
+     */
+
+    public function showInMetricCatalog()
+    {
+        return $this->showInCatalog;
+    }
+
+    /**
+     * @see iRealm::getCategory()
+     */
+
+    public function getCategory()
+    {
+        return $this->category;
     }
 
     /**

--- a/classes/Realm/Statistic.php
+++ b/classes/Realm/Statistic.php
@@ -83,12 +83,26 @@ class Statistic extends \CCR\Loggable implements iStatistic
     protected $disabled = false;
 
     /**
+     * @var boolean Set to false if this statistic should not be shown to the user in the metric
+     * catalog.
+     */
+
+    protected $showInCatalog = true;
+
+    /**
      * @var int PHP order specificaiton to determine how the query should sort results containing
      *   this Statistic.
      * @see http://php.net/manual/en/function.array-multisort.php
      */
 
     protected $sortOrder = SORT_DESC;
+
+    /**
+     * @var string The name of the weight statistic to use when normalizing data for this statistic.
+     *   This is typically used when calculating values such as standard error.
+     */
+
+    protected $weightStatisticId = 'weight_is_not_used';
 
     /**
      * @var array|null The definition of the additional where condition for this statistic. If not
@@ -175,8 +189,10 @@ class Statistic extends \CCR\Loggable implements iStatistic
             'module' => 'string',
             'order' => 'int',
             'precision' => 'int',
+            'show_in_catalog' => 'bool',
             'timeseries_formula' => 'string',
-            'use_timeseries_aggregate_tables' => 'bool'
+            'use_timeseries_aggregate_tables' => 'bool',
+            'weight_statistic_id' => 'string'
         );
 
         if ( ! \xd_utilities\verify_object_property_types($config, $optionalConfigTypes, $messages, true) ) {
@@ -227,6 +243,9 @@ class Statistic extends \CCR\Loggable implements iStatistic
                 case 'precision':
                     $this->precision = filter_var($value, FILTER_VALIDATE_INT);
                     break;
+                case 'show_in_catalog':
+                    $this->showInCatalog = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                    break;
                 case 'timeseries_formula':
                     $this->timeseriesFormula = trim($value);
                     break;
@@ -235,6 +254,9 @@ class Statistic extends \CCR\Loggable implements iStatistic
                     break;
                 case 'use_timeseries_aggregate_tables':
                     $this->useTimeseriesAggregateTables = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                    break;
+                case 'weight_statistic_id':
+                    $this->weightStatisticId = trim($value);
                     break;
                 default:
                     $this->logger->notice(
@@ -428,12 +450,21 @@ class Statistic extends \CCR\Loggable implements iStatistic
     }
 
     /**
-     * @see iStatistic::getWeightStatName()
+     * @see iStatistic::getWeightStatisticId()
      */
 
-    public function getWeightStatName()
+    public function getWeightStatisticId()
     {
-        return 'weight_is_not_used';
+        return $this->weightStatisticId;
+    }
+
+    /**
+     * @see iRealm::showInMetricCatalog()
+     */
+
+    public function showInMetricCatalog()
+    {
+        return $this->showInCatalog;
     }
 
     /**

--- a/classes/Realm/iRealm.php
+++ b/classes/Realm/iRealm.php
@@ -262,6 +262,21 @@ interface iRealm
     public function getMinimumAggregationUnit();
 
     /**
+     * @return boolean TRUE if this realm should be displayed in the metric catalog. In some cases,
+     *   a realm may be created to feed data to another component but not be intended to be directly
+     *   accessible via the user interface.
+     */
+
+    public function showInMetricCatalog();
+
+    /**
+     * @return string The category that this realm belongs to. If not set, the category will default
+     *   to the realm id.
+     */
+
+    public function getCategory();
+
+    /**
      * @return VariableStore The VariableStore object for this realm to support variable
      *   substitution in GroupBy and Statistics classes.
      */

--- a/classes/Realm/iStatistic.php
+++ b/classes/Realm/iStatistic.php
@@ -156,11 +156,23 @@ interface iStatistic
     public function usesTimePeriodTablesForAggregate();
 
     /**
-     * @return string The name of the weighting statistic. It is likely that this is not currently
+     * @return string The name of the weighting statistic for this statistic. This is typically used
+     *   when calculating values such as standard error but is likely that this is not currently
      *   used.
+     *
+     * Note: Was getWeightStatName()
      */
 
-    public function getWeightStatName();
+    public function getWeightStatisticId();
+
+    /**
+     * @return boolean TRUE if this statistic should be displayed in the metric catalog. In some cases,
+     *   a statistic may be created to feed data to another component but not be intended to be directly
+     *   accessible via the user interface. For example, the statistics that generate the data for
+     *   standard error markers in the user interface (Jobs_sem_avg_processors).
+     */
+
+    public function showInMetricCatalog();
 
     /**
      * Generate a string representation of the object

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -78,6 +78,11 @@ foreach ($roles as $activeRole) {
 
                     $statsObjects = $query_descripter->getStatisticsClasses($stats);
                     foreach ($statsObjects as $realm_group_by_statistic => $statistic_object) {
+
+                        if ( ! $statistic_object->showInMetricCatalog() ) {
+                            continue;
+                        }
+
                         $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
                             $query_descripter_realm,
                             $realm_group_by_statistic

--- a/html/controllers/user_interface/get_menus.php
+++ b/html/controllers/user_interface/get_menus.php
@@ -191,6 +191,11 @@ try {
 
                     foreach ($query_descripter->getPermittedStatistics() as $realm_group_by_statistic) {
                         $statistic_object = $query_descripter->getStatistic($realm_group_by_statistic);
+
+                        if ( ! $statistic_object->showInMetricCatalog() ) {
+                            continue;
+                        }
+
                         $statName = $statistic_object->getId();
                         $chartSettings = $query_descripter->getChartSettings();
                         if(!$statistic_object->usesTimePeriodTablesForAggregate()){

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/hidden-realm.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/hidden-realm.json
@@ -1,0 +1,22 @@
+{
+    "HiddenRealm": {
+        "name": "Do not show hidden realms in the metric catalog.",
+        "datasource": "Test Dataset",
+        "aggregate_schema": "sample_schema",
+        "aggregate_table_prefix": "sample_prefix",
+        "order": 3,
+        "show_in_catalog": false,
+        "group_bys": {
+        },
+        "statistics": {
+            "hidden_statistic": {
+                "#": "This statistic is not shown in the metric catalog",
+                "show_in_catalog": false,
+                "formula": "1",
+                "name": "1",
+                "description_html": "Hidden Statistic",
+                "unit": "Hidden"
+            }
+        }
+    }
+}

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/jobs.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/jobs.json
@@ -6,6 +6,7 @@
         "aggregate_schema": "modw_aggregates",
         "aggregate_table_prefix": "jobfact_by_",
         "aggregate_table_alias": "agg",
+        "category": "HPC Metrics",
         "order": 1,
         "group_bys": {
             "none": {

--- a/tests/unit/lib/Realm/RealmTest.php
+++ b/tests/unit/lib/Realm/RealmTest.php
@@ -56,13 +56,15 @@ class RealmTest extends \PHPUnit_Framework_TestCase
         $generated = Realm::getRealmNames(Realm::SORT_ON_ORDER);
         $expected = array(
             'Jobs' => 'Jobs',
-            'Cloud' => 'Cloud'
+            'Cloud' => 'Cloud',
+            'HiddenRealm' => 'Do not show hidden realms in the metric catalog.'
         );
         $this->assertEquals($expected, $generated, "Sort realm names on order");
 
         $generated = Realm::getRealmNames(Realm::SORT_ON_SHORT_ID);
         $expected = array(
             'Cloud' => 'Cloud',
+            'HiddenRealm' => 'Do not show hidden realms in the metric catalog.',
             'Jobs' => 'Jobs'
         );
         $this->assertEquals($expected, $generated, "Sort realm names on short id");
@@ -70,6 +72,7 @@ class RealmTest extends \PHPUnit_Framework_TestCase
         $generated = Realm::getRealmNames(Realm::SORT_ON_NAME);
         $expected = array(
             'Cloud' => 'Cloud',
+            'HiddenRealm' => 'Do not show hidden realms in the metric catalog.',
             'Jobs' => 'Jobs'
         );
         $this->assertEquals($expected, $generated, "Sort realm names on name");
@@ -225,5 +228,49 @@ class RealmTest extends \PHPUnit_Framework_TestCase
 
         $generated = $realm->getMinimumAggregationUnit();
         $this->assertNull($generated, "getMinimumAggregationUnit()");
+    }
+
+    /**
+     * (7) Test realm categories. The following cases are tested:
+     *   - A realm with a category defined
+     *   - A realm with no category defined (category defaults to realm id)
+     *   - A realm with show_in_catelog=false (category will be null)
+     */
+
+    public function testRealmCategories()
+    {
+        // Jobs realm has a category
+        $realmId = 'Jobs';
+        $category = \DataWarehouse::getCategoryForRealm($realmId);
+        $this->assertEquals('HPC Metrics', $category, sprintf("%s(): %s", __FUNCTION__, $realmId));
+
+        // Cloud realm has no category
+        $realmId = 'Cloud';
+        $category = \DataWarehouse::getCategoryForRealm($realmId);
+        $this->assertEquals($realmId, $category, sprintf("%s(): %s", __FUNCTION__, $realmId));
+
+        // HiddenRealm realm has show_in_catalog=false
+        $realmId = 'HiddenRealm';
+        $category = \DataWarehouse::getCategoryForRealm($realmId);
+        $this->assertNull($category, sprintf("%s(): %s", __FUNCTION__, $realmId));
+    }
+
+    /**
+     * (8) Test retrieval of the category list.
+     */
+
+    public function testRealmCategoryList()
+    {
+        $categoryList = \DataWarehouse::getCategories();
+        $expected = array(
+            'HPC Metrics' => array(
+                'Jobs'
+            ),
+            'Cloud' => array(
+                'Cloud'
+            )
+            // HiddenRealm will not be included
+        );
+        $this->assertEquals($expected, $categoryList, 'getCategories()');
     }
 }

--- a/tests/unit/lib/Realm/StatisticTest.php
+++ b/tests/unit/lib/Realm/StatisticTest.php
@@ -184,12 +184,21 @@ class StatisticTest extends \PHPUnit_Framework_TestCase
         $generated = $obj->getAdditionalWhereCondition();
         $this->assertNull($generated, "getAdditionalWhereCondition()");
 
-        $generated = $obj->getWeightStatName();
+        $generated = $obj->getWeightStatisticId();
         $expected = 'weight_is_not_used';
-        $this->assertEquals($expected, $generated, "getWeightStatName()");
+        $this->assertEquals($expected, $generated, "getWeightStatisticId()");
 
         $generated = $obj->usesTimePeriodTablesForAggregate();
         $this->assertTrue($generated, "usesTimePeriodTablesForAggregate()");
+
+        $generated = $obj->showInMetricCatalog();
+        $this->assertTrue($generated, "showInMetricCatalog() == true");
+
+        $realm = realm::factory('HiddenRealm', self::$logger);
+        $obj = $realm->getstatisticobject('hidden_statistic');
+
+        $generated = $obj->showInMetricCatalog();
+        $this->assertFalse($generated, "showInMetricCatalog() == false");
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Specifying `show_in_catalog: false` in Realm or Statistic configurations will hide these items from showing in the metric catalog. This allows for meta-statistics such as Standard Error Measurements (e.g., sem_avg_processors) to be hidden from the user but still available to XDMoD. Similarly, Realms such as Job Inefficiency can be created and available to XDMoD but hidden from direct access by a user. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
