### PR TITLE
Add walltime_accuracy metric to job summary data.

### DIFF
--- a/classes/DataWarehouse/Query/Jobs/RawData.php
+++ b/classes/DataWarehouse/Query/Jobs/RawData.php
@@ -84,6 +84,7 @@ class RawData extends \DataWarehouse\Query\Query implements \DataWarehouse\Query
         $this->addField(new TableField($factTable, 'start_time_ts'));
         $this->addField(new TableField($factTable, 'end_time_ts'));
         $this->addField(new FormulaField('-1', 'cpu_user'));
+        $this->addField(new FormulaField('COALESCE(LEAST(jt.wallduration / jt.timelimit, 1), -1)', 'walltime_accuracy'));
 
         // This is used by Integrations and not currently shown on the XDMoD interface
         $this->addField(new TableField($factTable, 'name', 'job_name'));


### PR DESCRIPTION
This was requested by the OnDemand folks and will be used to display
in their web interface. There is a corresponding change to the supremm
realm too.

This change does not result in any changes to the XDMoD user interface.
