### PR TITLE
Fix typo in EtlConfiguration

### DIFF
--- a/classes/ETL/Configuration/EtlConfiguration.php
+++ b/classes/ETL/Configuration/EtlConfiguration.php
@@ -449,7 +449,7 @@ class EtlConfiguration extends Configuration
     protected function merge(Configuration $localConfigObj, $overwrite = false)
     {
         if ( ! $localConfigObj instanceof EtlConfiguration ) {
-            $this-logAndThrowException("Local config object is not of type EtlConfiguration");
+            $this->logAndThrowException("Local config object is not of type EtlConfiguration");
         }
 
         parent::merge($localConfigObj, $overwrite);


### PR DESCRIPTION
As far as I can tell there is no way in the current code to get into
this if statement. However, I suppose this protects the code against
misuse by a class that inherits from this one.

