### PR TITLE
Improve input validation for download_report controller

### DIFF
--- a/html/controllers/report_builder/download_report.php
+++ b/html/controllers/report_builder/download_report.php
@@ -6,7 +6,10 @@ use DataWarehouse\Query\Exceptions\BadRequestException;
 $filters = array(
     'format' => array(
         'filter' => FILTER_VALIDATE_REGEXP,
-        'options' => array('regexp' => ReportGenerator::REPORT_FORMATS_REGEX)
+        'options' => array(
+            'regexp' => ReportGenerator::REPORT_FORMATS_REGEX,
+            'default' => ''
+        )
     ),
     'report_loc' => array(
         'filter' => FILTER_VALIDATE_REGEXP,

--- a/html/controllers/report_builder/download_report.php
+++ b/html/controllers/report_builder/download_report.php
@@ -1,6 +1,7 @@
 <?php
 
 use \DataWarehouse\Access\ReportGenerator;
+use DataWarehouse\Query\Exceptions\BadRequestException;
 
 $filters = array(
     'format' => array(
@@ -9,7 +10,10 @@ $filters = array(
     ),
     'report_loc' => array(
         'filter' => FILTER_VALIDATE_REGEXP,
-        'options' => array('regexp' => ReportGenerator::REPORT_TMPDIR_REGEX)
+        'options' => array(
+            'regexp' => ReportGenerator::REPORT_TMPDIR_REGEX,
+            'default' => null
+        )
     )
 );
 
@@ -25,6 +29,10 @@ try {
     if (!XDReportManager::isValidFormat($get['format'])) {
         print "Invalid format specified";
         exit;
+    }
+
+    if ($get['report_loc'] === null) {
+        throw new BadRequestException('Invalid filename');
     }
 
     $output_format = $get['format'];


### PR DESCRIPTION
The download_report controller endpoint already checks that the
filename is acceptable. However, in the case of an invalid filename
it potentially would try to open a file called [TMPDIR]/.[SUFFIX].

This change add an explicit exit if an invalid filename is supplied.

Also add a test for this scenario and to check some of the other input
validation code.
