### PR TITLE
allow iframe login

### DIFF
--- a/html/gui/general/login.php
+++ b/html/gui/general/login.php
@@ -51,9 +51,18 @@ try {
   </style>
   <script type="text/javascript">
     function loadPortal() {
-      setTimeout(function(){
-        parent.location.href = '/index.php' + document.location.hash;
-      }, 1500);
+        try {
+            var href = window.top.location.href;
+            setTimeout(function(){
+                parent.location.href = '/index.php' + document.location.hash;
+            }, 1500);
+        }
+        catch(exception){
+            window.top.postMessage({
+                application:'xdmod',
+                action: 'loginComplete'
+            },'*');
+        }
     }
 
     function contactAdmin() {
@@ -81,7 +90,7 @@ try {
                window.top.postMessage({
                    application:'xdmod',
                    action: 'error',
-                   info: '<?php echo $message; ?>'
+                   info: <?php echo json_encode($message); ?>
                },'*');
            }
         </script>
@@ -90,7 +99,7 @@ try {
     <?php
     } else {
     ?>
-<body>
+<body onload="loadPortal()">
   <center>
     <table border=0 width=100% height=100%>
         <tr>
@@ -108,18 +117,6 @@ try {
         </tr>
     </table>
   </center>
-  <script>
-      try {
-          var href = window.top.location.href;
-          loadPortal();
-      }
-      catch(exception){
-          window.top.postMessage({
-              application:'xdmod',
-              action: 'loginComplete'
-          },'*');
-      }
-</script>
 </body>
 </html>
 

--- a/html/gui/general/login.php
+++ b/html/gui/general/login.php
@@ -73,12 +73,24 @@ try {
             <br>
             <a href="javascript:contactAdmin()">Contact a system administrator.</a>
         </p>
+        <script>
+           try {
+               var href = window.top.location.href;
+           }
+           catch(exception){
+               window.top.postMessage({
+                   application:'xdmod',
+                   action: 'error',
+                   info: '<?php echo $message; ?>'
+               },'*');
+           }
+        </script>
       </body>
       </html>
     <?php
     } else {
     ?>
-<body onload="loadPortal()">
+<body>
   <center>
     <table border=0 width=100% height=100%>
         <tr>
@@ -96,6 +108,18 @@ try {
         </tr>
     </table>
   </center>
+  <script>
+      try {
+          var href = window.top.location.href;
+          loadPortal();
+      }
+      catch(exception){
+          window.top.postMessage({
+              application:'xdmod',
+              action: 'loginComplete'
+          },'*');
+      }
+</script>
 </body>
 </html>
 


### PR DESCRIPTION
detect if login is within an iframe and do no redirect to the portal, instead send a postMessage to allow the parent frame to do what it wants

something like this should work

```javascript
window.addEventListener("message", receiveMessage, false);

function receiveMessage(event) {
  if (event.origin !== "{FQDN OF XDMOD INSTANCE WITH PROTOCOL AND PORT IF NEEDED}"){
    console.log('Received message from untrusted origin, discarding');
    return;
  }
  if(event.data.application == 'xdmod'){
    if(event.data.message == 'loginComplete'){
      console.log('XDMoD has logged in successfully');
    }
	if(event.data.message == 'error'){
      console.log('ERROR: ' + event.data.info);
    }
  }
}
```
DO NOT MERGE RELATED TO #1193