### PR TITLE
Change chromium output error detection.

### DIFF
--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -130,10 +130,12 @@ function getSvgFromChromium($html, $width, $height){
 
     @unlink($tmpHtmlFile);
 
-    if ($return_value != 0) {
-        throw new \Exception('Unable execute command: "'. $command . '". Details: ' . $err);
-    }
     $result = json_decode(substr($out, 4, -6), true);
+
+    if ($result === null || !isset($result['result']) || !isset($result['result']['value'])) {
+        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $out . ' Errors: ' . $err);
+    }
+
     return $result['result']['value'];
 }
 

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -133,7 +133,7 @@ function getSvgFromChromium($html, $width, $height){
     $result = json_decode(substr($out, 4, -6), true);
 
     if ($result === null || !isset($result['result']) || !isset($result['result']['value'])) {
-        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $out . ' Errors: ' . $err);
+        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err);
     }
 
     return $result['result']['value'];


### PR DESCRIPTION
Starting with chromium-headless-89.0.4389.82-1.el7.x86_64 chrome crashes on
exit (due to the fortify stack smashing code firing). This appears to happen
on exit and does not prevent chrome from rendering the svg. This change
works around the problem by using the presence of valid output as the
test condition and ignores the chrome exit code.


