### PR TITLE
Update email notification text to be less mysterious.

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -91,13 +91,14 @@ EML;
     const USER_NOTIFICATION_EMAIL = <<<EML
 Dear %s,
 
-This email is to notify you that XDMoD has detected a change in your organization affiliation. We
-have taken steps to ensure that this is accurately reflected in our systems. If you have any questions
-or concerns please contact us at %s.
+The organization associated with your XDMoD user account has been automatically
+updated from %s to %s. You will no longer be able to view non-public data
+from %s.
 
-Thank You,
+If you were not expecting this change or the new organization affiliation is
+incorrect then please contact support at %s.
 
-XDMoD
+%s
 EML;
 
     /**
@@ -2523,7 +2524,11 @@ SQL;
                         'body' => sprintf(
                             self::USER_NOTIFICATION_EMAIL,
                             $this->getFormalName(),
-                            $contactAddress
+                            $userOrganizationName,
+                            $currentOrganizationName,
+                            $userOrganizationName,
+                            $contactAddress,
+                            MailWrapper::getMaintainerSignature()
                         ),
                         'toAddress' => $this->getEmailAddress(),
                         'replyAddress' => $contactAddress


### PR DESCRIPTION
The previous email text did not say what had actually changed, what
steps had been taken nor what (if anything) the poor user was supposed
to do about this.

This text conjures up the image of some sort of Orwellian bureaucracy
where sinister faceless operatives were updating your records behind the
scenes and you are allowed to know that the record had been modified
but are not permitted to see it or be told what actually changed.

## Tests performed
This code path is tested in the ci tests. The resultant email is included below for reference. In this test Reed Bunting changes from Screwdriver to "Organization 2".
```
From ccr-xdmod-help@buffalo.edu  Tue Dec 10 19:06:59 2019
Return-Path: <ccr-xdmod-help@buffalo.edu>
X-Original-To: centerdirector@example.com
Delivered-To: root@03ac3e5e60b3.localdomain
Date: Tue, 10 Dec 2019 19:06:59 +0000
To: centerdirector@example.com
From: Open XDMoD <ccr-xdmod-help@buffalo.edu>
Reply-To: Open XDMoD <ccr-xdmod-help@buffalo.edu>
Subject: XDMoD User: Organization Update
X-Mailer: PHPMailer 5.2.27 (https://github.com/PHPMailer/PHPMailer)
Sender: ccr-xdmod-help@buffalo.edu
Content-Type: text/plain; charset=iso-8859-1
Status: R

Dear Reed Bunting,

The organization associated with your XDMoD user account has been automatically
updated from Screwdriver to Organization 2. You will no longer be able to view non-public data
from Screwdriver.

If you were not expecting this change or the new organization affiliation is
incorrect then please contact support at ccr-xdmod-help@buffalo.edu.

Screwdriver

```
