### PR TITLE
Fix bug in job viewer save search when multiple realms available

### DIFF
--- a/html/gui/js/modules/job_viewer/SearchPanel.js
+++ b/html/gui/js/modules/job_viewer/SearchPanel.js
@@ -1463,8 +1463,7 @@ XDMoD.Module.JobViewer.SearchPanel = Ext.extend(Ext.Panel, {
             results: selected
         };
 
-        var realmField = Ext.getCmp('realm-field');
-        var realm = realmField ? realmField.getValue() : null;
+        var realm = params.searchterms.params.realm;
         var idFragment = id !== undefined ? '/' + id : '';
         var url = XDMoD.REST.url + '/' + self.jobViewer.rest.warehouse + '/search/history' + idFragment  + '?realm=' + realm + '&token=' + XDMoD.REST.token;
 


### PR DESCRIPTION
Fix bug in job viewer search dialog where the realm for the search was hardcoded to the dialog box setting for the advanced search dialog. This meant that basic search would fail to load correct data if the realm setting in the advanced search dialog was different from the basic search setting (when the search was originally run). Also the advanced search would also be wrong if you changed the realm value after running the search.

Tests for this scenario have been added to the xdmod-supremm module in PR: https://github.com/ubccr/xdmod-supremm/pull/196.