### PR TITLE
Cleanup / make acl-config more resilient

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -142,6 +142,7 @@ try {
 
 /**
  *
+ * @throws Exception
  **/
 function main()
 {
@@ -584,55 +585,6 @@ SQL;
 }
 
 /**
- * Attempt to drop the tables managed by this script.
- *
- * @param iDatabase $db
- * @throws Exception if a problem occurs while executing sql.
- */
-function wipeManagedTables(iDatabase $db)
-{
-    global $dryRun, $log;
-
-    $log->info("Wiping Managed Tables...");
-
-    $tables = array(
-        'user_acl_group_by_parameters',
-        'user_acls',
-        'acl_tabs',
-        'tabs',
-        'acl_hierarchies',
-        'acl_group_bys',
-        'report_template_acls',
-        'acls',
-        'acl_types',
-        'group_bys',
-        'statistics',
-        'hierarchies',
-        'realms',
-        'modules',
-        'resource_type_realms'
-    );
-
-    foreach($tables as $table) {
-        $query = <<<SQL
-DROP TABLE $table;
-SQL;
-        if ($dryRun) {
-            $log->info("Would have dropped: $table");
-            continue;
-        }
-
-        $log->debug("Dropping Table\n$query");
-
-        $db->execute($query);
-
-        $log->debug("Table dropped");
-    }
-
-    $log->info("Managed Tables Wiped!");
-}
-
-/**
  * Re-populate the user related tables
  * @param iDatabase $db the database to utilize while re-populating the tables.
  * @param array $tables the tables to be re-populated.
@@ -660,7 +612,6 @@ function repopulateNonManagedTables(iDatabase $db, array $tables)
 
     $log->info("Re-Population of Tables Complete!");
 }
-
 
 /**
  *

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -111,17 +111,6 @@ try {
         )
     );
 
-    // A handler function to make sure we cleanup the lock file, even if the process is killed.
-    $sigHandler = function ($sig) use ($lockFileHandle, $lockFile) {
-        @flock($lockFileHandle, LOCK_UN);
-        @fclose($lockFileHandle);
-        @unlink($lockFile);
-        exit(1);
-    };
-    pcntl_signal(SIGINT, $sigHandler);
-    pcntl_signal(SIGTERM, $sigHandler);
-    pcntl_signal(SIGHUP, $sigHandler);
-
     main();
 
     @flock($lockFileHandle, LOCK_UN);

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -534,15 +534,17 @@ SQL;
     dropTables($db, $nonManagedBackupTables);
 
     // and finally, we DELETE * from  && INSERT INTO the final tables from the staging tables.
-    refreshAclTables($db);
+    syncTableData($db, $tables);
 
-    $reversed = array_map(
+    $stagingTables = array_map(
         function ($item) {
             return "{$item}_staging";
         },
         array_reverse($tables)
     );
-    dropTables($db, $reversed);
+    dropTables($db, $stagingTables);
+
+    Utilities::runEtlPipeline(array('acls-import'), $log, array('dryrun' => $dryRun));
 }
 
 /**
@@ -2113,36 +2115,40 @@ function verifyJsonSyntax()
 }
 
 /**
- * This function attempts to, for each acl related table:
+ * This function attempts to, for each table supplied in $tables:
  *   - Remove all of the current records in the production table.
  *   - Populate the production table from the corresponding `_staging` table.
  *
  * NOTE: All of the actions taken by this function are protected by a db transaction. This is to ensure we either get
  * all of the new data, or none of it.
  *
- * @param iDatabase $db the database connection that will be used when executing sql statements.
+ * @param iDatabase $db     the database connection that will be used when executing sql statements.
+ * @param array     $tables the array of tables that data will ultimately end up in.
  *
  * @throws Exception if there is a problem executing a sql statement or if there are problems rolling back any uncommitted
  * changes.
  */
-function refreshAclTables(iDatabase $db)
+function syncTableData(iDatabase $db, array $tables)
 {
-    global $log, $tables;
+    global $log;
 
     $log->info("Refreshing production acl tables from staging tables.");
 
     $db->beginTransaction();
-
     foreach ($tables as $table) {
         $log->debug("Refreshing $table");
 
         $deleteStatement = "DELETE FROM $table";
         $populationStatement = "INSERT INTO $table SELECT * FROM {$table}_staging";
 
-        $db->execute($deleteStatement);
-        $log->debug("Deletion of $table complete");
+
+        if ($table === 'modules') {
+            $db->execute($deleteStatement);
+            $log->debug("Deletion of $table complete");
+        }
 
         $db->execute($populationStatement);
+
         $log->debug("Population of $table complete");
     }
 

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -53,19 +53,11 @@ $tables = array(
     'user_acl_group_by_parameters'
 );
 
+$lockFile = new \ETL\LockFile(sys_get_temp_dir(), 'acl-config');
+
 try {
-    $lockFile = implode(DIRECTORY_SEPARATOR, array(sys_get_temp_dir(), 'acl-config.lock'));
-    $lockFileHandle = @fopen($lockFile, 'w');
-    if ($lockFileHandle === false) {
-        $lastError = error_get_last();
-        fwrite(STDERR, sprintf("Current User: %s\n", get_current_user()));
-        fwrite(STDERR, sprintf("Failed to open lock file \"%s\": %s", $lockFile, print_r($lastError, true)));
-        exit(1);
-    }
-    if (!@flock($lockFileHandle, LOCK_EX | LOCK_NB)) {
-        fwrite(STDERR, "acl-config not running due to another process holding the lock.\n");
-        exit(1);
-    }
+
+    $lockFile->lock(array());
 
     $options = getopt(implode('', array_keys($opts)), array_values($opts));
 
@@ -113,18 +105,14 @@ try {
 
     main();
 
-    @flock($lockFileHandle, LOCK_UN);
-    @fclose($lockFileHandle);
-    @unlink($lockFile);
+    $lockFile->unlock();
 } catch (Exception $e) {
     do {
         fwrite(STDERR, $e->getMessage() . "\n");
         fwrite(STDERR, $e->getTraceAsString() . "\n");
     } while ($e = $e->getPrevious());
 
-    @flock($lockFileHandle, LOCK_UN);
-    @fclose($lockFileHandle);
-    @unlink($lockFile);
+    $lockFile->unlock();
 
     exit(1);
 }
@@ -135,7 +123,7 @@ try {
  **/
 function main()
 {
-    global $dryRun, $log, $verify, $logLevel, $recover, $tables;
+    global $dryRun, $log, $verify, $logLevel, $tables;
 
     $log->notice("*** Beginning Acl Configuration Tool...");
     $log->info(

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -35,6 +35,24 @@ $dryRun = false;
 $logLevel = Log::ERR;
 $recover = false;
 
+$lockFile = null;
+$lockFileHandle = null;
+$tables = array(
+    'modules',
+    'realms',
+    'hierarchies',
+    'statistics',
+    'group_bys',
+    'acl_types',
+    'acls',
+    'acl_group_bys',
+    'acl_hierarchies',
+    'tabs',
+    'acl_tabs',
+    'user_acls',
+    'user_acl_group_by_parameters'
+);
+
 try {
     $lockFile = implode(DIRECTORY_SEPARATOR, array(sys_get_temp_dir(), 'acl-config.lock'));
     $lockFileHandle = @fopen($lockFile, 'w');
@@ -114,6 +132,11 @@ try {
         fwrite(STDERR, $e->getMessage() . "\n");
         fwrite(STDERR, $e->getTraceAsString() . "\n");
     } while ($e = $e->getPrevious());
+
+    @flock($lockFileHandle, LOCK_UN);
+    @fclose($lockFileHandle);
+    @unlink($lockFile);
+
     exit(1);
 }
 
@@ -122,7 +145,7 @@ try {
  **/
 function main()
 {
-    global $dryRun, $log, $verify, $logLevel, $recover;
+    global $dryRun, $log, $verify, $logLevel, $recover, $tables;
 
     $log->notice("*** Beginning Acl Configuration Tool...");
     $log->info(
@@ -280,12 +303,12 @@ SQL;
      * their way back into the system.
      */
     $userAclRepopulate = <<<SQL
-    INSERT INTO user_acls (user_id, acl_id)
+    INSERT INTO user_acls_staging (user_id, acl_id)
       SELECT
         ua.user_id,
         a.acl_id
       FROM user_acls_bkup ua
-        LEFT JOIN acls a ON a.name = ua.acl_name
+        LEFT JOIN acls_staging a ON a.name = ua.acl_name
       WHERE a.acl_id IS NOT NULL
 SQL;
 
@@ -320,17 +343,17 @@ SQL;
      *   - group_bys
      */
     $uagbpRepopulate = <<<SQL
-INSERT INTO user_acl_group_by_parameters (user_id, acl_id, group_by_id, value)
+INSERT INTO user_acl_group_by_parameters_staging(user_id, acl_id, group_by_id, value)
   SELECT
     uagbp.user_id,
     a.acl_id,
     gb.group_by_id,
     uagbp.value
   FROM user_acl_group_by_parameters_bkup uagbp
-    LEFT JOIN acls a ON a.name = uagbp.acl_name
-    LEFT JOIN modules m ON m.name = uagbp.group_by_module_name
-    LEFT JOIN realms r ON r.name = uagbp.group_by_realm_name
-    LEFT JOIN group_bys gb
+    LEFT JOIN acls_staging a ON a.name = uagbp.acl_name
+    LEFT JOIN modules_staging m ON m.name = uagbp.group_by_module_name
+    LEFT JOIN realms_staging r ON r.name = uagbp.group_by_realm_name
+    LEFT JOIN group_bys_staging gb
       ON gb.name = uagbp.group_by_name AND
          gb.module_id = m.module_id AND
          gb.realm_id = r.realm_id
@@ -348,13 +371,13 @@ SQL;
         ),
         'user_acl_group_by_parameters' => array(
             'create_sql' => $uagbpCreateBkup,
-            'populate_sql' =>$uagbpRepopulate
+            'populate_sql' => $uagbpRepopulate
         )
     );
 
     $nonManagedBackupTables = array_reduce(
         array_keys($tablesToBeBackedUp),
-        function($carry, $item) {
+        function ($carry, $item) {
             $carry[] = "${item}_bkup";
             return $carry;
         },
@@ -462,12 +485,8 @@ SQL;
         backupNonManagedTables($db, $tablesToBeBackedUp);
     }
 
-    wipeManagedTables($db);
-
     // Create Managed Tables
     Utilities::runEtlPipeline(array('acls-xdmod-management'), $log, array('dryrun' => $dryRun));
-
-    repopulateNonManagedTables($db, $tablesToBeBackedUp);
 
     // Process the xdmod module first
     if (array_key_exists(DEFAULT_MODULE_NAME, $modules)) {
@@ -508,23 +527,31 @@ SQL;
         processResult($db, $module, $moduleData, $modules);
     }
 
-    // Now re-populate the user related tables.
+    // Now re-populate the user related tables to their respective staging tables.
     repopulateNonManagedTables($db, $tablesToBeBackedUp);
 
     // Make sure we drop the backup tables
     dropTables($db, $nonManagedBackupTables);
 
-    // Run the acl cleanup scripts
-    Utilities::runEtlPipeline(array('acls-import'), $log, array('dryrun' => $dryRun));
+    // and finally, we DELETE * from  && INSERT INTO the final tables from the staging tables.
+    refreshAclTables($db);
+
+    $reversed = array_map(
+        function ($item) {
+            return "{$item}_staging";
+        },
+        array_reverse($tables)
+    );
+    dropTables($db, $reversed);
 }
 
 /**
  * Create a backup of the user related acl tables so that we can later re-populate
  * them
  *
- * @param iDatabase $db     the database that the user related tables will be backed
+ * @param iDatabase $db the database that the user related tables will be backed
  *                          up in.
- * @param array     $tables
+ * @param array $tables
  * @throws Exception if a problem occurs while executing table backup sql.
  */
 function backupNonManagedTables(iDatabase $db, array $tables)
@@ -652,7 +679,7 @@ function processHierarchies(iDatabase $db, $hierarchies)
     //     - the same name / display as incoming
     //     - but a different module_id than incoming
     $query = <<<SQL
-    INSERT INTO hierarchies(module_id, name, display)
+    INSERT INTO hierarchies_staging(module_id, name, display)
     SELECT inc.module_id, inc.name, inc.display
     FROM
     (
@@ -660,10 +687,10 @@ function processHierarchies(iDatabase $db, $hierarchies)
           m.module_id AS module_id,
           :name       AS name,
           :display    AS display
-        FROM modules m
+        FROM modules_staging m
         WHERE BINARY m.name = BINARY :module_name
     ) inc
-    LEFT JOIN hierarchies cur
+    LEFT JOIN hierarchies_staging cur
     ON BINARY cur.name    = BINARY inc.name    AND
        BINARY cur.display = BINARY cur.display
     WHERE cur.hierarchy_id IS NULL;
@@ -876,13 +903,13 @@ function createModule(iDatabase $db, $name, $display, $enabled)
     global $dryRun, $log;
 
     $query = <<<SQL
-    INSERT INTO modules(name, display, enabled)
+    INSERT INTO modules_staging(name, display, enabled)
     SELECT inc.*
     FROM (
         SELECT :name    AS name,
                :display AS display,
                :enabled AS enabled ) inc
-    LEFT JOIN modules cur
+    LEFT JOIN modules_staging cur
         ON BINARY cur.name    = BINARY inc.name    AND
            BINARY cur.display = BINARY inc.display
     WHERE cur.module_id IS NULL
@@ -910,7 +937,7 @@ SQL;
         $log->info("[ALREADY EXISTS] Retrieving Identifier for Module: $name");
         $select = <<<SQL
     SELECT m.module_id
-    FROM modules m
+    FROM modules_staging m
     WHERE BINARY m.name    = BINARY :name    AND
           BINARY m.display = BINARY :display
 SQL;
@@ -944,7 +971,7 @@ function associateModuleAndVersion(iDatabase $db, $moduleId, $moduleVersionId)
 
     $exists = <<<SQL
     SELECT m.module_id
-    FROM modules m
+    FROM modules_staging m
     WHERE BINARY m.module_id          = BINARY :module_id AND
           BINARY m.current_version_id = BINARY :current_version_id
 SQL;
@@ -969,7 +996,7 @@ SQL;
     }
 
     $query = <<<SQL
-    UPDATE modules
+    UPDATE modules_staging
     SET current_version_id = :current_version_id
     WHERE BINARY module_id = BINARY :module_id
 SQL;
@@ -1108,7 +1135,7 @@ function processAcl(iDatabase $db, $module, $name, $display, $type = null, $hier
         $aclTypeId = processAclType($db, $module, $type);
 
         $query = <<<SQL
-INSERT INTO acls(module_id, acl_type_Id, name, display, enabled)
+INSERT INTO acls_staging(module_id, acl_type_Id, name, display, enabled)
 SELECT inc.*
 FROM (
     SELECT
@@ -1117,10 +1144,10 @@ FROM (
         :name          AS name,
         :display       AS display,
         :enabled       AS enabled
-    FROM modules m
+    FROM modules_staging m
     WHERE BINARY m.name = BINARY :module_name
  ) inc
-LEFT JOIN acls cur
+LEFT JOIN acls_staging cur
   ON cur.acl_type_id = inc.acl_type_id AND
      BINARY cur.name = BINARY inc.name
 WHERE cur.acl_id IS NULL
@@ -1140,7 +1167,7 @@ SQL;
         );
     } else {
         $query = <<<SQL
-INSERT INTO acls(module_id, name, display, enabled)
+INSERT INTO acls_staging(module_id, name, display, enabled)
 SELECT inc.*
 FROM (
     SELECT
@@ -1148,10 +1175,10 @@ FROM (
         :name          AS name,
         :display       AS display,
         :enabled       AS enabled
-    FROM modules m
+    FROM modules_staging m
     WHERE BINARY m.name = BINARY :module_name
  ) inc
-LEFT JOIN acls cur
+LEFT JOIN acls_staging cur
   ON BINARY cur.name        = BINARY inc.name
 WHERE cur.acl_id IS NULL;
 SQL;
@@ -1180,8 +1207,8 @@ SQL;
         $log->notice("[ALREADY EXISTS] Acl $msg");
         $query = <<<SQL
     SELECT a.acl_id
-    FROM acls a
-        JOIN modules m
+    FROM acls_staging a
+        JOIN modules_staging m
             ON a.module_id = m.module_id
     WHERE BINARY m.name    = BINARY :module_name AND
           BINARY a.name    = BINARY :name        AND
@@ -1228,17 +1255,17 @@ function processAclType(iDatabase $db, $module, $type)
     $log->info("Processing Acl Type...");
 
     $query = <<<SQL
-    INSERT INTO acl_types(module_id, name, display)
+    INSERT INTO acl_types_staging(module_id, name, display)
     SELECT inc.*
     FROM (
         SELECT
             m.module_id       AS module_id,
             :acl_type_name    AS name,
             :acl_type_display AS display
-        FROM modules m
+        FROM modules_staging m
         WHERE BINARY m.name = BINARY :module_name
     ) inc
-    LEFT JOIN acl_types cur
+    LEFT JOIN acl_types_staging cur
         ON BINARY cur.name  = BINARY inc.name
     WHERE cur.acl_type_id IS NULL;
 SQL;
@@ -1262,7 +1289,7 @@ SQL;
         // exists, attempt to retrieve the acl_type_id.
         $query = <<<SQL
     SELECT at.acl_type_id
-    FROM acl_types at
+    FROM acl_types_staging at
     WHERE BINARY at.name    = BINARY :acl_type_name
 SQL;
         $results = $db->query(
@@ -1303,7 +1330,7 @@ function processAclHierarchy(iDatabase $db, $module, $acl, array $hierarchies)
     $log->notice("Processing Acl Hierarchy Records...");
 
     $query = <<<SQL
-    INSERT INTO acl_hierarchies(acl_id, hierarchy_id, level, filter_override)
+    INSERT INTO acl_hierarchies_staging(acl_id, hierarchy_id, level, filter_override)
     SELECT inc.*
     FROM (
         SELECT
@@ -1311,13 +1338,13 @@ function processAclHierarchy(iDatabase $db, $module, $acl, array $hierarchies)
             h.hierarchy_id   AS hierarchy_id,
             :level           AS level,
             :filter_override AS filter_override
-        FROM acls a, hierarchies h, modules m
+        FROM acls_staging a, hierarchies_staging h, modules_staging m
         WHERE a.module_id        = m.module_id         AND
               h.module_id        = m.module_id         AND
               BINARY m.name      = BINARY :module_name AND
               BINARY a.name      = BINARY :acl_name
     ) inc
-    LEFT JOIN acl_hierarchies cur
+    LEFT JOIN acl_hierarchies_staging cur
         ON cur.acl_id              = inc.acl_id       AND
            cur.hierarchy_id        = inc.hierarchy_id AND
            BINARY cur.level        = BINARY inc.level
@@ -1326,15 +1353,12 @@ SQL;
 
     $log->debug($query);
 
-    if ( ! $dryRun ) {
+    if (!$dryRun) {
         $statement = $db->prepare($query);
     }
 
     $inserted = 0;
 
-    // Begin a transaction so that either all of the hierarchies are inserted or
-    // none of them are.
-    $db->beginTransaction();
     foreach ($hierarchies as $hierarchyName => $hierarchyInfo) {
         if (!isset($hierarchyInfo['level'])) {
             $log->warning("Malformed hierarchy information for Acl $acl. No level present.");
@@ -1374,16 +1398,7 @@ SQL;
             $log->warning("[WARNING] Inserted more than one Acl Hierarchy Record for: $id");
         }
     }
-    $committed = $db->commit();
-    if ($committed === false) {
-        $log->warning("[FAIL] Attempt to commit hierarchies for Acl [$acl] failed.");
-        $rolledBack = $db->rollBack();
 
-        // We throw an Exception so that we do not leave the db in an inconsistent state.
-        if ($rolledBack === false) {
-            throw new Exception("Unable to rollback Acl [$acl] hierarchy records. Database may be left in an inconsistent state.");
-        }
-    }
     $processed = count($hierarchies);
     $log->notice("Processed: $processed, Inserted: $inserted");
 }
@@ -1433,16 +1448,16 @@ function createTab(iDatabase $db, $module, $tab)
     $msg = "name: $tab";
 
     $query = <<<SQL
-    INSERT INTO tabs(module_id, name)
+    INSERT INTO tabs_staging(module_id, name)
     SELECT inc.*
     FROM (
         SELECT
             m.module_id AS module_id,
             :name       AS name
-        FROM modules m
+        FROM modules_staging m
         WHERE BINARY m.name = BINARY :module_name
     ) inc
-    LEFT JOIN tabs cur
+    LEFT JOIN tabs_staging cur
         ON BINARY cur.name = BINARY inc.name
     WHERE cur.tab_id IS NULL;
 SQL;
@@ -1469,7 +1484,7 @@ SQL;
         $log->info("[ALREADY EXISTS] Tab: $msg");
         $query = <<<SQL
     SELECT t.tab_id
-    FROM tabs t
+    FROM tabs_staging t
     WHERE BINARY t.name = BINARY :name
 SQL;
         $params = array(
@@ -1509,18 +1524,18 @@ function relateAclAndTab(iDatabase $db, $aclName, $tabName)
     global $dryRun, $log;
 
     $query = <<<SQL
-    INSERT INTO acl_tabs(acl_id, tab_id)
+    INSERT INTO acl_tabs_staging(acl_id, tab_id)
     SELECT inc.*
     FROM (
         SELECT
             a.acl_id AS acl_id,
             t.tab_id AS tab_id
-        FROM acls a, tabs t
+        FROM acls_staging a, tabs_staging t
         WHERE BINARY a.name = BINARY :acl_name AND
               BINARY t.name = BINARY :tab_name
 
     ) inc
-    LEFT JOIN acl_tabs cur
+    LEFT JOIN acl_tabs_staging cur
         ON cur.acl_id = inc.acl_id AND
            cur.tab_id = inc.tab_id
     WHERE cur.acl_tab_id IS NULL;
@@ -1598,7 +1613,7 @@ FROM (
         s.statistic_id AS statistic_id,
         :visible       AS visible,
         :enabled       AS enabled
-    FROM acls a, group_bys gb, statistics s, modules m, realms r
+    FROM acls_staging a, group_bys_staging gb, statistics_staging s, modules_staging m, realms_staging r
     WHERE BINARY m.name       = BINARY :module_name    AND
           BINARY r.name       = BINARY :realm_name     AND
           BINARY a.name       = BINARY :acl_name       AND
@@ -1610,7 +1625,7 @@ FROM (
           s.module_id         = m.module_id            AND
           s.realm_id          = r.realm_id
 ) inc
-LEFT JOIN acl_group_bys cur
+LEFT JOIN acl_group_bys_staging cur
     ON cur.realm_id    = inc.realm_id      AND
        cur.acl_id      = inc.acl_id        AND
        cur.group_by_id = inc.group_by_id   AND
@@ -1714,13 +1729,13 @@ SQL;
 
     fflush($bulkdatafile);
 
-    $bulkload = 'LOAD DATA LOCAL INFILE \'' . stream_get_meta_data($bulkdatafile)['uri'] . '\' INTO TABLE `acl_group_bys` FIELDS TERMINATED BY \',\' (realm_id, acl_id, group_by_id, statistic_id, visible, enabled)';
+    $bulkload = 'LOAD DATA LOCAL INFILE \'' . stream_get_meta_data($bulkdatafile)['uri'] . '\' INTO TABLE `acl_group_bys_staging` FIELDS TERMINATED BY \',\' (realm_id, acl_id, group_by_id, statistic_id, visible, enabled)';
     $databaseHelper = CCR\DB\MySQLHelper::factory($db);
     $output = $databaseHelper->executeStatement($bulkload);
 
     if (count($output) > 0) {
         $this->logger->warning($bulkload);
-        foreach($output as $line) {
+        foreach ($output as $line) {
             $this->logger->warning($line);
         }
     }
@@ -1779,17 +1794,17 @@ function createRealm(iDatabase $db, $moduleName, $realmDisplay)
     $successMsg = "[SUCCESS] Created Realm: $realmDisplay for Module: $moduleName";
 
     $query = <<<SQL
-    INSERT INTO realms(module_id, name, display)
+    INSERT INTO realms_staging(module_id, name, display)
     SELECT inc.*
     FROM (
         SELECT
             m.module_id AS module_id,
             :realm_name AS name,
             :realm_display AS display
-        FROM modules m
+        FROM modules_staging m
         WHERE BINARY m.name = BINARY :module_name
     ) inc
-    LEFT JOIN realms cur
+    LEFT JOIN realms_staging cur
         ON BINARY cur.name = BINARY inc.name
     WHERE cur.realm_id IS NULL;
 SQL;
@@ -1815,7 +1830,7 @@ SQL;
 
     if ($inserted === 0) {
         $updateQuery = <<<SQL
-    UPDATE realms
+    UPDATE realms_staging
     SET display = :realm_display
     WHERE name = :realm_name;
 SQL;
@@ -1858,19 +1873,19 @@ function createGroupBys(iDatabase $db, $moduleName, $realmName, array $groupBys)
     $successMsg = "[SUCCESS] Created Group By: %s for Module: $moduleName and Realm: $realmName";
 
     $query = <<<SQL
-INSERT INTO group_bys(module_id, realm_id, name)
+INSERT INTO group_bys_staging(module_id, realm_id, name)
 SELECT inc.*
 FROM (
     SELECT
         m.module_id    AS module_id,
         r.realm_id     AS realm_id,
         :group_by_name AS name
-    FROM modules m, realms r
+    FROM modules_staging m, realms_staging r
     WHERE BINARY m.name      = BINARY :module_name AND
           r.module_id        =  m.module_id        AND
           BINARY r.name      = BINARY :realm_name
 ) inc
-LEFT JOIN group_bys cur
+LEFT JOIN group_bys_staging cur
     ON cur.module_id        = inc.module_id   AND
        cur.realm_id         = inc.realm_id    AND
        BINARY cur.name      = BINARY inc.name
@@ -1935,19 +1950,19 @@ function createStatistics(iDatabase $db, $moduleName, $realmName, array $statist
     $successMsg = "[SUCCESS] Created Statistic: %s for Module: $moduleName and Realm: $realmName";
 
     $query = <<<SQL
-INSERT INTO statistics(module_id, realm_id, name)
+INSERT INTO statistics_staging(module_id, realm_id, name)
 SELECT inc.*
 FROM (
     SELECT
         m.module_id     AS module_id,
         r.realm_id      AS realm_id,
         :statistic_name AS name
-    FROM modules m, realms r
+    FROM modules_staging m, realms_staging r
     WHERE BINARY m.name = BINARY :module_name  AND
           BINARY r.name = BINARY :realm_name   AND
           r.module_id   = m.module_id
 ) inc
-LEFT JOIN statistics cur
+LEFT JOIN statistics_staging cur
     ON cur.module_id        = inc.module_id   AND
        cur.realm_id         = inc.realm_id    AND
        BINARY cur.name      = BINARY inc.name
@@ -2097,6 +2112,53 @@ function verifyJsonSyntax()
     }
 }
 
+/**
+ * This function attempts to, for each acl related table:
+ *   - Remove all of the current records in the production table.
+ *   - Populate the production table from the corresponding `_staging` table.
+ *
+ * NOTE: All of the actions taken by this function are protected by a db transaction. This is to ensure we either get
+ * all of the new data, or none of it.
+ *
+ * @param iDatabase $db the database connection that will be used when executing sql statements.
+ *
+ * @throws Exception if there is a problem executing a sql statement or if there are problems rolling back any uncommitted
+ * changes.
+ */
+function refreshAclTables(iDatabase $db)
+{
+    global $log, $tables;
+
+    $log->info("Refreshing production acl tables from staging tables.");
+
+    $db->beginTransaction();
+
+    foreach ($tables as $table) {
+        $log->debug("Refreshing $table");
+
+        $deleteStatement = "DELETE FROM $table";
+        $populationStatement = "INSERT INTO $table SELECT * FROM {$table}_staging";
+
+        $db->execute($deleteStatement);
+        $log->debug("Deletion of $table complete");
+
+        $db->execute($populationStatement);
+        $log->debug("Population of $table complete");
+    }
+
+    $committed = $db->commit();
+    if ($committed === false) {
+        $log->crit("[FAIL] Attempt to commit staging data to production tables has failed. Rollback has been initiated");
+        $rolledBack = $db->rollBack();
+
+        // We throw an Exception so that we do not leave the db in an inconsistent state.
+        if ($rolledBack === false) {
+            throw new Exception("Rollback failed. Database may be left in an inconsistent state. Please investigate and / or contact support before running acl-config again.");
+        }
+    }
+
+    $log->info("All acl tables have been re-populated");
+}
 
 /**
  * Attempt to load an instance of Configuration\XdmodConfiguration and retrieve

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -297,28 +297,10 @@ SQL;
       SELECT
         ua.user_id,
         a.acl_id
-      FROM user_acls_bkup ua
-        LEFT JOIN acls_staging a ON a.name = ua.acl_name
-      WHERE a.acl_id IS NOT NULL
-SQL;
-
-    /**
-     * to serve as the select query that will be used to create the backup
-     * table 'user_acl_group_by_parameters_bkup'.
-     */
-    $uagbpCreateBkup = <<<SQL
-    SELECT
-      uagbp.user_id,
-      a.name  AS acl_name,
-      m.name  AS group_by_module_name,
-      r.name  AS group_by_realm_name,
-      gb.name AS group_by_name,
-      uagbp.value
-    FROM user_acl_group_by_parameters uagbp
-      JOIN acls a ON a.acl_id = uagbp.acl_id
-      JOIN group_bys gb ON gb.group_by_id = uagbp.group_by_id
-      JOIN realms r ON r.realm_id = gb.realm_id
-      JOIN modules m ON m.module_id = gb.module_id;
+      FROM user_acls ua
+        JOIN acls a ON ua.acl_id = a.acl_id
+        LEFT JOIN acls_staging ast ON ast.name = a.name
+      WHERE ast.acl_id IS NOT NULL
 SQL;
 
     /**
@@ -337,41 +319,34 @@ INSERT INTO user_acl_group_by_parameters_staging(user_id, acl_id, group_by_id, v
   SELECT
     uagbp.user_id,
     a.acl_id,
-    gb.group_by_id,
+    gbst.group_by_id,
     uagbp.value
-  FROM user_acl_group_by_parameters_bkup uagbp
-    LEFT JOIN acls_staging a ON a.name = uagbp.acl_name
-    LEFT JOIN modules_staging m ON m.name = uagbp.group_by_module_name
-    LEFT JOIN realms_staging r ON r.name = uagbp.group_by_realm_name
-    LEFT JOIN group_bys_staging gb
-      ON gb.name = uagbp.group_by_name AND
-         gb.module_id = m.module_id AND
-         gb.realm_id = r.realm_id
-  WHERE a.acl_id IS NOT NULL AND
-        m.module_id IS NOT NULL AND
-        r.realm_id IS NOT NULL AND
-        gb.group_by_id IS NOT NULL;
+  FROM user_acl_group_by_parameters uagbp
+    JOIN acls a ON uagbp.acl_id = a.acl_id
+    JOIN group_bys g on uagbp.group_by_id = g.group_by_id
+    JOIN modules m ON m.module_id = g.module_id
+    JOIN realms r ON r.realm_id = g.realm_id
+    LEFT JOIN acls_staging ast ON ast.name = a.name
+    LEFT JOIN modules_staging mst ON mst.name = m.name
+    LEFT JOIN realms_staging rst ON rst.name = r.name
+    LEFT JOIN group_bys_staging gbst
+      ON gbst.name = g.name AND
+         gbst.module_id = mst.module_id AND
+         gbst.realm_id = rst.realm_id
+  WHERE ast.acl_id IS NOT NULL AND
+        mst.module_id IS NOT NULL AND
+        rst.realm_id IS NOT NULL AND
+        gbst.group_by_id IS NOT NULL;
 SQL;
 
 
     $tablesToBeBackedUp = array(
         'user_acls' => array(
-            'create_sql' => $userAclCreateBkup,
             'populate_sql' => $userAclRepopulate
         ),
         'user_acl_group_by_parameters' => array(
-            'create_sql' => $uagbpCreateBkup,
             'populate_sql' => $uagbpRepopulate
         )
-    );
-
-    $nonManagedBackupTables = array_reduce(
-        array_keys($tablesToBeBackedUp),
-        function ($carry, $item) {
-            $carry[] = "${item}_bkup";
-            return $carry;
-        },
-        array()
     );
 
     /* acl-config "recovery" documentation

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -36,6 +36,19 @@ $logLevel = Log::ERR;
 $recover = false;
 
 try {
+    $lockFile = implode(DIRECTORY_SEPARATOR, array(sys_get_temp_dir(), 'acl-config.lock'));
+    $lockFileHandle = @fopen($lockFile, 'w');
+    if ($lockFileHandle === false) {
+        $lastError = error_get_last();
+        fwrite(STDERR, sprintf("Current User: %s\n", get_current_user()));
+        fwrite(STDERR, sprintf("Failed to open lock file \"%s\": %s", $lockFile, print_r($lastError, true)));
+        exit(1);
+    }
+    if (!@flock($lockFileHandle, LOCK_EX | LOCK_NB)) {
+        fwrite(STDERR, "acl-config not running due to another process holding the lock.\n");
+        exit(1);
+    }
+
     $options = getopt(implode('', array_keys($opts)), array_values($opts));
 
     foreach ($options as $key => $value) {
@@ -80,8 +93,22 @@ try {
         )
     );
 
+    // A handler function to make sure we cleanup the lock file, even if the process is killed.
+    $sigHandler = function ($sig) use ($lockFileHandle, $lockFile) {
+        @flock($lockFileHandle, LOCK_UN);
+        @fclose($lockFileHandle);
+        @unlink($lockFile);
+        exit(1);
+    };
+    pcntl_signal(SIGINT, $sigHandler);
+    pcntl_signal(SIGTERM, $sigHandler);
+    pcntl_signal(SIGHUP, $sigHandler);
+
     main();
 
+    @flock($lockFileHandle, LOCK_UN);
+    @fclose($lockFileHandle);
+    @unlink($lockFile);
 } catch (Exception $e) {
     do {
         fwrite(STDERR, $e->getMessage() . "\n");

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -139,9 +139,6 @@ function main()
         exit($result);
     }
 
-    // Make sure that all of the required tables are present
-    Utilities::runEtlPipeline(array('acls-xdmod-management'), $log, array('dryrun' => $dryRun));
-
     // a role/acl blacklist. 'default' doesn't actually exist so don't bother
     // processing it.
     $blacklist = array('default');

--- a/bin/acl-config
+++ b/bin/acl-config
@@ -274,18 +274,6 @@ function main()
     // the managed tables.
 
     /**
-     * This sql statement should serve as the select query that will be used to
-     * create the backup table 'user_acls_bkup'.
-     */
-    $userAclCreateBkup = <<<SQL
-    SELECT
-      ua.user_id,
-      a.name AS acl_name
-    FROM user_acls ua
-      JOIN acls a ON a.acl_id = ua.acl_id
-SQL;
-
-    /**
      * Serves as the insertion query to utilize when reconstituting the
      * user_acls table. Notice the 'LEFT JOIN' on 'acls' and accompanying
      * where clause 'a.acl_id IS NOT NULL'. These are to ensure that if an
@@ -433,22 +421,6 @@ SQL;
      *   *after* a failed run but *before* acl-config is run with the --recover flag, then these
      *   changes will *not* be recovered.
      */
-    $backupTablesExist = tablesExist($db, $nonManagedBackupTables, SCHEMA, false);
-
-    if ($backupTablesExist && !$recover) {
-        $log->err('Backup tables detected! ');
-        $log->err('Unable to continue!');
-        $log->err('This may indicate a failed previous run.');
-        $log->err('Run "acl-config --recover" to recover using backup tables.');
-        $log->err('See https://open.xdmod.org/9.0/faq.html#why-do-i-see-backup-tables-detected-when-running-the-acl-config-script for more information.');
-        exit(1);
-    } elseif (!$backupTablesExist) {
-        if ($recover) {
-            $log->warning('Recover mode specified but no backup tables exist.');
-            $log->warning('Script execution will continue as normal.');
-        }
-        backupNonManagedTables($db, $tablesToBeBackedUp);
-    }
 
     // Create Managed Tables
     Utilities::runEtlPipeline(array('acls-xdmod-management'), $log, array('dryrun' => $dryRun));
@@ -495,9 +467,6 @@ SQL;
     // Now re-populate the user related tables to their respective staging tables.
     repopulateNonManagedTables($db, $tablesToBeBackedUp);
 
-    // Make sure we drop the backup tables
-    dropTables($db, $nonManagedBackupTables);
-
     // and finally, we DELETE * from  && INSERT INTO the final tables from the staging tables.
     syncTableData($db, $tables);
 
@@ -510,42 +479,6 @@ SQL;
     dropTables($db, $stagingTables);
 
     Utilities::runEtlPipeline(array('acls-import'), $log, array('dryrun' => $dryRun));
-}
-
-/**
- * Create a backup of the user related acl tables so that we can later re-populate
- * them
- *
- * @param iDatabase $db the database that the user related tables will be backed
- *                          up in.
- * @param array $tables
- * @throws Exception if a problem occurs while executing table backup sql.
- */
-function backupNonManagedTables(iDatabase $db, array $tables)
-{
-    global $dryRun, $log;
-    $log->info("Backing Up User Related Tables...");
-
-    foreach($tables as $table => $queries) {
-        $creationQuery = $queries['create_sql'];
-
-        $query = <<<SQL
-CREATE TABLE ${table}_bkup AS $creationQuery;
-SQL;
-
-        $log->debug("Backup query [$table]: $query");
-
-        if ($dryRun) {
-            $log->notice("Table[$table] would have been created");
-            continue;
-        }
-
-        // throws exception or returns row count
-        $rows = $db->execute($query);
-        $log->debug(sprintf('Inserted %d rows into %s', $rows, $table));
-    }
-
-    $log->info("User Related Tables Backed Up!");
 }
 
 /**
@@ -2134,55 +2067,6 @@ function verifyDatabase()
     } catch (Exception $e) {
     }
     return $result;
-}
-
-/**
- * Determines whether all of the provided tables currently exist.
- *
- * @param iDatabase $db to execute the required sql statement
- * @param array $tables an array of table names ( as strings )
- * @param string $schema the db schema that $tables belong to
- * @param bool $all only return true if all of the provided tables exist. Defaults to `true`.
- *
- * @return bool true if they do, false if they do not.
- */
-function tablesExist(iDatabase $db, array $tables, $schema, $all = true)
-{
-    $handle = $db->handle();
-
-    $tables = array_reduce(
-        $tables,
-        function($carry, $item) use ($handle)
-        {
-            $carry[] = $handle->quote($item);
-            return $carry;
-        },
-        array()
-    );
-
-    $tableList = implode(',', $tables);
-
-    $query = <<<SQL
-SELECT *
-FROM information_schema.tables
-WHERE table_schema = :table_schema
-AND table_name in ($tableList);
-SQL;
-
-    $params = array(
-        ':table_schema' => $schema
-    );
-
-    $results = $db->query(
-        $query,
-        $params
-    );
-
-    if ($all) {
-        return count($tables) === count($results);
-    }
-
-    return count($results) > 0;
 }
 
 /**

--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -274,6 +274,11 @@ function main()
                     $dwi->ingestStorageData();
                 }
             }
+            $aclstatus = 0;
+            passthru('acl-config', $aclstatus);
+            if ($aclstatus !== 0) {
+                exit($aclstatus);
+            }
         } catch (Exception $e) {
             $logger->crit(array(
                 'message'    => 'Ingestion failed: ' . $e->getMessage(),

--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -274,12 +274,6 @@ function main()
                     $dwi->ingestStorageData();
                 }
             }
-
-            $aclstatus = 0;
-            passthru('acl-config', $aclstatus);
-            if ($aclstatus !== 0) {
-                exit($aclstatus);
-            }
         } catch (Exception $e) {
             $logger->crit(array(
                 'message'    => 'Ingestion failed: ' . $e->getMessage(),

--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -274,6 +274,7 @@ function main()
                     $dwi->ingestStorageData();
                 }
             }
+
             $aclstatus = 0;
             passthru('acl-config', $aclstatus);
             if ($aclstatus !== 0) {

--- a/classes/OpenXdmod/Setup/DatabaseSetup.php
+++ b/classes/OpenXdmod/Setup/DatabaseSetup.php
@@ -148,6 +148,7 @@ EOT
             'shredder-bootstrap',
             'staging-bootstrap',
             'hpcdb-bootstrap',
+            'acls-xdmod-management'
         ), $logger);
 
 

--- a/configuration/etl/etl.d/acls-import.json
+++ b/configuration/etl/etl.d/acls-import.json
@@ -32,44 +32,6 @@
             "enabled": true
         },
         {
-            "name": "xdmod-scrub-acl-tabs",
-            "description": "Ensures that the acl_tabs table does not contain erroneous data",
-            "sql_file_list": [
-                {
-                    "sql_file": "acls/xdmod/scrub_acl_tabs.sql"
-                }
-            ],
-            "enabled": true
-        },
-        {
-            "name": "xdmod-update-admin-users",
-            "description": "Ensure that any users that only have 'mgr' have 'usr' added.",
-            "sql_file_list": [
-                {
-                    "sql_file": "acls/xdmod/update_admin_users.sql"
-                }
-            ],
-            "enabled": true
-        },
-        {
-            "name": "xdmod-normalize-user-organizations",
-            "description": "Ensure that current Users have valid organizations",
-            "sql_file_list": [
-                {
-                    "sql_file": "acls/xdmod/normalize_user_organizations.sql"
-                }
-            ]
-        },
-        {
-            "name": "xdmod-update-user-organizations",
-            "description": "Ensure that current Users have the most up to date organization",
-            "sql_file_list": [
-                {
-                    "sql_file": "acls/xdmod/update_user_organizations.sql"
-                }
-            ]
-        },
-        {
             "name": "report-template-acls",
             "description": "report-template-acls + data",
             "namespace": "ETL\\Ingestor",

--- a/configuration/etl/etl.d/acls-xdmod-management.json
+++ b/configuration/etl/etl.d/acls-xdmod-management.json
@@ -55,6 +55,27 @@
         }
       },
       "truncate_destination": true
+    },
+    {
+      "#": "AclStagingTableManagement should always be run after any changes have been made to the files ( tables ) found below.",
+      "name": "AclStagingTableManagement",
+      "class": "ManageTables",
+      "description": "Manage the various Acl related tables.",
+      "definition_file_list": [
+        "acls/staging/modules.json",
+        "acls/staging/realms.json",
+        "acls/staging/hierarchies.json",
+        "acls/staging/acl_types.json",
+        "acls/staging/acls.json",
+        "acls/staging/group_bys.json",
+        "acls/staging/statistics.json",
+        "acls/staging/acl_hierarchies.json",
+        "acls/staging/user_acls.json",
+        "acls/staging/acl_group_bys.json",
+        "acls/staging/tabs.json",
+        "acls/staging/acl_tabs.json",
+        "acls/staging/user_acl_group_by_parameters.json"
+      ]
     }
   ]
 }

--- a/configuration/etl/etl_tables.d/acls/group_bys.json
+++ b/configuration/etl/etl_tables.d/acls/group_bys.json
@@ -46,6 +46,16 @@
         "columns": [
           "realm_id"
         ]
+      },
+      {
+        "name": "idx_module_id_realm_id_name",
+        "columns": [
+          "module_id",
+          "realm_id",
+          "name"
+        ],
+        "type": "BTREE",
+        "is_unique": true
       }
     ],
     "foreign_key_constraints": [

--- a/configuration/etl/etl_tables.d/acls/realms.json
+++ b/configuration/etl/etl_tables.d/acls/realms.json
@@ -40,6 +40,15 @@
         "columns": [
           "module_id"
         ]
+      },
+      {
+        "name": "idx_module_id_name",
+        "columns": [
+          "module_id",
+          "name"
+        ],
+        "type": "BTREE",
+        "is_unique": true
       }
     ],
     "foreign_key_constraints": [

--- a/configuration/etl/etl_tables.d/acls/staging/acl_group_bys.json
+++ b/configuration/etl/etl_tables.d/acls/staging/acl_group_bys.json
@@ -1,0 +1,54 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/acl_group_bys.json#/table_definition",
+    "$overwrite": {
+      "name": "acl_group_bys_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_agb_staging_acl_id",
+          "columns": [
+            "acl_id"
+          ],
+          "referenced_table": "acls_staging",
+          "referenced_columns": [
+            "acl_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_agb_staging_group_by_id",
+          "columns": [
+            "group_by_id"
+          ],
+          "referenced_table": "group_bys_staging",
+          "referenced_columns": [
+            "group_by_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_agb_staging_realm_id",
+          "columns": [
+            "realm_id"
+          ],
+          "referenced_table": "realms_staging",
+          "referenced_columns": [
+            "realm_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_agb_staging_statistic_id",
+          "columns": [
+            "statistic_id"
+          ],
+          "referenced_table": "statistics_staging",
+          "referenced_columns": [
+            "statistic_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/acl_hierarchies.json
+++ b/configuration/etl/etl_tables.d/acls/staging/acl_hierarchies.json
@@ -1,0 +1,31 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/acl_hierarchies.json#/table_definition",
+    "$overwrite": {
+      "name": "acl_hierarchies_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_ah_staging_acl_id",
+          "columns": [
+            "acl_id"
+          ],
+          "referenced_table": "acls_staging",
+          "referenced_columns": [
+            "acl_id"
+          ],
+          "on_delete": "CASCADE"
+        },{
+          "name": "fk_ah_staging_hierarchy_id",
+          "columns": [
+            "hierarchy_id"
+          ],
+          "referenced_table": "hierarchies_staging",
+          "referenced_columns": [
+            "hierarchy_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/acl_tabs.json
+++ b/configuration/etl/etl_tables.d/acls/staging/acl_tabs.json
@@ -1,0 +1,32 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/acl_tabs.json#/table_definition",
+    "$overwrite": {
+      "name": "acl_tabs_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_at_staging_acl_id",
+          "columns": [
+            "acl_id"
+          ],
+          "referenced_table": "acls_staging",
+          "referenced_columns": [
+            "acl_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_at_staging_tab_id",
+          "columns": [
+            "tab_id"
+          ],
+          "referenced_table": "tabs_staging",
+          "referenced_columns": [
+            "tab_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/acl_types.json
+++ b/configuration/etl/etl_tables.d/acls/staging/acl_types.json
@@ -1,0 +1,21 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/acl_types.json#/table_definition",
+    "$overwrite": {
+      "name": "acl_types_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_atp_staging_module_id",
+          "columns": [
+            "module_id"
+          ],
+          "referenced_table": "modules_staging",
+          "referenced_columns": [
+            "module_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/acls.json
+++ b/configuration/etl/etl_tables.d/acls/staging/acls.json
@@ -1,0 +1,32 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/acls.json#/table_definition",
+    "$overwrite": {
+      "name": "acls_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_a_staging_module_id",
+          "columns": [
+            "module_id"
+          ],
+          "referenced_table": "modules_staging",
+          "referenced_columns": [
+            "module_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_a_staging_acl_type_id",
+          "columns": [
+            "acl_type_id"
+          ],
+          "referenced_table": "acl_types_staging",
+          "referenced_columns": [
+            "acl_type_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/group_bys.json
+++ b/configuration/etl/etl_tables.d/acls/staging/group_bys.json
@@ -1,0 +1,32 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/group_bys.json#/table_definition",
+    "$overwrite": {
+      "name": "group_bys_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_gb_staging_module_id",
+          "columns": [
+            "module_id"
+          ],
+          "referenced_table": "modules_staging",
+          "referenced_columns": [
+            "module_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_gb_staging_realm_id",
+          "columns": [
+            "realm_id"
+          ],
+          "referenced_table": "realms_staging",
+          "referenced_columns": [
+            "realm_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/hierarchies.json
+++ b/configuration/etl/etl_tables.d/acls/staging/hierarchies.json
@@ -1,0 +1,21 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/hierarchies.json#/table_definition",
+    "$overwrite": {
+      "name": "hierarchies_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_h_module_staging_id",
+          "columns": [
+            "module_id"
+          ],
+          "referenced_table": "modules_staging",
+          "referenced_columns": [
+            "module_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/modules.json
+++ b/configuration/etl/etl_tables.d/acls/staging/modules.json
@@ -1,0 +1,8 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/modules.json#/table_definition",
+    "$overwrite": {
+      "name": "modules_staging"
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/realms.json
+++ b/configuration/etl/etl_tables.d/acls/staging/realms.json
@@ -1,0 +1,21 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/realms.json#/table_definition",
+    "$overwrite": {
+      "name": "realms_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_r_module_staging_id",
+          "columns": [
+            "module_id"
+          ],
+          "referenced_table": "modules_staging",
+          "referenced_columns": [
+            "module_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/statistics.json
+++ b/configuration/etl/etl_tables.d/acls/staging/statistics.json
@@ -1,0 +1,32 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/statistics.json#/table_definition",
+    "$overwrite": {
+      "name": "statistics_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_s_staging_module_id",
+          "columns": [
+            "module_id"
+          ],
+          "referenced_table": "modules_staging",
+          "referenced_columns": [
+            "module_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_s_staging_realm_id",
+          "columns": [
+            "realm_id"
+          ],
+          "referenced_table": "realms_staging",
+          "referenced_columns": [
+            "realm_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/tabs.json
+++ b/configuration/etl/etl_tables.d/acls/staging/tabs.json
@@ -1,0 +1,32 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/tabs.json#/table_definition",
+    "$overwrite": {
+      "name": "tabs_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_t_staging_module_id",
+          "columns": [
+            "module_id"
+          ],
+          "referenced_table": "modules_staging",
+          "referenced_columns": [
+            "module_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_t_staging_parent_tab_id",
+          "columns": [
+            "parent_tab_id"
+          ],
+          "referenced_table": "tabs_staging",
+          "referenced_columns": [
+            "tab_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/user_acl_group_by_parameters.json
+++ b/configuration/etl/etl_tables.d/acls/staging/user_acl_group_by_parameters.json
@@ -1,0 +1,43 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/user_acl_group_by_parameters.json#/table_definition",
+    "$overwrite": {
+      "name": "user_acl_group_by_parameters_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_uagbp_staging_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_table": "Users",
+          "referenced_columns": [
+            "id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_uagbp_staging_acl_id",
+          "columns": [
+            "acl_id"
+          ],
+          "referenced_table": "acls_staging",
+          "referenced_columns": [
+            "acl_id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_uagbp_staging_group_by_id",
+          "columns": [
+            "group_by_id"
+          ],
+          "referenced_table": "group_bys_staging",
+          "referenced_columns": [
+            "group_by_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/staging/user_acls.json
+++ b/configuration/etl/etl_tables.d/acls/staging/user_acls.json
@@ -1,0 +1,32 @@
+{
+  "table_definition": {
+    "$ref-with-overwrite": "etl_tables.d/acls/user_acls.json#/table_definition",
+    "$overwrite": {
+      "name": "user_acls_staging",
+      "foreign_key_constraints": [
+        {
+          "name": "fk_ua_staging_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_table": "Users",
+          "referenced_columns": [
+            "id"
+          ],
+          "on_delete": "CASCADE"
+        },
+        {
+          "name": "fk_ua_staging_acl_id",
+          "columns": [
+            "acl_id"
+          ],
+          "referenced_table": "acls_staging",
+          "referenced_columns": [
+            "acl_id"
+          ],
+          "on_delete": "CASCADE"
+        }
+      ]
+    }
+  }
+}

--- a/configuration/etl/etl_tables.d/acls/statistics.json
+++ b/configuration/etl/etl_tables.d/acls/statistics.json
@@ -46,6 +46,16 @@
         "columns": [
           "realm_id"
         ]
+      },
+      {
+        "name": "idx_module_id_realm_id_name",
+        "columns": [
+          "module_id",
+          "realm_id",
+          "name"
+        ],
+        "type": "BTREE",
+        "is_unique": true
       }
     ],
     "foreign_key_constraints": [

--- a/configuration/etl/etl_tables.d/acls/user_acls.json
+++ b/configuration/etl/etl_tables.d/acls/user_acls.json
@@ -41,6 +41,15 @@
         "columns": [
           "acl_id"
         ]
+      },
+      {
+        "name": "idx_user_id_acl_id",
+        "columns": [
+          "user_id",
+          "acl_id"
+        ],
+        "type": "BTREE",
+        "is_unique": true
       }
     ],
     "foreign_key_constraints": [


### PR DESCRIPTION
## Description
- `acl-config`:
  - Added Lock File protection to protect against multiple copies of `acl-config` running simultaneously 
  - Added a signal handler that should ensure the lock file is unlocked when `acl-config` is ctrl-c'd etc. 
  - We no longer need to run `acls-xdmod-management` multiple times within `acl-config`, we now run 
    it once after the backup tables are handled.
  - We've refactored the way that `acl-config` works, previously we wholesale Truncated / re- 
    populated the "managed" tables ( any table that we can completely recreate from available 
    configuration files ) and then re-populated the "non-managed" tables i.e. `user_acls` and 
    `user_acl_group_by_parameters`. This method did not allow us to utilize db transactions as both 
    `TRUNCATE` and DDL ( drop / create / update table ) force an implicit commit on execution. This 
    left us open to having the database in an inconsistent state. Now, instead of truncating / populating 
    the tables directly we instead create / populate a set of `staging` tables from the configuration files 
    first. This leaves the production tables in tact in the event some problem arises. Then, wrapped in 
    a db transaction, we DELETE FROM && INSERT INTO each production table from it's associated 
    staging table. 


## Motivation and Context
We have run into a number of problems lately that we believe to be caused by multiple copies of `acl-config` running at the same time and or interrupted runs of `acl-config`. It's hoped that these changes will resolve these issues. 

## Tests performed
- All automated tests in an OpenXDMoD docker: upgrade / fresh install
- Manual testing: 
  - Inserting an Exception at random times to make sure that existing functionality is not compromised with an incomplete execution. Also, to make sure that we can still utilize the lock file. 
  - Ctrl+C out of an execution at various times to make sure that we don't bork things with an incomplete execution. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
