### PR TITLE
Fix typo in etl groupby generation code.

### DIFF
--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -537,7 +537,7 @@ var generateGroupBy = function (itemAlias, column)
         attribute_values_query: {
             joins: [
                 {
-                    name: column.name
+                    name: column.dimension_table
                 }
             ],
             orderby: [


### PR DESCRIPTION
The join field should be set to the table name not the column
name. The tests associated with this fix are in

https://github.com/ubccr/xdmod-supremm/pull/224