### PR TITLE
added updating version in appkernels.ini upon upgrade

### DIFF
--- a/bin/xdmod-upgrade
+++ b/bin/xdmod-upgrade
@@ -299,5 +299,6 @@ Usage: xdmod-upgrade [-v]
         databases that you are upgrading.  This option is necessary when
         the version number in portal_settings.ini does not match the
         version of your config files and databases.
+
 EOF;
 }

--- a/classes/OpenXdmod/Migration/Version851To900/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version851To900/ConfigFilesMigration.php
@@ -25,5 +25,9 @@ class ConfigFilesMigration extends AbstractConfigFilesMigration
                'roadmap_url' => $roadmapUrl
             )
         );
+
+        foreach ($this->modulePortalSettingsPaths as $moduleName => $modulePortalSettingsPath) {
+            $this->writeModulePortalSettingsFile($moduleName);
+        }
     }
 }

--- a/classes/OpenXdmod/Migration/Version851To900/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/Version851To900/ConfigFilesMigration.php
@@ -26,8 +26,6 @@ class ConfigFilesMigration extends AbstractConfigFilesMigration
             )
         );
 
-        foreach ($this->modulePortalSettingsPaths as $moduleName => $modulePortalSettingsPath) {
-            $this->writeModulePortalSettingsFile($moduleName);
-        }
+        $this->writeModulePortalSettingsFiles();
     }
 }


### PR DESCRIPTION
added updating version variable in modules portal setting upon upgrade.

In appkernels version variable doesn't do much but it will be nice to have matching config version and software.

The big question is should it really be in core xdmod or in xdmod-appkernel. This would largely depends on how user is going to upgrade their system. In xdmod-upgrade, we did mentioned update supremm/appkernel tools first and then run xdmod-upgrade. Under this scenario it should work.

Since there are no other changes in appkernels.ini besides version and I don't anticipate any change in near future, just version update should be fine for a while.
