### PR TITLE
Add input validation to report generator controller endpoints.

### DIFF
--- a/classes/DataWarehouse/Access/ReportGenerator.php
+++ b/classes/DataWarehouse/Access/ReportGenerator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DataWarehouse\Access;
+
+class ReportGenerator extends Common
+{
+    /* Properties of reports. See also the enum columns in the moddb.Reports
+     * table  */
+    const REPORT_ID_REGEX = '/^[0-9]+-[0-9\.]+$/';
+    const REPORT_DATE_REGEX =  '/^[0-9]{4}(-[0-9]{2}){2}$/';
+    const REPORT_FORMATS_REGEX = '/^doc|pdf$/';
+    const REPORT_FONT_REGEX = '/^Arial$/';
+    const REPORT_SCHEDULE_REGEX = '/^Once|Daily|Weekly|Monthly|Quarterly|Semi-annually|Annually$/';
+    const REPORT_DELIVERY_REGEX = '/^E-Mail$/';
+
+    /* Patterns related to report charts */
+    const REPORT_CHART_TYPE_REGEX = '/^chart_pool|volatile|report|cached$/';
+    const REPORT_CHART_REF_REGEX = '/^[0-9]+(-[0-9]+)?;[0-9]+$/';
+    const REPORT_CHART_DID_REGEX = '/^_d[0-9]+$/';
+
+    /* the save_report controller use a custom data serialization for charts
+     * that have been modified from the original report */
+    const CHART_CACHEREF_REGEX = '/^([0-9]{4}(-[0-9]{2}){2};){2}(?(?=xd_report_volatile_)xd_report_volatile_[0-9]+;[0-9]+(_d[0-9]+)?|[0-9]+-[0-9\.]+;[0-9]+)$/';
+
+    /* The report download endpoint retrieves the report data from a temporary
+     * directory that is created dynamically based on the report_id
+     */
+    const REPORT_TMPDIR_REGEX = '/^[0-9]+-[0-9\.]+-[a-zA-Z0-9\.]+$/';
+
+    /*
+     * Character encoding used in the (user supplied) text contained in the
+     * report. This must be consistent with the character set used in the
+     * moddb.Report table.
+     */
+    const REPORT_CHAR_ENCODING = 'ISO-8859-1';
+}

--- a/html/controllers/report_builder/download_report.php
+++ b/html/controllers/report_builder/download_report.php
@@ -22,7 +22,7 @@ try {
 
     $get = filter_input_array(INPUT_GET, $filters);
 
-    if (XDReportManager::isValidFormat($get['format']) == false) {
+    if (!XDReportManager::isValidFormat($get['format'])) {
         print "Invalid format specified";
         exit;
     }

--- a/html/controllers/report_builder/download_report.php
+++ b/html/controllers/report_builder/download_report.php
@@ -1,17 +1,33 @@
 <?php
 
+use \DataWarehouse\Access\ReportGenerator;
+
+$filters = array(
+    'format' => array(
+        'filter' => FILTER_VALIDATE_REGEXP,
+        'options' => array('regexp' => ReportGenerator::REPORT_FORMATS_REGEX)
+    ),
+    'report_loc' => array(
+        'filter' => FILTER_VALIDATE_REGEXP,
+        'options' => array('regexp' => ReportGenerator::REPORT_TMPDIR_REGEX)
+    )
+);
+
 \xd_security\assertParametersSet(array(
     'report_loc',
     'format'
 ));
 
 try {
-    if (XDReportManager::isValidFormat($_GET['format']) == false) {
+
+    $get = filter_input_array(INPUT_GET, $filters);
+
+    if (XDReportManager::isValidFormat($get['format']) == false) {
         print "Invalid format specified";
         exit;
     }
 
-    $output_format = $_GET['format'];
+    $output_format = $get['format'];
 
     $user = \xd_security\getLoggedInUser();
 
@@ -21,9 +37,9 @@ try {
 
     // Resolve absolute path to report document on backend
 
-    $report_id = preg_replace('/(.+)-(.+)-(.+)/', '$1-$2', $_GET['report_loc']);
+    $report_id = preg_replace('/(.+)-(.+)-(.+)/', '$1-$2', $get['report_loc']);
 
-    $working_directory = sys_get_temp_dir() . '/' . $_GET['report_loc'];
+    $working_directory = sys_get_temp_dir() . '/' . $get['report_loc'];
 
     $report_file = $working_directory.'/'.$report_id.'.'.$output_format;
 

--- a/html/controllers/report_builder/send_report.php
+++ b/html/controllers/report_builder/send_report.php
@@ -1,37 +1,57 @@
 <?php
 
+use \DataWarehouse\Access\ReportGenerator;
+
+$filters = array(
+    'build_only' => array(
+        'filter' => FILTER_VALIDATE_BOOLEAN
+    ),
+    'report_id' => array(
+        'filter' => FILTER_VALIDATE_REGEXP,
+        'options' => array('regexp' => ReportGenerator::REPORT_ID_REGEX)
+    ),
+    'start_date' => array(
+        'filter' => FILTER_VALIDATE_REGEXP,
+        'options' => array('regexp' => ReportGenerator::REPORT_DATE_REGEX)
+    ),
+    'end_date' => array(
+        'filter' => FILTER_VALIDATE_REGEXP,
+        'options' => array('regexp' => ReportGenerator::REPORT_DATE_REGEX)
+    ),
+    'export_format' => array(
+        'filter' => FILTER_VALIDATE_REGEXP,
+        'options' => array('regexp' => ReportGenerator::REPORT_FORMATS_REGEX)
+    )
+);
+
    try {
+
+      $userdata = filter_input_array(INPUT_POST, $filters);
       
       $user = \xd_security\getLoggedInUser();
       
       $rm = new XDReportManager($user);
       	
-      \xd_security\assertParametersSet(array(
-         'report_id',
-         'build_only'
-      ));
-         
-      $report_id = $_POST['report_id'];
-      $build_only = $_POST['build_only'];
-         
-      // ==========================================================================        
-   
-      $export_format = XDReportManager::DEFAULT_FORMAT;
-      
-      if (isset($_POST['export_format']) && (XDReportManager::isValidFormat($_POST['export_format']) == true)) {
-         $export_format = $_POST['export_format'];
-      }   
-
-      if (isset($_POST['start_date']) && !empty($_POST['start_date']) && isset($_POST['end_date']) && !empty($_POST['end_date'])) {
-         $start_date = $_POST['start_date'];
-         $end_date = $_POST['end_date'];
-      } else {
-         $start_date = null;
-         $end_date = null;
+      $report_id = $userdata['report_id'];
+      if ($report_id === null) {
+          \xd_response\presentError('Invalid value specified for report_id');
       }
 
+      $build_only = $userdata['build_only'];
+      if ($build_only === null) {
+          \xd_response\presentError('Invalid value specified for build_only');
+      }
+
+      $export_format = $userdata['export_format'];
+    if ($export_format === null) {
+        $export_format = XDReportManager::DEFAULT_FORMAT;
+    }
+
+      $start_date = $userdata['start_date'];
+      $end_date = $userdata['end_date'];
+
       $returnData['action'] = 'send_report';  
-      $returnData['build_only'] = ($build_only == "true");         
+      $returnData['build_only'] = $build_only;
       
       try {
             
@@ -40,7 +60,7 @@
          $working_dir = $build_response['template_path'];
          $report_filename = $build_response['report_file'];
          
-         if ($build_only == "true") {
+         if ($build_only) {
    
             // Present enough information so that the download_report controller can serve up the file
             // (and provide appropriate cleanup) afterwards.

--- a/tests/unit/lib/DataWarehouse/Access/ReportGeneratorTest.php
+++ b/tests/unit/lib/DataWarehouse/Access/ReportGeneratorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace UnitTests\DataWarehouse\Access;
+
+use \DataWarehouse\Access\ReportGenerator;
+
+class ReportGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function reportTmpProvider() {
+        $data = array();
+        $data[]  = array('1-1579636800-yk3aoO', true);
+        $data[]  = array('1-1579636800-../etc/shadow', false);
+        $data[]  = array('../../root/.ssh/id_rsa', false);
+
+        return $data;
+    }
+
+    public function reportIdProvider() {
+        $data = array();
+        $data[]  = array('1-1579636800', true);
+        $data[]  = array('1021-1479636800.234', true);
+        $data[]  = array('cat /etc/passwd', false);
+
+        return $data;
+    }
+
+    public function chartRefProvider() {
+        $data = array();
+        $data[] = array('1-1579636800;2', true);
+        $data[] = array('1;161', true);
+        $data[] = array('/var/log/messages;161', false);
+        $data[] = array('; SELECT * FROM Users;161', false);
+
+        return $data;
+    }
+
+    public function cacheVarProvider() {
+        $data = array();
+        $data[] = array('2019-12-01;2019-12-31;1-1579636800;2', true);
+        $data[] = array('2019-12-01;2019-12-31;160-1579636800.234;2', true);
+        $data[] = array('2019-12-01;2019-12-31;xd_report_volatile_1;153', true);
+        $data[] = array('2010-01-22;2020-01-22;xd_report_volatile_1;161_d1579741925', true);
+        $data[] = array('2-1-22;2020-01-22;xd_report_volatile_1;161_d1579741925', false);
+        $data[] = array('2019-12-01;2019-12-31;../etc/passwd;2', false);
+
+        return $data;
+    }
+
+    /*
+     * run a regular expression via the php filter_var api and check
+     * whether the input is valid.
+     */
+    private function runFilter($regexp, $input, $isValid)
+    {
+        $r = filter_var(
+            $input,
+            FILTER_VALIDATE_REGEXP,
+            array('options'=> array('regexp'=> $regexp))
+        );
+
+        if ($isValid) {
+            $this->assertEquals($input, $r);
+        } else {
+            $this->assertFalse($r);
+        }
+    }
+
+    /**
+     * @dataProvider cacheVarProvider
+     */
+    public function testCacheVar($input, $isValid) {
+        $this->runFilter(ReportGenerator::CHART_CACHEREF_REGEX, $input, $isValid);
+    }
+
+    /**
+     * @dataProvider reportIdProvider
+     */
+    public function testReportIdVar($input, $isValid) {
+        $this->runFilter(ReportGenerator::REPORT_ID_REGEX, $input, $isValid);
+    }
+
+    /**
+     * @dataProvider chartRefProvider
+     */
+    public function testChartRefVar($input, $isValid) {
+        $this->runFilter(ReportGenerator::REPORT_CHART_REF_REGEX, $input, $isValid);
+    }
+
+    /**
+     * @dataProvider reportTmpProvider
+     */
+    public function testReportTmpVar($input, $isValid) {
+        $this->runFilter(ReportGenerator::REPORT_TMPDIR_REGEX, $input, $isValid);
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds input validation filters to the user-supplied
untrusted data provided to the report generator controller endpoints.

The modifications do not change any of the data serialization or api of
the endpoints.

The user-supplied report text (title, header, footer etc.) is modified
to filter out data that does not have a valid character encoding. This
mitigates a bug in the report generator if you tried to create a report
with a filename containing an invalid character such as 😊 then the UI would
show an error message:

```
There was a problem creating / updating this report.
(SQLSTATE[HY000]: General error: 1267 Illegal mix of collations (latin1_swedish_ci,IMPLICIT) and (utf8_general_ci,COERCIBLE) for operation 'like')
```

the new behaviour is that the report will save ok but any invalid
characters will be converted to '?'. A complete fix for this bug is
beyond the scope of this pull request.

## Motivation and Context

Potential security vulnerability using untrusted user data.

## Tests performed

There are several complex regular expressions used to validate the data
this is necessary due to the non-standard serialization used in the
report generator.  Unit tests have been added to confirm that the more
complex regular expressions used do pass through permissible data.