### PR TITLE
Ensure statistic ids are prefixed with realm id

### DIFF
--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -402,6 +402,11 @@ class MetricExplorer extends Common
 
         foreach ($jret as &$y) {
 
+            // Statistic ids are now prefixed with the realm id. Ensure this is the case when
+            // working with statistic names that were not queried from XDMoD, such as test data.
+
+            $y->metric = ( 0 !== strpos($y->metric, $y->realm) ? sprintf("%s_%s", $y->realm, $y->metric) : $y->metric );
+
             // Set values of new attribs for backward compatibility.
             if (!isset($y->line_type) || empty($y->line_type)) {
                 $y->line_type = 'Solid';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Statistic ids are now prefixed with the realm id. Ensure this is the case when working with statistic names that were not queried from XDMoD, such as test data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
