### PR TITLE
Fix stragglers for getAlias and getLongNameColumnName

### DIFF
--- a/classes/DataWarehouse/Data/SimpleDataset.php
+++ b/classes/DataWarehouse/Data/SimpleDataset.php
@@ -339,7 +339,7 @@ class SimpleDataset
 
         foreach ($stats as $stat) {
             $stat_unit  = $stat->getUnit();
-            $stat_alias = $stat->getAlias();
+            $stat_alias = $stat->getId();
 
             $data_unit = '';
             if (substr( $stat_unit, -1 ) == '%') {
@@ -374,13 +374,13 @@ class SimpleDataset
             $record = array();
             foreach ($group_bys as $group_by) {
                 $record[$group_by->getId()]
-                    = $result[$group_by->getLongNameColumnName(true)];
+                    = $result[ sprintf('%s_name', $group_by->getId()) ];
             }
 
             $stats = $this->_query->getStats();
             foreach ($stats as $stat) {
-                $record[$stat->getAlias()]
-                    = $result[$stat->getAlias()];
+                $record[$stat->getId()]
+                    = $result[$stat->getId()];
             }
 
             $rows[] = $record;
@@ -442,7 +442,7 @@ class SimpleDataset
 
             foreach ($stats as $stat) {
                 $stat_unit = $stat->getUnit();
-                $stat_alias = $stat->getAlias();
+                $stat_alias = $stat->getId();
 
                 $data_unit = '';
                 if (substr( $stat_unit, -1 ) == '%') {
@@ -485,13 +485,13 @@ class SimpleDataset
                 $record = array();
                 foreach ($group_bys as $group_by) {
                     $record[$group_by->getId()]
-                        = $result[$group_by->getLongNameColumnName(true)];
+                        = $result[ sprintf('%s_name', $group_by->getId()) ];
                 }
 
                 $stats = $this->_query->getStats();
                 foreach ($stats as $stat) {
-                    $record[$stat->getAlias()]
-                        =  $result[$stat->getAlias()];
+                    $record[$stat->getId()]
+                        =  $result[$stat->getId()];
                 }
 
                 $records[] = $record;

--- a/classes/DataWarehouse/Query/TimeseriesQuery.php
+++ b/classes/DataWarehouse/Query/TimeseriesQuery.php
@@ -231,7 +231,7 @@ SQL;
             throw new \Exception('Timeseries: main_stat_field is null');
         }
 
-        $stat        = $this->_main_stat_field->getAlias();
+        $stat        = $this->_main_stat_field->getId();
         $stat_weight = $this->_main_stat_field->getWeightStatName();
 
         $sem_name = Realm::getStandardErrorStatisticFromStatistic(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix `getAlias()` and `getLongNameColumnName()` calls found during @plessbd testing that @smgallo missed.
- `$stat->getAlias()` -> `$stat->getId()`
- `$groupby->getLongNameColumnName()` -> `sprintf('%s_name', $group_by->getId())`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
