### PR TITLE
Remove remaining deprecated html from About tab pages

### DIFF
--- a/html/about/links.html
+++ b/html/about/links.html
@@ -1,5 +1,5 @@
 
-<p><b><font size="5">Links</font></b></p>
+<p><h1>Links</h1></p>
 <table cellspacing=1 cellpadding=20>
 <tr>
   <td div align=center width="50%"> <a href="http://open.xdmod.org" target="_blank" rel="noopener noreferrer"><img src="/about/images/xdmod_logo.png" height=100></a> </td>

--- a/html/about/openxd.html
+++ b/html/about/openxd.html
@@ -1,5 +1,5 @@
 
-<p><b><font size="5">Open XDMoD</font></b></p>
+<p><h1>Open XDMoD</h1></p>
 <br>
 <p>While initially focused on the NSF XSEDE program, an open source version of XDMoD that provides similar functionality for academic and industrial HPC centers is available and undergoing continued development, namely Open XDMoD.  Open XDMoD for use by academic and industrial HPC centers is available for download through GitHub (<a href="http://open.xdmod.org" target="_blank" rel="noopener noreferrer">http://open.xdmod.org</a>).</p>
 <p>Highlights include:</p>
@@ -25,7 +25,7 @@
   </td>
 </tr>
 <tr>
-  <td div align=center><em><font size=2>Fig.1 Open Source XDMoD Summary Tab</em></font></p></td>
+  <td div align=center><em>Fig.1 Open Source XDMoD Summary Tab</em></p></td>
 </tr>
 <tr>
   <td>
@@ -33,7 +33,7 @@
   <td><img src="/about/images/OpenXDMoDUsage.png" width="750" height="350" hspace="70"></td>
 </tr>
 <tr>
-  <td div align=center><em><font size=2>Fig.2 Open Source XDMoD Usage Tab</em></font></p></td>
+  <td div align=center><em>Fig.2 Open Source XDMoD Usage Tab</em></p></td>
 </tr>
 
 </table>

--- a/html/about/supremm.html
+++ b/html/about/supremm.html
@@ -1,5 +1,5 @@
 
-<p><b><font size="5">SUPReMM Program</font></b></p>
+<p><h1>SUPReMM Program</h1></p>
 <br>
 <p>The SUPReMM program is designed integrate job level performance data into the XDMoD framework so it is available for detailed analysis.  Initially an independently funded NSF program, SUPReMM was subsequently merged into the TAS program.  The goal of the SUPReMM program is to develop the TACC_Stats and Lariat data sources and pipe this data into the XDMoD data warehouse.</p>
 <p>Lariat captures application information at the time that jobs are launched.  TACC_Stats uses collectors sampled at the beginning and end of every job and at 10 minute intervals to provide a wide variety of job performance information including memory, I/O file data, CPU data and network data.  Accordingly, with this data system personnel will have at their fingertips detailed performance data for every job that runs on the HPC resource.  Starting with XDMoD 4.0, this job performance information has been available in the XDMoD SUPReMM data realm.</p>
@@ -9,7 +9,7 @@
   <td><img src="/about/images/SUPPReM.png" width="700" hspace="160"></td>
 </tr>
 <tr>
-  <td><div align=center><em><font size=2>Fig 1. SUPReMM data workflow diagram</front></em></td>
+  <td><div align=center><em>Fig 1. SUPReMM data workflow diagram</em></td>
 </tr>
 <tr>
   <td>
@@ -17,7 +17,7 @@
   <td><img src="/about/images/Supremm_drop_off.png" width="700" hspace="160"></td>
 </tr>
 <tr>
-  <td><div align=center><em><font size=2>Fig 2. Serial Data Copy causing a large dropoff of performance.</front></em></td>
+  <td><div align=center><em>Fig 2. Serial Data Copy causing a large dropoff of performance.</em></td>
 </tr>
 
 </table>

--- a/html/about/xdmod.php
+++ b/html/about/xdmod.php
@@ -24,6 +24,6 @@ Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert 
 "Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources",
 <i>Computing in Science &amp; Engineering</i>, Vol 17, Issue 4, 2015, pp. 52-62.
 <a href="http://dx.doi.org/10.1109/MCSE.2015.68" target="_blank" rel="noopener noreferrer">10.1109/MCSE.2015.68</a>
-</strong</p>
+</strong></p>
 
 <p id="about-xdmod-version-number">XDMoD Version: <?php print xd_versioning\getPortalVersion(true); ?></p>

--- a/html/about/xdmod.php
+++ b/html/about/xdmod.php
@@ -1,7 +1,7 @@
 <?php require_once __DIR__ . '/../../configuration/linker.php'; ?>
 <div>
 <img src="/gui/images/xdmod_main.png"></img>
-<br><b><font size="5">XDMoD:  Comprehensive HPC System Management Tool</font></b>
+<br><h1>XDMoD:  Comprehensive HPC System Management Tool</h1>
 </div>
 
 <p>The University at Buffalo Center for Computational Research (CCR) has been at the forefront of the development of open source tools for use by national and campus level high performance computing (HPC) centers to help ensure their optimal operation as well as provide metrics to demonstrate the utility, service, competitive advantage, and return on investment that these centers provide. </p>
@@ -12,18 +12,18 @@
   <td> <img src="/about/images/XDMoDsummary.png" height=400 width="800" hspace="90"></img></td>
 </tr>
 <tr>
-  <td div align=center> <em><font size=2>XDMoD Summary Tab</em></font></p> </td>
+  <td div align=center> <em>XDMoD Summary Tab</em></p> </td>
 </tr>
 </table>
 <br>
 <p>Funded by the National Science Foundation, XDMoD (<a href="https://xdmod.ccr.buffalo.edu" target="_blank" rel="noopener noreferrer">https://xdmod.ccr.buffalo.edu/</a>) is designed to audit and facilitate the operation and utilization of XSEDE, the most advanced and robust collection of integrated advanced digital resources and services in the world.  Similarly, Open XDMoD (<a href="http://open.xdmod.org" target="_blank" rel="noopener noreferrer">http://open.xdmod.org</a>), the open source version of XDMoD, is designed to provide similar capability to academic and industrial HPC centers.</p>
 
-<p><b>
+<p><strong>
 When referencing XDMoD, please cite the following publication: <br><br>
 Jeffrey T. Palmer, Steven M. Gallo, Thomas R. Furlani, Matthew D. Jones, Robert L. DeLeon, Joseph P. White, Nikolay Simakov, Abani K. Patra, Jeanette Sperhac, Thomas Yearke, Ryan Rathsam, Martins Innus, Cynthia D. Cornelius, James C. Browne, William L. Barth, Richard T. Evans,
 "Open XDMoD: A Tool for the Comprehensive Management of High-Performance Computing Resources",
 <i>Computing in Science &amp; Engineering</i>, Vol 17, Issue 4, 2015, pp. 52-62.
 <a href="http://dx.doi.org/10.1109/MCSE.2015.68" target="_blank" rel="noopener noreferrer">10.1109/MCSE.2015.68</a>
-</b></p>
+</strong</p>
 
 <p id="about-xdmod-version-number">XDMoD Version: <?php print xd_versioning\getPortalVersion(true); ?></p>


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
Change deprecated html in balance of About pages, in keeping with SonarCloud recommendations. Elements affected are `<font>` and `<b>`. Note that deprecated html in the About tab's publications, presentations, and staff pages has recently been addressed in other PRs (#1474, #1470). This PR replaces #1472.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change brings the pages of the About tab in compliance with current html guidelines. It will also make these pages more accessible to screen readers, as it replaces the use of arbitrary font elements with the more expressive section heading elements.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- viewed changed files in browser
- deployed branch in docker instance for viewing

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
