### PR TITLE
Adding documentation related to cloud upgrade for 9.5 release

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -136,6 +136,6 @@ This upgrade fixed a bug with the memory buckets for the cloud realm which was c
 
     $ xdmod-shredder -r RESOURCE_NAME -d /path/to/logs
     $ xdmod-ingestor --datatype=CLOUD_DATATYPE
-    $ xdmod-ingestor --aggregate=cloud --last-modified-start-date "$last_modified_start_date"
+    $ xdmod-ingestor --aggregate=cloud --last-modified-start-date "2017-01-01 00:00:00"
 
 The `CLOUD_DATATYPE` should be either `openstack` or `genericcloud` and `RESOURCE_NAME` should be the name of the cloud resource you and shredding data for. See documentation for the [`xdmod-shredder`](shredder.md) and [`xdmod-ingestor`](ingestor.md) commands for more information.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -134,5 +134,10 @@ necessary.
 
 This upgrade fixed a bug with the memory buckets for the cloud realm which was causing certain cloud data to not display correctly. To ensure that all previous cloud data is being displayed and recorded correctly, you can re-ingest the cloud data after the upgrade is complete.
 
-After the upgrade is complete re-ingest and aggregate your cloud data using the
-commands recommended in our documentation.
+After the upgrade is complete, re-ingest and aggregate your cloud data using the [`xdmod-shredder`](shredder.md) and [`xdmod-ingestor`](ingestor.md) commands.
+
+    $ xdmod-shredder -r RESOURCE_NAME -d /path/to/logs
+    $ xdmod-ingestor --datatype=CLOUD_DATATYPE
+    $ xdmod-ingestor --aggregate=cloud --last-modified-start-date "$last_modified_start_date"
+
+The `CLOUD_DATATYPE` should be either `openstack` or `genericcloud`. See documentation for the [`xdmod-ingestor`](ingestor.md) command for more information.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -132,9 +132,7 @@ necessary.
 
 ### Cloud Realm Changes
 
-This upgrade fixed a bug with the memory buckets for the cloud realm which was causing certain cloud data to not display correctly. To ensure that all previous cloud data is being displayed and recorded correctly, you can re-ingest the cloud data after the upgrade is complete.
-
-After the upgrade is complete, re-ingest and aggregate your cloud data using the [`xdmod-shredder`](shredder.md) and [`xdmod-ingestor`](ingestor.md) commands.
+This upgrade fixed a bug with the memory buckets for the cloud realm which was causing certain cloud data to not display correctly. To ensure that all previous cloud data is being displayed and recorded correctly, you can re-ingest the cloud data after the upgrade is complete by using the [`xdmod-shredder`](shredder.md) and [`xdmod-ingestor`](ingestor.md) commands.
 
     $ xdmod-shredder -r RESOURCE_NAME -d /path/to/logs
     $ xdmod-ingestor --datatype=CLOUD_DATATYPE

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -138,4 +138,4 @@ This upgrade fixed a bug with the memory buckets for the cloud realm which was c
     $ xdmod-ingestor --datatype=CLOUD_DATATYPE
     $ xdmod-ingestor --aggregate=cloud --last-modified-start-date "$last_modified_start_date"
 
-The `CLOUD_DATATYPE` should be either `openstack` or `genericcloud`. See documentation for the [`xdmod-ingestor`](ingestor.md) command for more information.
+The `CLOUD_DATATYPE` should be either `openstack` or `genericcloud` and `RESOURCE_NAME` should be the name of the cloud resource you and shredding data for. See documentation for the [`xdmod-shredder`](shredder.md) and [`xdmod-ingestor`](ingestor.md) commands for more information.


### PR DESCRIPTION
Adding documentation to detail how to re-shred, ingest and aggregate cloud data because of a bug with the cloud memory buckets after upgrading to xdmod9.5

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
