### PR TITLE
Update jQuery to 3.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "greenlion/php-sql-parser": "~4.2",
         "highsoft/highcharts": "^4.2.5",
         "ircmaxell/password-compat": "~1",
-        "jquery/jquery-min-file": "^1.12.4",
+        "jquery/jquery-min-file": "^3.6",
         "justinrainbow/json-schema": "~5.2",
         "moment/moment-min-file": "^2.13.0",
         "moment/moment-timezone-min-file": "^0.5.4",
@@ -147,13 +147,13 @@
             "package": {
                 "name": "jquery/jquery-min-file",
                 "type": "vanilla-plugin",
-                "version": "1.12.4",
+                "version": "3.6.0",
                 "license": "MIT",
                 "homepage": "https://jquery.com",
                 "dist": {
-                    "url": "https://code.jquery.com/jquery-1.12.4.min.js",
+                    "url": "https://code.jquery.com/jquery-3.6.0.min.js",
                     "type": "file",
-                    "shasum": "5a9dcfbef655a2668e78baebeaa8dc6f41d8dabb"
+                    "shasum": "b82d238d4e31fdf618bae8ac11a6c812c03dd0d4"
                 },
                 "require": {
                     "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2ea6be5f2da98081a49b4f4e324affe",
+    "content-hash": "fce9c9d08c33d4bf9cdad9f768ebedcb",
     "packages": [
         {
             "name": "carlo/jquery-base64-file",
@@ -733,11 +733,11 @@
         },
         {
             "name": "jquery/jquery-min-file",
-            "version": "1.12.4",
+            "version": "3.6.0",
             "dist": {
                 "type": "file",
-                "url": "https://code.jquery.com/jquery-1.12.4.min.js",
-                "shasum": "5a9dcfbef655a2668e78baebeaa8dc6f41d8dabb"
+                "url": "https://code.jquery.com/jquery-3.6.0.min.js",
+                "shasum": "b82d238d4e31fdf618bae8ac11a6c812c03dd0d4"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/html/highchart_template.html
+++ b/html/highchart_template.html
@@ -6,7 +6,7 @@
       <title>Highcharts Template</title>
 
       <style type="text/css">html,body{margin:0px;height:100%;}</style>
-      <script type="text/javascript" src="_html_dir_/gui/lib/jquery/jquery-1.12.4.min.js"></script>
+      <script type="text/javascript" src="_html_dir_/gui/lib/jquery/jquery-3.6.0.min.js"></script>
       <script type="text/javascript" src="_html_dir_/gui/js/StringExtensions.js"></script>
 
       <script type="text/javascript">
@@ -22,7 +22,7 @@
          // _ chartOptions _ is a macro that is substituted by \xd_charting\exportHighchart()
          var inputChartOptions = _chartOptions_;
 
-         $(document).ready(function() {
+         document.addEventListener("DOMContentLoaded", function() {
 
             var chartOptions = {
 
@@ -71,7 +71,7 @@
             }
             chart = XDMoD.utils.createChart(inputChartOptions);
 
-         });//$(document).ready(...
+         });
 
       </script>
 

--- a/html/index.php
+++ b/html/index.php
@@ -123,7 +123,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
     ExtJS::loadSupportScripts('gui/lib');
     ?>
     <script type="text/javascript" src="gui/lib/ext-oldie-history-patch.js"></script>
-    <script type="text/javascript" src="gui/lib/jquery/jquery-1.12.4.min.js"></script>
+    <script type="text/javascript" src="gui/lib/jquery/jquery-3.6.0.min.js"></script>
     <?php if ($userLoggedIn): ?>
         <script type="text/javascript" src="gui/lib/jquery-plugins/base64/jquery.base64.js"></script>
     <?php endif; ?>

--- a/html/internal_dashboard/index.php
+++ b/html/internal_dashboard/index.php
@@ -28,7 +28,7 @@ require_once 'user_check.php';
   <script type="text/javascript" src="../gui/lib/internet-explorer-polyfills.js"></script>
   <?php ExtJS::loadSupportScripts('../gui/lib'); ?>
   <script type="text/javascript" src="../gui/lib/ext-oldie-history-patch.js"></script>
-  <script type="text/javascript" src="../gui/lib/jquery/jquery-1.12.4.min.js"></script>
+  <script type="text/javascript" src="../gui/lib/jquery/jquery-3.6.0.min.js"></script>
 
   <script type="text/javascript">
     jQuery.noConflict();

--- a/html/password_reset.php
+++ b/html/password_reset.php
@@ -94,7 +94,7 @@ if ($rid === false) {
          ExtJS::loadSupportScripts('gui/lib');
       ?>
 	  
-      <script type="text/javascript" src="gui/lib/jquery/jquery-1.12.4.min.js"></script>
+      <script type="text/javascript" src="gui/lib/jquery/jquery-3.6.0.min.js"></script>
       <script type="text/javascript" src="gui/lib/PasswordStrengthMeter.js"></script>
       
       <link rel="stylesheet" type="text/css" href="gui/css/PasswordReset.css">


### PR DESCRIPTION
The `ready()` function in jQuery 3 has different behaviour
than the one in 1.x and cannot be used in the chart export
code path. This has been replaced with an event listener for
DOMContentLoaded. Only other changes are updating the filename.