### PR TITLE
Adjust ETL database model table schema assignment

### DIFF
--- a/classes/ETL/DbModel/Table.php
+++ b/classes/ETL/DbModel/Table.php
@@ -1146,8 +1146,11 @@ ORDER BY trigger_name ASC";
                 break;
 
             case 'schema':
-                // Changing the schema is not allowed.
-                if (isset($this->properties[$property])) {
+                // The schema is not required, but may be defined in both the
+                // table definition and the destination endpoint.  This is fine
+                // as long as they both specify the same schema.
+                if (isset($this->properties[$property])
+                    && $this->properties[$property] != $value) {
                     $this->logAndThrowException('Table schema may not be changed');
                 }
 

--- a/tests/unit/lib/ETL/DbModel/TableTest.php
+++ b/tests/unit/lib/ETL/DbModel/TableTest.php
@@ -27,6 +27,7 @@ class TableTest extends PHPUnit_Framework_TestCase
     {
         $config = (object) [
             'schema' => 'my_schema',
+            'name' => 'my_table',
             'columns' => [
                 (object) [
                     'name' => 'id',
@@ -36,5 +37,135 @@ class TableTest extends PHPUnit_Framework_TestCase
         ];
         $table = new Table($config, '`', self::$logger);
         $table->schema = 'test';
+    }
+
+    /**
+     * Test that the table schema may be set after the table is instantiated.
+     */
+    public function testTableSchemaAssignmentAfterInstantiation()
+    {
+        $schemaName = 'my_schema';
+        $config = (object) [
+            'name' => 'my_table',
+            'columns' => [
+                (object) [
+                    'name' => 'id',
+                    'type' => 'int(11)'
+                ]
+            ]
+        ];
+        $table = new Table($config, '`', self::$logger);
+        $table->schema = $schemaName;
+        $this->assertTrue($table->verify(), 'Table is verified');
+        $this->assertEquals($schemaName, $table->schema, 'Schema name');
+    }
+
+    /**
+     * Test that the table schema may be set by both the constructor and
+     * afterward.
+     */
+    public function testTableSchemaDuplicateAssignment()
+    {
+        $schemaName = 'my_schema';
+        $config = (object) [
+            'schema' => $schemaName,
+            'name' => 'my_table',
+            'columns' => [
+                (object) [
+                    'name' => 'id',
+                    'type' => 'int(11)'
+                ]
+            ]
+        ];
+        $table = new Table($config, '`', self::$logger);
+        $table->schema = $schemaName;
+        $this->assertTrue($table->verify(), 'Table is verified');
+        $this->assertEquals($schemaName, $table->schema, 'Schema name');
+    }
+
+    /**
+     * Test that the table schema may be set repeatedly to the same name.
+     */
+    public function testTableSchemaMultipleAssignment()
+    {
+        $schemaName = 'my_schema';
+
+        // Schema in configuration object.
+        $config = (object) [
+            'schema' => $schemaName,
+            'name' => 'my_table',
+            'columns' => [
+                (object) [
+                    'name' => 'id',
+                    'type' => 'int(11)'
+                ]
+            ]
+        ];
+        $table = new Table($config, '`', self::$logger);
+        $table->schema = $schemaName;
+        $table->schema = $schemaName;
+        $this->assertTrue($table->verify(), 'Table is verified');
+        $this->assertEquals($schemaName, $table->schema, 'Schema name');
+
+        // No schema in configuration object.
+        $config = (object) [
+            'name' => 'my_table',
+            'columns' => [
+                (object) [
+                    'name' => 'id',
+                    'type' => 'int(11)'
+                ]
+            ]
+        ];
+        $table = new Table($config, '`', self::$logger);
+        $table->schema = $schemaName;
+        $table->schema = $schemaName;
+        $this->assertTrue($table->verify(), 'Table is verified');
+        $this->assertEquals($schemaName, $table->schema, 'Schema name');
+    }
+
+    /**
+     * Test that the table schema must be a string.
+     *
+     * @dataProvider tableSchemaTypeErrorProvider
+     * @expectedException Exception
+     */
+    public function testTableSchemaTypeError($schemaName)
+    {
+        $config = (object) [
+            'schema' => $schemaName,
+            'name' => 'my_table',
+            'columns' => [
+                (object) [
+                    'name' => 'id',
+                    'type' => 'int(11)'
+                ]
+            ]
+        ];
+        $table = new Table($config, '`', self::$logger);
+        $table->verify();
+    }
+
+    public function tableSchemaTypeErrorProvider()
+    {
+        return [
+            'boolean' => [
+                true
+            ],
+            'number' => [
+                1.1
+            ],
+            'array' => [
+                ['schema' => 'schema_in_array']
+            ],
+            'object' => [
+                (object) ['schema' => 'schema_in_object']
+            ],
+            'function' => [
+                function () {
+                    return 'schema_returned_from_function';
+                }
+            ]
+        ];
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Allow the table schema to be set in the constructor or after instantiation as long as it is the same each time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The table schema may be set in the `table_definition` or the destination endpoint or not at all.  This change allows the schema to be specified in both places as long as it is the same in both places.  Changes in #1257 broke this behavior.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
