### PR TITLE
Removing unused log file exposing user sessions

### DIFF
--- a/classes/Rest/Utilities/Authentication.php
+++ b/classes/Rest/Utilities/Authentication.php
@@ -221,22 +221,6 @@ class Authentication
             ':init_time' => $_SESSION['xdInit'],
         );
 
-        $access_logfile = LOG_DIR . '/session_manager.log';
-
-        $logConf = array('mode' => 0644);
-
-        $sessionManagerLogger = Log::factory(
-            'file',
-            $access_logfile,
-            'SESSION_MANAGER',
-            $logConf
-        );
-
-        $sessionManagerLogger->log(
-            $_SERVER['REMOTE_ADDR'] . ' QUERY ' . $resolver_query
-            . ' PARAMS ' . json_encode($resolver_query_params)
-        );
-
         $pdo = DB::factory('database');
 
         $user_check = $pdo->query(

--- a/configuration/logrotate.conf
+++ b/configuration/logrotate.conf
@@ -10,17 +10,6 @@
     dateext
 }
 
-/var/log/xdmod/session_manager.log
-{
-    su apache apache
-    create 0640 apache apache
-    rotate 4
-    weekly
-    compress
-    missingok
-    dateext
-}
-
 /var/log/xdmod/apache*.log
 {
     su root root


### PR DESCRIPTION
**NOTE** there will be an accompanying PR for ccr-private as there's one usage of `session_manager.log` there. 

## Description
- Removed the creation / use of the logger that wrote the session information to the file `session_manager.log`. 
- Removed the entry in the logrotate configuration file that referenced `session_manager.log`

## Motivation and Context
This file was identified in the security review by TrustedCI via the
XDMoD-2020-0002 vulnerability report. Additional changes tracked in
https://app.asana.com/0/342819846538629/1178746552707810

## Tests performed
All automated tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code Cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
