### PR TITLE
updates needed for xsede groupbys

### DIFF
--- a/classes/ETL/DbModel/Query.php
+++ b/classes/ETL/DbModel/Query.php
@@ -109,7 +109,7 @@ class Query extends Entity implements iEntity
             case 'overseer_restrictions':
                 if ( ! is_object($value) ) {
                     $this->logAndThrowException(
-                        sprintf("%s name must be an object, '%s' given", $property, gettype($value))
+                        sprintf("%s must be an object, '%s' given", $property, gettype($value))
                     );
                 }
                 break;
@@ -120,11 +120,17 @@ class Query extends Entity implements iEntity
             case 'macros':
             case 'joins':
                 // Note that we are only checking that the value is an array here and not
-                // the array elements. That must come later.
+                // the array elements. The elements can be mixed content that must be checked later.
 
                 if ( ! is_array($value) ) {
                     $this->logAndThrowException(
-                        sprintf("%s name must be an array, '%s' given", $property, gettype($value))
+                        sprintf("%s must be an array, '%s' given", $property, gettype($value))
+                    );
+                }
+                // If this is a join property it must contain elements
+                if ( $property === 'joins' && count($value) === 0 ) {
+                    $this->logAndThrowException(
+                        sprintf("%s must have at least one item in it", $property)
                     );
                 }
 
@@ -142,7 +148,7 @@ class Query extends Entity implements iEntity
             case 'query_hint':
                 if ( ! is_string($value) ) {
                     $this->logAndThrowException(
-                        sprintf("%s name must be a string, '%s' given", $property, gettype($value))
+                        sprintf("%s must be a string, '%s' given", $property, gettype($value))
                     );
                 }
                 break;

--- a/configuration/datawarehouse.d/ref/Cloud-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Cloud-group-bys.json
@@ -3,7 +3,6 @@
         "name": "Instance Type",
         "description_html": "The instance type of a virtual machine.",
         "attribute_table_schema": "modw_cloud",
-        "attribute_table": "instance_type",
         "attribute_to_aggregate_table_key_map": [
             {
                 "instance_type_id": "instance_type_id"
@@ -50,7 +49,6 @@
             }
         ],
         "attribute_table_schema": "modw_cloud",
-        "attribute_table": "domains",
         "attribute_to_aggregate_table_key_map": [
             {
                 "id": "domain_id"
@@ -84,7 +82,6 @@
         "$ref": "datawarehouse.d/ref/group-by-time-period.json#/month"
     },
     "person": {
-        "attribute_table": "person",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -112,7 +109,6 @@
         "name": "User"
     },
     "project": {
-        "attribute_table": "account",
         "attribute_table_schema": "modw_cloud",
         "attribute_filter_map_query": {
             "account_id": "SELECT account_id FROM modw_cloud.account WHERE display in (__filter_values__)"
@@ -147,44 +143,17 @@
         "$ref": "datawarehouse.d/ref/group-by-time-period.json#/quarter"
     },
     "resource": {
-        "attribute_table": "resourcefact",
-        "attribute_table_schema": "modw",
-        "attribute_to_aggregate_table_key_map": [
-            {
-                "id": "host_resource_id"
-            }
-        ],
-        "attribute_values_query": {
-            "joins": [
+        "$overwrite": {
+            "attribute_to_aggregate_table_key_map": [
                 {
-                    "alias": "rf",
-                    "name": "resourcefact"
-                },
-                {
-                    "alias": "rs",
-                    "name": "resourcespecs",
-                    "on": "rf.id = rs.resource_id"
+                    "id": "host_resource_id"
                 }
             ],
-            "orderby": [
-                "rf.code",
-                "rf.name"
-            ],
-            "records": {
-                "id": "rf.id",
-                "name": "rf.code",
-                "order_id": "id",
-                "short_name": "rf.code"
-            },
-            "where": [
-                "rs.processors IS NOT NULL"
-            ]
+            "description_html": "A resource is defined as any infrastructure that hosts virtual machines."
         },
-        "description_html": "A resource is defined as any infrastructure that hosts virtual machines.",
-        "name": "Resource"
+        "$ref-with-overwrite": "datawarehouse.d/ref/group-by-common.json#/resource"
     },
     "provider": {
-        "attribute_table": "serviceprovider",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -212,7 +181,6 @@
         "show_in_catalog": false
     },
     "submission_venue": {
-        "attribute_table": "submission_venue",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -243,7 +211,6 @@
         "$ref": "datawarehouse.d/ref/group-by-common.json#/username"
     },
     "vm_size": {
-        "attribute_table": "processor_buckets",
         "attribute_table_schema": "modw_cloud",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -278,7 +245,6 @@
         "name": "VM Size: Cores"
     },
     "vm_size_memory": {
-        "attribute_table": "memory_buckets",
         "attribute_table_schema": "modw_cloud",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/Jobs-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Jobs-group-bys.json
@@ -12,7 +12,6 @@
         "$ref": "datawarehouse.d/ref/group-by-common.json#/gpucount"
     },
     "jobwaittime": {
-        "attribute_table": "job_wait_times",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/Storage-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Storage-group-bys.json
@@ -18,7 +18,6 @@
         "$ref": "datawarehouse.d/ref/group-by-hierarchy.json#/parentscience"
     },
     "mountpoint": {
-        "attribute_table": "mountpoint",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/group-by-common.json
+++ b/configuration/datawarehouse.d/ref/group-by-common.json
@@ -1,6 +1,5 @@
 {
     "jobsize": {
-        "attribute_table": "processor_buckets",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -35,7 +34,6 @@
         "name": "Job Size"
     },
     "gpucount": {
-        "attribute_table": "gpu_buckets",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -70,7 +68,6 @@
         "name": "GPU Count"
     },
     "jobwalltime": {
-        "attribute_table": "job_times",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -105,7 +102,6 @@
         "name": "Job Wall Time"
     },
     "nodecount": {
-        "attribute_table": "nodecount",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -133,7 +129,6 @@
         "name": "Node Count"
     },
     "person": {
-        "attribute_table": "person",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -161,7 +156,6 @@
         "name": "User"
     },
     "pi": {
-        "attribute_table": "piperson",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -189,7 +183,6 @@
         "name": "PI"
     },
     "provider": {
-        "attribute_table": "serviceprovider",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -225,7 +218,6 @@
                 "aggregate_expr": "task_resource_id"
             }
         ],
-        "attribute_table": "queue",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -253,7 +245,15 @@
         "name": "Queue"
     },
     "resource": {
-        "attribute_table": "resourcefact",
+        "additional_join_constraints": [
+            {
+                 "attribute_table": "resourcefact",
+                 "attribute_expr": "id",
+                 "operation": "=",
+                 "aggregate_table": "resourcespecs",
+                 "aggregate_expr": "resource_id"
+            }
+        ],
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -263,35 +263,32 @@
         "attribute_values_query": {
             "joins": [
                 {
-                    "alias": "rf",
                     "name": "resourcefact"
                 },
                 {
-                    "alias": "rs",
                     "name": "resourcespecs",
-                    "on": "rf.id = rs.resource_id"
+                    "on": "resourcefact.id = resourcespecs.resource_id"
                 }
             ],
             "orderby": [
-                "rf.code",
-                "rf.name"
+                "resourcefact.code",
+                "resourcefact.name"
             ],
             "query_hint": "DISTINCT",
             "records": {
-                "id": "rf.id",
-                "name": "REPLACE(rf.code, '-', ' ')",
+                "id": "resourcefact.id",
+                "name": "REPLACE(resourcefact.code, '-', ' ')",
                 "order_id": "id",
-                "short_name": "REPLACE(rf.code, '-', ' ')"
+                "short_name": "REPLACE(resourcefact.code, '-', ' ')"
             },
             "where": [
-                "rs.processors IS NOT NULL"
+                "resourcespecs.processors IS NOT NULL"
             ]
         },
         "description_html": "A resource is a remote computer that can run jobs.",
         "name": "Resource"
     },
     "resource_type": {
-        "attribute_table": "resourcetype",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -326,7 +323,6 @@
             "systemaccount_id": "SELECT DISTINCT id FROM modw.systemaccount WHERE username IN (__filter_values__)"
         },
         "attribute_description_query": "SELECT DISTINCT username AS filter_name FROM modw.systemaccount WHERE username IN (__filter_values__) ORDER BY username",
-        "attribute_table": "systemaccount",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/group-by-hierarchy.json
+++ b/configuration/datawarehouse.d/ref/group-by-hierarchy.json
@@ -1,6 +1,5 @@
 {
     "fieldofscience": {
-        "attribute_table": "fieldofscience_hierarchy",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -31,7 +30,6 @@
         "alternate_group_by_columns": [
             "directorate_id"
         ],
-        "attribute_table": "fieldofscience_hierarchy",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -75,7 +73,6 @@
         "alternate_group_by_columns": [
             "parent_id"
         ],
-        "attribute_table": "fieldofscience_hierarchy",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/group-by-none.json
+++ b/configuration/datawarehouse.d/ref/group-by-none.json
@@ -2,7 +2,6 @@
     "name": "${ORGANIZATION_NAME}",
     "description_html": "Summarizes ${REALM_NAME} data reported to the ${ORGANIZATION_NAME} database.",
     "attribute_table_schema": "modw",
-    "attribute_table": "dual",
     "show_in_catalog": false,
     "is_aggregation_unit": true,
     "attribute_to_aggregate_table_key_map": [],

--- a/configuration/datawarehouse.d/ref/group-by-time-period.json
+++ b/configuration/datawarehouse.d/ref/group-by-time-period.json
@@ -3,7 +3,6 @@
         "name": "Day",
         "description_html": "Day",
         "attribute_table_schema": "modw",
-        "attribute_table": "days",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
@@ -35,7 +34,6 @@
         "name": "Month",
         "description_html": "Month",
         "attribute_table_schema": "modw",
-        "attribute_table": "months",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
@@ -67,7 +65,6 @@
         "name": "Quarter",
         "description_html": "Quarter",
         "attribute_table_schema": "modw",
-        "attribute_table": "quarters",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
@@ -99,7 +96,6 @@
         "name": "Year",
         "description_html": "Year",
         "attribute_table_schema": "modw",
-        "attribute_table": "years",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [

--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -527,7 +527,6 @@ var generateGroupBy = function (itemAlias, column)
         description = description.replace(new RegExp(':Label_' + tagidx, 'g'), wordToUpper(column.dynamictags[tagidx]));
     }
     return {
-        attribute_table: column.dimension_table,
         attribute_table_schema: 'modw_supremm',
         attribute_to_aggregate_table_key_map: [
             {

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/add-alternate-class.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/add-alternate-class.json
@@ -7,7 +7,6 @@
                 "name": "Alternate GroupBy Class Example",
                 "description_html": "Alternate GroupBy Class Example.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "systemaccount",
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "systemaccount_id" }
                 ],

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/add-cloud-groupby.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/add-cloud-groupby.json
@@ -6,7 +6,6 @@
                 "name": "System Username",
                 "description_html": "The specific system username associated with a running session of a virtual machine.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "systemaccount",
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "systemaccount_id" }
                 ],

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/cloud.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/cloud.json
@@ -12,7 +12,6 @@
                 "name": "None",
                 "description_html": "Summarizes ${REALM_NAME} data reported to the ${ORGANIZATION_NAME} database (excludes non-${ORGANIZATION_NAME} usage).",
                 "attribute_table_schema": "modw",
-                "attribute_table": "dual",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [],
                 "order": 1,
@@ -34,7 +33,6 @@
                 "name": "Day",
                 "description_html": "Day",
                 "attribute_table_schema": "modw",
-                "attribute_table": "days",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     {
@@ -65,7 +63,6 @@
                 "name": "Month",
                 "description_html": "Month",
                 "attribute_table_schema": "modw",
-                "attribute_table": "months",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     {
@@ -96,7 +93,6 @@
                 "name": "Instance Type",
                 "description_html": "The instance type of a virtual machine.",
                 "attribute_table_schema": "modw_cloud",
-                "attribute_table": "instance_type",
                 "attribute_to_aggregate_table_key_map": [
                     {
                         "instance_type_id": "instance_type_id"

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/jobs.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/jobs.json
@@ -13,7 +13,6 @@
                 "name": "None",
                 "description_html": "Summarizes ${REALM_NAME} data reported to the ${ORGANIZATION_NAME} database (excludes non-${ORGANIZATION_NAME} usage).",
                 "attribute_table_schema": "modw",
-                "attribute_table": "dual",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                 ],
@@ -36,7 +35,6 @@
                 "name": "Day",
                 "description_html": "Day",
                 "attribute_table_schema": "modw",
-                "attribute_table": "days",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "day_id" }
@@ -65,7 +63,6 @@
                 "name": "Month",
                 "description_html": "Month",
                 "attribute_table_schema": "modw",
-                "attribute_table": "months",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "month_id" }
@@ -93,7 +90,6 @@
             "resource": {
                 "name": "Resource",
                 "description_html": "A resource is a remote computer that can run jobs.",
-                "attribute_table": "resourcefact",
                 "attribute_table_schema": "modw",
                 "order": 4,
                 "#": "Multi-column key",
@@ -134,7 +130,6 @@
                 "description_html": "A person who is on a PIs allocation, hence able run jobs on resources.",
                 "category": "Administrative",
                 "attribute_table_schema": "modw",
-                "attribute_table": "person",
                 "order": 5,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "person_id" }
@@ -161,7 +156,6 @@
                 "name": "System Username",
                 "description_html": "The specific system username of the users who ran jobs.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "systemaccount",
                 "order": 6,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "systemaccount_id" }
@@ -190,7 +184,6 @@
                 "name": "Queue",
                 "description_html": "Queue pertains to the low level job queues on each resource.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "queue",
                 "order": 7,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "queue" }
@@ -224,7 +217,6 @@
                 "disabled": true,
                 "name": "Disabled Group By",
                 "description_html": "Disabled GroupBy",
-                "attribute_table": "unknown",
                 "attribute_to_aggregate_table_key_map": [
                 ],
                 "attribute_values_query": {


### PR DESCRIPTION
The XSEDE GroupBys need to be able to use a secondary table to link to aggregates (through the account table to the grant table) this update allows that, while getting rid of the need for the attribute_table key as it is provided by the first (and usually only) join table in the attributes value query.