### PR TITLE
WIP: Fix edge case when Realm gets removed

### DIFF
--- a/html/gui/js/modules/DataExport.js
+++ b/html/gui/js/modules/DataExport.js
@@ -358,7 +358,11 @@ XDMoD.Module.DataExport.RequestsGrid = Ext.extend(Ext.grid.GridPanel, {
                     dataIndex: 'realm_id',
                     scope: this,
                     renderer: function (value) {
-                        return this.realmsStore.getById(value).get('name');
+                        var realmById = this.realmsStore.getById(value);
+                        if(realmById){
+                                return realmById.get('name');
+                        }
+                        return 'Unsupported Realm';
                     }
                 },
                 {


### PR DESCRIPTION
There is an edge case that prevents the data warehouse export from working when a realm has been removed.

this resolves that only by putting that the realm is invalid as the name.

the ability to resubmit the request will fail as the realm is invalid, deleting the request will work as will downloading the file if it is currently available.