### PR TITLE
Fix mysql command line defaults file option

### DIFF
--- a/classes/CCR/DB/MySQLHelper.php
+++ b/classes/CCR/DB/MySQLHelper.php
@@ -230,9 +230,9 @@ class MySQLHelper
 
         $optionsFile = static::createPasswordFile($this->db->_db_password);
 
-        // --defaults-file must be the first argument.
+        // --defaults-extra-file must be the first argument.
         $args = array(
-            '--defaults-file=' . $optionsFile,
+            '--defaults-extra-file=' . $optionsFile,
             '-ss',
             '--local-infile',
             '-h', $this->db->_db_host,
@@ -269,9 +269,9 @@ class MySQLHelper
 
         $optionsFile = static::createPasswordFile($this->db->_db_password);
 
-        // --defaults-file must be the first argument.
+        // --defaults-extra-file must be the first argument.
         $args = array(
-            '--defaults-file=' . $optionsFile,
+            '--defaults-extra-file=' . $optionsFile,
             '-h', $this->db->_db_host,
             '-P', $this->db->_db_port,
             '-u', $this->db->_db_username,
@@ -508,8 +508,8 @@ class MySQLHelper
         if ($password !== '') {
             $optionsFile = static::createPasswordFile($password);
 
-            // --defaults-file must be the first argument.
-            array_unshift($args, '--defaults-file=' . $optionsFile);
+            // --defaults-extra-file must be the first argument.
+            array_unshift($args, '--defaults-extra-file=' . $optionsFile);
         }
 
         if ($dbName !== null) {
@@ -556,8 +556,8 @@ class MySQLHelper
         if ($password !== '') {
             $optionsFile = static::createPasswordFile($password);
 
-            // --defaults-file must be the first argument.
-            array_unshift($args, '--defaults-file=' . $optionsFile);
+            // --defaults-extra-file must be the first argument.
+            array_unshift($args, '--defaults-extra-file=' . $optionsFile);
         }
 
         $args[] = $dbName;


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Replaces the use of `--defaults-file` with `--defaults-extra-file`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Changes to the MySQL configuration were being ignored resulting in errors.

https://app.asana.com/0/0/1199666656644652/f

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Changed the socket in /etc/my.cnf (and /etc/php.ini).  Before the change the socket configuration would be ignored by anything using the `MySQLHelper` class.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
