### PR TITLE
More robustness improvements for webdriverio-based UI tests

### DIFF
--- a/tests/ui/test/specs/xdmod/loginPage.page.js
+++ b/tests/ui/test/specs/xdmod/loginPage.page.js
@@ -65,6 +65,7 @@ class LoginPage {
     logout() {
         describe('Logout', function logout() {
             it('Click the logout link', function clickLogout() {
+                browser.waitForInvisible('.ext-el-mask-msg');
                 browser.waitAndClick('#logout_link');
             });
             it('Display Logged out State', function clickLogout() {

--- a/tests/ui/webdriverHelpers/waitForAllInvisible.js
+++ b/tests/ui/webdriverHelpers/waitForAllInvisible.js
@@ -8,6 +8,6 @@
  */
 
 module.exports = function waitForAllInvisible(selector, ms) {
-    var timeOut = ms || 9000;
+    var timeOut = ms || 18000;
     browser.waitUntil(() => $$(selector).filter(el => el.isVisible()).length === 0, timeOut);
 };


### PR DESCRIPTION
Recent circle-ci builds have been failing due to timeout errors in a few different places. This has been happening even for pull requests that do not change the indelying code.

This pull requst adds an extra mask invisible check and increases the "mask disappear" timeout in the hope of mitigating these type of errors.