### PR TITLE
Update moddb.module_version table

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -785,7 +785,7 @@ function processModules(iDatabase $db, array $modules)
         $version = $data['version'];
         $installedOn = isset($data['installed_on'])
                      ? $data['installed_on']
-                     : date("Y-m-d");
+                     : date("Y-m-d H:i:s");
 
         $moduleId = createModule(
             $db,

--- a/configuration/etl/etl_tables.d/acls/module_versions.json
+++ b/configuration/etl/etl_tables.d/acls/module_versions.json
@@ -42,12 +42,14 @@
             {
                 "name": "created_on",
                 "type": "timestamp",
-                "nullable": true
+                "nullable": false,
+                "default": 0
             },
             {
                 "name": "last_modified_on",
                 "type": "timestamp",
-                "nullable": true
+                "nullable": false,
+                "default": "CURRENT_TIMESTAMP"
             }
         ],
         "indexes": [


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Updates `TIMESTAMP` columns in the `moddb.module_versions` table and updates PHP code to insert both date and time into the `created_on` column.

Due to how MySQL handles timestamp columns this table was triggering an alter statement by the ETL system.  See https://github.com/ubccr/xdmod/blob/xdmod9.5/classes/ETL/DbModel/Column.php#L186 for more about how those columns are handled by the ETL system.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I noticed the table was being altered while I was debugging some role configurations.  Since the `ALTER` statement doesn't do anything this will prevent it from being executed every time `acl-config` is used.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `acl-config --debug` then checked for `ALTER` statements.  Then checked contents of `moddb.module_versions`.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
