### PR TITLE
Change ETL logging identification strings

### DIFF
--- a/background_scripts/etl_aggregation_table_manager.php
+++ b/background_scripts/etl_aggregation_table_manager.php
@@ -154,7 +154,7 @@ $conf = array(
 
 if ( NULL !== $scriptOptions['verbosity'] ) $conf['consoleLogLevel'] = $scriptOptions['verbosity'];
 
-$logger = Log::factory('DWI', $conf);
+$logger = Log::factory('etl_aggregation_table_manager', $conf);
 
 if ( NULL === $scriptOptions['config-file'] ||
      NULL === $scriptOptions['operation'] ) {

--- a/tools/etl/etl_action_state_mgr.php
+++ b/tools/etl/etl_action_state_mgr.php
@@ -170,7 +170,7 @@ $conf = array(
 
 if ( null !== $scriptOptions['verbosity'] ) $conf['consoleLogLevel'] = $scriptOptions['verbosity'];
 
-$logger = Log::factory('DWI', $conf);
+$logger = Log::factory('etl_action_state_mgr', $conf);
 
 $cmd = implode(' ', array_map('escapeshellarg', $argv));
 $logger->info("Command: $cmd");

--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -395,7 +395,7 @@ if ( null !== $scriptOptions['verbosity'] ) {
     $conf['consoleLogLevel'] = $scriptOptions['verbosity'];
 }
 
-$logger = Log::factory('DWI', $conf);
+$logger = Log::factory('etl_overseer', $conf);
 
 $cmd = implode(' ', array_map('escapeshellarg', $argv));
 $logger->info("Command: $cmd");

--- a/tools/etl/etl_table_manager.php
+++ b/tools/etl/etl_table_manager.php
@@ -159,7 +159,7 @@ if ( null !== $scriptOptions['verbosity'] ) {
     $conf['consoleLogLevel'] = $scriptOptions['verbosity'];
 }
 
-$logger = Log::factory('DWI', $conf);
+$logger = Log::factory('etl_table_manager', $conf);
 
 if ( null === $scriptOptions['config-file'] ||
      null === $scriptOptions['operation'] ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Replaces the `DWI` identification strings with more specific names.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The ident `DWI` has a specific meaning in the XSEDE ETL processes.  It is used to identify the `dw_extract_transform_load` process.  There is a script that checks to make sure this process has been run in the past couple days.  If all these other scripts use the same ident then the check script is unable to notify us that the ETL script has not been running.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I haven't tested this.  I'm not sure if there could be any side effects so I've requested reviews from many team members.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
