### PR TITLE
Fix bug in highchart wrapper code.

### DIFF
--- a/html/gui/js/HighChartWrapper.js
+++ b/html/gui/js/HighChartWrapper.js
@@ -99,11 +99,9 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
 
                         for (var i = 0; i < this.series.length; i++) {
                             var series = this.series[i];
-                            if (!series.options.isRestrictedByRoles) {
-                                continue;
+                            if (series.options.isRestrictedByRoles && series.legendItem) {
+                                this.options.chart.events.helperFunctions.addBackgroundColor(series.legendItem, '#DFDFDF');
                             }
-
-                            this.options.chart.events.helperFunctions.addBackgroundColor(series.legendItem, '#DFDFDF');
                         }
                     }
                 ],


### PR DESCRIPTION
The code tries to shade the legend background when the data in the chart
are restricted by roles. This happens e.g. when you have user role and
try to plot some supremm data. Pie charts do not have legends so the
series.legendItem property is absent. This change makes sure the legend
background colour is only changed if there is a legend to change.

![image](https://user-images.githubusercontent.com/5342179/79255246-f4a41200-7e53-11ea-98dc-c32a8f70ae30.png)






