### PR TITLE
Improve Slurm TRES GRES/GPU parsing

### DIFF
--- a/classes/Xdmod/SlurmResourceParser.php
+++ b/classes/Xdmod/SlurmResourceParser.php
@@ -5,6 +5,8 @@
 
 namespace Xdmod;
 
+use xd_utilities;
+
 /**
  * Contains functions related to Slurm's TRES data.
  */
@@ -45,7 +47,10 @@ class SlurmResourceParser
     public function getGpuCountFromTres(array $tres)
     {
         foreach ($tres as $resource) {
-            if ($resource[0] === 'gres/gpu' && count($resource) > 1) {
+            if (($resource[0] === 'gres/gpu'
+                || xd_utilities\string_begins_with($resource[0], 'gres/gpu:')
+                ) && count($resource) > 1
+            ) {
                 return (int)$resource[1];
             }
         }

--- a/tests/artifacts/xdmod/unit/slurm-resource-parser/alloc-tres-gpu-count.json
+++ b/tests/artifacts/xdmod/unit/slurm-resource-parser/alloc-tres-gpu-count.json
@@ -22,5 +22,17 @@
     [
         "billing=1,cpu=1,gres/gpu=1,mem=125G,node=1",
         1
+    ],
+    [
+        "billing=1,cpu=1,gres/gpu:p100=1,mem=125G,node=1",
+        1
+    ],
+    [
+        "gres/gpu:volta=2,mem=125G,node=1",
+        2
+    ],
+    [
+        "billing=1,cpu=1,gres/gpu:tesla=4",
+        4
     ]
 ]


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds support for slurm TRES accounting data that includes a GPU type specifier.  (eg. <code>gres/gpu<b>:tesla</b>=4</code>)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was missing in the initial implementation and was reported by an Open XDMoD user.

https://app.asana.com/0/1200028182662861/1200481198259377/f

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
