### PR TITLE
Fix institution loading during manual user creation

### DIFF
--- a/html/gui/js/TGUserDropDown.js
+++ b/html/gui/js/TGUserDropDown.js
@@ -43,18 +43,24 @@ CCR.xdmod.ui.TGUserDropDown = Ext.extend(Ext.form.ComboBox, {
     /**
      * Set the value and raw value.
      *
-     * @param {integer} v - The person ID.
-     * @param {string} l - The person display value.
-     * @param {boolean} c - Execute cascade function if true (defaults to true).
+     * @param {number} personId - A person ID.
+     * @param {string} personName - A person name.
+     * @param {boolean} updateCascadeComponent - Execute cascade function if
+     * true (defaults to true).
      */
-    initializeWithValue: function (v, l, c) {
-        var cascade = (typeof c !== 'undefined') ? c : true;
+    initializeWithValue: function (
+        personId,
+        personName,
+        updateCascadeComponent
+    ) {
+        var cascade = (typeof updateCascadeComponent !== 'undefined') ?
+            updateCascadeComponent : true;
 
-        this.setValue(v);
-        this.setRawValue(l);
+        this.setValue(personId);
+        this.setRawValue(personName);
 
         if (cascade) {
-            this.cascadeSelect(v);
+            this.cascadeSelect(personId);
         }
     },
 
@@ -104,6 +110,11 @@ CCR.xdmod.ui.TGUserDropDown = Ext.extend(Ext.form.ComboBox, {
         CCR.xdmod.ui.TGUserDropDown.superclass.initComponent.apply(this, arguments);
     }, // initComponent
 
+    /**
+     * Update the cascade component if cascade options are defined.
+     *
+     * @param {number} personId - The person ID that was selected.
+     */
     cascadeSelect: function (personId) {
         var cascadeOptions = this.cascadeOptions;
         var comp;

--- a/html/gui/js/TGUserDropDown.js
+++ b/html/gui/js/TGUserDropDown.js
@@ -40,10 +40,22 @@ CCR.xdmod.ui.TGUserDropDown = Ext.extend(Ext.form.ComboBox, {
         return this;
     },
 
-    initializeWithValue: function (v, l) {
-        this.setValue(v, l);
+    /**
+     * Set the value and raw value.
+     *
+     * @param {integer} v - The person ID.
+     * @param {string} l - The person display value.
+     * @param {boolean} c - Execute cascade function if true (defaults to true).
+     */
+    initializeWithValue: function (v, l, c) {
+        var cascade = (typeof c !== 'undefined') ? c : true;
+
+        this.setValue(v);
         this.setRawValue(l);
-        this.cascadeSelect(v);
+
+        if (cascade) {
+            this.cascadeSelect(v);
+        }
     },
 
     initComponent: function () {

--- a/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
+++ b/html/internal_dashboard/js/admin_panel/SectionExistingUsers.js
@@ -1254,7 +1254,7 @@ XDMoD.ExistingUsers = Ext.extend(Ext.Panel, {
 
 
                         // Remaining inputs ----------------------
-                        cmbUserMapping.initializeWithValue(json.user_information.assigned_user_id, json.user_information.assigned_user_name);
+                        cmbUserMapping.initializeWithValue(json.user_information.assigned_user_id, json.user_information.assigned_user_name, false);
                         cmbUserMapping.originalValue = json.user_information.assigned_user_id;
 
                         var userType = parseInt(json.user_information.user_type, 10);


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Updates the `TGUserDropDown` (used for the "Map To" field when creating users in the internal dashboard) to execute the cascade options after the field is set programmatically. (Previously the cascade options were only executed after the `select` event which is only triggered by a user selecting an item from the drop down.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using the "Find" option during user creation wasn't setting the institution which then produces an error message when attempting to create the user.

https://app.asana.com/0/807770147051221/1193376020829900/f

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
