### PR TITLE
Add truncate_destination directive back to openstack staging event action that was erroneously removed

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_openstack.json
+++ b/configuration/etl/etl.d/jobs_cloud_openstack.json
@@ -74,8 +74,7 @@
                             "record_type",
                             "size",
                             "created_at",
-                            "volume_id",
-                            "service_provider"
+                            "volume_id"
                         ],
                         "filters": [{
                           "#": "Open Stack records do not contain a record_type field so we determine it by looking at the",
@@ -83,7 +82,7 @@
                           "type": "external",
                           "name": "jq",
                           "path": "jq",
-                          "arguments" :"-c '.[] | .[\"record_type\"] += if .[\"event_type\"] == \"compute.instance.exists\" then \"ADMINISTRATIVE\" else \"ACCOUNTING\" end | .[\"service_provider\"] += \"${SERVICE_PROVIDER}\"'"
+                          "arguments" :"-c '.[] | .[\"record_type\"] += if .[\"event_type\"] == \"compute.instance.exists\" then \"ADMINISTRATIVE\" else \"ACCOUNTING\" end"
                         }]
                     }
                 }

--- a/configuration/etl/etl.d/jobs_cloud_openstack.json
+++ b/configuration/etl/etl.d/jobs_cloud_openstack.json
@@ -74,7 +74,8 @@
                             "record_type",
                             "size",
                             "created_at",
-                            "volume_id"
+                            "volume_id",
+                            "service_provider"
                         ],
                         "filters": [{
                           "#": "Open Stack records do not contain a record_type field so we determine it by looking at the",
@@ -82,7 +83,7 @@
                           "type": "external",
                           "name": "jq",
                           "path": "jq",
-                          "arguments" :"-c '.[] | .[\"record_type\"] += if .[\"event_type\"] == \"compute.instance.exists\" then \"ADMINISTRATIVE\" else \"ACCOUNTING\" end'"
+                          "arguments" :"-c '.[] | .[\"record_type\"] += if .[\"event_type\"] == \"compute.instance.exists\" then \"ADMINISTRATIVE\" else \"ACCOUNTING\" end | .[\"service_provider\"] += \"${SERVICE_PROVIDER}\"'"
                         }]
                     }
                 }
@@ -304,6 +305,7 @@
             "description": "OpenStack staging data for cloud events",
             "class": "DatabaseIngestor",
             "definition_file": "cloud_openstack/staging_event.json",
+            "truncate_destination": true,
             "endpoints": {
               "utility": {
                 "type": "mysql",

--- a/configuration/etl/etl.d/jobs_cloud_openstack.json
+++ b/configuration/etl/etl.d/jobs_cloud_openstack.json
@@ -82,7 +82,7 @@
                           "type": "external",
                           "name": "jq",
                           "path": "jq",
-                          "arguments" :"-c '.[] | .[\"record_type\"] += if .[\"event_type\"] == \"compute.instance.exists\" then \"ADMINISTRATIVE\" else \"ACCOUNTING\" end"
+                          "arguments" :"-c '.[] | .[\"record_type\"] += if .[\"event_type\"] == \"compute.instance.exists\" then \"ADMINISTRATIVE\" else \"ACCOUNTING\" end'"
                         }]
                     }
                 }


### PR DESCRIPTION
It seems that the truncate_destination directive for the openstack staging table was erroneously removed in #797. This adds it back in.

## Tests performed
Ran automated tests in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
