### PR TITLE
Replace ghostscript with exiftool

### DIFF
--- a/docs/software-requirements.md
+++ b/docs/software-requirements.md
@@ -25,7 +25,7 @@ Open XDMoD requires the following software:
 - [Chromium][]
     - `chromium-headless` is assumed, but chromium has been known to work
 - [libRsvg][]
-- [ghostscript][] 9+
+- [exiftool][]
 - [cron][]
 - [logrotate][]
 - [MTA][] with `sendmail` compatibility (e.g. [postfix][], [exim][] or
@@ -54,7 +54,7 @@ Open XDMoD requires the following software:
 [jdk]:             http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [chromium]:        https://www.chromium.org/Home
 [librsvg]:         https://wiki.gnome.org/Projects/LibRsvg
-[ghostscript]:     https://www.ghostscript.com/
+[exiftool]:        http://www.sno.phy.queensu.ca/%7Ephil/exiftool/
 [cron]:            https://en.wikipedia.org/wiki/Cron
 [logrotate]:       https://linux.die.net/man/8/logrotate
 [mta]:             https://en.wikipedia.org/wiki/Message_transfer_agent

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -88,8 +88,8 @@ changed in the new version.  You do not need to merge
 If you have manually edited this file, you should create a backup and
 merge any changes after running the upgrade script.
 
-*NOTE: This upgrade changes the dependency on `PhantomJS` to `chromium` and `libRSVG`. These new dependencies will need to be manually installed. See the [Software Requirements](software-requirements.html) for more details.
-`PhantomJS` is no longer required by Open XDMoD and will need to be removed manually.*
+*NOTE: This upgrade removes the `PhantomJS` and `ghostscript` dependencies; it adds dependencies of `chromium`, `libRSVG` and `exiftool`. These new dependencies will need to be manually installed. See the [Software Requirements](software-requirements.html) for more details.
+`PhantomJS` s no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
 
 ### Verify Server Configuration Settings
 
@@ -108,8 +108,8 @@ enhancements and bug fixes.
 
 You may upgrade directly from 9.0.0.
 
-*NOTE: This upgrade changes the dependency on `PhantomJS` to `chromium` and `libRSVG`. These new dependencies will be automatically installed by the RPM.
-`PhantomJS` WILL NOT be removed automatically; it will need to be removed manually.*
+*NOTE: This upgrade removes the `PhantomJS` and `ghostscript` dependencies; it adds dependencies of `chromium`, `libRSVG` and `exiftool`.. These new dependencies will be automatically installed by the RPM.
+`PhantomJS` s no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
 
 ### Configuration File Changes
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -89,7 +89,7 @@ If you have manually edited this file, you should create a backup and
 merge any changes after running the upgrade script.
 
 *NOTE: This upgrade removes the `PhantomJS` and `ghostscript` dependencies; it adds dependencies of `chromium`, `libRSVG` and `exiftool`. These new dependencies will need to be manually installed. See the [Software Requirements](software-requirements.html) for more details.
-`PhantomJS` s no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
+`PhantomJS` is no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
 
 ### Verify Server Configuration Settings
 
@@ -109,7 +109,7 @@ enhancements and bug fixes.
 You may upgrade directly from 9.0.0.
 
 *NOTE: This upgrade removes the `PhantomJS` and `ghostscript` dependencies; it adds dependencies of `chromium`, `libRSVG` and `exiftool`.. These new dependencies will be automatically installed by the RPM.
-`PhantomJS` s no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
+`PhantomJS` is no longer required, however, it WILL NOT be removed automatically; it will need to be removed manually.*
 
 ### Configuration File Changes
 

--- a/open_xdmod/modules/xdmod/xdmod.spec.in
+++ b/open_xdmod/modules/xdmod/xdmod.spec.in
@@ -1,4 +1,4 @@
-Name:          xdmod
+name:          xdmod
 Version:       __VERSION__
 Release:       __RELEASE__%{?dist}
 Summary:       Data warehouse and web portal for mining statistical data from resource managers
@@ -20,7 +20,7 @@ Requires:      chromium-headless
 Requires:      librsvg2-tools
 Requires:      crontabs
 Requires:      logrotate
-Requires:      ghostscript
+Requires:      perl-Image-ExifTool
 Requires:      jq
 
 %description
@@ -96,6 +96,7 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 * Tue Aug 18 2020 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
     - Add `chromium-headless` and `librsvg2-tools` to required dependencies
+    - Replace `ghostscript` with `exiftool`
 * Thu Aug 13 2020 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.0.0-1.0
     - Release 9.0.0
     - Add `mod_ssl` to required dependencies


### PR DESCRIPTION
`ghostscript` was added to set proper pdf width and height, this can be done with `rsvg-convert` and the metadata can be added with `exiftool` use these tools instead as they are "smaller"

Another PR will be added to cleanup all the temporary files.

Url for exiftool comes from yum

```text
$ yum info perl-Image-ExifTool
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: mirror.clarkson.edu
 * epel: ord.mirror.rackspace.com
 * extras: mirror.atlanticmetro.net
 * updates: mirror.atlanticmetro.net
Installed Packages
Name        : perl-Image-ExifTool
Arch        : noarch
Version     : 12.00
Release     : 1.el7
Size        : 15 M
Repo        : installed
From repo   : epel
Summary     : Utility for reading and writing image meta info
URL         : http://www.sno.phy.queensu.ca/%7Ephil/exiftool/
License     : GPL+ or Artistic
Description : ExifTool is a Perl module with an included command-line application for
            : reading and writing meta information in image, audio, and video files.
            : It reads EXIF, GPS, IPTC, XMP, JFIF, MakerNotes, GeoTIFF, ICC Profile,
            : Photoshop IRB, FlashPix, AFCP, and ID3 meta information from JPG, JP2,
            : TIFF, GIF, PNG, MNG, JNG, MIFF, EPS, PS, AI, PDF, PSD, BMP, THM, CRW,
            : CR2, MRW, NEF, PEF, ORF, DNG, and many other types of images. ExifTool
            : also extracts information from the maker notes of many digital cameras
            : by various manufacturers including Canon, Casio, FujiFilm, GE, HP,
            : JVC/Victor, Kodak, Leaf, Minolta/Konica-Minolta, Nikon, Olympus/Epson,
            : Panasonic/Leica, Pentax/Asahi, Reconyx, Ricoh, Samsung, Sanyo,
            : Sigma/Foveon, and Sony.
```