### PR TITLE
Fix stderr checkbox disablement in Metric Explorer.

### DIFF
--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -2174,7 +2174,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                                         group_by: n.attributes.group_by,
                                         x_axis: false,
                                         log_scale: chartToolbar.getLogScale() == 'y',
-                                        has_std_err: 'y',
+                                        has_std_err: chartToolbar.getEnableErrors(),
                                         std_err: chartToolbar.getShowErrorBars() == 'y',
                                         std_err_labels: chartToolbar.getShowErrorLabels() == 'y',
                                         value_labels: chartToolbar.getShowAggregateLabels() == 'y' || dt == 'pie',

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -2829,6 +2829,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                                     singleClickExpand: true,
                                     type: 'metric',
                                     text: realm_metrics[rm].text,
+                                    has_std_err: realm_metrics[rm].std_err,
                                     iconCls: 'chart',
                                     category: category,
                                     realm: realm,
@@ -2861,6 +2862,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                                                             group_by: d,
                                                             metric: n.attributes.metric,
                                                             realm: n.attributes.realm,
+                                                            has_std_err: n.attributes.has_std_err,
                                                             category: n.attributes.category
                                                         };
                                                         Ext.apply(config, this.defaultDatasetConfig);


### PR DESCRIPTION
The "Err Bars" and "Err Labels" columns in the "Data" menu in the metric
explorer were incorrectly shown or incorrectly not shown in certian
circumstances.

a) if a chart was 'geared over' from the Usage Tab then the "Data" menu would
always show the "Err Bars" and "Err Labels" checkboxes regardless of whether
they should have been shown.

b) if data were added to the metric explorer from the "Metric Catalog" then
the "Data" menu would never show the checkboxes regardless of whether they
should have been shown.

If data are added to a chart via the "Data Series Definition" dialog then the
checkboxes are correct.

This change fixes it so the checkboxes work correctly.

**Old:**
![image](https://user-images.githubusercontent.com/5342179/70675662-cf11bc80-1c57-11ea-835c-30baf3151500.png)
**New:**
![image](https://user-images.githubusercontent.com/5342179/70675678-dc2eab80-1c57-11ea-8b3a-e9db8962b9c8.png)


**Old:**
![image](https://user-images.githubusercontent.com/5342179/70675720-f9637a00-1c57-11ea-8ac1-7de3bf3faa1c.png)
**New:**
![image](https://user-images.githubusercontent.com/5342179/70675761-113afe00-1c58-11ea-9993-3d82f46fbfc6.png)
