### PR TITLE
Groupby/fix getname getid

### DIFF
--- a/classes/DB/FilterListBuilder.php
+++ b/classes/DB/FilterListBuilder.php
@@ -363,7 +363,14 @@ class FilterListBuilder extends Loggable
             throw new TableNotFoundException("Could not find table $dimensionTable", 0, null, $dimensionTable);
         }
 
-        $columnDescriptionResults = $db->query("DESCRIBE {$dimensionTable} {$dimensionColumn}");
+        $sql = sprintf('DESCRIBE %s %s', $dimensionTable, $dimensionColumn);
+        try {
+            $columnDescriptionResults = $db->query($sql);
+        } catch (\PDOException $e) {
+            throw new \Exception(
+                sprintf("Error inspecting dimension column '%s': %s", $sql, $e->getMessage())
+            );
+        }
         if (empty($columnDescriptionResults)) {
             $realmName = $realmQuery->getRealmName();
             throw new Exception("Could not find column $dimensionColumn in table {$dimensionTable}. Realm: $realmName, Dimension: $dimensionId");

--- a/classes/DB/FilterListBuilder.php
+++ b/classes/DB/FilterListBuilder.php
@@ -356,7 +356,7 @@ class FilterListBuilder extends Loggable
         $dimensionQueryFields = $dimensionQuery->getSelectFields();
         $dimensionTableStringComponents = explode(' ', $dimensionQueryTables[1]);
         $dimensionTable = $dimensionTableStringComponents[0];
-        preg_match('/\.(\S+)\s/', $dimensionQueryFields['id'], $dimensionColumnMatches);
+        preg_match('/\.(\S+)\s/', $dimensionQueryFields[ sprintf('%s_id', $dimensionId) ], $dimensionColumnMatches);
         $dimensionColumn = $dimensionColumnMatches[1];
 
         if (!$helper->tableExists($dimensionTable)) {

--- a/classes/ETL/DbModel/Entity.php
+++ b/classes/ETL/DbModel/Entity.php
@@ -452,7 +452,7 @@ class Entity extends Loggable
             $this->properties[$property] = $this->filterAndVerifyValue($property, $value);
         } else {
             $this->logger->warning(
-                sprintf("%s: Attempt to set unsupported property: '%s'", get_class($this), $property)
+                sprintf("%s: Attempt to set unsupported property: '%s' with value '%s'", get_class($this), $property, print_r($value, true))
             );
         }
     }  // __set()

--- a/configuration/datawarehouse.d/ref/Jobs-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Jobs-group-bys.json
@@ -330,7 +330,7 @@
                 "rf.name"
             ],
             "records": {
-                "id": "CONCAT(rf.id, '^', rf.code)",
+                "id": "rf.id",
                 "name": "rf.code",
                 "order_id": "id",
                 "short_name": "rf.code"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix a bug where the filterlist was referencing the `id` column in query results but that value is now `sprintf('%s_id', $realmId)`
- Improve logging when an unsupported property is being used in the ETL query model
- Add `STATISTIC_ID` and `WEIGHT_STATISTIC_ID` to the list of variables available to in a statistic formula

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
