### PR TITLE
Only show the New User Tour Dialog once per session.

### DIFF
--- a/html/gui/js/modules/Dashboard.js
+++ b/html/gui/js/modules/Dashboard.js
@@ -120,7 +120,7 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
                     portalwindow.add(portal);
                     portalwindow.doLayout();
 
-                    if (CCR.xdmod.publicUser !== true) {
+                    if (CCR.xdmod.publicUser !== true && !XDMoD.tourPromptShown) {
                         var conn = new Ext.data.Connection();
                         conn.request({
                             url: XDMoD.REST.url + '/dashboard/viewedUserTour',
@@ -129,7 +129,7 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
                                 token: XDMoD.REST.token
                             },
                             method: 'GET',
-                            callback: function (options, success, response) {
+                            success: function (response) {
                                 var serverResp = Ext.decode(response.responseText);
                                 if (serverResp.data.length === 0 || !serverResp.data[0].viewedTour) {
                                     Ext.Msg.show({
@@ -163,6 +163,7 @@ Ext.extend(XDMoD.Module.Summary, XDMoD.PortalModule, {
                                         }
                                     });
                                 }
+                                XDMoD.tourPromptShown = true;
                             } // callback
                         }); // conn.request
                     }


### PR DESCRIPTION
The new user tour dialog checking-and-showing code runs every time the
dashboard is loaded. The dashboard is reloaded when you navigate to it
and the data have changed. I.e. multiple times per session. This change
sets a flag so that the tour checking code only runs once.

While investigating this issue I noticed another bug where the response
data was being parsed even in the error case (which lead to a unhandled exception
in the javascript). This mitigates this problem by switching the
code to use the success callback function. In the error case the request
will be retried the next time the dashboard loads. I saw the load failure
case when using XDMoD on a noisy wi-fi connection.

Asana issue:  https://app.asana.com/0/808093868887967/1140113137533641