### PR TITLE
Improve robustness of integration and regression tests.

### DIFF
--- a/tests/integration/lib/BaseTest.php
+++ b/tests/integration/lib/BaseTest.php
@@ -4,7 +4,6 @@ namespace IntegrationTests;
 
 use \TestHarness\Utilities;
 
-
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
     protected static $XDMOD_REALMS;

--- a/tests/integration/lib/BaseTest.php
+++ b/tests/integration/lib/BaseTest.php
@@ -2,7 +2,8 @@
 
 namespace IntegrationTests;
 
-use Models\Services\Realms;
+use \TestHarness\Utilities;
+
 
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
@@ -10,25 +11,11 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
 
     public static function setUpBeforeClass()
     {
-        if(!isset(self::$XDMOD_REALMS)) {
-            $xdmod_realms = array();
-            $rawRealms = Realms::getRealms();
-            foreach($rawRealms as $item) {
-                array_push($xdmod_realms, $item->name);
-            }
-            self::$XDMOD_REALMS = $xdmod_realms;
-        }
+        self::$XDMOD_REALMS = Utilities::getRealmsToTest();
     }
 
     public static function getRealms()
     {
-        if(!isset(self::$XDMOD_REALMS)) {
-            $xdmod_realms = array();
-            $rawRealms = Realms::getRealms();
-            foreach($rawRealms as $item) {
-                array_push($xdmod_realms, $item->name);
-            }
-            return $xdmod_realms;
-        }
+        return Utilities::getRealmsToTest();
     }
 }

--- a/tests/integration/runtests.sh
+++ b/tests/integration/runtests.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+XDMOD_REALMS=${XDMOD_REALMS:-'jobs,storage,cloud'}
+export XDMOD_REALMS
+
 echo "Integration tests beginning:" `date +"%a %b %d %H:%M:%S.%3N %Y"`
 
 UATCU=""

--- a/tests/regression/runtests.sh
+++ b/tests/regression/runtests.sh
@@ -9,9 +9,8 @@ then
     junit_output_dir="$2"
 fi
 
-if [ -z $XDMOD_REALMS ]; then
-    export XDMOD_REALMS=$(echo `mysql -Ne "SELECT name FROM moddb.realms"` | tr ' ' ',')
-fi
+XDMOD_REALMS=${XDMOD_REALMS:-'jobs,storage,cloud'}
+export XDMOD_REALMS
 
 # Output PHPUnit logging options.  First argument is a unique identifier that
 # will be used in the log file name.


### PR DESCRIPTION
The integration and regression tests should not get their
test parameters from the system that they are testing. If the
system to test is broken then the test may erroneously pass.

For this pull request: the old code was querying XDMoD
to find out what realms existed and then only testing the realms
that XDMoD reported as present. **This is not the way it should be done.**
What should actually happen is that the developer sets up XDMoD
with the desired set of realms and then the tests check that
the desired set of realms are actually present.