### PR TITLE
Use absolute path when running acl-config

### DIFF
--- a/classes/OpenXdmod/Migration/AclConfigMigration.php
+++ b/classes/OpenXdmod/Migration/AclConfigMigration.php
@@ -15,8 +15,7 @@ class AclConfigMigration extends Migration
      */
     public function execute()
     {
-        // NOTE: we assume that acl-config is in PATH as that's how we have it setup.
-        $cmd = 'acl-config';
+        $cmd = BIN_DIR . '/acl-config';
 
         $output = shell_exec($cmd);
         $hadError = strpos($output, 'error') !== false;

--- a/classes/OpenXdmod/Setup/AclConfig.php
+++ b/classes/OpenXdmod/Setup/AclConfig.php
@@ -31,7 +31,7 @@ MSG;
         $this->console->displayMessage($this->sectionMessage);
         $this->console->displayBlankLine();
 
-        $cmd = $this->scriptName;
+        $cmd = BIN_DIR . '/' . $this->scriptName;
         $this->console->displayMessage("This may take a minute or two...");
 
         $output = shell_exec($cmd);

--- a/classes/OpenXdmod/Setup/DatabaseSetup.php
+++ b/classes/OpenXdmod/Setup/DatabaseSetup.php
@@ -164,6 +164,9 @@ EOT
             $tpg->generateMainTable(DB::factory('datawarehouse'), new \DateTime('2000-01-01'), new \DateTime('2038-01-18'));
         }
 
-        passthru('acl-config');
+        passthru(BIN_DIR . '/acl-config', $aclstatus);
+        if ($aclstatus !== 0) {
+            $logger->err('Error while running acl-config');
+        }
     }
 }

--- a/configuration/constants.php
+++ b/configuration/constants.php
@@ -47,6 +47,9 @@ define('STATUS_CENTER_DIRECTOR_ROLE', 3);
 define('CONFIG_DIR', $currentDir);
 define('BASE_DIR', dirname($currentDir));
 
+// Open XDMoD bin directory
+define('BIN_DIR', '__XDMOD_BIN_PATH__');
+
 // Open XDMoD data directory, e.g. /usr/share/xdmod or PREFIX/share
 define('DATA_DIR', BASE_DIR);
 define('LOG_DIR', BASE_DIR.'/logs');

--- a/open_xdmod/build_scripts/templates/install.template
+++ b/open_xdmod/build_scripts/templates/install.template
@@ -519,6 +519,7 @@ function substitutePaths($dirs)
     ));
 
     substituteInFile($destDir . $dirs['data'] . '/configuration/constants.php', array(
+        '/__XDMOD_BIN_PATH__/' => $dirs['bin'],
         "#^define\('CONFIG_DIR',.+$#m"
         => "define('CONFIG_DIR', '" . $dirs['conf'] . "');",
         "#^define\('LOG_DIR',.+$#m"


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Update executing of `acl-config` to use the absolute path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This has been an issue because `acl-config` may not be in the `PATH` environment variable (for the source installation).  It's also possible that another command named `acl-config` may be in the `PATH` before the correct version (see #1306).

https://listserv.buffalo.edu/cgi-bin/wa?A2=CCR-XDMOD-LIST;a2f9993d.2008
https://listserv.buffalo.edu/cgi-bin/wa?A2=CCR-XDMOD-LIST;59d4a324.2008

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
