### PR TITLE
Update GroupByDomain display value to not include resource

### DIFF
--- a/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByDomain.php
+++ b/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByDomain.php
@@ -84,30 +84,21 @@ class GroupByDomain extends GroupBy
      */
     public function applyTo(Query &$query, Table $dataTable, $multiGroup = false)
     {
-        $resourceTable = new Table(new Schema('modw'), 'resourcefact', 'rf');
-        $resourceFactIdField = new TableField($resourceTable, 'id');
-        $resourceFactNameField = new TableField($resourceTable, 'name');
-
         $query->addTable($this->table);
-        $query->addTable($resourceTable);
 
         $domainIdField = new TableField($this->table, $this->_id_field_name, $this->getColumnName('id', $multiGroup));
         $domainNameField = new TableField($this->table, $this->_long_name_field_name, $this->getColumnName('name', $multiGroup));
-        $resourceIdField = new TableField($this->table, 'resource_id', $this->getColumnName('resource_id', $multiGroup));
 
         $query->addField($domainIdField);
-        $query->addField(new FormulaField("CONCAT({$domainNameField->getQualifiedName()}, ' - ', {$resourceFactNameField->getQualifiedName()})", $this->getColumnName('name', $multiGroup)));
+        $query->addField(new TableField($this->table, $this->_long_name_field_name, $this->getColumnName('name', $multiGroup)));
         $query->addField(new TableField($this->table, $this->_short_name_field_name, $this->getColumnName('short_name', $multiGroup)));
         $query->addField(new TableField($this->table, $this->_id_field_name, $this->getColumnName('order_id', $multiGroup)));
 
-        $query->addGroup($domainIdField);
+        $query->addGroup($domainNameField);
 
         $fkField = new TableField($dataTable, 'domain_id');
-        $resourceFkField = new TableField($dataTable, 'host_resource_id');
 
         $query->addWhereCondition(new WhereCondition($domainIdField, '=', $fkField));
-        $query->addWhereCondition(new WhereCondition($resourceIdField, '=', $resourceFkField));
-        $query->addWhereCondition(new WhereCondition($resourceFactIdField, '=', $resourceFkField));
 
         $this->addOrder($query);
     }

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Cores Reserved Weighted By Wall Hours"
-"Default - OpenStack",1.4297
+Default,1.4297
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Cores Reserved Weighted By Wall Hours"
-"Default - OpenStack",1.4297
+Default,1.4297
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Cores Reserved Weighted By Wall Hours"
-"Default - OpenStack",1.4297
+Default,1.4297
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Cores Reserved Weighted By Wall Hours"
-"Default - OpenStack",1.4297
+Default,1.4297
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Average Cores Reserved Weighted By Wall Hours"
+Day,"[Default] Average Cores Reserved Weighted By Wall Hours"
 2018-04-18,1.3753
 2018-04-19,1.1291
 2018-04-20,1.3285

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Average Cores Reserved Weighted By Wall Hours"
+Month,"[Default] Average Cores Reserved Weighted By Wall Hours"
 2018-04,1.4297
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Average Cores Reserved Weighted By Wall Hours"
+Quarter,"[Default] Average Cores Reserved Weighted By Wall Hours"
 "2018 Q2",1.4297
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_cores_reserved/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Average Cores Reserved Weighted By Wall Hours"
+Year,"[Default] Average Cores Reserved Weighted By Wall Hours"
 2018,1.4297
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Memory Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",5389444295.8833
+Default,5389444295.8833
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Memory Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",5389444295.8833
+Default,5389444295.8833
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Memory Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",5389444295.8833
+Default,5389444295.8833
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Memory Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",5389444295.8833
+Default,5389444295.8833
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Average Memory Reserved Weighted By Wall Hours (Bytes)"
+Day,"[Default] Average Memory Reserved Weighted By Wall Hours (Bytes)"
 2018-04-18,5825397016.2531
 2018-04-19,4270382534.7701
 2018-04-20,4294967296.0000

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Average Memory Reserved Weighted By Wall Hours (Bytes)"
+Month,"[Default] Average Memory Reserved Weighted By Wall Hours (Bytes)"
 2018-04,5389444295.8833
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Average Memory Reserved Weighted By Wall Hours (Bytes)"
+Quarter,"[Default] Average Memory Reserved Weighted By Wall Hours (Bytes)"
 "2018 Q2",5389444295.8833
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_memory_reserved/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Average Memory Reserved Weighted By Wall Hours (Bytes)"
+Year,"[Default] Average Memory Reserved Weighted By Wall Hours (Bytes)"
 2018,5389444295.8833
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",21474836480.0000
+Default,21474836480.0000
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",21474836480.0000
+Default,21474836480.0000
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",21474836480.0000
+Default,21474836480.0000
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
-"Default - OpenStack",21474836480.0000
+Default,21474836480.0000
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
+Day,"[Default] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
 2018-04-18,21474836480.0000
 2018-04-19,21474836480.0000
 2018-04-20,21474836480.0000

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
+Month,"[Default] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
 2018-04,21474836480.0000
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
+Quarter,"[Default] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
 "2018 Q2",21474836480.0000
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_rv_storage_reserved/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
+Year,"[Default] Average Root Volume Storage Reserved Weighted By Wall Hours (Bytes)"
 2018,21474836480.0000
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Wall Hours per Session"
-"Default - OpenStack",23.14954403
+Default,23.14954403
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Wall Hours per Session"
-"Default - OpenStack",23.14954403
+Default,23.14954403
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Wall Hours per Session"
-"Default - OpenStack",23.14954403
+Default,23.14954403
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Average Wall Hours per Session"
-"Default - OpenStack",23.14954403
+Default,23.14954403
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Average Wall Hours per Session"
+Day,"[Default] Average Wall Hours per Session"
 2018-04-18,1.72284091
 2018-04-19,4.89306667
 2018-04-20,6.64260101

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Average Wall Hours per Session"
+Month,"[Default] Average Wall Hours per Session"
 2018-04,23.14954403
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Average Wall Hours per Session"
+Quarter,"[Default] Average Wall Hours per Session"
 "2018 Q2",23.14954403
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_avg_wallduration_hours/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Average Wall Hours per Session"
+Year,"[Default] Average Wall Hours per Session"
 2018,23.14954403
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Core Hours: Total"
-"Default - OpenStack",1754.1644
+Default,1754.1644
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Core Hours: Total"
-"Default - OpenStack",1754.1644
+Default,1754.1644
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Core Hours: Total"
-"Default - OpenStack",1754.1644
+Default,1754.1644
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Core Hours: Total"
-"Default - OpenStack",1754.1644
+Default,1754.1644
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Core Hours: Total"
+Day,"[Default] Core Hours: Total"
 2018-04-18,52.1283
 2018-04-19,138.1206
 2018-04-20,97.0686

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Core Hours: Total"
+Month,"[Default] Core Hours: Total"
 2018-04,1754.1644
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Core Hours: Total"
+Quarter,"[Default] Core Hours: Total"
 "2018 Q2",1754.1644
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Core Hours: Total"
+Year,"[Default] Core Hours: Total"
 2018,1754.1644
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Ended"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Ended"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Ended"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Ended"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Number of Sessions Ended"
+Day,"[Default] Number of Sessions Ended"
 2018-04-18,15
 2018-04-19,23
 2018-04-20,7

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Number of Sessions Ended"
+Month,"[Default] Number of Sessions Ended"
 2018-04,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Number of Sessions Ended"
+Quarter,"[Default] Number of Sessions Ended"
 "2018 Q2",53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_ended/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Number of Sessions Ended"
+Year,"[Default] Number of Sessions Ended"
 2018,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Active Sessions (Number of Sessions)"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Active Sessions (Number of Sessions)"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Active Sessions (Number of Sessions)"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Active Sessions (Number of Sessions)"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Number of Active Sessions (Number of Sessions)"
+Day,"[Default] Number of Active Sessions (Number of Sessions)"
 2018-04-18,22
 2018-04-19,25
 2018-04-20,11

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Number of Active Sessions (Number of Sessions)"
+Month,"[Default] Number of Active Sessions (Number of Sessions)"
 2018-04,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Number of Active Sessions (Number of Sessions)"
+Quarter,"[Default] Number of Active Sessions (Number of Sessions)"
 "2018 Q2",53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_running/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Number of Active Sessions (Number of Sessions)"
+Year,"[Default] Number of Active Sessions (Number of Sessions)"
 2018,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Started"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Started"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Started"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Number of Sessions Started"
-"Default - OpenStack",53
+Default,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Number of Sessions Started"
+Day,"[Default] Number of Sessions Started"
 2018-04-18,22
 2018-04-19,18
 2018-04-20,9

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Number of Sessions Started"
+Month,"[Default] Number of Sessions Started"
 2018-04,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Number of Sessions Started"
+Quarter,"[Default] Number of Sessions Started"
 "2018 Q2",53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_num_sessions_started/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Number of Sessions Started"
+Year,"[Default] Number of Sessions Started"
 2018,53
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Day-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Wall Hours: Total"
-"Default - OpenStack",1226.9258
+Default,1226.9258
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Month-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Wall Hours: Total"
-"Default - OpenStack",1226.9258
+Default,1226.9258
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Quarter-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Wall Hours: Total"
-"Default - OpenStack",1226.9258
+Default,1226.9258
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/aggregate-Year-reference.csv
@@ -6,5 +6,5 @@ start,end
 2018-04-18,2018-04-30
 ---------
 Domain,"Wall Hours: Total"
-"Default - OpenStack",1226.9258
+Default,1226.9258
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Day-reference.csv
@@ -5,7 +5,7 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default - OpenStack] Wall Hours: Total"
+Day,"[Default] Wall Hours: Total"
 2018-04-18,37.9025
 2018-04-19,122.3267
 2018-04-20,73.0686

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Month-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default - OpenStack] Wall Hours: Total"
+Month,"[Default] Wall Hours: Total"
 2018-04,1226.9258
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Quarter-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default - OpenStack] Wall Hours: Total"
+Quarter,"[Default] Wall Hours: Total"
 "2018 Q2",1226.9258
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_wall_time/timeseries-Year-reference.csv
@@ -5,6 +5,6 @@ parameters
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default - OpenStack] Wall Hours: Total"
+Year,"[Default] Wall Hours: Total"
 2018,1226.9258
 ---------


### PR DESCRIPTION
- Updated `GroupByDomain` to function the way `GroupByQueue` does i.e. it will
  not display the associated resource and will instead just show the domain
  name.
- Since the `GroupByDomain` display value has changed, the `cloud/domain/`
  regression test artifacts needed to be updated.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
