### PR TITLE
consistient log levels

### DIFF
--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -319,7 +319,7 @@ class DataWarehouseInitializer
     public function aggregateCloudData($lastModifiedStartDate)
     {
         if( !$this->isRealmEnabled('Cloud') ){
-            $this->logger->debug('Cloud realm not enabled, not aggregating');
+            $this->logger->notice('Cloud realm not enabled, not aggregating');
             return;
         }
 


### PR DESCRIPTION
Log messages at the same level for similar things.

before:
```
[root@xdmod9 /]# xdmod-ingestor --realm Cloud --debug
2020-06-18 13:24:37 [notice] xdmod-ingestor start (process_start_time: 2020-06-18 13:24:37)
2020-06-18 13:24:41 [notice] Jobs realm not enabled, not aggregating
2020-06-18 13:24:41 [notice] Storage realm not enabled, not aggregating
2020-06-18 13:24:41 [notice] xdmod-ingestor end (process_end_time: 2020-06-18 13:24:41)
[root@xdmod9 /]#
```
after:
```
[root@xdmod9 /]# xdmod-ingestor --realm Cloud --debug
2020-06-18 13:24:37 [notice] xdmod-ingestor start (process_start_time: 2020-06-18 13:24:37)
2020-06-18 13:24:41 [notice] Jobs realm not enabled, not aggregating
2020-06-18 13:24:41 [notice] Cloud realm not enabled, not aggregating
2020-06-18 13:24:41 [notice] Storage realm not enabled, not aggregating
2020-06-18 13:24:41 [notice] xdmod-ingestor end (process_end_time: 2020-06-18 13:24:41)
[root@xdmod9 /]#
```