### PR TITLE
Update SSO to pull the configured SP's IdP metadata directly

### DIFF
--- a/classes/Authentication/SAML/XDSamlAuthentication.php
+++ b/classes/Authentication/SAML/XDSamlAuthentication.php
@@ -220,30 +220,31 @@ EML;
      */
     public function getLoginLink()
     {
-        if ($this->isSamlConfigured()) {
-            $idpAuth = \SimpleSAML_Metadata_MetaDataStorageHandler::getMetadataHandler()->getList();
-            $orgDisplay = "";
-            $icon = "";
-            foreach ($idpAuth as $idp) {
-                if (!empty($idp['OrganizationDisplayName'])) {
-                    $orgDisplay = $idp['OrganizationDisplayName'];
-                }
-                if (!empty($idp['icon'])) {
-                    $icon = $idp['icon'];
-                }
-            }
-            if ($orgDisplay === "") {
-                $orgDisplay = array(
-                    'en' => 'Single Sign On'
-                );
-            }
-            return array(
-                'organization' => $orgDisplay,
-                'icon' => $icon
-            );
-        } else {
+        if (!$this->isSamlConfigured()) {
             return false;
         }
+        $idp = \SimpleSAML_Metadata_MetaDataStorageHandler::getMetadataHandler()->getMetadata(
+            \SimpleSAML_Auth_Source::getById($this->authSourceName)->getMetadata()->toArray()['idp'],
+            'saml20-idp-remote'
+        );
+        if (!empty($idp['OrganizationDisplayName'])) {
+            $orgDisplay = $idp['OrganizationDisplayName'];
+        }
+        else {
+            $orgDisplay = array(
+                'en' => 'Single Sign On'
+            );
+        }
+        if (!empty($idp['icon'])) {
+            $icon = $idp['icon'];
+        }
+        else {
+            $icon = "";
+        }
+        return array(
+            'organization' => $orgDisplay,
+            'icon' => $icon
+        );
     }
 
     /**


### PR DESCRIPTION
The previous code was bad.  It just got the "last" configured information.
This update uses the configured authsource to get its IdP and use that information to get the proper metadata.

This has been tested on metrics-dev by switching the configured authsource