### PR TITLE
Workaround inconsistent return types in XDMoDConfiguration factory

### DIFF
--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -467,13 +467,20 @@ class DataWarehouseInitializer
             return $this->enabledRealms;
         }
 
-        $resources = XdmodConfiguration::assocArrayFactory('resources.json', CONFIG_DIR);
+        $resources = XdmodConfiguration::factory('resources.json', CONFIG_DIR)->toStdClass();
         $resourceTypes = XdmodConfiguration::assocArrayFactory('resource_types.json', CONFIG_DIR)['resource_types'];
+
+        // If there is only one entry in the json array in the config file then
+        // the XdmodConfiguration returns the entry. If there are multiple
+        // entries then it returns an array containing the entries.
+        if (!is_array($resources)) {
+            $resources = array($resources);
+        }
 
         $currentResourceTypes = array();
         foreach($resources as $resource) {
-            if (isset($resource['resource_type'])) {
-                $currentResourceTypes[] = $resource['resource_type'];
+            if (isset($resource->resource_type)) {
+                $currentResourceTypes[] = $resource->resource_type;
             }
         }
         $currentResourceTypes = array_unique($currentResourceTypes);


### PR DESCRIPTION
The new configuration API has an odd feature where if the parsed data
has a top level json array and there is one entry in the array then the
entry is returned, If there are multiple entries in the array then an
array is returned. This requires the developer to handle the one and
many cases seperately.

This change adds the one- and many- handling code. I hope that in
future we can remove this and change the confguration API to be
consistent. See https://app.asana.com/0/342819846538629/1146629814310601
