### PR TITLE
Ensure resource[fact|types] table is pre-populated.

### DIFF
--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -240,6 +240,7 @@ function main()
     if ($ingest) {
         $logger->info('Ingesting data');
         try {
+            $dwi->initializeIngestion();
 
             // If no ingestion phase is specified, ingest all.
             if (!$ingestShredded && !$ingestStaging && !$ingestHpcdb && !$datatype){

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -115,7 +115,7 @@ class DataWarehouseInitializer
      */
     public function initializeIngestion()
     {
-        Utilities::runEtlPipeline(array('jobs-common', 'ingest-organizations', 'ingest-resource-types', 'ingest-resources'), $this->logger);
+        Utilities::runEtlPipeline(array('ingest-organizations', 'ingest-resource-types', 'ingest-resources'), $this->logger);
     }
 
     /**

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -111,6 +111,14 @@ class DataWarehouseInitializer
     }
 
     /**
+     * Ran any prerequisite pipelines before ingestion.
+     */
+    public function initializeIngestion()
+    {
+        Utilities::runEtlPipeline(array('jobs-common', 'ingest-organizations', 'ingest-resource-types', 'ingest-resources'), $this->logger);
+    }
+
+    /**
      * Ingest all data needed for the data warehouse.
      *
      * @param string $startDate
@@ -148,7 +156,7 @@ class DataWarehouseInitializer
         }
 
         $this->logger->debug('Ingesting shredded data to staging tables');
-        Utilities::runEtlPipeline(array('staging-ingest-common', 'staging-ingest-jobs', 'ingest-resource-types'), $this->logger);
+        Utilities::runEtlPipeline(array('staging-ingest-common', 'staging-ingest-jobs'), $this->logger);
     }
 
     /**

--- a/configuration/etl/etl.d/staging.json
+++ b/configuration/etl/etl.d/staging.json
@@ -96,6 +96,17 @@
             }
         },
         {
+            "name": "ResourceTypesStagingUnknown",
+            "description": "Populates the resource types table w/ the Unknown resource",
+            "namespace": "ETL\\Maintenance",
+            "truncate_destination": false,
+            "class": "ExecuteSql",
+            "options_class": "MaintenanceOptions",
+            "sql_file_list": [
+                "cloud_openstack/unknown_resource_type.sql"
+            ]
+        },
+        {
             "name": "resource-config",
             "description": "Ingest resource configuration file",
             "definition_file": "common/staging/resource-config.json",

--- a/configuration/etl/etl_sql.d/cloud_openstack/unknown_resource_type.sql
+++ b/configuration/etl/etl_sql.d/cloud_openstack/unknown_resource_type.sql
@@ -1,2 +1,3 @@
-INSERT INTO ${DESTINATION_SCHEMA}.`staging_resource_type` (resource_type_id, resource_type_description, resource_type_abbrev)
-VALUES (-1, 'Unknown Resource Type', 'UNK');
+SET SESSION sql_mode='NO_AUTO_VALUE_ON_ZERO';
+INSERT IGNORE INTO ${DESTINATION_SCHEMA}.`staging_resource_type` (resource_type_id, resource_type_description, resource_type_abbrev)
+VALUES ('0', 'Unknown Resource Type', 'UNK');


### PR DESCRIPTION
The `isRealmEnabled()` function is used by the ingestor to determine
which realms should be shredded / ingested. Unfortunately this function
relies on the resourcefact and resource_types tables to be populated and
returns no realms enabled if these tables are empty.
These tables are populated by the ingestor only if there are realms enabled otherwise
they will be empty.
Needless to say this is quite a conundrum. For those interested in the
idea of self-reference, I highly recommend the book Gödel, Escher, Bach:
an Eternal Golden Braid by Douglas Hofstadter.

This bug was not seen in the CI builds because the cloud realm is
hard-coded to run an action that populates the resource* tables outside
of the ingestor code.

This change also reverts the (now unneeded) change to the pipeline run
on the ingestAllStaging path made as part of #1006.

This change also adds an IGNORE to the code that adds the UNK row to the
resource_types table and reverts the change of id to -1 from the original 0. This is because we have
not determined the consequences of a change to the id and are choosing a conservative
approach.