### PR TITLE
Surface Error instead of sitting on "Loading..."

### DIFF
--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -660,7 +660,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
                             }
                             if (resp.success === false) {
-                                Ext.MessageBox.alert("Error", resp.message);
+                                Ext.MessageBox.alert('Error', resp.message);
                             }
 
                         } //if (resp.message)

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -659,6 +659,9 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                                 CCR.xdmod.ui.actionLogout.defer(1000);
 
                             }
+                            if (resp.success === false) {
+                                Ext.MessageBox.alert("Error", resp.message);
+                            }
 
                         } //if (resp.message)
 


### PR DESCRIPTION
When there is an error in get_menus it can get 'lost' behind a 'Loading...' this will surface the error so that an admin can fix the configuration files.