### PR TITLE
Ensure correct log message from ETL overseer.

### DIFF
--- a/classes/ETL/EtlOverseer.php
+++ b/classes/ETL/EtlOverseer.php
@@ -460,7 +460,7 @@ class EtlOverseer extends \CCR\Loggable implements iEtlOverseer
         $this->logger->info(array(
                                 'message'     => 'start',
                                 'action_name' => $actionName,
-                                'action'      => $actionObj,
+                                'action'      => (string) $actionObj,
                                 'start_date'  => $this->etlOverseerOptions->getStartDate(),
                                 'end_date'    => $this->etlOverseerOptions->getEndDate(),
                                 ));
@@ -486,7 +486,7 @@ class EtlOverseer extends \CCR\Loggable implements iEtlOverseer
         $this->logger->info(array(
                                 'message'    => 'end',
                                 'action_name' => $actionName,
-                                'action'     => $actionObj
+                                'action'     => (string) $actionObj,
                                 ));
     }  // _execute()
 }  // class EtlOverseer


### PR DESCRIPTION
The php type engine gets confused when you try to string convert an
iAction object in the Logger code. Possibly something to do with the way
the class is constructed or the loader????

Anyway the old code results in the iAction object being treated as an
Array like object in the classes/CCR/CCRLineFormatter.php on line 44.
This change ensures a string is sent to the logger since that is
what we want.

