### PR TITLE
Change table definition for vcpus field for the cloud_resource_specs table 

### DIFF
--- a/configuration/etl/etl_tables.d/cloud_common/cloud_resource_specs.json
+++ b/configuration/etl/etl_tables.d/cloud_common/cloud_resource_specs.json
@@ -32,7 +32,8 @@
             {
                 "name": "vcpus",
                 "type": "int(5)",
-                "nullable": false
+                "nullable": false,
+                "default": null
             },
             {
                 "name": "start_date_ts",

--- a/configuration/etl/etl_tables.d/cloud_common/cloud_resource_specs.json
+++ b/configuration/etl/etl_tables.d/cloud_common/cloud_resource_specs.json
@@ -32,8 +32,7 @@
             {
                 "name": "vcpus",
                 "type": "int(5)",
-                "nullable": true,
-                "default": null
+                "nullable": false
             },
             {
                 "name": "start_date_ts",


### PR DESCRIPTION
The vcpus field for the cloud_resource_specs table had the nullable property set to be true. This is incorrect and in MySQL 5.7 or higher causes an error since this field is part of the primary key.

```
xdmod.jobs-cloud-common.CloudTableManagement (ETL\Maintenance\ManageTables): Error managing ETL table `modw_cloud`.`cloud_resource_specs`: SQLSTATE[42000]: Syntax error or access violation: 1171 All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
```
Setting the field to be `nullable: false` fixes the problem

## Tests performed
Tested manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
