### PR TITLE
Removed unused curl settings in test helper.

### DIFF
--- a/tests/integration/lib/TestHarness/XdmodTestHelper.php
+++ b/tests/integration/lib/TestHarness/XdmodTestHelper.php
@@ -55,10 +55,6 @@ class XdmodTestHelper
         # Enable header information in the response data
         curl_setopt($this->curl, CURLOPT_HEADERFUNCTION, array($this, 'processResponseHeader'));
 
-        # Disable ssl certificate checks (needed when using self-signed certificates).
-        curl_setopt($this->curl, CURLOPT_SSL_VERIFYHOST, false);
-        curl_setopt($this->curl, CURLOPT_SSL_VERIFYPEER, false);
-
         curl_setopt($this->curl, CURLOPT_COOKIEFILE, $this->cookiefile);
         curl_setopt($this->curl, CURLOPT_COOKIEJAR, $this->cookiefile);
 


### PR DESCRIPTION
The disable ssl checks used to be necessary when we used self-signed
certs on the dev machine. No longer needed.

