### PR TITLE
Updating QA Setup Script to not explicitly set remote branch for build.sh

### DIFF
--- a/tests/ci/scripts/qa-test-setup.sh
+++ b/tests/ci/scripts/qa-test-setup.sh
@@ -10,9 +10,9 @@ if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
     QA_GIT_URL=${QA_GIT_URL:-https://github.com/ubccr/xdmod-qa.git}
 
 
-    # Check if XDMOD_SOURCE_DIR env variable exists, if not then we can't continue.
+    # Check if SHIPPABLE_BUILD_DIR env variable exists, if not then we can't continue.
     if [[ -z "$SHIPPABLE_BUILD_DIR" ]]; then
-        echo "XDMOD_SOURCE_DIR must be set before running this script."
+        echo "The SHIPPABLE_BUILD_DIR env variable must be set before running this script."
         exit 1
     fi
 
@@ -23,13 +23,6 @@ if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
 
     # Setup the xdmod-qa environment / requirements.
     $HOME/.qa/scripts/install.sh
-
-    # If we're running on Shippable then make sure to include the
-    # base branch that we're merging into.
-    build_args=""
-    if [ "$SHIPPABLE" = "true" ]; then
-        build_args="-r $BASE_BRANCH"
-    fi
 
     # Run the xdmod-qa tests.
     $HOME/.qa/scripts/build.sh $build_args

--- a/tests/ci/scripts/qa-test-setup.sh
+++ b/tests/ci/scripts/qa-test-setup.sh
@@ -25,7 +25,7 @@ if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
     $HOME/.qa/scripts/install.sh
 
     # Run the xdmod-qa tests.
-    $HOME/.qa/scripts/build.sh $build_args
+    $HOME/.qa/scripts/build.sh
 
     popd >/dev/null || exit 1
 fi


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
I've updated the `qa-test-setup` script  to not explicitly set a remote branch for `build.sh`. This was causing problems because it was using the `BASE_BRANCH` env variable which in certain situations would be empty. This ultimately had `build.sh` erroring out w/ the message: `Could not resolve remote branch: `. 

## Motivation and Context
It's a good thing to have our QA tests actually run.

## Tests performed
I've tested this change locally w/ both a base XDMoD & SUPREMM build using the last merged PR's for both as the target. Both builds complete successfully.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
