### PR TITLE
Job Analytics panel charts dynamically configurable.

### DIFF
--- a/html/gui/js/modules/job_viewer/JobPanel.js
+++ b/html/gui/js/modules/job_viewer/JobPanel.js
@@ -11,7 +11,7 @@ Ext.ns('XDMoD', 'XDMoD.Module', 'XDMoD.Module.JobViewer');
  */
 XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
 
-    MAX_ANALYTICS: 4,
+    MAX_ANALYTICS: 6,
 
     COMPONENT_DEFAULTS: {
         closable: true,
@@ -188,18 +188,25 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
          */
         update_analytics: function (data) {
             var analyticsPanel = this.getComponent('analytics_container');
+            var i;
+            var metricPanel;
+
             if (!analyticsPanel) {
                 return;
+            }
+
+            // Shrink panel to available metric count
+            if (data.length < this.MAX_ANALYTICS) {
+                for (i = data.length; i < this.MAX_ANALYTICS; i++) {
+                    analyticsPanel.remove('metric' + i);
+                }
+                this.MAX_ANALYTICS = data.length;
             }
 
             analyticsPanel.show();
             this.doLayout();
 
-            var i;
-            var metricPanel;
-            var nMetrics = Math.min(data.length, this.MAX_ANALYTICS);
-
-            for (i = 0; i < nMetrics; i++) {
+            for (i = 0; i < this.MAX_ANALYTICS; i++) {
                 metricPanel = analyticsPanel.getComponent('metric' + i);
                 metricPanel.fireEvent('update_data', {
                     name: data[i].key,


### PR DESCRIPTION
## Motivation and Context

The job analytics panel had a hardcoded number of analytics plots. This change
makes it (slightly) more flexible in that it wil only show the number of
analytics that are actually returned by the rest call (up to a hard-coded
maximum which is now 6).

This change now allows different jobs to have a different number of analytics.
However, the main motivation for the change is to make it easier to
configure the charts that are displayed because now they are managed in one
place rather than having hardcoded values in multiple places.

One of the reasons why a hardcoded maximum is still present is due to
the original design of the panel. The plots are all instantiated in the
constructor, but the number of charts with data is only known once the
rest call has returned. The ideal design would wait until the rest
call has returned before construting the object, but that would require
a substantial rewrite of the software. Instead we slice off the extra
charts that are not needed.

## Tests performed
Manually tested on metrics-dev. See also the pull request in supremm https://github.com/ubccr/xdmod-supremm/pulls
