### PR TITLE
Character encoding is not commutative.

### DIFF
--- a/classes/Rest/Controllers/DashboardControllerProvider.php
+++ b/classes/Rest/Controllers/DashboardControllerProvider.php
@@ -287,11 +287,12 @@ class DashboardControllerProvider extends BaseControllerProvider
             $data = $rm->loadReportData($userReport['report_id']);
             $count = 0;
             foreach($data['queue'] as $queue) {
-                $chart_id = urldecode($queue['chart_id']);
-                $chart_id = explode("&", $chart_id);
+                $chart_id = explode("&", $queue['chart_id']);
                 $chart_id_parsed = array();
                 foreach($chart_id as $value) {
                     list($key, $value) = explode("=", $value);
+                    $key = urldecode($key);
+                    $value = urldecode($value);
                     $json = json_decode($value, true);
                     if ($json === null) {
                         $chart_id_parsed[$key] = $value;


### PR DESCRIPTION
The getRoleReport() decoding was manging the chart data. This is seen
for charts that have either & or = in the config.

For example:

global_filters=%7B%22data%22%3A%5B%7B%22id%22%3A%22institution%3D400%22%2C%22value_id%22%3A%22400%22%2C%22dimension_id%22%3A%22institution%22%2C%22checked%22%3Atrue%7D%5D%2C%22total%22%3A1%7D
