### PR TITLE
Updates for cloud Data Export and migration pipelines.

### DIFF
--- a/classes/DataWarehouse/Query/Cloud/JobDataset.php
+++ b/classes/DataWarehouse/Query/Cloud/JobDataset.php
@@ -45,23 +45,6 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
                 new TableField($tables[$join['foreignTableAlias']], $join['foreignKey'])
             ));
 
-            /*if(is_array($join[0])) {
-                foreach($join as $j) {
-                    $this->addWhereCondition(new WhereCondition(
-                        new TableField($table, $j['primaryKey']),
-                        '=',
-                        new TableField($tables[$j['foreignTableAlias']], $j['foreignKey'])
-                    ));
-                }
-            } else {
-                $this->addWhereCondition(new WhereCondition(
-                    new TableField($table, $join['primaryKey']),
-                    '=',
-                    new TableField($tables[$join['foreignTableAlias']], $join['foreignKey'])
-                ));
-            }*/
-        }
-
         // This table is defined in the configuration file, but used in the section below.
         $factTable = $tables['i'];
         $sessionTable = $tables['sr'];

--- a/classes/DataWarehouse/Query/Cloud/JobDataset.php
+++ b/classes/DataWarehouse/Query/Cloud/JobDataset.php
@@ -44,6 +44,7 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
                 '=',
                 new TableField($tables[$join['foreignTableAlias']], $join['foreignKey'])
             ));
+        }
 
         // This table is defined in the configuration file, but used in the section below.
         $factTable = $tables['i'];

--- a/classes/OpenXdmod/Migration/Version900To950/DatabaseMigration.php
+++ b/classes/OpenXdmod/Migration/Version900To950/DatabaseMigration.php
@@ -26,7 +26,7 @@ class DatabasesMigration extends \OpenXdmod\Migration\DatabasesMigration
         if ($mysql_helper->tableExists('modw_cloud.event')) {
 
             Utilities::runEtlPipeline(
-                ['cloud-migration-9_0_0-9_5_0'],
+                ['cloud-migration-9-0-0_9-5-0'],
                 $this->logger,
                 [
                     'last-modified-start-date' => '2017-01-01 00:00:00'
@@ -59,7 +59,7 @@ EOT
             }
 
             Utilities::runEtlPipeline(
-                ['cloud-resource-specs-migration-9_0_0-9_5_0'],
+                ['cloud-resource-specs-migration-9-0-0_9-5-0'],
                 $this->logger,
                 [
                     'last-modified-start-date' => '2017-01-01 00:00:00'

--- a/configuration/etl/etl.d/jobs_cloud_common.json
+++ b/configuration/etl/etl.d/jobs_cloud_common.json
@@ -50,6 +50,7 @@
                 "cloud_common/account.json",
                 "cloud_common/event.json",
                 "cloud_common/asset.json",
+                "cloud_common/host.json",
                 "cloud_common/instance_data.json",
                 "cloud_common/event_asset.json",
                 "cloud_common/raw_resource_specs.json",
@@ -105,6 +106,21 @@
                     "type": "jsonfile",
                     "name": "Cloud record types",
                     "path": "cloud_common/record_type.json"
+                }
+            }
+        },
+        {
+            "#": "Note that any actions run after this cannot truncate the tables set here",
+
+            "name": "CloudHostUnknownInitializer",
+            "description": "Initialize value for unknown host",
+            "class": "StructuredFileIngestor",
+            "definition_file": "cloud_common/host.json",
+            "endpoints": {
+                "source": {
+                    "type": "jsonfile",
+                    "name": "Cloud record types",
+                    "path": "cloud_common/host.json"
                 }
             }
         },

--- a/configuration/etl/etl.d/xdmod-migration-9_0_0-9_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-9_0_0-9_5_0.json
@@ -6,7 +6,7 @@
             "class": "ExecuteSql",
             "options_class": "MaintenanceOptions"
         },
-        "cloud-migration-9_0_0-9_5_0": {
+        "cloud-migration-9-0-0_9-5-0": {
             "namespace": "ETL\\Ingestor",
             "options_class": "IngestorOptions",
             "endpoints": {
@@ -24,7 +24,7 @@
               }
             }
          },
-         "cloud-resource-specs-migration-9_0_0-9_5_0": {
+         "cloud-resource-specs-migration-9-0-0_9-5-0": {
              "namespace": "ETL\\Ingestor",
              "options_class": "IngestorOptions",
              "endpoints": {
@@ -159,7 +159,7 @@
             }
         }
     ],
-    "cloud-migration-9_0_0-9_5_0": [
+    "cloud-migration-9-0-0_9-5-0": [
         {
           "name": "UpdateEventTypes",
           "description": "Update event type on event table",
@@ -170,6 +170,10 @@
               {
                   "delimiter": ";",
                   "sql_file": "migrations/9.0.0-9.5.0/modw_cloud/update_event_types.sql"
+              },
+              {
+                  "delimiter": ";",
+                  "sql_file":"migrations/9.0.0-9.5.0/modw_cloud/update_hosts_table_index.sql"
               }
           ]
         },
@@ -223,7 +227,7 @@
             }
         }
     ],
-    "cloud-resource-specs-migration-9_0_0-9_5_0": [
+    "cloud-resource-specs-migration-9-0-0_9-5-0": [
         {
             "name": "CloudResourceSpecsReconstructor",
             "class": "CloudResourceSpecsStateTransformIngestor",

--- a/configuration/etl/etl_action_defs.d/cloud_common/host.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/host.json
@@ -1,0 +1,8 @@
+{
+    "#": "This action loads data from a structured file and only needs the table definition",
+    "table_definition": [
+        {
+            "$ref": "${table_definition_dir}/cloud_common/host.json#/table_definition"
+        }
+    ]
+}

--- a/configuration/etl/etl_action_defs.d/cloud_common/initialize_unknown_dimension_values.json
+++ b/configuration/etl/etl_action_defs.d/cloud_common/initialize_unknown_dimension_values.json
@@ -15,9 +15,6 @@
 
     "table_definition": [
         {
-            "$ref": "${table_definition_dir}/cloud_common/host.json#/table_definition"
-        },
-        {
             "$ref": "${table_definition_dir}/cloud_common/image.json#/table_definition"
         }
     ],
@@ -52,11 +49,6 @@
     },
 
     "destination_record_map": {
-        "host": {
-            "resource_id": "resource_id",
-            "host_id": "unknown_id",
-            "hostname": "unknown_key"
-        },
         "image": {
             "resource_id": "resource_id",
             "image_id": "unknown_id",

--- a/configuration/etl/etl_data.d/cloud_common/host.json
+++ b/configuration/etl/etl_data.d/cloud_common/host.json
@@ -1,0 +1,4 @@
+[
+    ["resource_id", "host_id", "hostname"],
+    [-1,            1,         "Unknown"]
+]

--- a/configuration/etl/etl_sql.d/migrations/9.0.0-9.5.0/modw_cloud/update_hosts_table_index.sql
+++ b/configuration/etl/etl_sql.d/migrations/9.0.0-9.5.0/modw_cloud/update_hosts_table_index.sql
@@ -1,0 +1,25 @@
+LOCK TABLES
+  modw_cloud.host WRITE,
+  modw_cloud.host as h WRITE,
+  modw_cloud.event WRITE,
+  modw_cloud.event as ev WRITE;
+
+ALTER TABLE modw_cloud.host MODIFY host_id INT NOT NULL;
+ALTER TABLE modw_cloud.host DROP INDEX autoincrement_key;
+ALTER TABLE modw_cloud.host ADD COLUMN new_host_id INT(11) UNSIGNED NOT NULL auto_increment unique;
+CREATE INDEX host_resource_idx ON modw_cloud.host (host_id, resource_id);
+
+UPDATE
+  modw_cloud.event as ev
+JOIN
+  modw_cloud.host as h
+ON
+  ev.resource_id = h.resource_id AND ev.host_id = h.host_id
+SET
+  ev.host_id = h.new_host_id;
+
+ALTER TABLE modw_cloud.host DROP COLUMN host_id;
+ALTER TABLE modw_cloud.host CHANGE new_host_id host_id INT(11) UNSIGNED;
+DROP INDEX host_resource_idx ON modw_cloud.host;
+
+UNLOCK TABLES;

--- a/configuration/etl/etl_tables.d/cloud_common/host.json
+++ b/configuration/etl/etl_tables.d/cloud_common/host.json
@@ -40,15 +40,8 @@
                 "is_unique": true
             },
             {
-                "#": "For MyISAM tables, you can specify AUTO_INCREMENT on a secondary column in a",
-                "#": "multiple-column index. In this case, the generated value for the AUTO_INCREMENT column",
-                "#": "is calculated as MAX(auto_increment_column) + 1 WHERE prefix=given-prefix. This is",
-                "#": "useful when you want to put data into ordered groups.",
-                "#": "See [MyISAM Notes](https://dev.mysql.com/doc/refman/5.7/en/example-auto-increment.html)",
-                "#": "and https://www.ryadel.com/en/mysql-two-columns-primary-key-with-auto-increment/",
                 "name": "autoincrement_key",
                 "columns": [
-                    "resource_id",
                     "host_id"
                 ],
                 "is_unique": true


### PR DESCRIPTION
This PR fixes three issues.

1. Using the correct table for the time field in the `JobDataset.php` file. The `session_records` table has the `start_time_ts` and `end_time_ts` columns that should be used for the start time and end time parameters. It was trying to use the instance table which does not have those columns.
2. Changing the `host` table to have a single autoincrement column instead of a composite autoincrement. In PR #1263 we changed most of the cloud realm dimension tables that use a composite autoincrement key to use a single unique column for the autoincrement key. At the time the `host` table was not used for anything so it was not converted. It is now being used in the cloud instance viewer and Data Export and should be changed to match the other cloud realm dimension tables so it can provide accurate data. The changes for the `host` table match changes made for the `instance`, `account`, and `instance_type` tables in PR #1263 and #1272 including a SQL statement that is run during the migration to add the new autoincrement key and update rows in the event table with the appropriate `host_id`.
3. Renaming the cloud migration pipelines so they are not automatically run. Having the cloud migration pipelines with `migration-9_0_0-9_5_0` in them meant they automatically ran. We do not want that as not all XDMoD installations may be using the cloud realm. 

## Tests performed
Tested fresh install and upgrade in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
