### PR TITLE
Proposed Fix for the underlying json config parsing problems

### DIFF
--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -170,14 +170,6 @@ class Configuration extends Loggable implements iConfiguration
     protected $initialized = false;
 
     /**
-     * Will force the results of `parse` to be an array.
-     *
-     * @var boolean
-     */
-
-    protected $forceArrayReturn = false;
-
-    /**
      * @var string The late static binding name of this class (e.g., the class that was
      * instantiated)
      */
@@ -512,10 +504,6 @@ class Configuration extends Loggable implements iConfiguration
             }
         }
 
-        if ( isset($options['force_array_return']) ) {
-            $this->forceArrayReturn = $options['force_array_return'];
-        }
-
         // Set the last modified time of the global config file. Note that PHP caches stat
         // information on a per-filename basis and we want the most recent data so the cache is
         // cleared.
@@ -689,30 +677,15 @@ class Configuration extends Loggable implements iConfiguration
         $options = new DataEndpointOptions(array(
             'name' => "Configuration",
             'path' => $this->filename,
-            'type' => "jsonfile"
+            'type' => "jsonconfigfile"
         ));
 
         $jsonFile = DataEndpoint::factory($options, $this->logger);
 
         $parsed = $jsonFile->parse();
 
-        /* We currently support json files that have an object or an array as the root element.
-         * If the root element is an object then $parsed will contain the first element in the
-         * object ( missing both of these if cases ). If it's an array, then the `elseif` will hit
-         * and we use the `getRecordList` to retrieve all of the data parsed from the file as
-         * opposed to just the first record in the element.
-         *
-         * If there is a problem parsing the file then `false` will be returned. To allow for the
-         * the rest of this class to work we supply an empty object.
-         */
         if ($parsed === false) {
             $parsed = new stdClass();
-        } elseif(count($jsonFile) > 1) {
-            $parsed = $jsonFile->getRecordList();
-        }
-
-        if ($this->forceArrayReturn && !is_array($parsed)) {
-            $parsed = array($parsed);
         }
 
         $this->parsedConfig = $parsed;

--- a/classes/ETL/DataEndpoint/JsonConfigFile.php
+++ b/classes/ETL/DataEndpoint/JsonConfigFile.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * JSON config file data endpoint. Supports reading a valid json file.
+ */
+
+namespace ETL\DataEndpoint;
+
+class JsonConfigFile extends JsonFile
+{
+    /**
+     * @const string Defines the name for this endpoint that should be used in configuration files.
+     * It also allows us to implement auto-discovery.
+     */
+
+    const ENDPOINT_NAME = 'jsonconfigfile';
+
+    /**
+     * A configuration file contain a single json object that can contain
+     * arbirtrary structure. THis is completely unlike the type of Json
+     * file that is parsed by the JsonFile class. The JsonFile class is
+     * designed for parsing structured record-based data in json format.
+     */
+    protected function decodeRecord($data)
+    {
+        $decoded = @json_decode($data);
+
+        if ( null === $decoded ) {
+            $this->logAndThrowException(
+                sprintf(
+                    "Error decoding JSON from file '%s': %s\n%s",
+                    $this->path,
+                    $this->jsonLastErrorMsg(json_last_error()),
+                    $data
+                )
+            );
+        }
+
+        $this->recordList = array($decoded);
+
+        return true;
+    }
+
+
+    /**
+     * No discovery of record field names is performed since there is no
+     * concept of multiple records in a configuration file.
+     */
+
+    protected function discoverRecordFieldNames()
+    {
+        return;
+    }
+
+    /**
+     * This is a simple passthrough since there is no concept of records
+     * or record fields in a configuration file.
+     */
+
+    protected function createReturnRecord($record)
+    {
+        return $record;
+    }
+}

--- a/classes/ETL/DataEndpoint/JsonFile.php
+++ b/classes/ETL/DataEndpoint/JsonFile.php
@@ -298,7 +298,7 @@ class JsonFile extends aStructuredFile implements iStructuredFile, iComplexDataR
      * @return A human-readable error message
      */
 
-    private function jsonLastErrorMsg($errorCode)
+    protected function jsonLastErrorMsg($errorCode)
     {
         $message = "";
 

--- a/classes/OpenXdmod/Shredder.php
+++ b/classes/OpenXdmod/Shredder.php
@@ -1019,10 +1019,7 @@ class Shredder
         $resources = XdmodConfiguration::assocArrayFactory(
             'resources.json',
             CONFIG_DIR,
-            $this->logger,
-            array(
-                'force_array_return' => true
-            )
+            $this->logger
         );
 
         foreach ($resources as $resource) {

--- a/tests/artifacts/xdmod/configuration/input/to_assoc_array.json
+++ b/tests/artifacts/xdmod/configuration/input/to_assoc_array.json
@@ -2,26 +2,8 @@
   [
     {
       "base_file": "single_resource",
-      "options": {
-        "force_array_return": true
-      },
-      "expected": "single_resource_force_array_return"
-    }
-  ],
-  [
-    {
-      "base_file": "single_resource",
       "options": [],
       "expected": "single_resource"
-    }
-  ],
-  [
-    {
-      "base_file": "resources",
-      "options": {
-        "force_array_return": true
-      },
-      "expected": "resources"
     }
   ],
   [

--- a/tests/artifacts/xdmod/configuration/output/single_resource.json
+++ b/tests/artifacts/xdmod/configuration/output/single_resource.json
@@ -1,5 +1,7 @@
-{
-  "resource": "frearson",
-  "resource_type_id": 1,
-  "name": "Frearson"
-}
+[
+  {
+    "resource": "frearson",
+    "resource_type_id": 1,
+    "name": "Frearson"
+  }
+]

--- a/tests/artifacts/xdmod/configuration/output/single_resource_force_array_return.json
+++ b/tests/artifacts/xdmod/configuration/output/single_resource_force_array_return.json
@@ -1,7 +1,0 @@
-[
-  {
-    "resource": "frearson",
-    "resource_type_id": 1,
-    "name": "Frearson"
-  }
-]


### PR DESCRIPTION
## Description
The `XDMoDConfiguration` class has problems parsing some of the xdmod configuration files. There have been a couple of attempts to workaround the problem notably f989888b0 and 7c497ac4c
but both of these did not fix the underlying design problem. 

The underlying problem is that the `JsonFile.php` parser is designed to be used
to parse structured record-based json data. It includes support for parsing hybid json-like files
that contain multiple json blobs and it has code that validates the files based on a very
limited set of allowable content structure. The XDMoD configuration files are not record-based
json, they do not contain multiple json blobs and they do not conform to the content structure
that the JsonFile class is designed to handle.

My proposed solution is to stop using the record-based parser for the config data.

This change also backs out the now unneeded workarounds and updates the test artifacts appropriately.