### PR TITLE
Improve search history panel UI.

### DIFF
--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -1755,11 +1755,15 @@ class WarehouseControllerProvider extends BaseControllerProvider
         $results = array();
 
         foreach(\DataWarehouse\Access\RawData::getRawDataRealms($user) as $realmconfig) {
-            $results[] = array(
-                'dtype' => 'realm',
-                'realm' => $realmconfig->name,
-                'text' => $realmconfig->display
-            );
+            $history = $this->getUserStore($user, $realmconfig->name);
+            $records = $history->get();
+            if (!empty($records)) {
+                $results[] = array(
+                    'dtype' => 'realm',
+                    'realm' => $realmconfig->name,
+                    'text' => $realmconfig->display
+                );
+            }
         }
 
         return $app->json(

--- a/html/gui/js/modules/job_viewer/JobViewer.js
+++ b/html/gui/js/modules/job_viewer/JobViewer.js
@@ -291,17 +291,28 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             title: 'Search History',
             collapsible: true,
             collapsed: false,
-            layout: 'border',
+            layout: 'card',
+            activeItem: 0,
             collapseFirst: false,
             pinned: false,
             plugins: new Ext.ux.collapsedPanelTitlePlugin('Navigation'),
             width: 250,
             items: [
+                new CCR.xdmod.ui.AssistPanel({
+                    region: 'center',
+                    border: true,
+                    headerText: 'No saved searches',
+                    subHeaderText: 'Use the search button above to find jobs',
+                    userManualRef: 'job+viewer'
+                }),
                 self.searchHistoryPanel
             ],
             listeners: {
                 collapse: function (p) {
 
+                },
+                history_exists: function (hasHistory) {
+                    this.getLayout().setActiveItem(hasHistory ? 1 : 0);
                 },
                 expand: function (p) {
                     if (p.pinned) {
@@ -1843,17 +1854,16 @@ XDMoD.Module.JobViewer = Ext.extend(XDMoD.PortalModule, {
             // It wasn't found, so we need to create it.
             var upsertPromise = self._upsertSearch(realm, searchTitle, null, [jobData], null);
             upsertPromise.then(function (data) {
-                var realmNode = self.searchHistoryPanel.root.findChild('text', realm);
-                var path = self._getPath(realmNode);
-                var recordId = recordId || data.results.recordid;
-                path.push({
+                var path = [{
+                    dtype: 'realm',
+                    value: realm
+                }, {
                     dtype: 'recordid',
-                    value: recordId
-                });
-                path.push({
+                    value: data.results.recordid
+                }, {
                     dtype: 'jobid',
                     value: jobId
-                });
+                }];
                 self.fireEvent('reload_root', path);
                 self.historyEventWaiting = false;
             });

--- a/html/gui/js/modules/job_viewer/SearchHistoryTree.js
+++ b/html/gui/js/modules/job_viewer/SearchHistoryTree.js
@@ -61,6 +61,10 @@ XDMoD.Module.JobViewer.SearchHistoryTree = Ext.extend(Ext.tree.TreePanel, {
 
 
         if (success) {
+            if (options.node.isRoot) {
+                this.ownerCt.fireEvent('history_exists', data.results.length > 0);
+            }
+
             var nodes = this._processNodes(rawNodes);
             var node = CCR.exists(options) && CCR.exists(options.node) ? options.node : null;
 


### PR DESCRIPTION
The search history in the job viewer always displayed all possible
realms that could have search history regardless of whether there were
any saved searches. This was reported as a bug by a user. The realm
nodes in the tree would have a triangle mark indicating that the could
be unfolded, but when the unfold was clicked then it would dissaper.

old:

![image](https://user-images.githubusercontent.com/5342179/72447419-4b317f80-3783-11ea-8a4a-0b2adc05b4ac.png)

new:

![image](https://user-images.githubusercontent.com/5342179/72447429-508eca00-3783-11ea-8664-68ed7219b49e.png)

![image](https://user-images.githubusercontent.com/5342179/72447440-571d4180-3783-11ea-88d4-ba6708dd267f.png)


This change makes it so that the search history only shows the realm
folder nodes for realms that have search history. If there a no saved
searches then an assist panel is shown.

There is a corresponding pull request in the supremm module that updates the UI tests to confirm the new code works.

