### PR TITLE
Fix bug viewing raw data as demo user.

### DIFF
--- a/classes/DataWarehouse/Data/RawDataset.php
+++ b/classes/DataWarehouse/Data/RawDataset.php
@@ -100,7 +100,7 @@ class RawDataset
                 }
             }
 
-            if ($this->userType == DEMO_USER_TYPE && $docs[$key]['visibility'] == 'non-public') {
+            if ($this->userType == DEMO_USER_TYPE && isset($docs[$key]['visibility']) && $docs[$key]['visibility'] == 'non-public') {
                 $redactlist[] = $value;
                 $value = "&lt;REDACTED&gt;";
             }


### PR DESCRIPTION
XDMoD filters data for accounts with the DEMO type (to facilitate
demonstrations without revealing potentially sensitive info).

This error is seen when using a demo user account to try to view a
job in the job viewer.
