### PR TITLE
Add ability to apply filters to the aggregatedata request.

### DIFF
--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -774,6 +774,10 @@ class WarehouseControllerProvider extends BaseControllerProvider
             $query->addStat($stat);
         }
 
+        if (property_exists($config, 'filters')) {
+            $query->setRoleParameters($config->filters);
+        }
+
         if (!property_exists($config->order_by, 'field') || !property_exists($config->order_by, 'dirn')) {
             throw new BadRequestException('Malformed config property order_by');
         }

--- a/tests/integration/lib/Rest/WarehouseControllerTest.php
+++ b/tests/integration/lib/Rest/WarehouseControllerTest.php
@@ -118,4 +118,23 @@ class WarehouseControllerTest extends BaseTest
         $this->assertCount($params['limit'], $response[0]['results']);
         $this->assertEquals(66, $response[0]['total']);
     }
+
+    /**
+     * Confirm that a filter can be applied to the aggregatedata endpoint
+     */
+    public function testGetAggregateWithFilters()
+    {
+        if (!in_array("jobs", self::$XDMOD_REALMS)) {
+            $this->markTestSkipped('This test requires the Jobs realm');
+        }
+
+        $params = $this->getAggDataParameterGenerator(array('filters' => array('jobsize' => 1)));
+
+        $response = self::$helpers['cd']->get('rest/warehouse/aggregatedata', $params);
+
+        $this->assertEquals(200, $response[1]['http_code']);
+        $this->assertTrue($response[0]['success']);
+        $this->assertCount($params['limit'], $response[0]['results']);
+        $this->assertEquals(23, $response[0]['total']);
+    }
 }


### PR DESCRIPTION
This is needed for the ondemand integration. If the filters parameter is
absent then the behaviour is unchanged so this should not cause any regressions.

This filtering works in identical way to the metric explorer global filters so
any caveats for that code also are applicable here.
