### PR TITLE
Fix bugs in Configuration classes.

### DIFF
--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -131,6 +131,12 @@ class Configuration extends Loggable implements iConfiguration
 
     protected $localConfigDir = null;
 
+
+    /**
+     * @var array of filenames of local configuration files
+     */
+    protected $localConfigFiles = array();
+
     /**
      * @var boolean Flag indicating that the directory for local configuration files has been
      * scanned and the list of filenames has been stored for use.

--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -525,9 +525,9 @@ class EtlConfiguration extends Configuration
      * ------------------------------------------------------------------------------------------
      */
 
-    public function cleanup()
+    public function cleanup($deepCleanup = false)
     {
-        parent::cleanup();
+        parent::cleanup($deepCleanup);
         $this->parentDefaults = null;
     }  // cleanup()
 


### PR DESCRIPTION
Ensure function prototype is correct for cleanup() function.
Ensure member variables are declared before they are used.

These errors showed up when I was running the unit tests on my ubuntu
box (php 7.2.24). It seems that earlier versions of php let you get away
with it but not in later versions.

