### PR TITLE
Focus on the Username field when the Login Button is clicked

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1386,7 +1386,7 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
                 XDMoD.TrackEvent('Login Window', 'Closed Window');
             },
             activate: function () {
-                txtLoginUsername.focus(true, 300);
+                txtLoginUsername.focus(false);
             }
         }
     });

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1384,6 +1384,9 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
         listeners: {
             close: function () {
                 XDMoD.TrackEvent('Login Window', 'Closed Window');
+            },
+            activate: function () {
+                txtLoginUsername.focus(true, 300);
             }
         }
     });


### PR DESCRIPTION
When clicking the login button focus on the username field when the form activates.

Verified that this works with and without SSO enabled.

This should have been part of #1115 