### PR TITLE
Change GroupBy available_for_drilldown to show_in_catalog

### DIFF
--- a/classes/Realm/GroupBy.php
+++ b/classes/Realm/GroupBy.php
@@ -137,10 +137,11 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
     protected $category = 'uncategorized';
 
     /**
-     * @var boolean Indicates that this dimension is available for drill-down in the user interface.
+     * @var boolean Indicates that this dimension should be shown in the metric catalog and is
+     *   available for drill-down in the user interface.
      */
 
-    protected $isAvailableForDrilldown = true;
+    protected $showInCatalog = true;
 
     /**
      * @var boolean Indicates that this dimension is an aggregation unit such as day, month,
@@ -266,14 +267,14 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
             'attribute_description_query' => 'int',
             'attribute_filter_map_query' => 'object',
             'attribute_table_schema' => 'string',
-            'available_for_drilldown' => 'bool',
             'category' => 'string',
             'chart_options' => 'object',
             'data_sort_order' => 'string',
             'disabled' => 'bool',
             'is_aggregation_unit' => 'bool',
             'module' => 'string',
-            'order' => 'int'
+            'order' => 'int',
+            'show_in_catalog' => 'bool'
         );
 
         if ( ! \xd_utilities\verify_object_property_types($config, $optionalConfigTypes, $messages, true) ) {
@@ -312,8 +313,8 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
                 case 'attribute_description_query':
                     $this->attributeDescriptionSql = trim($value);
                     break;
-                case 'available_for_drilldown':
-                    $this->isAvailableForDrilldown = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                case 'show_in_catalog':
+                    $this->showInCatalog = filter_var($value, FILTER_VALIDATE_BOOLEAN);
                     break;
                 case 'category':
                     $this->category = trim($value);
@@ -610,12 +611,12 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
     }
 
     /**
-     * @see iGroupBy::isAvailableForDrilldown()
+     * @see iGroupBy::showInMetricCatalog()
      */
 
-    public function isAvailableForDrilldown()
+    public function showInMetricCatalog()
     {
-        return $this->isAvailableForDrilldown;
+        return $this->showInCatalog;
     }
 
     /**

--- a/classes/Realm/Realm.php
+++ b/classes/Realm/Realm.php
@@ -833,7 +833,7 @@ class Realm extends \CCR\Loggable implements iRealm
         foreach ( $groupByObjects as $gId => $groupByObj ) {
             // Don't include the current group by or any group bys that are not available for drill
             // down.
-            if ( $gId == $groupById || ! $groupByObj->isAvailableForDrilldown() ) {
+            if ( $gId == $groupById || ! $groupByObj->showInMetricCatalog() ) {
                 continue;
             }
             $drillTargets[] = sprintf('%s-%s', $gId, $groupByObj->getName());

--- a/classes/Realm/iGroupBy.php
+++ b/classes/Realm/iGroupBy.php
@@ -122,11 +122,11 @@ interface iGroupBy
     public function getSortOrder();
 
     /**
-     * @return boolean TRUE if the attribute represented by this GroupBy should be available as a
-     *   drill-down for a statistic in the user interface.
+     * @return boolean TRUE if the attribute represented by this GroupBy should be available in the
+     *   metric catalog and as a drill-down for a statistic in the user interface.
      */
 
-    public function isAvailableForDrilldown();
+    public function showInMetricCatalog();
 
     /**
      * @return boolean TRUE if the attribute represented by this GroupBy is an aggregation unit such

--- a/configuration/datawarehouse.d/ref/group-by-none.json
+++ b/configuration/datawarehouse.d/ref/group-by-none.json
@@ -3,7 +3,7 @@
     "description_html": "Summarizes ${REALM_NAME} data reported to the ${ORGANIZATION_NAME} database.",
     "attribute_table_schema": "modw",
     "attribute_table": "dual",
-    "available_for_drilldown": false,
+    "show_in_catalog": false,
     "is_aggregation_unit": true,
     "attribute_to_aggregate_table_key_map": [],
     "order": 1,

--- a/configuration/datawarehouse.d/ref/group-by-time-period.json
+++ b/configuration/datawarehouse.d/ref/group-by-time-period.json
@@ -4,7 +4,7 @@
         "description_html": "Day",
         "attribute_table_schema": "modw",
         "attribute_table": "days",
-        "available_for_drilldown": false,
+        "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
             {
@@ -36,7 +36,7 @@
         "description_html": "Month",
         "attribute_table_schema": "modw",
         "attribute_table": "months",
-        "available_for_drilldown": false,
+        "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
             {
@@ -68,7 +68,7 @@
         "description_html": "Quarter",
         "attribute_table_schema": "modw",
         "attribute_table": "quarters",
-        "available_for_drilldown": false,
+        "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
             {
@@ -100,7 +100,7 @@
         "description_html": "Year",
         "attribute_table_schema": "modw",
         "attribute_table": "years",
-        "available_for_drilldown": false,
+        "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
             {

--- a/tests/unit/lib/Realm/GroupByTest.php
+++ b/tests/unit/lib/Realm/GroupByTest.php
@@ -217,8 +217,8 @@ class GroupByTest extends \PHPUnit_Framework_TestCase
         $expected = SORT_DESC;
         $this->assertEquals($expected, $generated, 'getSortOrder()');
 
-        $generated = $obj->isAvailableForDrilldown();
-        $this->assertTrue($generated, 'isAvailableForDrilldown()');
+        $generated = $obj->showInMetricCatalog();
+        $this->assertTrue($generated, 'showInMetricCatalog()');
 
         $generated = $obj->getAttributeValuesQuery()->getSql();
         $expected =<<<SQL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change `available_for_drilldown` in the group by configuration to `show_in_catalog` to be consistent with Realms and Statistics.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
