### PR TITLE
set cookies so that iframed login works

### DIFF
--- a/html/gui/general/login.php
+++ b/html/gui/general/login.php
@@ -20,6 +20,7 @@ try {
         if ($xdmodUser->getAccountStatus()) {
             $formal_name = $xdmodUser->getFormalName();
             $xdmodUser->postLogin();
+            \xd_rest\setCookies();
         } else {
             $message = 'Your account is currently inactive, please contact an administrator.';
         }


### PR DESCRIPTION
Seemes I messed up while testing the other CORS changes to make sure that login actually sets the cookies.  This will actually set the cookies.