### PR TITLE
Fix decoding of report chart settings in the dashboard controller.

### DIFF
--- a/classes/Rest/Controllers/DashboardControllerProvider.php
+++ b/classes/Rest/Controllers/DashboardControllerProvider.php
@@ -294,11 +294,13 @@ class DashboardControllerProvider extends BaseControllerProvider
                     $key = urldecode($key);
                     $value = urldecode($value);
                     $json = json_decode($value, true);
-                    if ($json === null) {
-                        $chart_id_parsed[$key] = $value;
-                    } else {
-                        $chart_id_parsed[$key] = $json;
+
+                    if ($key === 'timeseries') {
+                        $value = $value === 'y' || $value === 'true';
+                    } elseif ($json !== null) {
+                        $value = $json;
                     }
+                    $chart_id_parsed[$key] = $value;
                 }
                 $data['queue'][$count]['chart_id'] = $chart_id_parsed;
                 $count++;


### PR DESCRIPTION
This addresses asana issue https://app.asana.com/0/159049597309611/1153459826874569

Note that I checked the various other chart parameters and the timeseries parameter is the only one that appears to cause breakage. 

The parameters "show_guide_lines" and "showContextMenu" still appear as y/n values. However these are not actually used anywhere.