### PR TITLE
Updating pipelines that get run when ingesting data in generic cloud data format

### DIFF
--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -291,7 +291,7 @@ class DataWarehouseInitializer
         }
 
         try {
-            $this->logger->notice('Ingesting generic cloud log files');            
+            $this->logger->notice('Ingesting generic cloud log files');
             Utilities::runEtlPipeline(
                 array(
                   'staging-ingest-common',

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -291,9 +291,17 @@ class DataWarehouseInitializer
         }
 
         try {
-            $this->logger->notice('Ingesting generic cloud log files');
+            $this->logger->notice('Ingesting generic cloud log files');            
             Utilities::runEtlPipeline(
-                array('jobs-cloud-common', 'jobs-cloud-import-users-generic', 'jobs-cloud-extract-generic'),
+                array(
+                  'staging-ingest-common',
+                  'jobs-cloud-common',
+                  'jobs-cloud-import-users-generic',
+                  'hpcdb-ingest-common',
+                  'hpcdb-xdw-ingest-common',
+                  'jobs-cloud-extract-generic',
+                  'jobs-cloud-ingest-pi'
+                ),
                 $this->logger
             );
 


### PR DESCRIPTION
The pipelines that are run when ingesting data in the generic cloud data format need to be updated to include some pipelines that allow you to use the cloud realms without having the jobs realm existing.

## Motivation and Context
We want the cloud realm to be able to exist independently of the jobs realm

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
