### PR TITLE
Populate PDF MetaData with more than a filename

### DIFF
--- a/classes/DataWarehouse/Access/Common.php
+++ b/classes/DataWarehouse/Access/Common.php
@@ -276,7 +276,7 @@ class Common
         return \xd_utilities\array_get($this->request, 'filename');
     }
 
-    protected function exportImage($returnData, $width, $height, $scale, $format, $filename)
+    protected function exportImage($returnData, $width, $height, $scale, $format, $filename, $fileMeta = null)
     {
         if (isset($this->request['render_thumbnail']))
         {
@@ -306,9 +306,12 @@ class Common
 
         if ($format === 'png' || $format === 'svg' || $format === 'pdf')
         {
-            $fileMeta = array(
-                'title' => $filename
-            );
+            if (is_null($fileMeta))
+            {
+                $fileMeta = array(
+                    'title' => $filename
+                );
+            }
 
             $result = array(
                 "headers" => \DataWarehouse\ExportBuilder::getHeader( $format, false, $filename),

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -216,7 +216,19 @@ class MetricExplorer extends Common
                 'included_in_report' => $includedInReport ? 'y' : 'n',
             );
 
-            return $this->exportImage($returnData, $width, $height, $scale, $format, $filename);
+            return $this->exportImage(
+                $returnData,
+                $width,
+                $height,
+                $scale,
+                $format,
+                $filename,
+                array(
+                    'author' => $user->getFormalName(),
+                    'subject' => ($timeseries ? 'Timeseries' : 'Aggregate') . ' data for period ' . $start_date. ' -> ' . $end_date,
+                    'title' => $title
+                )
+            );
         } // if $format === 'hc_jsonstore' || $format === 'png' || $format === 'svg'
           //  || $format === 'png_inline' || $format === 'svg_inline'
         elseif ($format === 'jsonstore' || $format === 'json' || $format === 'csv' || $format === 'xml') {

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -1011,7 +1011,12 @@ class Usage extends Common
             $usageHeight,
             \xd_utilities\array_get($this->request, 'scale', self::DEFAULT_SCALE),
             $usageFormat,
-            $usageFileName
+            $usageFileName,
+            array(
+                'author' => $user->getFormalName(),
+                'subject' => ($usageIsTimeseries ? 'Timeseries' : 'Aggregate') . ' data for period ' . $this->request['start_date'] . ' -> ' . $this->request['end_date'],
+                'title' => $usageFileNameTitle
+            )
         );
     }
 


### PR DESCRIPTION
Found when switching to `chromium` that the PDF export has metadata that is sometimes only populated with the filename, this put it to something useful.