### PR TITLE
xdmod-update-resource-specs: fix resources file name

### DIFF
--- a/bin/xdmod-update-resource-specs
+++ b/bin/xdmod-update-resource-specs
@@ -161,7 +161,7 @@ function main()
         DIRECTORY_SEPARATOR,
         array(
             CONFIG_DIR,
-            'resource-specs.json'
+            'resource_specs.json'
         )
     );
 


### PR DESCRIPTION
## Description

The resource file name referenced in `xdmod-update-resource-specs` does not match the real file name.
The script references a `resource-specs.json` while the actual file name is `resource_specs.json` (underscore `_` vs. dash `-`).

## Motivation and Context
Running the current script results in the following error
```
# xdmod-update-resource-specs -r cluster --node-count 1000 --cpu-count 20000
PHP Warning:  file_get_contents(/etc/xdmod/resource-specs.json): failed to open stream: No such file or directory in /usr/share/xdmod/classes/CCR/Json.php on line 26
2019-10-02 09:33:17 [critical] Failed to read file '/etc/xdmod/resource-specs.json' (stacktrace: #0 /usr/bin/xdmod-update-resource-specs(168): CCR\Json::loadFile('/etc/xdmod/reso...')
#1 /usr/bin/xdmod-update-resource-specs(18): main()
#2 {main})
```

## Tests performed
With the change, the script doesn't fail and the resource file is updated correctly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
