### PR TITLE
Use strtolower to check format for a PDF report

### DIFF
--- a/classes/XDReportManager.php
+++ b/classes/XDReportManager.php
@@ -1615,7 +1615,7 @@ class XDReportManager
         $rp = new \Reports\ClassicReport($settings);
         $rp->writeReport($template_path . '/' . $report_id . '.doc');
 
-        if ($report_format == 'pdf') {
+        if (strtolower($report_format) == 'pdf') {
             exec('HOME=' . $template_path . ' libreoffice --headless --convert-to pdf ' . $template_path . '/' .  $report_id . '.doc --outdir ' . $template_path);
         }
 


### PR DESCRIPTION
The database stores the format of a PDF report as `Pdf` and when checking if a pdf of a report should be created strtolower should be used to compare to `pdf`. If not, the pdf will not be made, and when the report is emailed it will fail to find the pdf to attach.

## Motivation and Context
This makes sure that PDF reports will be created.

## Tests performed
Tested in docker and on metrics-staging

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
