### PR TITLE
Clear report cache operation will remove image files too.

### DIFF
--- a/html/controllers/user_admin/empty_report_image_cache.php
+++ b/html/controllers/user_admin/empty_report_image_cache.php
@@ -18,6 +18,7 @@
 
       $report_manager = new XDReportManager($target_user);
       $report_manager->emptyCache();
+      $report_manager->flushReportImageCache();
             
       $displayUsername = $target_user->getUsername();
 


### PR DESCRIPTION
The internal dashboards 'Empty Report Image Cache' only clears the
database contents. The code that retrieves the images checks the
filesystem before the database, so if the file is already on the
filesystem it will served and the database cache will never be
consulted.

This update adds a call to the existing XDReportManager function that cleans up
all report image files.