### PR TITLE
Update host dimension migration sql to avoid primary key duplicate during migration

### DIFF
--- a/configuration/etl/etl_sql.d/migrations/9.0.0-9.5.0/modw_cloud/update_hosts_table_index.sql
+++ b/configuration/etl/etl_sql.d/migrations/9.0.0-9.5.0/modw_cloud/update_hosts_table_index.sql
@@ -7,6 +7,8 @@ LOCK TABLES
 ALTER TABLE modw_cloud.host MODIFY host_id INT NOT NULL;
 ALTER TABLE modw_cloud.host DROP INDEX autoincrement_key;
 ALTER TABLE modw_cloud.host ADD COLUMN new_host_id INT(11) UNSIGNED NOT NULL auto_increment unique;
+ALTER TABLE modw_cloud.event DROP PRIMARY KEY;
+CREATE INDEX host_resource_idx ON modw_cloud.event (host_id, resource_id);
 CREATE INDEX host_resource_idx ON modw_cloud.host (host_id, resource_id);
 
 UPDATE
@@ -20,6 +22,8 @@ SET
 
 ALTER TABLE modw_cloud.host DROP COLUMN host_id;
 ALTER TABLE modw_cloud.host CHANGE new_host_id host_id INT(11) UNSIGNED;
+ALTER TABLE modw_cloud.event ADD PRIMARY KEY(resource_id, instance_id, event_time_ts, event_type_id, host_id);
 DROP INDEX host_resource_idx ON modw_cloud.host;
+DROP INDEX host_resource_idx ON modw_cloud.event;
 
 UNLOCK TABLES;


### PR DESCRIPTION
The 9.5 release changes the `host` table in `modw_cloud` to have a single auto-increment column instead of a multi-column one. When running the migration SQL to update the `event` table with the value from the new auto-increment column on the host table it is possible the primary key on an updated row can match the primary key on a row that is not yet updated causing a primary key duplicate error. This PR helps prevent this by removing the primary key during the update and then adding it back after the update is done.

## Tests performed
Tested an upgrade in a docker container with a production copy `modw_cloud` and the upgrade was successful.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
