### PR TITLE
Add missing attributes when gearing over from Usage to Metric

### DIFF
--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -2173,6 +2173,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                                         id: Math.random(),
                                         metric: n.attributes.statistic,
                                         realm: n.attributes.realm,
+                                        category: n.attributes.category,
                                         group_by: n.attributes.group_by,
                                         x_axis: false,
                                         log_scale: chartToolbar.getLogScale() == 'y',
@@ -2184,6 +2185,12 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                                         display_type: (dt == 'bar' || dt == 'h_bar' /*|| dt == 'pie'*/ || dt == 'auto') ? "column" : dt,
                                         combine_type: (ct == 'side' || ct == 'auto') ? "side" : ct == 'percentage' ? 'percent' : 'stack',
                                         sort_type: chartStore.getAt(0).get('sort_type'),
+                                        color: 'auto',
+                                        shadow: false,
+                                        visibility: null,
+                                        z_index: 0,
+                                        line_type: 'Solid',
+                                        line_width: 2,
                                         filters: {
                                             "data": [],
                                             "total": 0


### PR DESCRIPTION
This fixes an issue with adding data to charts that were originally configured by "gearing over" from the Usage tab.

Steps to reproduce the original problem:
1) View a chart in the Usage tab
2) Gear over to load the chart in the Metric Explorer
3) Add data for a _different_ realm to the chart
4) The Realm label  should appear as a prefix for the dataset labels for each dataset. But is is missing for the first dataset.

For the original bug report see:

See https://app.asana.com/0/808093868887967/1184327725706337

Note the bug is fixed by the one line that populates the category object property. However, in investigating the bug there were several other configuration keys that were not defined. This change also ensures that all the required properties are given a value.
