### PR TITLE
Enforce realm acls for show raw data endpoints.

### DIFF
--- a/classes/DataWarehouse/Access/RawData.php
+++ b/classes/DataWarehouse/Access/RawData.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace DataWarehouse\Access;
+
+use Configuration\XdmodConfiguration;
+use XDUser;
+use Models\Services\Realms;
+
+/*
+ * Data access for raw data from the fact tables
+ */
+class RawData
+{
+    public static function getRawDataRealms(XDUser $user)
+    {
+        $realms = array();
+
+        $raw = XdmodConfiguration::factory('rawstatistics.json', CONFIG_DIR)->toStdClass();
+         
+        if (!property_exists($raw, 'realms')) {
+            return $realms;
+        }
+
+        $allowedRealms = Realms::getRealmsForUser($user);
+
+        foreach($raw->realms as $realmConfig)
+        {
+            if (property_exists($realmConfig, 'raw_data')) {
+                if ($realmConfig->raw_data === false) {
+                    continue;
+                }
+            }
+
+            if (in_array($realmConfig->name, $allowedRealms)) {
+                $realms[] = $realmConfig;
+            }
+        }
+
+        return $realms;
+    }
+
+    public static function realmExists(XDUser $user, $realm)
+    {
+        $realmlist = self::getRawDataRealms($user);
+
+        foreach ($realmlist as $realmConfig) {
+            if ($realm == $realmConfig->name) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/classes/DataWarehouse/Access/RawData.php
+++ b/classes/DataWarehouse/Access/RawData.php
@@ -16,7 +16,7 @@ class RawData
         $realms = array();
 
         $raw = XdmodConfiguration::factory('rawstatistics.json', CONFIG_DIR)->toStdClass();
-         
+
         if (!property_exists($raw, 'realms')) {
             return $realms;
         }
@@ -25,10 +25,8 @@ class RawData
 
         foreach($raw->realms as $realmConfig)
         {
-            if (property_exists($realmConfig, 'raw_data')) {
-                if ($realmConfig->raw_data === false) {
-                    continue;
-                }
+            if (property_exists($realmConfig, 'raw_data') && $realmConfig->raw_data === false) {
+                continue;
             }
 
             if (in_array($realmConfig->name, $allowedRealms)) {

--- a/html/index.php
+++ b/html/index.php
@@ -271,13 +271,13 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
             print "CCR.xdmod.ui.isCenterDirector = " . json_encode($user->hasAcl(ROLE_ID_CENTER_DIRECTOR)) . ";\n";
         }
 
-        $config = \Configuration\XdmodConfiguration::assocArrayFactory('rawstatistics.json', CONFIG_DIR);
+        $rawRealmConfig = \DataWarehouse\Access\RawData::getRawDataRealms($user);
 
         $rawDataRealms = array_map(
             function ($item) {
-                return $item['name'];
+                return $item->name;
             },
-            $config['realms']
+            $rawRealmConfig
         );
 
         print "CCR.xdmod.ui.rawDataAllowedRealms = " . json_encode($rawDataRealms) . ";\n";


### PR DESCRIPTION
Previously, even though the raw data was protected by ACLs the list of
realms was not. So a user could see all realms that supported raw data
access (even if they did not have permission to see the realm itself).

This scenario is not seen in the default open xdmod installs since all
uses have access to jobs and supremm realms. This is seen in the XSEDE
version where different roles have different realm access.

Also add the capabilty to disable a realm from raw data access via the
config file.

