### PR TITLE
Make shippable failure logging better

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -31,7 +31,7 @@ build:
         - ./tests/ui/runtests.sh --headless --log-junit `pwd`/shippable/testresults --sso
         - ./vendor/phpunit/phpunit/phpunit -c ./tests/integration/phpunit.xml.dist --testsuite sso --log-junit `pwd`/shippable/testresults/xdmod-sso-integration.xml
         - mv ./configuration/portal_settings.ini.old ./configuration/portal_settings.ini
-        - if [ -s /var/log/xdmod/apache-error.log ]; then cat /var/log/xdmod/apache-error.log; false; fi
+        - [ ! -s /var/log/xdmod/apache-error.log ]
     on_failure:
         - cat /var/log/xdmod/apache-error.log
         - cat /var/log/xdmod/exceptions.log

--- a/shippable.yml
+++ b/shippable.yml
@@ -31,7 +31,7 @@ build:
         - ./tests/ui/runtests.sh --headless --log-junit `pwd`/shippable/testresults --sso
         - ./vendor/phpunit/phpunit/phpunit -c ./tests/integration/phpunit.xml.dist --testsuite sso --log-junit `pwd`/shippable/testresults/xdmod-sso-integration.xml
         - mv ./configuration/portal_settings.ini.old ./configuration/portal_settings.ini
-        - [ ! -s /var/log/xdmod/apache-error.log ]
+        - test ! -s /var/log/xdmod/apache-error.log
     on_failure:
         - cat /var/log/xdmod/apache-error.log
         - cat /var/log/xdmod/exceptions.log

--- a/shippable.yml
+++ b/shippable.yml
@@ -33,6 +33,7 @@ build:
         - mv ./configuration/portal_settings.ini.old ./configuration/portal_settings.ini
         - if [ -s /var/log/xdmod/apache-error.log ]; then cat /var/log/xdmod/apache-error.log; false; fi
     on_failure:
+        - cat /var/log/xdmod/apache-error.log
         - cat /var/log/xdmod/exceptions.log
         - cat /var/log/xdmod/query.log
         - cat /var/log/xdmod/apache-access.log

--- a/shippable.yml
+++ b/shippable.yml
@@ -33,7 +33,9 @@ build:
         - mv ./configuration/portal_settings.ini.old ./configuration/portal_settings.ini
         - if [ -s /var/log/xdmod/apache-error.log ]; then cat /var/log/xdmod/apache-error.log; false; fi
     on_failure:
-        - cat /var/log/xdmod/*
+        - cat /var/log/xdmod/exceptions.log
+        - cat /var/log/xdmod/query.log
+        - cat /var/log/xdmod/apache-access.log
 integrations:
   notifications:
     - integrationName: slack-notification-xdmod


### PR DESCRIPTION
on failures the logs sometimes get truncated this prioritizes the logs that get output so that we can hopefully get better logging.