### PR TITLE
Add convenience function for getting realm/statistic/groupby ids

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -191,8 +191,8 @@ function main()
 
         // Process the realms provided by this module, if any.
         foreach ( $realmObjects as $realmId => $realmObj ) {
-            $groupBys = array_keys($realmObj->getGroupByNames());
-            $statistics = array_keys($realmObj->getStatisticNames());
+            $groupBys = $realmObj->getGroupByIds();
+            $statistics = $realmObj->getStatisticIds();
             $results[$module]['realms'][$realmId] = array(
                 'display_name' => $realmObj->getName(),
                 'group_bys' => json_decode(json_encode($groupBys), true),

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -109,7 +109,7 @@ class Usage extends Common
                     $userStatistic
                 );
 
-                if (in_array($errorstat, array_keys($realm->getStatisticNames())) ) {
+                if (in_array($errorstat, $realm->getStatisticIds()) ) {
                     $statUsageChartSettings['enable_errors'] = 'y';
                 }
                 $statUsageChartSettings['statistic'] = $userStatistic;
@@ -648,7 +648,7 @@ class Usage extends Common
                     $meRequest['data_series_unencoded'][0]['metric']
                 );
 
-                if (in_array($errorstat, array_keys($realm->getStatisticNames())) ) {
+                if (in_array($errorstat, $realm->getStatisticIds()) ) {
                     $usageChartSettings['enable_errors'] = 'y';
                 }
 
@@ -1097,7 +1097,7 @@ class Usage extends Common
 
         $meFilters = array();
         $realm = Realm::factory($usageRealm);
-        $realmGroupByNames = array_values($realm->getGroupByNames());
+        $realmGroupByIds = $realm->getGroupByIds();
 
         // Extract the supported filter values from $usageRequest
         foreach ($usageRequest as $usageKey => $usageValue) {
@@ -1123,7 +1123,7 @@ class Usage extends Common
             }
 
             // handles '<dimension>' properties
-            if (in_array($usageKey, $realmGroupByNames)) {
+            if (in_array($usageKey, $realmGroupByIds)) {
                 $meFilters[] = array(
                     'id' => "$usageKey=$usageValue",
                     'value_id' => $usageValue,

--- a/classes/DataWarehouse/Query/Query.php
+++ b/classes/DataWarehouse/Query/Query.php
@@ -1316,7 +1316,7 @@ SQL;
 
     public function setStat($stat)
     {
-        $permitted_statistics = array_keys($this->realm->getStatisticNames());
+        $permitted_statistics = $this->realm->getStatisticIds();
 
         if ($stat == 'all') {
             $this->_main_stat_field = null;

--- a/classes/DataWarehouse/Query/TimeAggregationUnit.php
+++ b/classes/DataWarehouse/Query/TimeAggregationUnit.php
@@ -301,7 +301,7 @@ abstract class TimeAggregationUnit
             return null;
         }
 
-        $groupByIds = array_keys($realm->getGroupByNames());
+        $groupByIds = $realm->getGroupByIds();
         $minUnit = null;
         $minUnitDays = PHP_INT_MAX;
 

--- a/classes/Realm/Realm.php
+++ b/classes/Realm/Realm.php
@@ -182,6 +182,18 @@ class Realm extends \CCR\Loggable implements iRealm
     }
 
     /**
+     * @see iRealm::getRealmIds()
+     *
+     * Essentially, call array_keys() on the list of realm names to get the ids. This keeps the code
+     * in one place rather than littered throughout the codebase.
+     */
+
+    public static function getRealmIds($order = self::SORT_ON_ORDER, Logger $logger = null)
+    {
+        return array_keys(static::getRealmNames($order, $logger));
+    }
+
+    /**
      * @see iRealm::getRealmObjects()
      */
 
@@ -650,12 +662,36 @@ class Realm extends \CCR\Loggable implements iRealm
     }
 
     /**
+     * @see iRealm::getGroupByIds()
+     *
+     * Essentially, call array_keys() on the list of groupby names to get the ids. This keeps the
+     * code in one place rather than littered throughout the codebase.
+     */
+
+    public function getGroupByIds($order = self::SORT_ON_ORDER)
+    {
+        return array_keys($this->getGroupByNames($order));
+    }
+
+    /**
      * @see iRealm::getStatisticNames()
      */
 
     public function getStatisticNames($order = self::SORT_ON_ORDER)
     {
         return static::getSortedNameList($this->statisticConfigs, $order);
+    }
+
+    /**
+     * @see iRealm::getStatisticIds()
+     *
+     * Essentially, call array_keys() on the list of statistic names to get the ids. This keeps the
+     * code in one place rather than littered throughout the codebase.
+     */
+
+    public function getStatisticIds($order = self::SORT_ON_ORDER)
+    {
+        return array_keys($this->getStatisticNames($order));
     }
 
     /**

--- a/classes/Realm/iRealm.php
+++ b/classes/Realm/iRealm.php
@@ -69,6 +69,18 @@ interface iRealm
     public static function getRealmNames($order = self::SORT_ON_ORDER, Logger $logger = null);
 
     /**
+     * This is a convenience function to return only the list of realm ids.
+     *
+     * @param int $order A specification on how the realm list will be ordered. Possible values are:
+     *   SORT_ON_ORDER, SORT_ON_SHORT_ID, SORT_ON_NAME.
+     * @param Log|null $logger A Log instance that will be utilized during processing.
+     *
+     * @return array An array of realm ids, ordered as specified
+     */
+
+    public static function getRealmIds($order = self::SORT_ON_ORDER, Logger $logger = null);
+
+    /**
      * Return an associative array where the array keys are realm short identifier (id) and the values
      * are the Realm objects associated with that key.
      *
@@ -190,6 +202,18 @@ interface iRealm
     public function getGroupByNames($order = self::SORT_ON_ORDER);
 
     /**
+     * This is a convenience function to return only the list of groupby ids. Note that disabled
+     * groupby ids are not included.
+     *
+     * @param int $order A specification on how the list will be ordered. Possible values are:
+     *   SORT_ON_ORDER, SORT_ON_SHORT_ID, SORT_ON_NAME.
+     *
+     * @return array An array of the groupby ids available to this realm, ordered as specified.
+     */
+
+    public function getGroupByIds($order = self::SORT_ON_ORDER);
+
+    /**
      * Note that disabled Statistic names are not included.
      *
      * @param int $order A specification on how the list will be ordered. Possible values are:
@@ -200,6 +224,18 @@ interface iRealm
      */
 
     public function getStatisticNames($order = self::SORT_ON_ORDER);
+
+    /**
+     * This is a convenience function to return only the list of statistic ids. Note that disabled
+     * statistic ids are not included.
+     *
+     * @param int $order A specification on how the list will be ordered. Possible values are:
+     *   SORT_ON_ORDER, SORT_ON_SHORT_ID, SORT_ON_NAME.
+     *
+     * @return array An array of the statistic ids available to this realm, ordered as specified.
+     */
+
+    public function getStatisticIds($order = self::SORT_ON_ORDER);
 
     /**
      * Note that disabled GroupBy objects are not included.

--- a/classes/User/Elements/QueryDescripter.php
+++ b/classes/User/Elements/QueryDescripter.php
@@ -252,7 +252,7 @@ class QueryDescripter
 
     public function getPermittedStatistics()
     {
-        return array_keys($this->realm->getStatisticNames());
+        return $this->realm->getStatisticIds();
     }
 
     public function getStatistic($statistic_name)

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -65,7 +65,7 @@ foreach ($roles as $activeRole) {
 
                     $groupByName = $query_descripter->getGroupByName();
                     $group_by_object = $query_descripter->getGroupByInstance();
-                    $permittedStatistics = array_keys($group_by_object->getRealm()->getStatisticNames());
+                    $permittedStatistics = $group_by_object->getRealm()->getStatisticIds();
 
                     $groupByObjects[$query_descripter_realm . '_' . $groupByName] = array(
                         'object' => $group_by_object,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `getRealmIds()`, `getStatisticIds()`, `getGroupByIds()` methods rather than calling `array_keys()` on the associative array of names.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
