### PR TITLE
Fixing a bug found by sonarcloud and general code cleanup

### DIFF
--- a/tests/integration/lib/Controllers/ControllerTest.php
+++ b/tests/integration/lib/Controllers/ControllerTest.php
@@ -582,7 +582,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     protected function compareUsers($expectedUsers, $actualUsers)
     {
         $allFound = true;
-        foreach ($expectedUsers as $key => $expectedUser) {
+        foreach ($expectedUsers as $expectedUser) {
             $entryExists = $this->entryExists(
                 $actualUsers,
                 /**


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
## Description
- line 342: The code fragment `. "\n"` was meant to be *inside* the
  `file_put_contents` parenthesis.
- Removed the unused function `arrayRecursiveDiff`
- Refactored duplicated code in `testListUsers` and `testEnumExistingUsers` into
  a new function `compareUsers`.
- Added documentation to the `entryExists` function.

## Motivation and Context
While fixing the bug that SonarCloud found I noticed it had flagged sections of code in the same file as being duplicates, and while refactoring the duplicate code out into a new function I found that the `arrayRecursiveDiff` function was no longer used. 

## Tests performed
All automated tests for an upgrade / fresh_install

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code Cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
