### PR TITLE
Only try to load metric explorer charts.

### DIFF
--- a/html/gui/js/modules/dashboard/ReportThumbnailsComponent.js
+++ b/html/gui/js/modules/dashboard/ReportThumbnailsComponent.js
@@ -99,6 +99,13 @@ XDMoD.Module.Dashboard.ReportThumbnailsComponent = Ext.extend(Ext.Panel, {
             listeners: {
                 click: {
                     fn: function (dataView, index, node, e) {
+                        var config = JSON.parse(JSON.stringify(dataView.store.data.items[index].json.chart_id));
+
+                        if (config.controller_module !== 'metric_explorer') {
+                            // Only metric explorer charts are supported
+                            return;
+                        }
+
                         var win; // Window to display the chart
                         this.tmpHpc = new CCR.xdmod.ui.HighChartPanel({
                             chartOptions: {
@@ -149,7 +156,6 @@ XDMoD.Module.Dashboard.ReportThumbnailsComponent = Ext.extend(Ext.Panel, {
 
                         }); // hcp
 
-                        var config = JSON.parse(JSON.stringify(dataView.store.data.items[index].json.chart_id));
                         this.tmpHpc.store.removeAll();
                         for (var key in config) {
                             if (key === 'data_series') {


### PR DESCRIPTION
This mitigates the UI lockup when trying to click on a Usage chart from
a report thumbnail (asana issue
https://app.asana.com/0/159049597309611/1153563882786297)

A complete fix will be to actually support all types of charts that can
be shown (Usage, Custom Queries, App Kernel . etc. ). But this at least
ensures that the UI does not lockup.
