### PR TITLE
Add alternate_group_by_column field to Project and Instance Type group by

### DIFF
--- a/configuration/datawarehouse.d/ref/Cloud-group-bys.json
+++ b/configuration/datawarehouse.d/ref/Cloud-group-bys.json
@@ -4,6 +4,9 @@
         "description_html": "The instance type of a virtual machine.",
         "attribute_table_schema": "modw_cloud",
         "attribute_table": "instance_type",
+        "alternate_group_by_columns": [
+            "display"
+        ],
         "attribute_to_aggregate_table_key_map": [
             {
                 "instance_type_id": "instance_type_id"
@@ -114,6 +117,9 @@
     "project": {
         "attribute_table": "account",
         "attribute_table_schema": "modw_cloud",
+        "alternate_group_by_columns": [
+            "display"
+        ],
         "attribute_filter_map_query": {
             "account_id": "SELECT account_id FROM modw_cloud.account WHERE display in (__filter_values__)"
         },


### PR DESCRIPTION
This adds alternate_group_by_columns to the Project and Instance Type group bys. One place the column in `alternate_group_by_column`, when present, is used is in the group by WHERE clause to filter results. If alternate_group_by_column is not specified the column(s) in `attribute_to_aggregate_table_key_map` are used instead. For the Project and Instance Type group by's the correct column for WHERE clause is the `display` column not the `instance_type_id` specified in `attribute_to_aggregate_table_key_map`. 

An example of the difference in the sql when alternate_group_by_column is used is shown in the Instance Type group by sql below.

Query before change: 
```sql
SELECT
  duration.id as 'day_id',
  DATE(duration.day_start) as 'day_short_name',
  DATE(duration.day_start) as 'day_name',
  duration.day_start_ts as 'day_start_ts',
  instance_type.display as 'configuration_id',
  instance_type.display as 'configuration_short_name',
  instance_type.display as 'configuration_name',
  instance_type.display as 'configuration_order_id',
  COALESCE(SUM(agg.core_time) / 3600.0, 0) AS cloud_core_time
FROM
  modw_cloud.cloudfact_by_day agg,
  modw.days duration,
  modw_cloud.instance_type instance_type
WHERE
  duration.id = agg.day_id
  AND agg.day_id between 202000061 and 202000091
  AND instance_type.instance_type_id = agg.instance_type_id
  AND instance_type.instance_type_id IN ('c4.m16','c8.m16','c4.m8','c2.m4','c16.m64','c2.m8','c16.m32','c8.m32','c1.m4','c1.m1')
GROUP BY 
  duration.id,
  instance_type.instance_type_id
ORDER BY duration.id ASC,
  instance_type.instance_type_id ASC
```
Query after change:
```sql
SELECT
  duration.id as 'day_id',
  DATE(duration.day_start) as 'day_short_name',
  DATE(duration.day_start) as 'day_name',
  duration.day_start_ts as 'day_start_ts',
  instance_type.display as 'configuration_id',
  instance_type.display as 'configuration_short_name',
  instance_type.display as 'configuration_name',
  instance_type.display as 'configuration_order_id',
  COALESCE(SUM(agg.core_time) / 3600.0, 0) AS cloud_core_time
FROM
  modw_cloud.cloudfact_by_day agg,
  modw.days duration,
  modw_cloud.instance_type instance_type
WHERE
  duration.id = agg.day_id
  AND agg.day_id between 202000061 and 202000091
  AND instance_type.instance_type_id = agg.instance_type_id
  AND instance_type.display IN ('c4.m16','c8.m16','c4.m8','c2.m4','c16.m64','c2.m8','c16.m32','c8.m32','c1.m4','c1.m1')
GROUP BY 
  duration.id,
  instance_type.display
ORDER BY duration.id ASC,
  instance_type.instance_type_id ASC
```
I've updated my port (9008) on metrics-dev with the fix. 

## Tests performed
Tested on port 9008 on metrics-dev

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
