### PR TITLE
Fix data encoding in etlv2 pdoIngestor

### DIFF
--- a/classes/ETL/Ingestor/pdoIngestor.php
+++ b/classes/ETL/Ingestor/pdoIngestor.php
@@ -985,7 +985,7 @@ class pdoIngestor extends aIngestor
                 $value = '\N';
             } elseif ( '' === $value ) {
                 $value = $this->stringEnclosure . '' . $this->stringEnclosure;
-            } else if (strpos($value, $this->lineSeparator) !== false
+            } elseif (strpos($value, $this->lineSeparator) !== false
                 || strpos($value, $this->fieldSeparator) !== false
                 || strpos($value, $this->stringEnclosure) !== false
                 || strpos($value, $this->escapeChar) !== false) {


### PR DESCRIPTION
The data encoding in the mysql LOAD DATA INFILE mechanism
in the pdoIngestor was incorrect. It did not properly encode
the data in the cases where the various delimiter characters appeared
in the fields.

The correct algorithm is to enclose a field in the field enclosure
character if the field contains any special character. In addition
the field enclosure character and the escape character must be
escaped with an escape character.

Also, the various delimiter characters were class member
variables. However, their values were not actually used to generate the SQL
so if they were ever changed then the code would not have worked.

