### PR TITLE
Propogate errors in acl-config subprocess run

### DIFF
--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -275,7 +275,11 @@ function main()
                 }
             }
 
-            passthru('acl-config');
+            $aclstatus = 0;
+            passthru('acl-config', $aclstatus);
+            if ($aclstatus !== 0) {
+                exit($aclstatus);
+            }
         } catch (Exception $e) {
             $logger->crit(array(
                 'message'    => 'Ingestion failed: ' . $e->getMessage(),


### PR DESCRIPTION
## Description
The `xdmod-ingestor` command runs `acl-config` as part of the processing. The return value of the command was not being checked so the follow on processing in the ingestor would still run even if `acl-config` failed. This has the potential to cause database corruption (of course the database is probably corrupt if acl-config fails, but this at least has a `--recover` flag).