### PR TITLE
Rename internal dashboard button from "Dashboard" to "Admin Dashboard"

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -128,11 +128,11 @@ XDMoD.GlobalToolbar.Profile = {
 // -------------------------------------------------
 
 XDMoD.GlobalToolbar.Dashboard = {
-    text: 'Dashboard',
+    text: 'Admin Dashboard',
     scale: 'small',
     iconCls: 'btn_dashboard',
     id: 'global-toolbar-dashboard',
-    tooltip: 'Internal Dashboard',
+    tooltip: 'Load the admin dashboard in a new window.',
     handler: function () {
         XDMoD.TrackEvent("Portal", "Dashboard Button Clicked");
         CCR.xdmod.initDashboard();

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -134,7 +134,7 @@ XDMoD.GlobalToolbar.Dashboard = {
     id: 'global-toolbar-dashboard',
     tooltip: 'Load the admin dashboard in a new window.',
     handler: function () {
-        XDMoD.TrackEvent("Portal", "Admin Dashboard Button Clicked");
+        XDMoD.TrackEvent('Portal', 'Admin Dashboard Button Clicked');
         CCR.xdmod.initDashboard();
     } //handler
 

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -134,7 +134,7 @@ XDMoD.GlobalToolbar.Dashboard = {
     id: 'global-toolbar-dashboard',
     tooltip: 'Load the admin dashboard in a new window.',
     handler: function () {
-        XDMoD.TrackEvent("Portal", "Dashboard Button Clicked");
+        XDMoD.TrackEvent("Portal", "Admin Dashboard Button Clicked");
         CCR.xdmod.initDashboard();
     } //handler
 


### PR DESCRIPTION
Also update the tooltip to be slightly less uninformative.

This increases the width of the button. However there is still plenty
of space in the top toolbar. The width of the page that causes the
Help button to disappear is still mcuh narrower than any usable width
for the rest of XDMoD.

![image](https://user-images.githubusercontent.com/5342179/87978988-5b624880-ca9f-11ea-802d-38a1cda80545.png)

The rest of the labels and paths are unchanged