### PR TITLE
Updates to mod_logger tables

### DIFF
--- a/classes/CCR/CCRDBHandler.php
+++ b/classes/CCR/CCRDBHandler.php
@@ -93,7 +93,24 @@ class CCRDBHandler extends AbstractProcessingHandler
      */
     protected function getNextId()
     {
-        $this->db->execute(sprintf('UPDATE %s.log_id_seq SET sequence = LAST_INSERT_ID(sequence+1);', $this->schema));
+        $query = sprintf('UPDATE %s.log_id_seq SET sequence = LAST_INSERT_ID(sequence+1);', $this->schema);
+
+        try {
+            // Attempt to update the log_id_seq.sequence value
+            $this->db->execute($query);
+        } catch (\PDOException $e) {
+            if ($e->errorInfo[0] === 'HY000' && $e->errorInfo[1] === 2006) {
+                // This is the MySQL server gone away error, which is seen when
+                // there is a long delay between log messages and the
+                // connection times out. It occurs here since this is the first DB
+                // call for a log message.
+                $this->db->disconnect();
+                $this->db->execute($query);
+            } else {
+                throw $e;
+            }
+        }
+
         $stmt = $this->db->query('SELECT LAST_INSERT_ID() as id', array(), true);
         $stmt->execute();
         $id = $stmt->fetchAll(\PDO::FETCH_COLUMN, 0)[0];

--- a/configuration/etl/etl.d/xdmod-migration-9_5_0-10_0_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-9_5_0-10_0_0.json
@@ -215,6 +215,25 @@
             }
         },
         {
+            "name": "alter-mod_logger-log_id_seq-sequence_column",
+            "description": "Remove `AUTO_INCREMENT` from the `sequence` column",
+            "class": "ExecuteSql",
+            "sql_file_list": [
+                {
+                    "delimiter": ";",
+                    "sql_file": "migrations/9.5.0-10.0.0/mod_logger/alter_log_id_seq.sql"
+                }
+            ],
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "XDMoD Data Warehouse",
+                    "config": "datawarehouse",
+                    "schema": "mod_logger"
+                }
+            }
+        },
+        {
             "name": "alter-shredded_job_slurm",
             "description": "Alter mod_shredder.shredded_job_slurm to add qos_name column",
             "class": "ExecuteSql",

--- a/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_logger/alter_log_id_seq.sql
+++ b/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_logger/alter_log_id_seq.sql
@@ -1,0 +1,2 @@
+-- This is to account for the table schema change in db/schema/mod_logger.sql.
+ALTER TABLE `mod_logger`.`log_id_seq` MODIFY sequence int(11) NOT NULL;

--- a/db/data/mod_logger.sql
+++ b/db/data/mod_logger.sql
@@ -15,6 +15,12 @@ LOCK TABLES `log_level` WRITE;
 INSERT INTO `log_level` VALUES (0,'EMERG','System is unusable'),(1,'ALERT','Immediate action required'),(2,'CRIT','Critical conditions'),(3,'ERR','Error conditions'),(4,'WARNING','Warning conditions'),(5,'NOTICE','Normal but significant'),(6,'INFO','Informational'),(7,'DEBUG','Debug-level message'),(8,'TRACE','Trace-level message');
 /*!40000 ALTER TABLE `log_level` ENABLE KEYS */;
 UNLOCK TABLES;
+
+LOCK TABLES `log_id_seq` WRITE;
+/*!40000 ALTER TABLE `log_id_seq` DISABLE KEYS */;
+INSERT INTO `log_id_seq` VALUES (0);
+/*!40000 ALTER TABLE `log_id_seq` ENABLE KEYS */;
+UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/db/schema/mod_logger.sql
+++ b/db/schema/mod_logger.sql
@@ -13,7 +13,7 @@ DROP TABLE IF EXISTS `log_id_seq`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `log_id_seq` (
-  `sequence` int(11) NOT NULL AUTO_INCREMENT,
+  `sequence` int(11) NOT NULL,
   PRIMARY KEY (`sequence`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION




<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
- I've moved from the previous INSERT / DELETE algorithm to using an UPDATE.
This allows us to remove the explicit transaction management as we only have one
query that applies modifications as opposed to two. This new method was chosen
after a conversation with @jpwhite & @gmdean.
- To implement this change there were a couple of small changes that needed to
be made to the log_id_seq table schema & it's initial population.
  - `mod_logger`.`log_id_seq`.`sequence` has had it's `AUTO_INCREMENT` keyword
  removed as we'll be manually controlling the way the sequence is generated.
  - Since the `sequence` column is no longer an `AUTO_INCREMENT` we need to add
  an initial value, this has been done in `data/db/mod_logger.sql` by inserting
  an initial value of `0`.


## Motivation and Context
These changes are an attempt to remediate lock problems that we're seeing since
the change to InnoDB.

## Tests performed
These changes have been manually tested locally w/ both an upgrade & fresh
install.

Example test ( Executed at various points during upgrade & fresh install )
```sql
SELECT
( SELECT sequence FROM log_id_seq ) as current_id,
( SELECT COUNT(*) FROM log_table ) as log_count,
( SELECT MAX(id) FROM log_table ) as current_log_id;
```

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
