### PR TITLE
Move truncate_declaration directives to correct spot for cloud resource specs migration

### DIFF
--- a/configuration/etl/etl.d/xdmod-migration-9_0_0-9_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-9_0_0-9_5_0.json
@@ -38,8 +38,7 @@
                    "type": "mysql",
                    "name": "Cloud DB",
                    "config": "datawarehouse",
-                   "schema": "modw_cloud",
-                   "truncate_destination": true
+                   "schema": "modw_cloud"
                }
              }
           }
@@ -228,7 +227,8 @@
             "name": "CloudResourceSpecsReconstructor",
             "class": "CloudResourceSpecsStateTransformIngestor",
             "definition_file": "cloud_common/resource_specifications_transformer.json",
-            "description": "Sets a start and end time for memory and vcpu paring for a compute node on a cloud resource"
+            "description": "Sets a start and end time for memory and vcpu paring for a compute node on a cloud resource",
+            "truncate_destination": true
         },
         {
             "#": "Asset data must be aggregated post ingestion",
@@ -239,6 +239,7 @@
             "description": "Aggregate cloud records.",
             "definition_file": "cloud_common/cloud_resource_specs_aggregation.json",
             "table_prefix": "resourcespecsfact_by_",
+            "truncate_destination": true,
             "aggregation_units": [
                 "day", "month", "quarter", "year"
             ],
@@ -248,8 +249,7 @@
                     "name": "Aggregate DB",
                     "config": "datawarehouse",
                     "schema": "modw_aggregates",
-                    "create_schema_if_not_exists": true,
-                    "truncate_destination": true
+                    "create_schema_if_not_exists": true
                 }
             }
         }

--- a/configuration/etl/etl.d/xdmod-migration-9_0_0-9_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-9_0_0-9_5_0.json
@@ -239,7 +239,6 @@
             "description": "Aggregate cloud records.",
             "definition_file": "cloud_common/cloud_resource_specs_aggregation.json",
             "table_prefix": "resourcespecsfact_by_",
-            "truncate_destination": true,
             "aggregation_units": [
                 "day", "month", "quarter", "year"
             ],


### PR DESCRIPTION
The truncate_destination directive for the cloud_resource_specs table during the upgrade was in the wrong spot meaning the table was not truncated.

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
