### PR TITLE
Throw Expected exception when JSON is invalid

### DIFF
--- a/classes/ETL/JsonPointer.php
+++ b/classes/ETL/JsonPointer.php
@@ -145,7 +145,7 @@ class JsonPointer
                 if ( null !== self::$loggable ) {
                     self::$loggable->getLogger()->err('Invalid JSON');
                 }
-                return false;
+                throw new Exception('Invalid JSON');
             }
         } else {
             $jsonObj = $json;


### PR DESCRIPTION
When parsing an invalid json it is supposed to throw an error (according to documentation and code calling the function expecting it)