### PR TITLE
Add additional ETL DB Model error checking

### DIFF
--- a/classes/ETL/DbModel/ForeignKeyConstraint.php
+++ b/classes/ETL/DbModel/ForeignKeyConstraint.php
@@ -57,6 +57,9 @@ class ForeignKeyConstraint extends NamedEntity implements iEntity
     public function initialize(stdClass $config)
     {
         if (!isset($config->name)) {
+            if (!isset($config->columns) || !is_array($config->columns)) {
+                $this->logAndThrowException('"columns" must be an array');
+            }
             $config->name = $this->generateForeignKeyConstraintName($config->columns);
         }
 

--- a/classes/ETL/DbModel/Index.php
+++ b/classes/ETL/DbModel/Index.php
@@ -54,6 +54,9 @@ class Index extends NamedEntity implements iEntity
         // Local verifications
 
         if ( ! isset($config->name) ) {
+            if (!isset($config->columns) || !is_array($config->columns)) {
+                $this->logAndThrowException('"columns" must be an array');
+            }
             $config->name = $this->generateIndexName($config->columns);
         }
 

--- a/tests/unit/lib/ETL/DbModel/DbModelTest.php
+++ b/tests/unit/lib/ETL/DbModel/DbModelTest.php
@@ -117,6 +117,74 @@ class DbModelTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test index initialization error.
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage "columns" must be an array
+     */
+    public function testIndexInitializationError()
+    {
+        $config = (object) [
+            'name' => 'initialize_error',
+            'columns' => [
+                (object) [
+                    'name' => 'column1',
+                    'type' => 'int(11)',
+                    'nullable' => false,
+                    'default' => 0,
+                    'comment' => 'This is my comment'
+                ]
+            ],
+            'indexes' => [
+                (object) [
+                    'type' => 'PRIMARY'
+                ]
+            ]
+        ];
+
+        $table = new Table($config);
+        $table->verify();
+    }
+
+    /**
+     * Test foreign key constraint initialization error.
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage "columns" must be an array
+     */
+    public function testForeignKeyConstraintInitializationError()
+    {
+        $config = (object) [
+            'name' => 'initialize_error',
+            'columns' => [
+                (object) [
+                    'name' => 'column1',
+                    'type' => 'int(11)',
+                    'nullable' => false
+                ]
+            ],
+            'indexes' => [
+                (object) [
+                    'columns' => [
+                        'column1'
+                    ]
+                ]
+            ],
+            'foreign_key_constraints' => [
+                (object) [
+                    'referenced_table' => 'other_table',
+                    'referenced_columns' => [
+                        'id'
+                    ]
+                ]
+            ]
+        ];
+
+        $table = new Table($config);
+        $table->verify();
+    }
+
+    /**
      * Test table verification error
      *
      * @expectedException Exception


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds additional error checking to the initialize functions of the index and foreign key constraint database models.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `initialize` functions use the `columns` from the configuration when a `name` is not specified.  The `columns` are required local properties of the entities, but their existence is not verified until the parent `initialize` function is called.  This function must be called last in the child `initialize` because the parent `initialize` uses the `name` configuration to set the entities `name`.

Without this change any missing columns produce an `Undefined property: stdClass::$columns` error which cannot be caught and logged.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
