### PR TITLE
updates needed for xsede groupbys

### DIFF
--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -701,7 +701,7 @@ class MetricExplorer extends Common
         // Check if the realms were specified, and if not, use all realms.
         $realmsSpecified = !empty($realms);
         if (!$realmsSpecified) {
-            $realms = self::getRealmsFromUser($user);
+            $realms = Realms::getRealmIdsForUser($user);
         }
 
         // Determine which aggregation unit to use for dimension values queries.
@@ -904,7 +904,7 @@ class MetricExplorer extends Common
         XDUser $user,
         $dimension_id
     ) {
-        $realms = self::getRealmsFromUser($user);
+        $realms = Realms::getRealmIdsForUser($user);
 
         foreach ($realms as $realm) {
             try {
@@ -935,7 +935,7 @@ class MetricExplorer extends Common
         XDUser $user,
         $dimension_id
     ) {
-        $realms = self::getRealmsFromUser($user);
+        $realms = Realms::getRealmIdsForUser($user);
 
         $dimensionRealms = array();
         foreach ($realms as $realm) {
@@ -977,7 +977,7 @@ class MetricExplorer extends Common
         $value_id,
         $getLongName = false
     ) {
-        $realms = self::getRealmsFromUser($user);
+        $realms = Realms::getRealmIdsForUser($user);
 
         $dimensionValueName = null;
         foreach ($realms as $realm) {
@@ -1000,17 +1000,6 @@ class MetricExplorer extends Common
         }
 
         return $dimensionValueName;
-    }
-
-    /**
-     * Get a list of realms available to a user.
-     *
-     * @param  XDUser $user       The user whose realms are being retrieved.
-     *
-     * @return array              The realms available to the user.
-     */
-    public static function getRealmsFromUser(XDUser $user) {
-        return Realms::getRealmsForUser($user);
     }
 
     /**

--- a/classes/DataWarehouse/Visualization/HighChart2.php
+++ b/classes/DataWarehouse/Visualization/HighChart2.php
@@ -1094,7 +1094,7 @@ class HighChart2
                 }
                 if($this->_multiCategory) {
                     $dataSeriesName = (
-                        DataWarehouse::getCategoryForRealm($data_description->realm)
+                        $data_description->category
                         . ': '
                         . $dataSeriesName
                     );

--- a/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
+++ b/classes/DataWarehouse/Visualization/HighChartTimeseries2.php
@@ -536,7 +536,7 @@ class HighChartTimeseries2 extends HighChart2
                         if($multiCategory)
                         {
                             $dataSeriesName = (
-                                DataWarehouse::getCategoryForRealm($data_description->realm)
+                                $data_description->category
                                 . ': '
                                 . $dataSeriesName
                             );

--- a/classes/ETL/DbModel/Query.php
+++ b/classes/ETL/DbModel/Query.php
@@ -109,7 +109,7 @@ class Query extends Entity implements iEntity
             case 'overseer_restrictions':
                 if ( ! is_object($value) ) {
                     $this->logAndThrowException(
-                        sprintf("%s name must be an object, '%s' given", $property, gettype($value))
+                        sprintf("%s must be an object, '%s' given", $property, gettype($value))
                     );
                 }
                 break;
@@ -120,11 +120,17 @@ class Query extends Entity implements iEntity
             case 'macros':
             case 'joins':
                 // Note that we are only checking that the value is an array here and not
-                // the array elements. That must come later.
+                // the array elements. The elements can be mixed content that must be checked later.
 
                 if ( ! is_array($value) ) {
                     $this->logAndThrowException(
-                        sprintf("%s name must be an array, '%s' given", $property, gettype($value))
+                        sprintf("%s must be an array, '%s' given", $property, gettype($value))
+                    );
+                }
+                // If this is a join property it must contain elements
+                if ( $property === 'joins' && count($value) === 0 ) {
+                    $this->logAndThrowException(
+                        sprintf("%s must have at least one item in it", $property)
                     );
                 }
 
@@ -142,7 +148,7 @@ class Query extends Entity implements iEntity
             case 'query_hint':
                 if ( ! is_string($value) ) {
                     $this->logAndThrowException(
-                        sprintf("%s name must be a string, '%s' given", $property, gettype($value))
+                        sprintf("%s must be a string, '%s' given", $property, gettype($value))
                     );
                 }
                 break;

--- a/classes/Models/Services/Acls.php
+++ b/classes/Models/Services/Acls.php
@@ -987,7 +987,7 @@ SQL;
 SELECT
     r.name as realm,
     gb.name as group_by,
-    MAX(agb.enabled) as enabled,
+    !MAX(agb.enabled) as not_enabled,
     MAX(agb.visible) as visible
 FROM group_bys gb
   JOIN realms r ON gb.realm_id = r.realm_id

--- a/classes/Models/Services/Acls.php
+++ b/classes/Models/Services/Acls.php
@@ -984,11 +984,11 @@ SQL;
         }
 
         $query = <<<SQL
-        SELECT DISTINCT
-            r.display as realm,
-            gb.name as group_by,
-            !agb.enabled as not_enabled,
-            agb.visible
+SELECT
+    r.name as realm,
+    gb.name as group_by,
+    MAX(agb.enabled) as enabled,
+    MAX(agb.visible) as visible
 FROM group_bys gb
   JOIN realms r ON gb.realm_id = r.realm_id
   JOIN acl_group_bys agb
@@ -1055,7 +1055,8 @@ SQL;
             $query .= " AND s.name = :statistic_name\n";
             $params[':statistic_name'] = $statisticName;
         }
-
+        $query .= "\nGROUP BY 1,2";
+        $query .= "\nORDER BY 1,2,3,4 DESC";
         $results = array();
         $sorted = array();
 

--- a/classes/Models/Services/Acls.php
+++ b/classes/Models/Services/Acls.php
@@ -1056,7 +1056,7 @@ SQL;
             $params[':statistic_name'] = $statisticName;
         }
         $query .= "\nGROUP BY 1,2";
-        $query .= "\nORDER BY 1,2,3,4 DESC";
+        $query .= "\nORDER BY 1,2 DESC";
         $results = array();
         $sorted = array();
 

--- a/classes/Models/Services/Realms.php
+++ b/classes/Models/Services/Realms.php
@@ -51,6 +51,54 @@ SQL;
         }, array());
     }
 
+    public static function getRealmIdsForUser(\XDUser $user)
+    {
+        $query = <<<SQL
+            SELECT DISTINCT
+              r.name AS realm
+            FROM acl_group_bys agb
+              JOIN user_acls ua ON agb.acl_id = ua.acl_id
+              JOIN realms r ON r.realm_id = agb.realm_id
+            WHERE ua.user_id = :user_id
+            ORDER BY r.realm_id
+SQL;
+        $params = array(
+            ':user_id'=> $user->getUserID()
+        );
+
+        $db = DB::factory('database');
+        $rows = $db->query($query, $params);
+
+        return array_reduce($rows, function ($carry, $item) {
+            $carry[] = $item['realm'];
+            return $carry;
+        }, array());
+    }
+
+
+    public static function getRealmObjectsForUser(\XDUser $user)
+    {
+        $query = <<<SQL
+            SELECT DISTINCT
+              r.*
+            FROM acl_group_bys agb
+              JOIN user_acls ua ON agb.acl_id = ua.acl_id
+              JOIN realms r ON r.realm_id = agb.realm_id
+            WHERE ua.user_id = :user_id
+            ORDER BY r.realm_id
+SQL;
+        $params = array(
+            ':user_id'=> $user->getUserID()
+        );
+
+        $db = DB::factory('database');
+        $rows = $db->query($query, $params);
+
+        return array_reduce($rows, function ($carry, $item) {
+            $carry[$item['name']] = new Realm($item);
+            return $carry;
+        }, array());
+    }
     /**
      * Retrieve the Realms that are currently considered "enabled" for the current installation.
      *

--- a/classes/Realm/GroupBy.php
+++ b/classes/Realm/GroupBy.php
@@ -260,7 +260,6 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
 
         $messages = array();
         $configTypes = array(
-            'attribute_table' => 'string',
             'attribute_to_aggregate_table_key_map' => 'array',
             'attribute_values_query' => 'object',
             'description_html' => 'string',
@@ -309,9 +308,6 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
                         }
                         $this->additionalJoinConstraints[] = $constraint;
                     }
-                    break;
-                case 'attribute_table':
-                    $this->attributeTableName = trim($value);
                     break;
                 case 'attribute_values_query':
                     $this->attributeValuesQuery = new DbQuery($value, '`', $logger);
@@ -473,6 +469,7 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
         }
         $this->attributeValuesQuery->joins = $joins;
         $this->attributeValuesQueryAsStdClass = $this->attributeValuesQuery->toStdClass();
+        $this->attributeTableName = trim($this->attributeValuesQuery->joins[0]->name);
 
         if ( $this->attributeDescriptionSql && count($this->attributeToAggregateKeyMap) > 1 ){
             $this->logAndThrowException('The attribute_description_query does not work with more than one ');
@@ -924,7 +921,13 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
         // added by Query::setDuration()
 
         if ( ! $this->isAggregationUnit ) {
-            $query->addTable($this->attributeTableObj);
+            foreach ($this->attributeValuesQuery->joins as $join) {
+                $query->addTable(new Table(
+                    new Schema($join->schema),
+                    $join->name,
+                    $join->name
+                ));
+            }
         }
 
         if ( $this->isAggregationUnit && 'none' == $this->id ) {
@@ -970,8 +973,16 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
                 // The aggregation unit where condition is already added by Query::setDuration()
 
                 if ( ! $this->isAggregationUnit ) {
+                    $pieces = explode('.', $attributeKey);
+                    if ( count($pieces) === 2 ) {
+                        $alternateAttributeTableObj = new Table($this->attributeTableObj->getSchema(), $pieces[0], $pieces[0]);
+                        $attributeKey = $pieces[1];
+                    } else {
+                        $alternateAttributeTableObj = null;
+                    }
+
                     $where = new WhereCondition(
-                        new TableField($tableObj, $attributeKey),
+                        new TableField(!empty($alternateAttributeTableObj) ? $alternateAttributeTableObj : $tableObj, $attributeKey),
                         '=',
                         new TableField($query->getDataTable(), $aggregateKey)
                     );
@@ -986,9 +997,9 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
         if ( null !== $this->additionalJoinConstraints ) {
             foreach ( $this->additionalJoinConstraints as $constraint ) {
                 $where = new WhereCondition(
-                    new TableField($this->attributeTableObj, $constraint->attribute_expr),
+                    new TableField(!empty($constraint->attribute_table) ? new Table($this->attributeTableObj->getSchema(), $constraint->attribute_table, $constraint->attribute_table) : $this->attributeTableObj, $constraint->attribute_expr),
                     $constraint->operation,
-                    new TableField($query->getDataTable(), $constraint->aggregate_expr)
+                    new TableField(!empty($constraint->aggregate_table) ? new Table($query->getDataTable()->getSchema(), $constraint->aggregate_table, $constraint->aggregate_table) : $query->getDataTable(), $constraint->aggregate_expr)
                 );
                 $this->logger->trace(sprintf("%s Add additional JOIN condition '%s'", $this, $where));
                 $query->addWhereCondition($where);
@@ -1165,21 +1176,6 @@ class GroupBy extends \CCR\Loggable implements iGroupBy
             $this->logger->debug(sprintf('%s Add join condition: %s', $this, $where));
             $query->addWhereCondition($where);
         }
-
-        // If additional join constraints were specified add those here.
-
-        if ( null !== $this->additionalJoinConstraints ) {
-            foreach ( $this->additionalJoinConstraints as $constraint ) {
-                $where = new WhereCondition(
-                    new TableField($this->attributeTableObj, $constraint->attribute_expr),
-                    $constraint->operation,
-                    new TableField($query->getDataTable(), $constraint->aggregate_expr)
-                );
-                $this->logger->trace(sprintf("%s Add additional JOIN condition '%s'", $this, $where));
-                $query->addWhereCondition($where);
-            }
-        }
-
 
         // Normalize the WHERE constraint. We may be able to set this as an array in the parameter
         // list.

--- a/classes/User/Elements/QueryDescripter.php
+++ b/classes/User/Elements/QueryDescripter.php
@@ -109,7 +109,7 @@ class QueryDescripter
 
     public function getRealmName()
     {
-        return $this->realm->getId();
+        return $this->realm->getName();
     }
 
     public function getGroupByName()

--- a/configuration/datawarehouse.d/ref/Cloud-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Cloud-group-bys.json
@@ -3,7 +3,6 @@
         "name": "Instance Type",
         "description_html": "The instance type of a virtual machine.",
         "attribute_table_schema": "modw_cloud",
-        "attribute_table": "instance_type",
         "alternate_group_by_columns": [
             "display"
         ],
@@ -53,7 +52,6 @@
             }
         ],
         "attribute_table_schema": "modw_cloud",
-        "attribute_table": "domains",
         "attribute_to_aggregate_table_key_map": [
             {
                 "id": "domain_id"
@@ -87,7 +85,6 @@
         "$ref": "datawarehouse.d/ref/group-by-time-period.json#/month"
     },
     "person": {
-        "attribute_table": "person",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -115,7 +112,6 @@
         "name": "User"
     },
     "project": {
-        "attribute_table": "account",
         "attribute_table_schema": "modw_cloud",
         "alternate_group_by_columns": [
             "display"
@@ -153,44 +149,17 @@
         "$ref": "datawarehouse.d/ref/group-by-time-period.json#/quarter"
     },
     "resource": {
-        "attribute_table": "resourcefact",
-        "attribute_table_schema": "modw",
-        "attribute_to_aggregate_table_key_map": [
-            {
-                "id": "host_resource_id"
-            }
-        ],
-        "attribute_values_query": {
-            "joins": [
+        "$overwrite": {
+            "attribute_to_aggregate_table_key_map": [
                 {
-                    "alias": "rf",
-                    "name": "resourcefact"
-                },
-                {
-                    "alias": "rs",
-                    "name": "resourcespecs",
-                    "on": "rf.id = rs.resource_id"
+                    "id": "host_resource_id"
                 }
             ],
-            "orderby": [
-                "rf.code",
-                "rf.name"
-            ],
-            "records": {
-                "id": "rf.id",
-                "name": "rf.code",
-                "order_id": "id",
-                "short_name": "rf.code"
-            },
-            "where": [
-                "rs.processors IS NOT NULL"
-            ]
+            "description_html": "A resource is defined as any infrastructure that hosts virtual machines."
         },
-        "description_html": "A resource is defined as any infrastructure that hosts virtual machines.",
-        "name": "Resource"
+        "$ref-with-overwrite": "datawarehouse.d/ref/group-by-common.json#/resource"
     },
     "provider": {
-        "attribute_table": "serviceprovider",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -218,7 +187,6 @@
         "show_in_catalog": false
     },
     "submission_venue": {
-        "attribute_table": "submission_venue",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -249,7 +217,6 @@
         "$ref": "datawarehouse.d/ref/group-by-common.json#/username"
     },
     "vm_size": {
-        "attribute_table": "processor_buckets",
         "attribute_table_schema": "modw_cloud",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -284,7 +251,6 @@
         "name": "VM Size: Cores"
     },
     "vm_size_memory": {
-        "attribute_table": "memory_buckets",
         "attribute_table_schema": "modw_cloud",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/Jobs-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Jobs-group-bys.json
@@ -12,7 +12,6 @@
         "$ref": "datawarehouse.d/ref/group-by-common.json#/gpucount"
     },
     "jobwaittime": {
-        "attribute_table": "job_wait_times",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/Storage-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Storage-group-bys.json
@@ -18,7 +18,6 @@
         "$ref": "datawarehouse.d/ref/group-by-hierarchy.json#/parentscience"
     },
     "mountpoint": {
-        "attribute_table": "mountpoint",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/group-by-common.json
+++ b/configuration/datawarehouse.d/ref/group-by-common.json
@@ -1,6 +1,5 @@
 {
     "jobsize": {
-        "attribute_table": "processor_buckets",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -35,7 +34,6 @@
         "name": "Job Size"
     },
     "gpucount": {
-        "attribute_table": "gpu_buckets",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -70,7 +68,6 @@
         "name": "GPU Count"
     },
     "jobwalltime": {
-        "attribute_table": "job_times",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -105,7 +102,6 @@
         "name": "Job Wall Time"
     },
     "nodecount": {
-        "attribute_table": "nodecount",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -133,7 +129,6 @@
         "name": "Node Count"
     },
     "person": {
-        "attribute_table": "person",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -161,7 +156,6 @@
         "name": "User"
     },
     "pi": {
-        "attribute_table": "piperson",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -189,7 +183,6 @@
         "name": "PI"
     },
     "provider": {
-        "attribute_table": "serviceprovider",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -225,7 +218,6 @@
                 "aggregate_expr": "task_resource_id"
             }
         ],
-        "attribute_table": "queue",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -253,7 +245,15 @@
         "name": "Queue"
     },
     "resource": {
-        "attribute_table": "resourcefact",
+        "additional_join_constraints": [
+            {
+                 "attribute_table": "resourcefact",
+                 "attribute_expr": "id",
+                 "operation": "=",
+                 "aggregate_table": "resourcespecs",
+                 "aggregate_expr": "resource_id"
+            }
+        ],
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -263,35 +263,32 @@
         "attribute_values_query": {
             "joins": [
                 {
-                    "alias": "rf",
                     "name": "resourcefact"
                 },
                 {
-                    "alias": "rs",
                     "name": "resourcespecs",
-                    "on": "rf.id = rs.resource_id"
+                    "on": "resourcefact.id = resourcespecs.resource_id"
                 }
             ],
             "orderby": [
-                "rf.code",
-                "rf.name"
+                "resourcefact.code",
+                "resourcefact.name"
             ],
             "query_hint": "DISTINCT",
             "records": {
-                "id": "rf.id",
-                "name": "REPLACE(rf.code, '-', ' ')",
+                "id": "resourcefact.id",
+                "name": "REPLACE(resourcefact.code, '-', ' ')",
                 "order_id": "id",
-                "short_name": "REPLACE(rf.code, '-', ' ')"
+                "short_name": "REPLACE(resourcefact.code, '-', ' ')"
             },
             "where": [
-                "rs.processors IS NOT NULL"
+                "resourcespecs.processors IS NOT NULL"
             ]
         },
         "description_html": "A resource is a remote computer that can run jobs.",
         "name": "Resource"
     },
     "resource_type": {
-        "attribute_table": "resourcetype",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -326,7 +323,6 @@
             "systemaccount_id": "SELECT DISTINCT id FROM modw.systemaccount WHERE username IN (__filter_values__)"
         },
         "attribute_description_query": "SELECT DISTINCT username AS filter_name FROM modw.systemaccount WHERE username IN (__filter_values__) ORDER BY username",
-        "attribute_table": "systemaccount",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/group-by-hierarchy.json
+++ b/configuration/datawarehouse.d/ref/group-by-hierarchy.json
@@ -1,6 +1,5 @@
 {
     "fieldofscience": {
-        "attribute_table": "fieldofscience_hierarchy",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -31,7 +30,6 @@
         "alternate_group_by_columns": [
             "directorate_id"
         ],
-        "attribute_table": "fieldofscience_hierarchy",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {
@@ -75,7 +73,6 @@
         "alternate_group_by_columns": [
             "parent_id"
         ],
-        "attribute_table": "fieldofscience_hierarchy",
         "attribute_table_schema": "modw",
         "attribute_to_aggregate_table_key_map": [
             {

--- a/configuration/datawarehouse.d/ref/group-by-none.json
+++ b/configuration/datawarehouse.d/ref/group-by-none.json
@@ -2,7 +2,6 @@
     "name": "${ORGANIZATION_NAME}",
     "description_html": "Summarizes ${REALM_NAME} data reported to the ${ORGANIZATION_NAME} database.",
     "attribute_table_schema": "modw",
-    "attribute_table": "dual",
     "show_in_catalog": false,
     "is_aggregation_unit": true,
     "attribute_to_aggregate_table_key_map": [],

--- a/configuration/datawarehouse.d/ref/group-by-time-period.json
+++ b/configuration/datawarehouse.d/ref/group-by-time-period.json
@@ -3,7 +3,6 @@
         "name": "Day",
         "description_html": "Day",
         "attribute_table_schema": "modw",
-        "attribute_table": "days",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
@@ -35,7 +34,6 @@
         "name": "Month",
         "description_html": "Month",
         "attribute_table_schema": "modw",
-        "attribute_table": "months",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
@@ -67,7 +65,6 @@
         "name": "Quarter",
         "description_html": "Quarter",
         "attribute_table_schema": "modw",
-        "attribute_table": "quarters",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [
@@ -99,7 +96,6 @@
         "name": "Year",
         "description_html": "Year",
         "attribute_table_schema": "modw",
-        "attribute_table": "years",
         "show_in_catalog": false,
         "is_aggregation_unit": true,
         "attribute_to_aggregate_table_key_map": [

--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -527,7 +527,6 @@ var generateGroupBy = function (itemAlias, column)
         description = description.replace(new RegExp(':Label_' + tagidx, 'g'), wordToUpper(column.dynamictags[tagidx]));
     }
     return {
-        attribute_table: column.dimension_table,
         attribute_table_schema: 'modw_supremm',
         attribute_to_aggregate_table_key_map: [
             {

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -1,6 +1,7 @@
 <?php
 
 use Models\Services\Acls;
+use Models\Services\Realms;
 
 @require_once('common.php');
 
@@ -41,6 +42,7 @@ foreach ($roles as $activeRole) {
         $realms = array();
         $groupByObjects = array();
 
+        $realmObjects = Realms::getRealmObjectsForUser($user);
         $query_descripter_realms = Acls::getQueryDescripters($user);
 
         foreach($query_descripter_realms as $query_descripter_realm => $query_descripter_groups)
@@ -51,9 +53,11 @@ foreach ($roles as $activeRole) {
             }
             $seenstats = array();
 
+            $realmObject = $realmObjects[$query_descripter_realm];
+            $realmDisplay = $realmObject->getDisplay();
             $realms[$query_descripter_realm] = array(
                 'text' => $query_descripter_realm,
-                'category' => $category,
+                'category' => $realmDisplay,
                 'dimensions' => array(),
                 'metrics' => array(),
             );

--- a/html/controllers/user_interface/get_menus.php
+++ b/html/controllers/user_interface/get_menus.php
@@ -45,7 +45,7 @@ try {
         $categories = DataWarehouse::getCategories();
 
         // Retrieve the realms that the user has access to
-        $realms = Realms::getRealmsForUser($user);
+        $realms = Realms::getRealmIdsForUser($user);
 
         // Filter the categories by those that the user has access to.
         $categories = array_map(function ($category) use ($realms) {

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/add-alternate-class.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/add-alternate-class.json
@@ -7,7 +7,6 @@
                 "name": "Alternate GroupBy Class Example",
                 "description_html": "Alternate GroupBy Class Example.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "systemaccount",
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "systemaccount_id" }
                 ],

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/add-cloud-groupby.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/add-cloud-groupby.json
@@ -6,7 +6,6 @@
                 "name": "System Username",
                 "description_html": "The specific system username associated with a running session of a virtual machine.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "systemaccount",
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "systemaccount_id" }
                 ],

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/cloud.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/cloud.json
@@ -12,7 +12,6 @@
                 "name": "None",
                 "description_html": "Summarizes ${REALM_NAME} data reported to the ${ORGANIZATION_NAME} database (excludes non-${ORGANIZATION_NAME} usage).",
                 "attribute_table_schema": "modw",
-                "attribute_table": "dual",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [],
                 "order": 1,
@@ -34,7 +33,6 @@
                 "name": "Day",
                 "description_html": "Day",
                 "attribute_table_schema": "modw",
-                "attribute_table": "days",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     {
@@ -65,7 +63,6 @@
                 "name": "Month",
                 "description_html": "Month",
                 "attribute_table_schema": "modw",
-                "attribute_table": "months",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     {
@@ -96,7 +93,6 @@
                 "name": "Instance Type",
                 "description_html": "The instance type of a virtual machine.",
                 "attribute_table_schema": "modw_cloud",
-                "attribute_table": "instance_type",
                 "attribute_to_aggregate_table_key_map": [
                     {
                         "instance_type_id": "instance_type_id"

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/jobs.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/jobs.json
@@ -13,7 +13,6 @@
                 "name": "None",
                 "description_html": "Summarizes ${REALM_NAME} data reported to the ${ORGANIZATION_NAME} database (excludes non-${ORGANIZATION_NAME} usage).",
                 "attribute_table_schema": "modw",
-                "attribute_table": "dual",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                 ],
@@ -36,7 +35,6 @@
                 "name": "Day",
                 "description_html": "Day",
                 "attribute_table_schema": "modw",
-                "attribute_table": "days",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "day_id" }
@@ -65,7 +63,6 @@
                 "name": "Month",
                 "description_html": "Month",
                 "attribute_table_schema": "modw",
-                "attribute_table": "months",
                 "is_aggregation_unit": true,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "month_id" }
@@ -91,9 +88,17 @@
                 }
             },
             "resource": {
+                "additional_join_constraints": [
+                    {
+                        "attribute_table": "resourcefact",
+                        "attribute_expr": "id",
+                        "operation": "=",
+                        "aggregate_table": "resourcespecs",
+                        "aggregate_expr": "resource_id"
+                    }
+                ],
                 "name": "Resource",
                 "description_html": "A resource is a remote computer that can run jobs.",
-                "attribute_table": "resourcefact",
                 "attribute_table_schema": "modw",
                 "order": 4,
                 "#": "Multi-column key",
@@ -134,7 +139,6 @@
                 "description_html": "A person who is on a PIs allocation, hence able run jobs on resources.",
                 "category": "Administrative",
                 "attribute_table_schema": "modw",
-                "attribute_table": "person",
                 "order": 5,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "person_id" }
@@ -161,7 +165,6 @@
                 "name": "System Username",
                 "description_html": "The specific system username of the users who ran jobs.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "systemaccount",
                 "order": 6,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "systemaccount_id" }
@@ -190,7 +193,6 @@
                 "name": "Queue",
                 "description_html": "Queue pertains to the low level job queues on each resource.",
                 "attribute_table_schema": "modw",
-                "attribute_table": "queue",
                 "order": 7,
                 "attribute_to_aggregate_table_key_map": [
                     { "id": "queue" }
@@ -224,7 +226,6 @@
                 "disabled": true,
                 "name": "Disabled Group By",
                 "description_html": "Disabled GroupBy",
-                "attribute_table": "unknown",
                 "attribute_to_aggregate_table_key_map": [
                 ],
                 "attribute_values_query": {

--- a/tests/component/lib/Query/AggregateQueryTest.php
+++ b/tests/component/lib/Query/AggregateQueryTest.php
@@ -343,12 +343,14 @@ SELECT
 FROM
   modw_aggregates.jobfact_by_day agg,
   modw.days duration,
-  modw.resourcefact resourcefact
+  modw.resourcefact resourcefact,
+  modw.resourcespecs resourcespecs
 WHERE
   duration.id = agg.day_id
   AND agg.day_id between 201600357 and 201700001
   AND resourcefact.id = agg.record_resource_id
   AND resourcefact.code = agg.resource_code
+  AND resourcefact.id = resourcespecs.resource_id
 GROUP BY resourcefact.id,
   resourcefact.code
 ORDER BY resourcefact.code ASC,


### PR DESCRIPTION
The XSEDE GroupBys need to be able to use a secondary table to link to aggregates (through the account table to the grant table) this update allows that, while getting rid of the need for the attribute_table key as it is provided by the first (and usually only) join table in the attributes value query.