### PR TITLE
Extend JSON references to allow adding and/or overwriting of ke…

### DIFF
--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -732,6 +732,7 @@ class Configuration extends Loggable implements iConfiguration
     {
         $this->addKeyTransformer(new CommentTransformer($this->logger));
         $this->addKeyTransformer(new JsonReferenceTransformer($this->logger));
+        $this->addKeyTransformer(new JsonReferenceWithOverwriteTransformer($this->logger));
         $this->addKeyTransformer(new StripMergePrefixTransformer($this->logger));
         $this->addKeyTransformer(new IncludeTransformer($this->logger));
         return $this;

--- a/classes/Configuration/JsonReferenceWithOverwriteTransformer.php
+++ b/classes/Configuration/JsonReferenceWithOverwriteTransformer.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This transformer is a modification of the JsonReferenceTransformer to support cases where we want
+ * to be able to replace the reference with the JSON that it points to and at the same time
+ * overwrite or add to the referenced JSON supporting greater re-use of JSON configuraiton files.
+ * The original JsonReferenceTransformer was not modified because with these changes it would no
+ * longer conform to RFC-6901.
+ *
+ * Evaluate a JSON reference pointer (see https://tools.ietf.org/html/rfc6901) and allow specified
+ * keys in the referenced JSON to be overwritten (or added if they do not exist). The entire object
+ * containing the "$ref-with-overwrite" key is replaced with the thing that it points to with any
+ * overwrites applied.
+ *
+ * For example:
+ *
+ * {
+ *     "$ref-with-overwrite": "http://example.com/example.json#/foo/bar",
+ *     "$overwrite" : {
+ *         "key1": "new value"
+ *     }
+ * }
+ */
+
+namespace Configuration;
+
+// PEAR logger
+use Log;
+use stdClass;
+
+class JsonReferenceWithOverwriteTransformer extends JsonReferenceTransformer implements iConfigFileKeyTransformer
+{
+    const REFERENCE_KEY = '$ref-with-overwrite';
+
+    /**
+     * @see iConfigFileKeyTransformer::keyMatches()
+     */
+
+    public function keyMatches($key)
+    {
+        return (self::REFERENCE_KEY == $key);
+    }
+
+    /**
+     *  Transform the JSON pointer and then apply any overwrite directives.
+     *
+     * @see iConfigFileKeyTransformer::transform()
+     */
+
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config)
+    {
+        $overwriteKey = '$overwrite';
+        $overwriteDirectives = array();
+
+        // Need to look into the rest of the object here, do we have access to it?
+
+        if ( isset($obj->$overwriteKey) ) {
+            $overwriteDirectives = $obj->$overwriteKey;
+            // Remove the overwrite key from the object because the JsonReferenceTransformer will
+            // not allow it.
+            unset($obj->$overwriteKey);
+        } else {
+            // If the reference with overwrite was specified, it must contain the overwrite
+            // directive!
+            $this->logAndThrowException(sprintf("Expected '%s' directive not found", $overwriteKey));
+        }
+
+        $jsonRefUrl = $value;
+        parent::transform($key, $value, $obj, $config);
+
+        if ( ! is_object($value) ) {
+            $this->logger->warning(
+                sprintf("JSON reference '%s' does not generate object, got %s. Skipping.", $jsonRefUrl, gettype($value))
+            );
+        } else {
+            foreach ( $overwriteDirectives as $overwriteKey => $overwriteValue ) {
+                if ( ! isset($value->$overwriteKey) ) {
+                    $this->logger->debug(sprintf("Overwrite key '%s' not found in reference, adding.", $overwriteKey));
+                } else {
+                    $this->logger->debug(sprintf("Overwriting '%s' in reference.", $overwriteKey));
+                }
+                $value->$overwriteKey = $overwriteValue;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/artifacts/xdmod/etlv2/configuration/input/sample_config_with_json_overwrite_transformer_keys.json
+++ b/tests/artifacts/xdmod/etlv2/configuration/input/sample_config_with_json_overwrite_transformer_keys.json
@@ -1,0 +1,22 @@
+{
+    "reference": {
+        "$ref-with-overwrite": "file://${TMPDIR}/sample_config_with_variables.json#/key_one",
+        "$overwrite": {
+            "engine": "MyDatabaseEngine",
+            "MyAddedColumn": "Newly added column",
+            "columns": [
+                {
+                    "name": "resource",
+                    "type": "varchar(128)",
+                    "nullable": false
+                }
+            ]
+        }
+    },
+    "reference_to_array": {
+        "$ref-with-overwrite": "file://${TMPDIR}/sample_config_with_variables.json#/key_two",
+        "$overwrite": {
+            "MyAddedColumn": "Newly added column"
+        }
+    }
+}

--- a/tests/artifacts/xdmod/etlv2/configuration/input/sample_config_with_missing_json_overwrite_key.json
+++ b/tests/artifacts/xdmod/etlv2/configuration/input/sample_config_with_missing_json_overwrite_key.json
@@ -1,0 +1,5 @@
+{
+    "reference": {
+        "$ref-with-overwrite": "file://${TMPDIR}/sample_config_with_variables.json#/key_one"
+    }
+}

--- a/tests/artifacts/xdmod/etlv2/configuration/output/sample_config_with_json_overwrite_transformer_keys.expected
+++ b/tests/artifacts/xdmod/etlv2/configuration/output/sample_config_with_json_overwrite_transformer_keys.expected
@@ -1,0 +1,1 @@
+{"reference":{"name":"resource_allocations","engine":"MyDatabaseEngine","MyAddedColumn":"Newly added column","columns":[{"name":"resource","type":"varchar(128)","nullable":false}]},"reference_to_array":[{"object1":"value"},{"object2":"value"}]}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Often requested by @plessbd to improve JSON re-use, this feature has finally arrived! Extend JSON references to allow adding and/or overwriting of top-level keys in the referenced JSON. A new directive `$ref-with-overwrite` signals the `Configuration` class to resolve a JSON reference and look for a required `$overwrite` key specifying fields to overwrite or add in the referenced JSON.

For example, given the file `sample_config_with_variables.json`
```javascript
{
  "key_one": {
    "name": "mytable",
    "engine": "MyISAM",
    "columns": [
      {
        "name": "resource",
        "type": "varchar(40)",
        "nullable": true
      }
    ]
}
```
And a file that references it:
```javascript
{
    "reference": {
        "$ref-with-overwrite": "file:///tmp/sample_config_with_variables.json#/key_one",
        "$overwrite": {
            "engine": "MyDatabaseEngine",
            "comment": "Newly added field",
            "columns": [
                {
                    "name": "resource",
                    "type": "varchar(128)",
                    "nullable": false
                }
            ]
        }
    }
}
```

The resulting JSON will be:
```javascript
{
	"reference": {
	    "name": "mytable",
	    "engine": "MyDatabaseEngine",
		"comment": "Newly added field",
	    "columns": [
	      {
	        "name": "resource",
	        "type": "varchar(128)",
	        "nullable": false
	      }
	}
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed

Added tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
