### PR TITLE
Don't bother trying to set headers if not possible.

### DIFF
--- a/configuration/linker.php
+++ b/configuration/linker.php
@@ -173,7 +173,7 @@ function global_uncaught_exception_handler($exception)
     $exceptionOutput = handle_uncaught_exception($exception);
 
    // If running in a server context...
-    if ($exceptionOutput['isServerContext']) {
+    if ($exceptionOutput['isServerContext'] && !headers_sent()) {
         // Set the exception's headers (if any).
         foreach ($exceptionOutput['headers'] as $headerKey => $headerValue) {
             header("$headerKey: $headerValue");

--- a/docs/support.md
+++ b/docs/support.md
@@ -32,8 +32,12 @@ Email `ccr-xdmod-help` at `buffalo.edu` for support.  Please include the followi
 - The output of `xdmod-check-config`
 - PHP and MySQL version (e.g, the output from `php --version`, `mysql --version`, and the SQL command `SHOW VARIABLES LIKE "%version%";`)
 - The output of `php -i`
+- Any messages in the XDMoD exceptions log `/var/log/xdmod/exceptions.log`
 - A description of the problem you are experiencing
 - Detailed steps to reproduce the problem
+
+If the problem is observed when trying to access the web portal then please also include any
+messages in the web server error log `/var/log/xdmod/apache-error.log`
 
 Mailing List
 ------------


### PR DESCRIPTION
We often get error log reports with messages like the following:
```
PHP Warning:  Cannot modify header information - headers already sent by (output started at /opt/xdmod/share/html/index.php:180) in /opt/xdmod/share/configuration/linker.php on line 179
```

These are of course completely useless and are caused by the error
handler trying to set the headers and failing. The issue is that the
orignal message that the error handler is supposed to output does not
make it to the logs.

This change ensures that the exception handler only tries to set headers
if they have not already been sent and updates the documentation to
encourage folk to look in the xdmod exceptions log.

I manually tested this by adding a `throw new Exception` in index.php and loading the page.