### PR TITLE
Change query that deletes session records to have better performance

### DIFF
--- a/configuration/etl/etl_sql.d/cloud_common/delete_session_records.sql
+++ b/configuration/etl/etl_sql.d/cloud_common/delete_session_records.sql
@@ -1,5 +1,5 @@
-DELETE FROM
-  ${SOURCE_SCHEMA}.session_records
-WHERE
-  instance_id IN (SELECT DISTINCT instance_id FROM ${SOURCE_SCHEMA}.event_reconstructed)
+DELETE sr FROM
+  ${SOURCE_SCHEMA}.session_records AS sr
+JOIN
+  (SELECT DISTINCT instance_id FROM ${SOURCE_SCHEMA}.event_reconstructed) AS ev ON ev.instance_id = sr.instance_id;
 //

--- a/configuration/etl/etl_tables.d/cloud_common/event_reconstructed.json
+++ b/configuration/etl/etl_tables.d/cloud_common/event_reconstructed.json
@@ -33,6 +33,15 @@
                 "type": "int(11)",
                 "nullable": false
             }
+        ],
+        "indexes": [
+            {
+                "name": "event_instance_id",
+                "columns": [
+                    "instance_id"
+                ],
+                "is_unique": false
+            }
         ]
     }
 }

--- a/configuration/etl/etl_tables.d/cloud_common/session_records.json
+++ b/configuration/etl/etl_tables.d/cloud_common/session_records.json
@@ -182,6 +182,13 @@
                 "columns": [
                     "last_modified"
                 ]
+            },
+            {
+                "name": "session_instance_id",
+                "columns": [
+                    "instance_id"
+                ],
+                "is_unique": false
             }
         ]
     }


### PR DESCRIPTION
This PR adds two indexes and changes the query that is used during the aggregation process that removes all the sessions for instances we are aggregating from the session_records table. The previous query does not scale well when dealing with a larger amount of instances in the aggregation. One example of this is when trying to ingest 4-5 months of data from the Jetstream resource which can cause this action to take a very long time to complete.

## Motivation and Context
This should make this action perform better if there is a larger number of instances included in the aggregation

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
