### PR TITLE
Fix show remainder calculation for Jobs by System Username.

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByUsername.php
+++ b/classes/DataWarehouse/Query/Jobs/GroupBys/GroupByUsername.php
@@ -89,9 +89,15 @@ class GroupByUsername extends \DataWarehouse\Query\Jobs\GroupBy
             $whereConstraint="('". implode("','", $whereConstraint) ."')";
         }
 
+        $id_field = new \DataWarehouse\Query\Model\TableField(
+            $this->systemaccount_table,
+            $this->_id_field_name,
+            $this->getIdColumnName($multi_group)
+        );
+
         $query->addWhereCondition(
             new \DataWarehouse\Query\Model\WhereCondition(
-                $systemaccounttable_id_field,
+                $id_field,
                 $operation,
                 $whereConstraint
             )

--- a/tests/regression/lib/Controllers/MetricExplorerChartsTest.php
+++ b/tests/regression/lib/Controllers/MetricExplorerChartsTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace RegressionTests\Controllers;
+
+class MetricExplorerChartsTest extends \PHPUnit_Framework_TestCase
+{
+    /* If the 'expected' value is set to null then the test harness will
+     * use this function to print out the results from the api call. This
+     * can be used to generate new expected test results.
+     */
+    private function output($chartData)
+    {
+        $result = array(
+            'total' => $chartData->totalCount,
+            'series_data' => array()
+        );
+        foreach ($chartData->data[0]->series as $series) {
+            $result['series_data'][] = array(
+                'name' => $series->name,
+                'y' => $series->data[0]->y,
+                'percentage' => $series->data[0]->percentage
+            );
+        }
+        var_export($result);
+    }
+
+    /**
+     * @dataProvider remainderChartProvider
+     */
+    public function testChartData($requestData, $expected)
+    {
+        $helper = new \TestHarness\XdmodTestHelper();
+        $helper->authenticate('cd');
+
+        $response = $helper->post('controllers/metric_explorer.php', null, $requestData);
+
+        $this->assertEquals(200, $response[1]['http_code']);
+
+        $chartData = json_decode($response[0]);
+        $this->assertNotNull($chartData);
+
+        if ($expected === null) {
+            $this->output($chartData);
+            $this->markTestSkipped();
+            return;
+        }
+
+        $this->assertEquals($expected['total'], $chartData->totalCount);
+
+        $series = $chartData->data[0]->series;
+        $this->assertCount(count($expected['series_data']), $series);
+
+        $sdata = reset($expected['series_data']);
+
+        foreach ($series as $s) {
+            $this->assertEquals($sdata['name'], $s->name);
+            $this->assertEquals($sdata['y'], $s->data[0]->y, '', 1.0E-6);
+            $this->assertEquals($sdata['percentage'], $s->data[0]->percentage);
+            $sdata = next($expected['series_data']);
+        }
+
+        $helper->logout();
+    }
+
+    public function getChartRequest($realm, $group_by, $metric)
+    {
+        $dataseries = array (
+            array (
+                'id' => 0.1356380402688,
+                'metric' => $metric,
+                'category' => '',
+                'realm' => $realm,
+                'group_by' => $group_by,
+                'x_axis' => false,
+                'log_scale' => false,
+                'has_std_err' => false,
+                'std_err' => false,
+                'std_err_labels' => false,
+                'value_labels' => false,
+                'display_type' => 'line',
+                'line_type' => '',
+                'line_width' => '',
+                'combine_type' => 'side',
+                'sort_type' => 'value_desc',
+                'filters' => array (
+                    'data' => array (),
+                    'total' => 0,
+                ),
+                'ignore_global' => false,
+                'long_legend' => true,
+                'trend_line' => false,
+                'color' => '',
+                'shadow' => '',
+                'visibility' => '',
+                'z_index' => 0,
+                'enabled' => true,
+            )
+        );
+
+        $chartSettings = array(
+            'show_title' => 'y',
+            'timeseries' => 'y',
+            'aggregation_unit' => 'Auto',
+            'start_date' => '2016-12-31',
+            'end_date' => '2016-12-31',
+            'global_filters' => '%7B%22data%22%3A%5B%5D%2C%22total%22%3A0%7D',
+            'title' => 'Metric Explorer Test Chart',
+            'show_filters' => 'true',
+            'show_warnings' => 'true',
+            'show_remainder' => 'true',
+            'start' => '0',
+            'limit' => '4',
+            'timeframe_label' => 'User Defined',
+            'operation' => 'get_data',
+            'data_series' => urlencode(json_encode($dataseries)),
+            'swap_xy' => 'false',
+            'share_y_axis' => 'false',
+            'hide_tooltip' => 'false',
+            'show_guide_lines' => 'y',
+            'showContextMenu' => 'y',
+            'scale' => '1',
+            'format' => 'hc_jsonstore',
+            'width' => '1388',
+            'height' => '494',
+            'legend_type' => 'bottom_center',
+            'font_size' => '3',
+            'featured' => 'false',
+            'trendLineEnabled' => '',
+            'x_axis' => '%7B%7D',
+            'y_axis' => '%7B%7D',
+            'legend' => '%7B%7D',
+            'defaultDatasetConfig' => '%7B%7D',
+            'controller_module' => 'metric_explorer'
+        );
+        return $chartSettings;
+    }
+
+    /**
+     * These test cases cover the four different 'show remainder' cases: min, max, avg and sum.
+     */
+    public function remainderChartProvider()
+    {
+        $tests = array();
+
+        $tests[] = array(
+            $this->getChartRequest('Jobs', 'username', 'total_cpu_hours'),
+            array(
+                'total' => 55,
+                'series_data' => array(
+                    array( 'name' => 'honbu', 'y' => 86581.6175, 'percentage' => 0),
+                    array( 'name' => 'meapi', 'y' => 22004.0533, 'percentage' => 0),
+                    array( 'name' => 'moorh', 'y' => 20518.0064, 'percentage' => 0),
+                    array( 'name' => 'garwa', 'y' => 11780.8131, 'percentage' => 0),
+                    array( 'name' => 'All 51 Others', 'y' => 81345.1393, 'percentage' => null)
+                )
+            )
+        );
+
+        $tests[] = array(
+            $this->getChartRequest('Jobs', 'pi', 'max_processors'),
+            array (
+                'total' => '34',
+                'series_data' => array (
+                    array('name' => 'Thrush, Hermit', 'y' => 336, 'percentage' => 0),
+                    array('name' => 'Dunlin', 'y' => 192, 'percentage' => 0),
+                    array('name' => 'Scaup, Lesser', 'y' => 192, 'percentage' => 0),
+                    array('name' => 'Nuthatch', 'y' => 112, 'percentage' => 0),
+                    array('name' => 'Maximum over all 30 others', 'y' => 96, 'percentage' => null),
+                )
+            )
+        );
+
+        $tests[] = array(
+            $this->getChartRequest('Jobs', 'person', 'total_wallduration_hours'),
+            array (
+                'total' => '55',
+                'series_data' => array (
+                    array('name' => 'Moorhen', 'y' => 20518.0064, 'percentage' => 0),
+                    array('name' => 'Honey-buzzard', 'y' => 8276.1947, 'percentage' => 0),
+                    array('name' => 'Grey, Lesser', 'y' => 5534.6542, 'percentage' => 0),
+                    array('name' => 'Lapwing', 'y' => 2761.8142, 'percentage' => 0),
+                    array('name' => 'All 51 Others', 'y' => 5231.8753, 'percentage' => null),
+                )
+            )
+        );
+
+        $tests[] = array(
+            $this->getChartRequest('Jobs', 'queue', 'min_processors'),
+            array (
+                'total' => '17',
+                'series_data' => array (
+                    array('name' => 'roti', 'y' => 32, 'percentage' => 0),
+                    array('name' => 'chapti', 'y' => 12, 'percentage' => 0),
+                    array('name' => 'focaccia', 'y' => 12, 'percentage' => 0),
+                    array('name' => 'nann', 'y' => 12, 'percentage' => 0),
+                    array('name' => 'Minimum over all 13 others', 'y' => 1, 'percentage' => null),
+                )
+            )
+        );
+
+        return $tests;
+    }
+}

--- a/tests/regression/runtests.sh
+++ b/tests/regression/runtests.sh
@@ -46,7 +46,7 @@ if [ "$REG_TEST_ALL" = "1" ]; then
     set +e
     if [[ "$XDMOD_REALMS" == *"jobs"* ]];
     then
-        $phpunit $(log_opts "UsageCharts-pub") --filter UsageChartsTest . #TODO: Implement UsageChartsTest for Cloud and Storage realms
+        $phpunit $(log_opts "Charts-pub") --filter ChartsTest . #TODO: Implement UsageChartsTest for Cloud and Storage realms
     fi
 
     for role in ${roles[@]}; do
@@ -62,7 +62,7 @@ else
 
     if [[ "$XDMOD_REALMS" == *"jobs"* ]];
     then
-        $phpunit $(log_opts "UsageCharts-pub") --filter UsageChartsTest . & #TODO: Implement UsageChartsTest for Cloud and Storage realms
+        $phpunit $(log_opts "Charts-pub") --filter ChartsTest . & #TODO: Implement UsageChartsTest for Cloud and Storage realms
         pids+=($!)
     fi
 


### PR DESCRIPTION
Also added a regression test to check that the remainder calculation is
performed correctly.

# Description

The System Username group by in the Jobs realm used an incorrect column name when building the where conditions that are used in the remainder calculation in the metric explorer. This means that the "Avg of N others" calculation was actually the "Avg of all values". This fixes the query and adds a test to confirm the correct value. I've also added a couple of tests for the other types of remainder calculation.