### PR TITLE
Change table alias for consistency

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/JobDataset.php
+++ b/classes/DataWarehouse/Query/Jobs/JobDataset.php
@@ -24,8 +24,8 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
 
         $config = RawStatisticsConfiguration::factory();
 
-        // The data table is always aliased to "jf".
-        $tables = ['jf' => $this->getDataTable()];
+        // The data table is always aliased to "agg".
+        $tables = ['agg' => $this->getDataTable()];
 
         foreach ($config->getQueryTableDefinitions('Jobs') as $tableDef) {
             $alias = $tableDef['alias'];

--- a/configuration/rawstatistics.d/20_jobs.json
+++ b/configuration/rawstatistics.d/20_jobs.json
@@ -13,7 +13,7 @@
                 "alias": "jl",
                 "join": {
                     "primaryKey": "agg_id",
-                    "foreignTableAlias": "jf",
+                    "foreignTableAlias": "agg",
                     "foreignKey": "id"
                 }
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes the alias used for the aggregate table in the jobs realm `JobDataset` query.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The group by refactoring changed the table alias from `jf` to `agg`.  This file was not changed so it was still using `jf` as an associative array key in the PHP code even though the generated SQL is now using `agg`.  The change makes it clear that `agg` in the PHP code is the same `agg` in the corresponding SQL.  It also prevents another table from being aliased to `agg` and allowing other table to used `jf` as an alias if necessary.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
