### PR TITLE
changing account, instance and instance_type tables to have global un…

### DIFF
--- a/configuration/etl/etl.d/jobs_cloud_common.json
+++ b/configuration/etl/etl.d/jobs_cloud_common.json
@@ -40,6 +40,7 @@
             "namespace": "ETL\\Maintenance",
             "options_class": "MaintenanceOptions",
             "definition_file_list": [
+                "cloud_common/account.json",
                 "cloud_common/event.json",
                 "cloud_common/asset.json",
                 "cloud_common/instance_data.json",
@@ -91,6 +92,49 @@
                     "type": "jsonfile",
                     "name": "Cloud record types",
                     "path": "cloud_common/record_type.json"
+                }
+            }
+        },
+        {
+            "#": "Note that any actions run after this cannot truncate the tables set here",
+
+            "name": "CloudAccountUnknownInitializer",
+            "description": "Initialize values for unknown hosts, images, etc. that are specific to a resource",
+            "class": "StructuredFileIngestor",
+            "definition_file": "cloud_common/account.json",
+            "endpoints": {
+                "source": {
+                    "type": "jsonfile",
+                    "name": "Cloud record types",
+                    "path": "cloud_common/account.json"
+                }
+            }
+        },
+        {
+            "#": "Note that any actions run after this cannot truncate the tables set here",
+
+            "name": "CloudInstanceUnknownInitializer",
+            "description": "Initialize values for unknown hosts, images, etc. that are specific to a resource",
+            "class": "StructuredFileIngestor",
+            "definition_file": "cloud_common/instance.json",
+            "endpoints": {
+                "source": {
+                    "type": "jsonfile",
+                    "name": "Cloud record types",
+                    "path": "cloud_common/instance.json"
+                }
+            }
+        },
+        {
+            "name": "CloudInstanceTypeUnknownInitializer",
+            "description": "Initialize values for unknown hosts, images, etc. that are specific to a resource",
+            "class": "StructuredFileIngestor",
+            "definition_file": "cloud_common/instance_type.json",
+            "endpoints": {
+                "source": {
+                    "type": "jsonfile",
+                    "name": "Cloud record types",
+                    "path": "cloud_common/instance_type.json"
                 }
             }
         },

--- a/configuration/etl/etl_action_defs.d/cloud_common/account.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/account.json
@@ -1,0 +1,8 @@
+{
+    "#": "This action loads data from a structured file and only needs the table definition",
+    "table_definition": [
+        {
+            "$ref": "${table_definition_dir}/cloud_common/account.json#/table_definition"
+        }
+    ]
+}

--- a/configuration/etl/etl_action_defs.d/cloud_common/initialize_unknown_dimension_values.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/initialize_unknown_dimension_values.json
@@ -15,19 +15,10 @@
 
     "table_definition": [
         {
-            "$ref": "${table_definition_dir}/cloud_common/account.json#/table_definition"
-        },
-        {
             "$ref": "${table_definition_dir}/cloud_common/host.json#/table_definition"
         },
         {
             "$ref": "${table_definition_dir}/cloud_common/image.json#/table_definition"
-        },
-        {
-            "$ref": "${table_definition_dir}/cloud_common/instance.json#/table_definition"
-        },
-        {
-            "$ref": "${table_definition_dir}/cloud_common/instance_type.json#/table_definition"
         }
     ],
 
@@ -61,12 +52,6 @@
     },
 
     "destination_record_map": {
-        "account": {
-            "resource_id": "resource_id",
-            "account_id": "unknown_id",
-            "provider_account": "unknown_key",
-            "display": "unknown_display"
-        },
         "host": {
             "resource_id": "resource_id",
             "host_id": "unknown_id",
@@ -76,18 +61,6 @@
             "resource_id": "resource_id",
             "image_id": "unknown_id",
             "image": "unknown_key"
-        },
-        "instance": {
-            "resource_id": "resource_id",
-            "instance_id": "unknown_id",
-            "account_id": "unknown_id",
-            "provider_identifier": "unknown_key"
-        },
-        "instance_type": {
-            "resource_id": "resource_id",
-            "instance_type_id": "unknown_id",
-            "instance_type": "unknown_key",
-            "display": "unknown_display"
         }
     }
 }

--- a/configuration/etl/etl_action_defs.d/cloud_common/instance.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/instance.json
@@ -1,0 +1,8 @@
+{
+    "#": "This action loads data from a structured file and only needs the table definition",
+    "table_definition": [
+        {
+            "$ref": "${table_definition_dir}/cloud_common/instance.json#/table_definition"
+        }
+    ]
+}

--- a/configuration/etl/etl_action_defs.d/cloud_common/instance_type.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/instance_type.json
@@ -1,0 +1,8 @@
+{
+    "#": "This action loads data from a structured file and only needs the table definition",
+    "table_definition": [
+        {
+            "$ref": "${table_definition_dir}/cloud_common/instance_type.json#/table_definition"
+        }
+    ]
+}

--- a/configuration/etl/etl_data.d/cloud_common/account.json
+++ b/configuration/etl/etl_data.d/cloud_common/account.json
@@ -1,0 +1,4 @@
+[
+    ["resource_id", "account_id", "provider_account", "display"],
+    [-1,            1,            "Unknown",          "Unknown"]
+]

--- a/configuration/etl/etl_data.d/cloud_common/instance.json
+++ b/configuration/etl/etl_data.d/cloud_common/instance.json
@@ -1,0 +1,4 @@
+[
+    ["resource_id", "instance_id", "account_id", "provider_identifier", "person_id"],
+    [-1,            1,              1,           "unknown",             -1]
+]

--- a/configuration/etl/etl_data.d/cloud_common/instance_type.json
+++ b/configuration/etl/etl_data.d/cloud_common/instance_type.json
@@ -1,0 +1,4 @@
+[
+    ["resource_id", "instance_type_id", "instance_type", "display", "description", "num_cores", "memory_mb", "disk_gb", "start_time", "end_time"],
+    [-1,            1,                  "Unknown",       "Unknown", null,            0,           0,           0,         0,            null]
+]


### PR DESCRIPTION
This PR fixes the below error seen on metrics-dev 
```
2020-03-27 04:12:58 [warning] SQL warnings on table 'account' generated by action xdmod.jobs-cloud-common.CloudUnknownDimensionInitializer
2020-03-27 04:12:58 [warning] Warning   1062    Duplicate entry '1' for key 'autoincrement_key'
2020-03-27 04:12:58 [warning] SQL warnings on table 'instance' generated by action xdmod.jobs-cloud-common.CloudUnknownDimensionInitializer
2020-03-27 04:12:58 [warning] Warning   1062    Duplicate entry '1' for key 'increment_key'
2020-03-27 04:12:58 [warning] SQL warnings on table 'instance_type' generated by action xdmod.jobs-cloud-common.CloudUnknownDimensionInitializer
2020-03-27 04:12:58 [warning] Warning   1062    Duplicate entry '1' for key 'increment_key'
```
This was caused by changing the autoincrement keys of the instance, instance_type and account tables to a singe column autoincrement key in #3333. The fix involves moving the making of the unknown dimension values for those tables into their own action that will add a global unknown value with a resource_id of -1 and an id column with the value 1.

## Tests performed
Ran test suite in docker and manually tested that no warning showed up when ingesting cloud files and running the `xdmod.jobs-cloud-common.CloudUnknownDimensionInitializer` action

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
