### PR TITLE
Removing cs,cd restrictions on getResources

### DIFF
--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2627,10 +2627,6 @@ SQL;
     public function getResources($resourceNames = array())
     {
         // We need to make sure that this function is only called for Center [Director|Staff]
-        if ( ! ( $this->hasAcl(ROLE_ID_CENTER_DIRECTOR) ||  $this->hasAcl(ROLE_ID_CENTER_STAFF) ) ) {
-            throw new Exception('Unable to complete action. User is not authorized.');
-        }
-
         $db = DB::factory('database');
 
         $query = <<<SQL

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2622,11 +2622,9 @@ SQL;
      * @return integer[] an array of the resourcefact.id values
      *
      * @throws Exception if there is a problem connecting to / querying the database.
-     * @throws Exception if the user this function is called for is not a Center [Director|Staff]
      */
     public function getResources($resourceNames = array())
     {
-        // We need to make sure that this function is only called for Center [Director|Staff]
         $db = DB::factory('database');
 
         $query = <<<SQL


### PR DESCRIPTION
## Description
When this function is used in an XSEDE installation it's not just CS/CD that need to use this
function. Per a convo w/ @jpwhite4, this function does not need to be filtered. There will be an
accompanying PR in the AppKernels repo (https://github.com/ubccr/xdmod-appkernels/pull/74).


## Motivation and Context
To allow PO's to utilize the Center Report Card Dashboard component

## Tests performed
Open XDMoD: all automated fresh install / upgrade 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
