### PR TITLE
Adding table name to remove ambiguity from group by statement

### DIFF
--- a/configuration/etl/etl_action_defs.d/cloud_generic/instance.json
+++ b/configuration/etl/etl_action_defs.d/cloud_generic/instance.json
@@ -39,9 +39,9 @@
         ],
 
         "groupby": [
-            "resource_id",
-            "provider_instance_identifier",
-            "service_provider"
+            "raw.resource_id",
+            "raw.provider_instance_identifier",
+            "raw.service_provider"
         ]
     }
 }


### PR DESCRIPTION
This fixes the following error seen in the metrics-dev logs.

```
2020-02-12 04:19:05 [warning] SQL warnings on table '`modw_cloud`.`instance`' generated by action xdmod.jobs-cloud-extract-generic.GenericCloudInstanceIngestor
2020-02-12 04:19:05 [warning] Warning 1052 Column 'service_provider' in group statement is ambiguous
```

## Tests performed
Ran in docker and manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
