### PR TITLE
Fix html decoding in Job Viewer -> Edit Search

### DIFF
--- a/html/gui/js/modules/job_viewer/SearchPanel.js
+++ b/html/gui/js/modules/job_viewer/SearchPanel.js
@@ -474,7 +474,7 @@ XDMoD.Module.JobViewer.SearchPanel = Ext.extend(Ext.Panel, {
             this._retrieveSelected(node);
 
             this.ownerCt.setTitle("Editing Search: " + this.title);
-            Ext.getCmp('job-viewer-search-name').setValue(this.title);
+            Ext.getCmp('job-viewer-search-name').setValue(Ext.util.Format.htmlDecode(params.text));
 
             if (!this.ownerCt.isVisible()) {
                 this.ownerCt.show();
@@ -1456,7 +1456,7 @@ XDMoD.Module.JobViewer.SearchPanel = Ext.extend(Ext.Panel, {
         var selected = self._resultsToJSON(self._getSelectedRecords());
 
         var params = {
-            text: Ext.util.Format.htmlEncode(title),
+            text: title,
             searchterms: {
                 params: self.resultsStore.searchParams
             },


### PR DESCRIPTION
Original Bug Report:

https://app.asana.com/0/342819846538629/828830620362347

When entering a Search Title that contains html encodable values ( <, >,
& etc ), saving and then editing the search causes the encoded title to
be editable, not the decoded title.
Example:
  - Search Title: Pwned!<script>alert(1)</script>
    - When viewed this displays correctly as text. But if you 'edit' the
search you will instead see
      the value below.
  - Encoded: `Pwned!&lt;script&gt;alert(1)&lt;/script&gt;`
    - This is what you see when editing the search.
   - If you save the search after editing it then it will then become:
     - Pwned!&amp;lt;script&amp;&lt/script&amp;&gt;

Description:

the .text element contains html content. but you have to put normal
text in the form field.

--

## Notes

the actual fix for the problem is the one line change to add the `Ext.util.Format.htmlDecode` call in SearchPanel.js. However, on inspection of the code, the html sanitization was being performed in the client rather than the server. This is a serious bug. Since both fixes are needed and they both impact the same code flow this pull request fixes both bugs.