### PR TITLE
Remove php-mcrypt requirement

### DIFF
--- a/bin/xdmod-check-config
+++ b/bin/xdmod-check-config
@@ -122,13 +122,6 @@ try {
         'PHP GMP extension installed'
     );
 
-    _debug('Checking for mcrypt_cbc function');
-    $result = function_exists('mcrypt_cbc');
-    displayResult(
-        $result,
-        'PHP Mcrypt extension installed'
-    );
-
     _debug('Checking for curl_close function');
     $result = function_exists('curl_close');
     displayResult(

--- a/docs/software-requirements.md
+++ b/docs/software-requirements.md
@@ -12,7 +12,6 @@ Open XDMoD requires the following software:
     - [MySQL PDO Driver][pdo-mysql]
     - [GD][php-gd]
     - [GMP][php-gmp]
-    - [Mcrypt][php-mcrypt]
     - [cURL][php-curl]
     - [DOM][php-dom]
     - [XMLWriter][php-xmlwriter]
@@ -38,7 +37,6 @@ Open XDMoD requires the following software:
 [pdo-mysql]:       https://secure.php.net/manual/en/ref.pdo-mysql.php
 [php-gd]:          https://secure.php.net/manual/en/book.image.php
 [php-gmp]:         https://secure.php.net/manual/en/book.gmp.php
-[php-mcrypt]:      https://secure.php.net/manual/en/book.mcrypt.php
 [php-curl]:        https://secure.php.net/manual/en/book.curl.php
 [php-dom]:         https://secure.php.net/manual/en/book.dom.php
 [php-xmlwriter]:   https://secure.php.net/manual/en/book.xmlwriter.php
@@ -75,7 +73,7 @@ added with this command for CentOS 7:
 
     # yum install epel-release
 
-    # yum install httpd php php-cli php-mysql php-gd php-mcrypt \
+    # yum install httpd php php-cli php-mysql php-gd \
                   gmp-devel php-gmp php-pdo php-xml \
                   php-pear-MDB2 php-pear-MDB2-Driver-mysql \
                   java-1.8.0-openjdk java-1.8.0-openjdk-devel \

--- a/open_xdmod/modules/xdmod/xdmod.spec.in
+++ b/open_xdmod/modules/xdmod/xdmod.spec.in
@@ -13,7 +13,7 @@ BuildArch:     noarch
 BuildRequires: php-cli
 Requires:      httpd
 Requires:      mariadb >= 5.5.3
-Requires:      php >= 5.4 php-cli php-mysql php-pdo php-gd php-mcrypt php-xml php-mbstring
+Requires:      php >= 5.4 php-cli php-mysql php-pdo php-gd php-xml php-mbstring
 Requires:      php-pear-MDB2 php-pear-MDB2-Driver-mysql php-pecl-apcu
 Requires:      java-1.8.0-openjdk java-1.8.0-openjdk-devel
 Requires:      crontabs

--- a/tests/ci/bootstrap.sh
+++ b/tests/ci/bootstrap.sh
@@ -22,6 +22,10 @@ if [ "$XDMOD_TEST_MODE" = "fresh_install" ];
 then
     rpm -qa | grep ^xdmod | xargs yum -y remove || true
     rm -rf /etc/xdmod
+
+    # Remove php-mcrypt until new Docker image is built without it.
+    yum -y remove php-mcrypt || true
+
     rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql
     yum -y install ~/rpmbuild/RPMS/*/*.rpm
     ~/bin/services start
@@ -95,6 +99,10 @@ fi
 if [ "$XDMOD_TEST_MODE" = "upgrade" ];
 then
     yum -y install ~/rpmbuild/RPMS/*/*.rpm
+
+    # Remove php-mcrypt until new Docker image is built without it.
+    yum -y remove php-mcrypt || true
+
     ~/bin/services start
 
     # TODO: Replace diff files with hard fixes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Removes the `php-mcrypt` requirement from the RPM SPEC files. Removes `php-mycrypt` during tests bootstrap.  Removes `php-mcrypt` check and documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It would appear that `php-mcrypt` is no longer required.  It was required by earlier versions of `simpleSAMLphp`, but not by the currently used version.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated tests bootstrap to remove `php-mcrypt`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
