### PR TITLE
Disabling SSLv3 to prevent Poodle Attack

### DIFF
--- a/templates/apache.conf
+++ b/templates/apache.conf
@@ -36,6 +36,7 @@
 
     # Production Open XDMoD instances should use HTTPS
     SSLEngine on
+    SSLProtocol all -SSLv2 -SSLv3
 
     # Update the SSLCertificateFile and SSLCertificateKeyFile parameters
     # to the correct paths to your SSL certificate.


### PR DESCRIPTION


<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
tacc-frontera was flagged by a vulnerability can reported to UB's InfoSec
office. Per their recommendations I'm adding these changes to disable the
vulnerable SSLv3 protocol.

https://us-cert.cisa.gov/ncas/alerts/TA14-290A

## Motivation and Context
Mo secure is mo better

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
