### PR TITLE
Don't analyze tables during jobs aggregation for GPU data migration

### DIFF
--- a/classes/ETL/Utilities.php
+++ b/classes/ETL/Utilities.php
@@ -244,6 +244,9 @@ class Utilities
         if( array_key_exists('variable-overrides', $params) ){
             $configOptions['config_variables'] = $params['variable-overrides'];
         }
+        if (array_key_exists('option-overrides', $params)) {
+            $configOptions['option_overrides'] = $params['option-overrides'];
+        }
 
         $etlConfig = EtlConfiguration::factory(
             CONFIG_DIR . '/etl/etl.json',

--- a/classes/OpenXdmod/Migration/Version851To900/DatabaseMigration.php
+++ b/classes/OpenXdmod/Migration/Version851To900/DatabaseMigration.php
@@ -60,7 +60,12 @@ EOT
             Utilities::runEtlPipeline(
                 ['jobs-gpu-re-ingest-8_5_1-9_0_0', 'jobs-xdw-aggregate'],
                 $this->logger,
-                ['last-modified-start-date' => $lastModifiedStartDate]
+                [
+                    'last-modified-start-date' => $lastModifiedStartDate,
+                    'option-overrides' => [
+                        'analyze_table' => false
+                    ]
+                ]
             );
             $builder = new FilterListBuilder();
             $builder->setLogger($this->logger);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Sets `analyze_table` in the ETL configuration options to false to prevent tables from being analyzed or optimized during the re-aggregation of jobs data for the 9.0 migration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Analyzing and optimizing tables is slow and could cause a time out with the database.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
