### PR TITLE
Fix bug in language definition in main html page.

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -86,9 +86,9 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
 
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
-<head lang="en">
+<head>
 
     <!-- <meta http-equiv="X-UA-Compatible" content="IE=9" /> -->
     <meta charset="utf-8"/>


### PR DESCRIPTION
The lang=en should be in the html tag because the whole document
is in english not just the document head.