### PR TITLE
Remove `cloudfact_by_.json` from migration definition file list

### DIFF
--- a/configuration/etl/etl.d/xdmod-migration-8_5_1-9_0_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-8_5_1-9_0_0.json
@@ -15,8 +15,7 @@
                 "cloud_openstack/raw_event.json",
                 "cloud_common/session_records.json",
                 "cloud_common/event.json",
-                "cloud_common/instance.json",
-                "cloud_common/cloudfact_by_.json"
+                "cloud_common/instance.json"
             ],
             "endpoints": {
                 "destination": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Removes a file from a definition file list in an ETL migration configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Including aggregate table definitions doesn't work properly with the `ETL\Maintenance\ManageTables` class.  There is no way to specify the aggregation units resulting in incorrect table names.

The first problem is this warning:

```
2020-02-20 17:52:36 [warning] ETL\DbModel\Table: Attempt to set unsupported property: 'table_prefix'
```

The ETL system then creates the table without the aggregate unit suffix:

```
2020-02-20 17:52:38 [notice] Table `modw_cloud`.`cloudfact_by_` does not exist, creating.
```

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually inspected output from the upgrade script and checked the database to see the `cloudfact_by_` table was not created.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
