### PR TITLE
Ensure resourcetypes table is populated correctly.

### DIFF
--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -148,7 +148,7 @@ class DataWarehouseInitializer
         }
 
         $this->logger->debug('Ingesting shredded data to staging tables');
-        Utilities::runEtlPipeline(array('staging-ingest-common', 'staging-ingest-jobs', 'ingest-resource-types'), $this->logger);
+        Utilities::runEtlPipeline(array('staging-ingest-common', 'staging-ingest-jobs'), $this->logger);
     }
 
     /**

--- a/configuration/etl/etl.d/staging.json
+++ b/configuration/etl/etl.d/staging.json
@@ -99,7 +99,6 @@
             "name": "ResourceTypesStagingUnknown",
             "description": "Populates the resource types table w/ the Unknown resource",
             "namespace": "ETL\\Maintenance",
-            "truncate_destination": false,
             "class": "ExecuteSql",
             "options_class": "MaintenanceOptions",
             "sql_file_list": [

--- a/configuration/etl/etl.d/staging.json
+++ b/configuration/etl/etl.d/staging.json
@@ -96,6 +96,17 @@
             }
         },
         {
+            "name": "ResourceTypesStagingUnknown",
+            "description": "Populates the resource types table w/ the Unknown resource",
+            "namespace": "ETL\\Maintenance",
+            "truncate_destination": false,
+            "class": "ExecuteSql",
+            "options_class": "MaintenanceOptions",
+            "sql_file_list": [
+                "cloud_openstack/unknown_resource_type.sql"
+            ]
+        },
+        {
             "name": "resource-config",
             "description": "Ingest resource configuration file",
             "definition_file": "common/staging/resource-config.json",

--- a/configuration/etl/etl_sql.d/cloud_openstack/unknown_resource_type.sql
+++ b/configuration/etl/etl_sql.d/cloud_openstack/unknown_resource_type.sql
@@ -1,2 +1,3 @@
-INSERT INTO ${DESTINATION_SCHEMA}.`staging_resource_type` (resource_type_id, resource_type_description, resource_type_abbrev)
-VALUES (-1, 'Unknown Resource Type', 'UNK');
+SET SESSION sql_mode='NO_AUTO_VALUE_ON_ZERO';
+INSERT IGNORE INTO ${DESTINATION_SCHEMA}.`staging_resource_type` (resource_type_id, resource_type_description, resource_type_abbrev)
+VALUES ('0', 'Unknown Resource Type', 'UNK');

--- a/tests/ci/validate.sh
+++ b/tests/ci/validate.sh
@@ -20,4 +20,12 @@ do
     fi
 done
 
+# Check that the unknown resource is in the database with key 0
+unkrescount=$(echo 'SELECT COUNT(*) from resourcetype WHERE id = 0 and abbrev = '"'"'UNK'"'" | mysql -N modw)
+if [ $unkrescount -ne 1 ];
+then
+    echo "Missing / inconsistent 'UNK' row in modw.resourcetype"
+    exitcode=1
+fi
+
 exit $exitcode


### PR DESCRIPTION
- Revert the change to the primary key value for the 'UNK' resource
  type. This is now the same value (0) as previous s/w versions.
- Ensure the 'UNK' resource is added to the various resource type tables
  in the jobs_staging pipeline.
- Revert the addition of the ingest-resource-types pipeline when
  shredding jobs. This was added in #1006 possibly as a work around for
  the fact that the staging pipeline had not been modfied appropriately.
- Add a test to make sure this does not happen again.

