### PR TITLE
Remove unnecessary redirect in the job viewer rest stack.

### DIFF
--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -361,7 +361,7 @@ class WarehouseControllerProvider extends BaseControllerProvider
         } elseif ($jobId !== null && $recordId !== null && $realm !== null) {
             $result = $this->processJobByJobId($app, $user, $realm, $jobId, $action);
         } elseif ($recordId !== null && $realm !== null) {
-            $result = $this->processHistoryRecordRequest($request, $app, $user, $recordId, $action);
+            $result = $this->getHistoryById($request, $app, $recordId);
         } elseif ($realm !== null && $title !== null) {
             $result = $this->getHistoryByTitle($request, $app, $realm, $title);
         } elseif ($realm !== null) {
@@ -1714,20 +1714,6 @@ class WarehouseControllerProvider extends BaseControllerProvider
                 'results' => array_values($data)
             )
         );
-    }
-
-    /**
-     * @param Request $request
-     * @param Application $app
-     * @param XDUser $user
-     * @param int $recordId
-     * @param string $action
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
-     */
-    private function processHistoryRecordRequest(Request $request, Application $app, XDUser $user, $recordId, $action)
-    {
-        $url = $request->getBasePath() . $request->getPathInfo() . "/$recordId?".$request->getQueryString();
-        return $app->redirect($url);
     }
 
     /**


### PR DESCRIPTION
The job viewer rest api has an unusual code path to get the list of jobs
for a given saved search. There is a 302 redirect when the interface
gets the list of jobs. There is no 302 redirect for any of the other
equivalent queries (such as list of information for a job). All of the
required information to respond to the request is in the original request.

This pull request removes the redirect. The path that wasa being
redirected to still remains so as to not break compatibility with any
external systems (they both call the same underlying function).

This was observed while testing #1268 