### PR TITLE
Change slurm helper default end time

### DIFF
--- a/bin/xdmod-slurm-helper
+++ b/bin/xdmod-slurm-helper
@@ -277,10 +277,7 @@ function getSacctCmdArgs(
         $args[] = $endTime;
     } else {
         $end = new DateTime('now');
-        $end->sub(new DateInterval('P1D'));
-        $end->setTime(23, 59, 59);
         $end->setTimezone($utc);
-
         $args[] = '--endtime';
         $args[] = $end->format('Y-m-d\TH:i:s');
     }
@@ -422,7 +419,7 @@ Usage: xdmod-slurm-helper [-v] [-r resource] [-c cluster]
     --end-time *datetime*
         Specify the end date and time to shred from sacct.  The datetime
         must be in a format accepted by the sacct --endtime option.
-        Defaults to 23:59:59 of the day before the current day.
+        Defaults to the current date and time.
 
 
 EOF;


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Changes the default end time used by the `xdmod-slurm-helper` to be the current time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With the previous default end time it was possible that the default end time would be before the default start time.  This resulted in an error message from `sacct`.

See https://app.asana.com/0/159049597309611/1199962348183946/f

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually on metrics-dev.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
