### PR TITLE
Fix resource ingestor default resource type

### DIFF
--- a/configuration/etl/etl_action_defs.d/common/hpcdb/resources.json
+++ b/configuration/etl/etl_action_defs.d/common/hpcdb/resources.json
@@ -5,7 +5,7 @@
     "source_query": {
         "records": {
             "resource_id": "r.resource_id",
-            "resource_type_id": "COALESCE(srt.resource_type_id, -1)",
+            "resource_type_id": "COALESCE(srt.resource_type_id, 0)",
             "organization_id": "1",
             "resource_name": "rc.name",
             "resource_code": "rc.resource",


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Change the HPcDB resource ingestor to use 0 for the `resource_type_id` when no resource type is found.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://app.asana.com/0/0/1200481198259375/f

Previously, -1 was used for unknown values.  Since the unknown resource type uses 0 this will fix that.  I don't think this has ever worked since it appears that the unknown resource has always used 0.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
