### PR TITLE
Default GPU count to zero

### DIFF
--- a/configuration/etl/etl_tables.d/jobs/hpcdb/jobs.json
+++ b/configuration/etl/etl_tables.d/jobs/hpcdb/jobs.json
@@ -110,7 +110,8 @@
             {
                 "name": "gpucount",
                 "type": "int(11)",
-                "nullable": true
+                "nullable": false,
+                "default": 0
             },
             {
                 "name": "cpu_req",

--- a/configuration/etl/etl_tables.d/jobs/shredder/job.json
+++ b/configuration/etl/etl_tables.d/jobs/shredder/job.json
@@ -141,7 +141,8 @@
             {
                 "name": "gpu_count",
                 "type": "int(10) unsigned",
-                "nullable": false
+                "nullable": false,
+                "default": 0
             },
             {
                 "name": "cpu_req",

--- a/configuration/etl/etl_tables.d/jobs/staging/job.json
+++ b/configuration/etl/etl_tables.d/jobs/staging/job.json
@@ -127,7 +127,8 @@
             {
                 "name": "gpu_count",
                 "type": "int(10) unsigned",
-                "nullable": false
+                "nullable": false,
+                "default": 0
             },
             {
                 "name": "cpu_req",

--- a/configuration/etl/etl_tables.d/jobs/xdw/job-tasks.json
+++ b/configuration/etl/etl_tables.d/jobs/xdw/job-tasks.json
@@ -150,7 +150,7 @@
                 "name": "gpu_count",
                 "type": "int(11)",
                 "nullable": false,
-                "default": -1,
+                "default": 0,
                 "comment": "Number of GPUs consumed"
             },
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Change definition of columns that contain GPU counts so they are `NOT NULL` and default to `0`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It was previously possible to have `NULL` values which produces warning messages:

```
2020-03-31 04:22:32 [warning] SQL warnings on table 'job_tasks' generated by action xdmod.hpcdb-xdw-ingest-jobs.job-records-job-tasks (filtering codes: 1062)
2020-03-31 04:22:32 [warning] Warning	1263	Column set to default value; NULL supplied to NOT NULL column 'gpu_count' at row 2
```

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
