### PR TITLE
Use `postMessage` to alert `window.top`on framed login

### DIFF
--- a/html/gui/general/login.php
+++ b/html/gui/general/login.php
@@ -51,9 +51,18 @@ try {
   </style>
   <script type="text/javascript">
     function loadPortal() {
-      setTimeout(function(){
-        parent.location.href = '/index.php' + document.location.hash;
-      }, 1500);
+        try{
+            var href = window.top.location.href;
+            setTimeout(function(){
+                parent.location.href = '/index.php' + document.location.hash;
+            }, 1500);
+        }
+        catch(exception){
+            window.top.postMessage({
+                application:'xdmod',
+                action: 'loginComplete'
+            },'*');
+        }
     }
 
     function contactAdmin() {
@@ -73,6 +82,18 @@ try {
             <br>
             <a href="javascript:contactAdmin()">Contact a system administrator.</a>
         </p>
+        <script>
+           try {
+               var href = window.top.location.href;
+           }
+           catch(exception){
+               window.top.postMessage({
+                   application:'xdmod',
+                   action: 'error',
+                   info: <?php echo json_encode($message); ?>
+               },'*');
+           }
+        </script>
       </body>
       </html>
     <?php


### PR DESCRIPTION
Replaces #1198 

detect if login is within an iframe and do not redirect to the portal, instead send a `postMessage` to `window.top`

Use the following in window.top to recieve message and react accordingly

```javascript
window.addEventListener("message", receiveMessage, false);

function receiveMessage(event) {
  if (event.origin !== "{FQDN OF XDMOD INSTANCE WITH PROTOCOL AND PORT IF NEEDED}"){
    console.log('Received message from untrusted origin, discarding');
    return;
  }
  if(event.data.application == 'xdmod'){
    if(event.data.message == 'loginComplete'){
      console.log('XDMoD has logged in successfully');
    }
	if(event.data.message == 'error'){
      console.log('ERROR: ' + event.data.info);
    }
  }
}
```