### PR TITLE
Change raw statistics variable substitution format

### DIFF
--- a/configuration/rawstatistics.d/20_jobs.json
+++ b/configuration/rawstatistics.d/20_jobs.json
@@ -335,27 +335,27 @@
                 "batchExport": true
             },
             {
-                "name": "HIERARCHY_TOP_LEVEL_LABEL",
+                "name": "${HIERARCHY_TOP_LEVEL_LABEL}",
                 "tableAlias": "fos",
                 "column": "directorate_description",
                 "group": "Requested Resource",
-                "documentation": "HIERARCHY_TOP_LEVEL_INFO",
+                "documentation": "${HIERARCHY_TOP_LEVEL_INFO}",
                 "batchExport": true
             },
             {
-                "name": "HIERARCHY_MIDDLE_LEVEL_LABEL",
+                "name": "${HIERARCHY_MIDDLE_LEVEL_LABEL}",
                 "tableAlias": "fos",
                 "column": "parent_description",
                 "group": "Requested Resource",
-                "documentation": "HIERARCHY_MIDDLE_LEVEL_INFO",
+                "documentation": "${HIERARCHY_MIDDLE_LEVEL_INFO}",
                 "batchExport": true
             },
             {
-                "name": "HIERARCHY_BOTTOM_LEVEL_LABEL",
+                "name": "${HIERARCHY_BOTTOM_LEVEL_LABEL}",
                 "tableAlias": "fos",
                 "column": "description",
                 "group": "Requested Resource",
-                "documentation": "HIERARCHY_BOTTOM_LEVEL_INFO",
+                "documentation": "${HIERARCHY_BOTTOM_LEVEL_INFO}",
                 "batchExport": true
             }
         ]


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Change the format used for variable substitution in `rawstatistics.json` configuration files.

This changes the syntax for variable substitution to match the format used by the ETL configuration files (as well as using the same PHP class).  It also adds the other PHP constants that are not current used to the list of substitutions.

I'll update the upgrade documentation later since there will may be more changes made to the format of these files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is intended to make the substitutions more uniform with those used by the ETL and `datawarehouse.json` configuration file.

It is also a step working towards https://app.asana.com/0/342819846538629/1185671232325739/f

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually in the job viewer.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
