### PR TITLE
Fixing issue found by @plessbd in User Management

### DIFF
--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -804,11 +804,6 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
             }
         };
 
-        self.resetDirtyState = function () {
-            resetUserSettings();
-            roleGrid.setDirtyState(false);
-        };
-
         /**
          * Reset the start / original values for the User Settings fields for
          * accurate change tracking.
@@ -829,6 +824,11 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                     }
                 }
             }
+        };
+
+        self.resetDirtyState = function () {
+            resetUserSettings();
+            roleGrid.setDirtyState(false);
         };
 
         // ------------------------------------------

--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -805,7 +805,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
         };
 
         self.resetDirtyState = function () {
-            revertUserSettings();
+            resetUserSettings();
             roleGrid.setDirtyState(false);
         };
 
@@ -982,7 +982,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
                         }
 
                         self.resetDirtyState();
-                        resetUserSettings();
+                        revertUserSettings();
 
                         updateSaveIndicator();
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a problem when updating a user's Person which caused the Person's name
disappear after saving the change. This was caused by `resetUserSettings` &
`revertUserSettings` being called in reverse order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
