### PR TITLE
Maven changed their download url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,7 @@
                 "license": "AGPL-3.0",
                 "homepage": "http://itextpdf.com",
                 "dist": {
-                    "url": "http://central.maven.org/maven2/com/lowagie/itext/2.1.7/itext-2.1.7.jar",
+                    "url": "https://repo1.maven.org/maven2/com/lowagie/itext/2.1.7/itext-2.1.7.jar",
                     "type": "file",
                     "shasum": "892bfb3e97074a61123b3b2d7caa2db112750864"
                 }

--- a/composer.lock
+++ b/composer.lock
@@ -714,7 +714,7 @@
             "version": "2.1.7",
             "dist": {
                 "type": "file",
-                "url": "http://central.maven.org/maven2/com/lowagie/itext/2.1.7/itext-2.1.7.jar",
+                "url": "https://repo1.maven.org/maven2/com/lowagie/itext/2.1.7/itext-2.1.7.jar",
                 "shasum": "892bfb3e97074a61123b3b2d7caa2db112750864"
             },
             "type": "vanilla-plugin",


### PR DESCRIPTION
when trying to access the old http address:

501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
  