### PR TITLE
Removing code path for cloud project filter that is no longer necessary

### DIFF
--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1238,13 +1238,12 @@ class Usage extends Common
      *
      *   - 'pi':       modw.systemaccount ( username )
      *   - 'resource': modw.resourcefact  ( code )
-     *   - 'project':  modw_cloud.account ( display )
      *
      * If the $usageFilterValue is numeric or the $usageFilterType is not one of those currently
      * supported then array($usageFilterValue) is returned.
      *
      * @param string $usageFilterType the 'type' of filter to translate. Currently supported
-     *                                 values: pi, resource, project
+     *                                 values: pi, resource
      * @param string|int  $usageFilterValue the value to be translated
      * @return array of the translated values.
      * @throws Exception if there is a problem connecting to the db or executing a query.
@@ -1261,9 +1260,6 @@ class Usage extends Common
                 break;
             case 'resource':
                 $query = "SELECT id AS value FROM modw.resourcefact WHERE code = :value";
-                break;
-            case 'project':
-                $query = "SELECT account_id AS value FROM modw_cloud.account WHERE display = :value";
                 break;
         }
 


### PR DESCRIPTION
This removes code that is no longer necessary since PR #1263 was merged. The code is no longer needed since the project filter in the cloud realm uses the project name instead of the id now. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
