### PR TITLE
Set minimum username length to 2.

### DIFF
--- a/configuration/constants.php
+++ b/configuration/constants.php
@@ -159,7 +159,7 @@ define('RESTRICTION_YES_NO', '/^[ny]$/');
 define('RESTRICTION_NON_EMPTY', '/^.+$/');
 define('RESTRICTION_RID', '/^[0-9]+|[0-9]{10,19}|[a-zA-z0-9]{64}$/');
 define('RESTRICTION_UID', '/^(\-?)[0-9]+$/');
-define('RESTRICTION_USERNAME', '/^[a-zA-Z0-9@.\-_+\']{5,'.CHARLIM_USERNAME.'}$/');
+define('RESTRICTION_USERNAME', '/^[a-zA-Z0-9@.\-_+\']{2,'.CHARLIM_USERNAME.'}$/');
 define('RESTRICTION_PASSWORD', '/^.{5,60}$/');
 define('RESTRICTION_FIRST_NAME', '/^.{1,'.CHARLIM_FIRST_NAME.'}$/');
 define('RESTRICTION_LAST_NAME', '/^.{1,'.CHARLIM_LAST_NAME.'}$/');

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -449,7 +449,7 @@ XDMoD.constants.maxEmailLength = 200;
 /**
  * The minimum length of a username.
  */
-XDMoD.constants.minUsernameLength = 5;
+XDMoD.constants.minUsernameLength = 2;
 
 /**
  * The maximum length of a username.


### PR DESCRIPTION
This is still somewhat arbitrary, but 2 is the shorted username seen
at UB.

The regular expression change has been tested by manual install \<looks around shiftily\> _on metrics prod_!

This fixes an issue reported by two different users where they were unable to create a user account with username less than 5 characters long.