### PR TITLE
update error handling

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -2100,7 +2100,7 @@ function verifyConfigData()
             \Configuration\XdmodConfiguration::assocArrayFactory("$section.json", CONFIG_DIR);
             $log->info("[SUCCESS] $section loaded successfully.");
         } catch (Exception $e) {
-            $log->err("[FAIL] Unable to load section $section");
+            $log->err(sprintf('[FAIL] Unable to load section %s: %s', $section, $e->getMessage()));
             $invalid[] = $section;
         }
     }

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -2742,7 +2742,12 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
 
             baseParams: {
                 'operation': 'get_dw_descripter'
-            }
+            },
+            listeners: {
+                exception: function (proxy, type, action, exception, response) {
+                    CCR.xdmod.ui.presentFailureResponse(response);
+                }
+           }
 
         }); //dwDescriptionStore
 


### PR DESCRIPTION
* add error message to acl log on failed section load
* surface errors when get_dw_descriptor fails to load in metric explorer. 

Eventually these errors should be more user friendly but this is a step in the right direction