### PR TITLE
 Add an index to the modw.jobhosts table to help with queries in the federated module

### DIFF
--- a/configuration/etl/etl_tables.d/jobs/xdw/jobhosts.json
+++ b/configuration/etl/etl_tables.d/jobs/xdw/jobhosts.json
@@ -28,6 +28,12 @@
                 ],
                 "type": "BTREE",
                 "is_unique": true
+            },
+            {
+                "name": "job_id_idx",
+                "columns": ["job_id"],
+                "type": "BTREE",
+                "is_unique": false
             }
         ],
         "triggers": []


### PR DESCRIPTION
Adding an index to the jobhosts table to help with queries in the federated module that load the jobhosts from the federation instance jobhosts table to the federation hub jobhosts table.

## Motivation and Context
It helps speed up queries in the federated module

## Tests performed
Tested on the federated AMNH site

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
