### PR TITLE
Update openstack json event schema definition 

### DIFF
--- a/configuration/etl/etl_schemas.d/cloud_openstack/event.schema.json
+++ b/configuration/etl/etl_schemas.d/cloud_openstack/event.schema.json
@@ -65,7 +65,7 @@
         "type": "string"
       },
       "user_name": {
-        "type": "string"
+        "type": ["string", "null"]
       },
       "root_gb": {
         "type": "integer"


### PR DESCRIPTION
Update the json schema for openstack events to allow null for the user_name field. This allows events whose user_name field has a null value to be ingested. Any event with a user_name of null will be assigned to the unknown value when aggregated.

## Tests performed
Tested in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
