### PR TITLE
HighcartExport process cleanup and updates

### DIFF
--- a/docs/software-requirements.md
+++ b/docs/software-requirements.md
@@ -25,7 +25,7 @@ Open XDMoD requires the following software:
 - [Chromium][]
     - `chromium-headless` is assumed, but chromium has been known to work
 - [libRsvg][]
-- [ghostscript][] 9+
+- [exiftool][]
 - [cron][]
 - [logrotate][]
 - [MTA][] with `sendmail` compatibility (e.g. [postfix][], [exim][] or
@@ -54,7 +54,7 @@ Open XDMoD requires the following software:
 [jdk]:             http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [chromium]:        https://www.chromium.org/Home
 [librsvg]:         https://wiki.gnome.org/Projects/LibRsvg
-[ghostscript]:     https://www.ghostscript.com/
+[exiftool]:        http://www.sno.phy.queensu.ca/%7Ephil/exiftool/
 [cron]:            https://en.wikipedia.org/wiki/Cron
 [logrotate]:       https://linux.die.net/man/8/logrotate
 [mta]:             https://en.wikipedia.org/wiki/Message_transfer_agent

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -88,8 +88,9 @@ changed in the new version.  You do not need to merge
 If you have manually edited this file, you should create a backup and
 merge any changes after running the upgrade script.
 
-*NOTE: This upgrade changes the dependency on `PhantomJS` to `chromium` and `libRSVG`. These new dependencies will need to be manually installed. See the [Software Requirements](software-requirements.html) for more details.
-`PhantomJS` is no longer required by Open XDMoD and will need to be removed manually.*
+*NOTE: This upgrade removes the `PhantomJS` and `ghostscript` dependencies; it adds dependencies of `chromium`, `libRSVG` and `exiftool`. These new dependencies will need to be manually installed. See the [Software Requirements](software-requirements.html) for more details.
+`PhantomJS` s no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
+
 
 ### Verify Server Configuration Settings
 
@@ -108,8 +109,8 @@ enhancements and bug fixes.
 
 You may upgrade directly from 9.0.0.
 
-*NOTE: This upgrade changes the dependency on `PhantomJS` to `chromium` and `libRSVG`. These new dependencies will be automatically installed by the RPM.
-`PhantomJS` WILL NOT be removed automatically; it will need to be removed manually.*
+*NOTE: This upgrade removes the `PhantomJS` and `ghostscript` dependencies; it adds dependencies of `chromium`, `libRSVG` and `exiftool`.. These new dependencies will be automatically installed by the RPM.
+`PhantomJS` s no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
 
 ### Configuration File Changes
 

--- a/open_xdmod/modules/xdmod/xdmod.spec.in
+++ b/open_xdmod/modules/xdmod/xdmod.spec.in
@@ -20,7 +20,7 @@ Requires:      chromium-headless
 Requires:      librsvg2-tools
 Requires:      crontabs
 Requires:      logrotate
-Requires:      ghostscript
+Requires:      perl-Image-ExifTool
 Requires:      jq
 
 %description
@@ -96,6 +96,7 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 * Tue Aug 18 2020 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
     - Add `chromium-headless` and `librsvg2-tools` to required dependencies
+    - replace `ghostscript` with `exiftool`
 * Thu Aug 13 2020 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.0.0-1.0
     - Release 9.0.0
     - Add `mod_ssl` to required dependencies


### PR DESCRIPTION
`ghostscript` was specifically added to make the pdf have the proper width and height.  since `rsvg-convert` can handle this, remove the dependency on `ghostscript` and change to `exiftool` for reaming metadata

This also:

removes the temporary files and passes them around in memory
uses a safer temporary filename for image export