### PR TITLE
Remove write-only chart parameter.

### DIFF
--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -1375,7 +1375,6 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                     this.legendTypeComboBox.enable();
                     this.chartTitleField.enable();
 
-                    parameters.interactive_elements = 'y';
                     chartStore.removeAll(true);
 
                     //var restoreTool = images.getTool('restore');

--- a/tests/integration/lib/Controllers/UsageExplorerTest.php
+++ b/tests/integration/lib/Controllers/UsageExplorerTest.php
@@ -165,7 +165,6 @@ EOF;
             "height" => "590",
             "legend_type" => "bottom_center",
             "font_size" => "3",
-            "interactive_elements" => "y",
             "controller_module" => "user_interface"
         );
 
@@ -276,7 +275,6 @@ EOF;
     "height": "590",
     "legend_type": "bottom_center",
     "font_size": "3",
-    "interactive_elements": "y",
     "controller_module": "user_interface"
 }
 EOF;
@@ -489,7 +487,6 @@ EOF;
             'height' => '706',
             'legend_type' => 'bottom_center',
             'font_size' => '3',
-            'interactive_elements' => 'y',
             'operation' => 'get_charts',
             'controller_module' => 'user_interface'
         );


### PR DESCRIPTION
As far as I can tell this was used in `Visualization/Chart.php`
to determine whether to add an image `menu_dropdown.png`. This presumably had
an event on it in the javascript, but I couldn't find it, not could I find the png
file. This all predates Highcharts.

Below is a snippet of the original code. Note that the chart setting `interactive_elements` is used to initialise the class member variable `_interative_elements`

```php
    public function addTitle(\BaseChart &$base_chart_object, $include_title_map = false, &$dataset = NULL)
    {
        if($this->getShowTitle() && !isset($this->hasTitle))
        {
            $title = explode(' by ', $this->getTitle());
            $titleText = '';
            if($this->_interactive_elements===true && $this->getTitle() != "Empty Dataset")
            {

                if(isset($title[0])) $titleText = '<*underline=1*><*img='.dirname(__FILE__).'/menu_dropdown.png*> '.$title[0];
                if(isset($title[1])) $titleText .= '<*underline=0*> by '. $title[1];
            }
```