### PR TITLE
Adding coalesce statement for users that are not found in system account table

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_openstack/event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/event.json
@@ -14,7 +14,7 @@
             "record_type_id": "staging.record_type_id",
             "host_id": "staging.host_id",
             "person_id": "staging.person_id",
-            "systemaccount_id": "sa.id",
+            "systemaccount_id": "COALESCE(sa.id, -1)",
             "domain_id": "COALESCE(staging.domain_id, 1)",
             "#": "The default value of '3' corresponds to the 'OpenStack API' modw.submission_venue record.",
             "submission_venue_id": "COALESCE(dsv.submission_venue_id, 3)"
@@ -30,7 +30,7 @@
                 "schema": "${UTILITY_SCHEMA}",
                 "name": "systemaccount",
                 "alias": "sa",
-                "type": "INNER",
+                "type": "LEFT",
                 "on": "staging.person_id = sa.person_id AND staging.resource_id = sa.resource_id"
             },
             {

--- a/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
+++ b/configuration/etl/etl_action_defs.d/cloud_openstack/staging_event.json
@@ -17,7 +17,7 @@
             "event_type_id": "COALESCE(etype.event_type_id, -1)",
             "record_type_id": "COALESCE(rtype.record_type_id, -1)",
             "user_name": "raw.user_name",
-            "person_id": "sa.person_id",
+            "person_id": "COALESCE(sa.person_id, -1)",
             "account_id": "COALESCE(acct.account_id, 1)",
             "host_id": "COALESCE(h.host_id, 1)",
             "instance_id": "COALESCE(i.instance_id, 1)",
@@ -85,6 +85,7 @@
                 "name": "systemaccount",
                 "schema": "${UTILITY_SCHEMA}",
                 "alias": "sa",
+                "type": "LEFT",
                 "on": "raw.user_name = sa.username AND raw.resource_id = sa.resource_id"
             },
             {


### PR DESCRIPTION
Adding a coalesce statement on the staging and event table so users that are not in the systemaccount table will not be dropped from ingestion and aggregation. This will help with ubccr/xdmod-xsede#161

## Motivation and Context
Events with users that are not found in the systemaccount table are dropped from ingestion the jobs-cloud-extract-openstack.OpenStackCloudStagingEventIngestor action is run. This change makes sure those events are not dropped. This is mainly needed so that in for cloud resources in the XSEDE modules we can update events whose users are not yet in the XDCDB at a later date.

## Tests performed
All automated tests run and pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
