### PR TITLE
Fix regression bug when paging datasets.

### DIFF
--- a/classes/DataWarehouse/Data/TimeseriesDataset.php
+++ b/classes/DataWarehouse/Data/TimeseriesDataset.php
@@ -129,6 +129,11 @@ class TimeseriesDataset
             }
 
             $this->query->addWhereAndJoin($spaceGroup->getId(), 'IN', $seriesIds);
+        } else {
+            // this happens when the offset is greater than the number of series. This
+            // can occur when muliple datasets with different numbers of series
+            // are plotted on the same chart.
+            return array();
         }
 
         $statement = $this->query->getRawStatement();


### PR DESCRIPTION
Fix regression bug introduced in timeseries plot optimizations.

Steps to reproduce:
Use the metric explorer to plot multiple datasets with different number of series in each.
Switch on paging and page past the max series in one of the datasets.

A test has been added to prove the fix.

