### PR TITLE
Ensure summary controller only displays preset charts for realm…

### DIFF
--- a/html/controllers/ui_data/summary3.php
+++ b/html/controllers/ui_data/summary3.php
@@ -47,8 +47,8 @@ try {
             }
         }
     }
-
-    if (in_array('Jobs', \Models\Services\Realms::getEnabledRealms())) {
+    $enabledRealms = \Models\Services\Realms::getEnabledRealms();
+    if (in_array('Jobs', $enabledRealms)) {
         $query_descripter = new \User\Elements\QueryDescripter('Jobs', 'none');
 
         $query = new \DataWarehouse\Query\Jobs\Aggregate($aggregation_unit, $start_date, $end_date, 'none', 'all', $query_descripter->pullQueryParameters($raw_parameters));
@@ -82,20 +82,16 @@ try {
         $mostPrivilegedAclSummaryCharts = $roles[$mostPrivilegedAclName]['summary_charts'];
     }
 
-    $summaryCharts = array_map(
-        function ($chart) {
-            if (!isset($chart['preset'])) {
-                $chart['preset'] = true;
-            }
-            return json_encode($chart);
-        },
-        $mostPrivilegedAclSummaryCharts
-    );
+    $summaryCharts = array();
+    foreach ($mostPrivilegedAclSummaryCharts as $chart)
+    {
+        $realm = $chart['data_series']['data'][0]['realm'];
+        if (!in_array($realm, $enabledRealms)) {
+            continue;
+        }
+        $chart['preset'] = true;
 
-    foreach ($summaryCharts as $i => $summaryChart) {
-        $summaryChartObject = json_decode($summaryChart);
-        $summaryChartObject->preset = true;
-        $summaryCharts[$i] = json_encode($summaryChartObject);
+        $summaryCharts[] = json_encode($chart);
     }
 
     if (!isset($_REQUEST['public_user']) || $_REQUEST['public_user'] != 'true')


### PR DESCRIPTION
… are enabled

The cloud and jobs realms have charts defined to be displayed in the summary tab. These definitions are always installed, however the charts should only be loaded if the corresponding realm is defined.

Note that this code change does not handle the case where there are charts with multiple datasets for different realms. This scenario does not occur with the default build and would only be seen if an admin had customised the charts to include cloud data (unlikely).