### PR TITLE
Use the git-provided commit range.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
     environment:
       COMPOSER_ALLOW_SUPERUSER: 1
       XDMOD_REALMS: 'jobs,storage,cloud'
+      TRAVIS_COMMIT_RANGE: << pipeline.git.base_revision >>..<<pipeline.git.revision>>
       XDMOD_IS_CORE: yes
       XDMOD_INSTALL_DIR: /xdmod
       XDMOD_TEST_MODE: << parameters.install-type >>
@@ -54,9 +55,6 @@ jobs:
       - run:
           name: Make sure that the Composer Test Depedencies are installed
           command: composer install --no-progress
-      - run:
-          name: Add an upstream remote to XDMod so that the QA tests function properly
-          command: git remote add upstream https://github.com/ubccr/xdmod.git
       - run:
           name: Setup & Run QA Tests
           command: ./tests/ci/scripts/qa-test-setup.sh


### PR DESCRIPTION
## Description

The QA scripts will use the environment variable TRAVIS_COMMIT_RANGE to determine which commits to use when running the linter on the changed code. If this environment variable is not set then the script will attempt to diff against
upstream/HEAD.

The upstream/HEAD diff is a problem when trying to ci test against old branches since the diff will incorrectly compare the set of changes against the latest build and not the correct target branch.

This changes the code to set the commit range appropriately so the scripts diff against the correct commit.