### PR TITLE
Improvements validation of untrusted input.

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -503,7 +503,7 @@ EML;
         $pdo = DB::factory('database');
 
         $userCheck = $pdo->query("
-         SELECT username, password, email_address, first_name, middle_name, last_name,
+         SELECT id, username, password, email_address, first_name, middle_name, last_name,
          time_created, time_last_updated, password_last_updated, account_is_active, organization_id, person_id, field_of_science, token, user_type, sticky
          FROM Users
          WHERE id=:id
@@ -523,7 +523,7 @@ EML;
             $user->_update_token = false;
         }
 
-        $user->_id = $uid;
+        $user->_id = $userCheck[0]['id'];
 
         $user->_account_is_active = ($userCheck[0]['account_is_active'] == '1');
 

--- a/html/controllers/metric_explorer/get_rawdata.php
+++ b/html/controllers/metric_explorer/get_rawdata.php
@@ -135,14 +135,10 @@ try {
         // DEFINE: that we're going to be sending back json.
         header('Content-type: application/json');
 
-        $limit = isset($_REQUEST['limit']) ? $_REQUEST['limit'] : null;
-        $offset = isset($_REQUEST['start']) ? $_REQUEST['start'] : null;
+        $filterOpts = array('options' => array('default' => null, 'min_range' => 0));
 
-        $hasLimit = isset($limit);
-        $hasOffset = isset($offset);
-
-        $limitIsValid = $hasLimit && ctype_digit($limit);
-        $offsetIsValid = $hasOffset && ctype_digit($offset);
+        $limit = filter_input(INPUT_POST, 'limit', FILTER_VALIDATE_INT, $filterOpts);
+        $offset = filter_input(INPUT_POST, 'start', FILTER_VALIDATE_INT, $filterOpts);
 
         $totalCount  = $dataset->getTotalPossibleCount();
 
@@ -168,19 +164,7 @@ try {
             $ret['totalAvailable'] = $privdataset->getTotalPossibleCount();
         }
 
-        // BUILD: the results to be returned
-        $results = array();
-        if ($limitIsValid && $offsetIsValid) {
-            foreach ($dataset->getResults($limit, $offset) as $res) {
-                array_push($results, $res);
-            }
-        } else {
-            foreach ($dataset->getResults() as $res) {
-                array_push($results, $res);
-            }
-        }
-
-        $ret['data'] = $results;
+        $ret['data'] = $dataset->getResults($limit, $offset);
         $ret['totalCount'] = $totalCount;
 
         print json_encode($ret);

--- a/html/internal_dashboard/controllers/pseudo_login.php
+++ b/html/internal_dashboard/controllers/pseudo_login.php
@@ -27,7 +27,7 @@ function getAbsoluteURL()
       $user = XDUser::getUserById($user_to_login_as);
 
       if (!XDUser::isAuthenticated($user)) {
-         print "Unknown user id $user_to_login_as";
+         print "Unknown user id specified in the REQUEST['uid'] parameter";
          exit;
       }
 

--- a/html/password_reset.php
+++ b/html/password_reset.php
@@ -11,20 +11,16 @@
 	$page_title = xd_utilities\getConfiguration('general', 'title');
 	$site_address = xd_utilities\getConfigurationUrlBase('general', 'site_address');
 
-$params = array(
-    'rid' => RESTRICTION_RID
-);
+$rid = filter_input(INPUT_GET, 'rid', FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => RESTRICTION_RID)));
 
-$isValid = xd_security\secureCheck($params, 'GET');
-
-if (!$isValid) {
+if ($rid === false) {
     $validationCheck = array(
         'status' => INVALID,
         'user_first_name' => 'INVALID',
         'user_id' => INVALID
     );
 } else {
-    $validationCheck = XDUser::validateRID($_GET['rid']);
+    $validationCheck = XDUser::validateRID($rid);
 }
 
 
@@ -114,7 +110,7 @@ if (!$isValid) {
       <![endif]-->
 
       <script language="JavaScript">
-         var reset_id = '<?php print $_GET['rid']; ?>';
+         var reset_id = <?php print json_encode($rid); ?>;
       </script>
       
       <script type="text/javascript" src="gui/js/PasswordReset.js"></script>

--- a/tests/integration/lib/Controllers/MetricExplorerTest.php
+++ b/tests/integration/lib/Controllers/MetricExplorerTest.php
@@ -112,7 +112,7 @@ class MetricExplorerTest extends BaseTest
         $this->assertEquals(401, $response[1]['http_code']);
     }
 
-    function rawDataProvider()
+    public function rawDataProvider()
     {
         $params = array (
             'show_title' => 'y',

--- a/tests/integration/lib/Controllers/MetricExplorerTest.php
+++ b/tests/integration/lib/Controllers/MetricExplorerTest.php
@@ -160,7 +160,7 @@ class MetricExplorerTest extends BaseTest
                     'total' => 0,
                 ),
                 'z_index' => 0,
-                'visibility' => NULL,
+                'visibility' => null,
                 'enabled' => true,
                 'metric' => 'job_count',
                 'realm' => 'Jobs',

--- a/tests/integration/lib/Controllers/MetricExplorerTest.php
+++ b/tests/integration/lib/Controllers/MetricExplorerTest.php
@@ -112,6 +112,133 @@ class MetricExplorerTest extends BaseTest
         $this->assertEquals(401, $response[1]['http_code']);
     }
 
+    function rawDataProvider()
+    {
+        $params = array (
+            'show_title' => 'y',
+            'timeseries' => 'y',
+            'aggregation_unit' => 'Auto',
+            'start_date' => '2016-12-28',
+            'end_date' => '2017-01-01',
+            'global_filters' => array(
+                'data' => array(
+                    array(
+                        'checked' => true,
+                        'value_id' => '110',
+                        'dimension_id' => 'person'
+                    ),
+                 ),
+            ),
+            'title' => 'untitled query 1',
+            'show_filters' => 'true',
+            'show_warnings' => 'true',
+            'show_remainder' => 'false',
+            'start' => '0',
+            'limit' => '20',
+            'timeframe_label' => 'User Defined',
+            'operation' => 'get_rawdata',
+            'data_series' => array (
+                array(
+                'group_by' => 'person',
+                'color' => 'auto',
+                'log_scale' => false,
+                'std_err' => false,
+                'value_labels' => false,
+                'display_type' => 'line',
+                'combine_type' => 'side',
+                'sort_type' => 'value_desc',
+                'ignore_global' => false,
+                'long_legend' => true,
+                'x_axis' => false,
+                'has_std_err' => false,
+                'trend_line' => false,
+                'line_type' => 'Solid',
+                'line_width' => 2,
+                'shadow' => false,
+                'filters' => array (
+                    'data' => array (),
+                    'total' => 0,
+                ),
+                'z_index' => 0,
+                'visibility' => NULL,
+                'enabled' => true,
+                'metric' => 'job_count',
+                'realm' => 'Jobs',
+                'category' => 'Jobs',
+                'id' => 0.41070416068466,
+                ),
+            ),
+            'swap_xy' => 'false',
+            'share_y_axis' => 'false',
+            'hide_tooltip' => 'false',
+            'show_guide_lines' => 'y',
+            'showContextMenu' => 'y',
+            'scale' => '1',
+            'format' => 'jsonstore',
+            'width' => '1884',
+            'height' => '700',
+            'legend_type' => 'bottom_center',
+            'font_size' => '3',
+            'featured' => 'false',
+            'trendLineEnabled' => '',
+            'controller_module' => 'metric_explorer',
+            'inline' => 'n',
+            'datapoint' => '1483056000000',
+            'datasetId' => '0.41070416068466'
+        );
+
+        $params['global_filters'] = urlencode(json_encode($params['global_filters']));
+        $params['data_series'] = urlencode(json_encode($params['data_series']));
+
+        $tests = array();
+
+        $tests[] = array($params, 20, true);
+
+        $params['limit'] = '1000\'; DROP TABLE Users;';
+        $tests[] = array($params, 712, true);
+
+        unset($params['limit']);
+        $tests[] = array($params, 712, true);
+
+        $params['start'] = 40;
+        $params['limit'] = 40;
+        $tests[] = array($params, 40, false);
+
+        $params['start'] = -10;
+        $params['limit'] = -1;
+        $tests[] = array($params, 712, true);
+
+        unset($params['start']);
+        $params['limit'] = 10;
+        $tests[] = array($params, 712, true);
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider rawDataProvider
+     */
+    public function testGetRawData($params, $limit, $shouldHaveTotalAvail)
+    {
+        // Jobs realm specific test
+        if (!in_array("jobs", self::$XDMOD_REALMS)) {
+            $this->markTestSkipped('Needs realm integration.');
+        }
+
+        $this->helper->authenticate('cd');
+
+        $response = $this->helper->post('/controllers/metric_explorer.php', null, $params);
+
+        $this->assertArrayHasKey('data', $response[0]);
+        $this->assertCount($limit, $response[0]['data']);
+
+        if ($shouldHaveTotalAvail) {
+            $this->assertArrayHasKey('totalAvailable', $response[0]);
+        } else {
+            $this->assertArrayNotHasKey('totalAvailable', $response[0]);
+        }
+    }
+
     /**
      * @dataProvider chartDataProvider
      */


### PR DESCRIPTION

This pull request has several small updates to improve handling of untrusted user supplied data. Since these are all fixes for the same class of problem I have put them into the same pull request but kept the individual changes as separate commits.

1. Improve input validation for get_rawdata endpoint.

   The get_rawdata metric explorer endpoint had some rather  obfuscuted code that checked for valid   data in the start and    limit variables. This code was difficult to understand and    it also triggered false positives in the code analysis software.
    There was also a minor inconsistency if the start parameter    was missing from the request. The row data were returned    as if the start parameter was 0 but the totalAvailable metric    was not returned.
    This update changes the code to use the standard php filter    API to ensure sanitized input and now has consistent behavior    for the totalAvailable metric.
    
    Also added tests.

1. Suppress output of known-invalid untrusted user data in pseudo login. This code appears to be here for debug purposes.

1. Update the password reset page to validate the reset identifier
    
    Ensure the validated reset identifier is passed back to the browser
    rather than the unmodified user-supplied version.

1. Ensure user id is correctly validated.
    
    Update the XDUser class to use the known valid id from the database
    rather than a user-controlled value.


