### PR TITLE
Remove PHP GNU Multiple Precision dependency

### DIFF
--- a/bin/xdmod-check-config
+++ b/bin/xdmod-check-config
@@ -124,13 +124,6 @@ try {
         'PHP GD extension installed'
     );
 
-    _debug('Checking for gmp_abs function');
-    $result = function_exists('gmp_abs');
-    displayResult(
-        $result,
-        'PHP GMP extension installed'
-    );
-
     _debug('Checking for curl_close function');
     $result = function_exists('curl_close');
     displayResult(

--- a/docs/software-requirements.md
+++ b/docs/software-requirements.md
@@ -13,7 +13,6 @@ Open XDMoD requires the following software:
     - [PDO][]
     - [MySQL PDO Driver][pdo-mysql]
     - [GD][php-gd]
-    - [GMP][php-gmp]
     - [cURL][php-curl]
     - [DOM][php-dom]
     - [XMLWriter][php-xmlwriter]
@@ -41,7 +40,6 @@ Open XDMoD requires the following software:
 [pdo]:             https://secure.php.net/manual/en/book.pdo.php
 [pdo-mysql]:       https://secure.php.net/manual/en/ref.pdo-mysql.php
 [php-gd]:          https://secure.php.net/manual/en/book.image.php
-[php-gmp]:         https://secure.php.net/manual/en/book.gmp.php
 [php-curl]:        https://secure.php.net/manual/en/book.curl.php
 [php-dom]:         https://secure.php.net/manual/en/book.dom.php
 [php-xmlwriter]:   https://secure.php.net/manual/en/book.xmlwriter.php
@@ -76,8 +74,7 @@ added with this command for CentOS 7:
 
     # yum install epel-release
 
-    # yum install httpd php php-cli php-mysql php-gd \
-                  gmp-devel php-gmp php-pdo php-xml \
+    # yum install httpd php php-cli php-mysql php-gd php-pdo php-xml \
                   libreoffice \
                   mariadb-server mariadb cronie logrotate \
                   perl-Image-ExifTool php-mbstring php-pecl-apcu jq \


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
 
Removes references to `php-gmp` from the documentation and `xdmod-check-config`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I can't find anywhere that GMP is required.  None of the `gmp_*` functions are used anywhere in Open XDMoD.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No new tests.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
