### PR TITLE
Updating the logging code to not throw away all class information

### DIFF
--- a/classes/CCR/Logger.php
+++ b/classes/CCR/Logger.php
@@ -44,8 +44,28 @@ class Logger extends \Monolog\Logger implements LoggerInterface
     protected function extractMessage($record)
     {
         if (is_array($record)) {
-            return json_encode($record);
+            return json_encode($this->recursivelyStringifyObjects($record));
         }
         return json_encode(array('message' => $record));
+    }
+
+    /**
+     * This function recursively iterates over the provided $array keys and values. If a value is an object it replaces
+     * the object with it's cast string value.
+     *
+     * @param array $array The array to be recursively iterated over
+     *
+     * @return array returns the provided $array w/ any object values cast to strings.
+     */
+    protected function recursivelyStringifyObjects(&$array)
+    {
+        while (list($key, $value) = each($array)) {
+            if (is_object($value)) {
+                $array[$key] = (string) $value;
+            } elseif (is_array($value)) {
+                $array[$key] = $this->recursivelyStringifyObjects($value);
+            }
+        }
+        return $array;
     }
 }

--- a/classes/CCR/Logger.php
+++ b/classes/CCR/Logger.php
@@ -9,6 +9,9 @@ use Psr\Log\LoggerInterface;
  * messages while still utilizing Monolog but this will only be the case for loggers retrieved from CCR\Log::factory|singleton
  * or if code instantiates this class directly.
  *
+ * Note: This logger supports string and array "messages". If an array is provided that contains objects, then this class
+ * will use the __toString() function to convert the object to a string.
+ *
  * @package CCR
  */
 class Logger extends \Monolog\Logger implements LoggerInterface


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
We ran into a problem described in this PR: https://github.com/ubccr/xdmod/pull/1490 After some research I found that the
root of the problem is this function json_encode'ing `$record` when the contents
of `$record` may contain objects that do not support `JsonSerializable` but that
do implement `toString()`. After a conversation w/ Joe it's been decided that
our Logging API will be to support the logging of arrays w/ objects that
implement a `toString()` function. The eagle-eyed may notice that this solution
differs from the one I put forth in the above PR. The reason being that the
original solution only supported the use case of having an array w/ top level
value objects and would not work as expected if a nested array is supplied with
an object that implements `toString()`.


## Motivation and Context
It's nice to have a logging api that works as expected. 

## Tests performed
All automated tests.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
