### PR TITLE
Force realm config load if using alternate config location

### DIFF
--- a/classes/Realm/Realm.php
+++ b/classes/Realm/Realm.php
@@ -162,7 +162,13 @@ class Realm extends \CCR\Loggable implements iRealm
         $filename = ( isset($options->config_file_name) ? $options->config_file_name : 'datawarehouse.json' );
         $configDir = ( isset($options->config_base_dir) ? $options->config_base_dir : CONFIG_DIR );
 
-        if ( null === self::$dataWarehouseConfig ) {
+        // When using a non-standard configuration file location we always re-load the configuration
+        // class. Otherwise, tests that reference different locations or artifacts will fail
+        // depending on the order that they are run in.
+
+        $nonStandardConfig = ( isset($options->config_file_name) || isset($options->config_base_dir) );
+
+        if ( null === self::$dataWarehouseConfig || $nonStandardConfig ) {
             self::$dataWarehouseConfig = Configuration::factory(
                 $filename,
                 $configDir,

--- a/tests/component/lib/Query/AggregateQueryTest.php
+++ b/tests/component/lib/Query/AggregateQueryTest.php
@@ -448,7 +448,7 @@ WHERE
   duration.id = agg.day_id
   AND agg.day_id between 201600357 and 201700001
   AND person.id = agg.person_id
-  AND person.id > (constraint)
+  AND person.id > ('constraint')
 GROUP BY person.id
 ORDER BY person.order_id ASC
 SQL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using a non-standard configuration file location we always re-load the configuration class. Otherwise, tests that reference different locations or artifacts will fail depending on the order that they are run in.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
