### PR TITLE
Store warehouse export retention value as string

### DIFF
--- a/classes/DataWarehouse/Export/QueryHandler.php
+++ b/classes/DataWarehouse/Export/QueryHandler.php
@@ -153,6 +153,13 @@ class QueryHandler
         // read export retention duration from config file. Value is stored in days.
         $expires_in_days = \xd_utilities\getConfiguration('data_warehouse_export', 'retention_duration_days');
 
+        if (!is_numeric($expires_in_days)) {
+            throw new Exception(sprintf(
+                'Configuration "data_warehouse_export" "retention_duration_days" value "%s" is not numeric',
+                $expires_in_days
+            ));
+        }
+
         $sql = "UPDATE batch_export_requests
                 SET export_created_datetime = NOW(),
                     export_expires_datetime = DATE_ADD(NOW(), INTERVAL :expires_in_days DAY),

--- a/configuration/portal_settings.ini
+++ b/configuration/portal_settings.ini
@@ -156,6 +156,6 @@ sacct = "sacct"
 ; Exported data files will be stored in this directory.
 export_directory = "/var/spool/xdmod/export"
 ; Length of time in days that files will be retained before automatic deletion.
-retention_duration_days = 30
+retention_duration_days = "30"
 ; Salt used during deidentification.
 hash_salt = ""

--- a/templates/portal_settings.template
+++ b/templates/portal_settings.template
@@ -156,6 +156,6 @@ sacct = "[:slurm_sacct:]"
 ; Exported data files will be stored in this directory.
 export_directory = "[:data_warehouse_export_export_directory:]"
 ; Length of time in days that files will be retained before automatic deletion.
-retention_duration_days = [:data_warehouse_export_retention_duration_days:]
+retention_duration_days = "[:data_warehouse_export_retention_duration_days:]"
 ; Salt used during deidentification.
 hash_salt = "[:data_warehouse_export_hash_salt:]"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes `portal_settings.ini` and corresponding template to store data warehouse export retention configuration as a string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `\Xdmod\Template` class requires all configuration values to be strings.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
