### PR TITLE
Restore global exception file name and number, and stack trace logging

### DIFF
--- a/configuration/linker.php
+++ b/configuration/linker.php
@@ -122,11 +122,11 @@ function handle_uncaught_exception($exception)
 
     $logger->err(array( 'message' => 'Exception Code: '.$exception->getCode()));
     $logger->err(array( 'message' => 'Message: '.$exception->getMessage()));
-    $logger->info(array( 'message' => 'Origin: '.$exception->getFile().' (line '.$exception->getLine().')'));
+    $logger->err(array( 'message' => 'Origin: '.$exception->getFile().' (line '.$exception->getLine().')'));
 
     $stringTrace = (get_class($exception) == 'UniqueException') ? $exception->getVerboseTrace() : $exception->getTraceAsString();
 
-    $logger->info(array('message' => "Trace:\n".$stringTrace."\n-------------------------------------------------------"));
+    $logger->err(array('message' => "Trace:\n".$stringTrace."\n-------------------------------------------------------"));
 
    // If working in a server context, build headers to output.
     $httpCode = 500;


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Change the log level used for the global exception handler.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The default file log level is "warning" and these were logged as "info" so they were never written to the file.

Previous to the log refactoring the PEAR logger was used directly, which defaults to "debug", so the messages were logged.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No new tests.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
