### PR TITLE
Fix configuration settings for configuration class.

### DIFF
--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -467,7 +467,7 @@ class DataWarehouseInitializer
             return $this->enabledRealms;
         }
 
-        $resources = XdmodConfiguration::assocArrayFactory('resources.json', CONFIG_DIR);
+        $resources = XdmodConfiguration::assocArrayFactory('resources.json', CONFIG_DIR, null, array('force_array_return' => true));
         $resourceTypes = XdmodConfiguration::assocArrayFactory('resource_types.json', CONFIG_DIR)['resource_types'];
 
         $currentResourceTypes = array();


### PR DESCRIPTION
The new configuration API has an odd feature where the default settings
have this behavior:
if the parsed data has a top level json array and there is one entry in the array then the
entry is returned, If there are multiple entries in the array then an
array is returned. This requires the developer to handle the one and
many cases separately.

This lead to a bug because the code assumed that the data was always being returned in 
an array. This change sets the configuration class parameter `force_array_return`
so that the resource information is always returned in an array data structure.

This API design seems bug prone since the defaults settings are almost always not what you want. See  issue for follow up:  https://app.asana.com/0/342819846538629/1146629814310601
