### PR TITLE
Updating qa-test-setup to include remote branch for Shippable

### DIFF
--- a/tests/ci/scripts/qa-test-setup.sh
+++ b/tests/ci/scripts/qa-test-setup.sh
@@ -24,8 +24,15 @@ if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
     # Setup the xdmod-qa environment / requirements.
     $HOME/.qa/scripts/install.sh
 
+    # If we're running on Shippable then make sure to include the
+    # base branch that we're merging into.
+    build_args=""
+    if [ "$SHIPPABLE" = "true" ]; then
+        build_args="-r $BASE_BRANCH"
+    fi
+
     # Run the xdmod-qa tests.
-    $HOME/.qa/scripts/build.sh
+    $HOME/.qa/scripts/build.sh $build_args
 
     popd >/dev/null || exit 1
 fi


### PR DESCRIPTION

<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
It was found that while the new qa setup worked well for checking XDMoD
modules ( which have a remote upstream added in shippable.yml ), it had started
failing to pass when run for XDMoD proper due to not being able to identify a
remote branch to check against. Thankfully Shippable provides this information
in the `$BASE_BRANCH` environment variable so, if we're running in Shippable
then update the `build_args` to specify the BASE_BRANCH as the remote for
`build.sh`.


## Motivation and Context


## Tests performed
This was tested with a straight XDMoD install & a module build ( SUPREMM ) to make sure that things were still working w/ the modules. 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
