### PR TITLE
adding addWhereJoin to domain and service provider cloud group bys

### DIFF
--- a/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByDomain.php
+++ b/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByDomain.php
@@ -103,6 +103,31 @@ class GroupByDomain extends GroupBy
         $this->addOrder($query);
     }
 
+    public function addWhereJoin(Query &$query, Table $data_table, $multi_group, $operation, $whereConstraint) {
+        $query->addTable($this->table);
+        $domainIdField = new TableField($this->table, $this->_id_field_name);
+
+        $query->addWhereCondition(
+            new WhereCondition(
+                $domainIdField,
+                '=',
+                new TableField($data_table, 'domain_id')
+            )
+        );
+        // the where condition that specifies the constraint on the joined table
+        if (is_array($whereConstraint)) {
+            $whereConstraint = '(' . implode(',', $whereConstraint) . ')';
+        }
+
+        $query->addWhereCondition(
+            new WhereCondition(
+                $domainIdField,
+                $operation,
+                $whereConstraint
+            )
+        );
+    }
+
     /**
      * Add this GroupBy's order by clauses to the provided `Query` instance.
      *

--- a/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByServiceProvider.php
+++ b/classes/DataWarehouse/Query/Cloud/GroupBys/GroupByServiceProvider.php
@@ -42,6 +42,32 @@ class GroupByServiceProvider extends \DataWarehouse\Query\Cloud\GroupBy
         $this->configuration_table = new Table($this->modw_schema, 'serviceprovider', 'sp');
     }
 
+    public function addWhereJoin(Query &$query, Table $data_table, $multi_group, $operation, $whereConstraint) {
+        $query->addTable($this->configuration_table);
+        $service_provider_id_field = new TableField($this->configuration_table, $this->_id_field_name);
+
+        $query->addWhereCondition(
+            new WhereCondition(
+                $service_provider_id_field,
+                '=',
+                new TableField($data_table, 'service_provider')
+            )
+        );
+
+        // the where condition that specifies the constraint on the joined table
+        if (is_array($whereConstraint)) {
+            $whereConstraint = '(' . implode(',', $whereConstraint) . ')';
+        }
+
+        $query->addWhereCondition(
+            new WhereCondition(
+                $service_provider_id_field,
+                $operation,
+                $whereConstraint
+            )
+        );
+    }
+
     public function applyTo(Query &$query, Table $data_table, $multi_group = false)
     {
         $query->addTable($this->configuration_table);


### PR DESCRIPTION
If a group by does not have an addWhereJoin function it will fail when looking at a timeseries chart and paging is disabled for the chart. 

## Tests performed
Tested in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
