### PR TITLE
Fix null QOS ID

### DIFF
--- a/configuration/etl/etl_action_defs.d/jobs/hpcdb/jobs.json
+++ b/configuration/etl/etl_action_defs.d/jobs/hpcdb/jobs.json
@@ -9,7 +9,7 @@
             "resource_id": "r.resource_id",
             "allocation_breakdown_id": "upr.user_pi_resource_id",
             "allocation_id": "pr.pi_resource_id",
-            "qos_id": "IFNULL(q.qos_id, -1)",
+            "qos_id": "q.qos_id",
             "account_id": "p.pi_id",
             "local_jobid": "j.job_id",
             "local_job_array_index": "IFNULL(j.job_array_index, -1)",

--- a/configuration/etl/etl_action_defs.d/jobs/xdw/job-records-job-tasks.json
+++ b/configuration/etl/etl_action_defs.d/jobs/xdw/job-records-job-tasks.json
@@ -31,7 +31,7 @@
             "local_job_array_index": "j.local_job_array_index",
             "local_job_id_raw": "j.local_job_id_raw",
             "job_name": "j.jobname",
-            "qos_id": "j.qos_id",
+            "qos_id": "COALESCE(j.qos_id, -1)",
             "queue": "COALESCE(j.queue, 'NA')",
             "node_count": "j.nodecount",
             "systemaccount_id": "sa.system_account_id",


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Fix QOS bug.  See #1589

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`modw` does not allow NULL, but `mod_hpcdb` does.

```
2021-12-19 04:30:20 [warning] Warning	1263	Column set to default value; NULL supplied to NOT NULL column 'qos_id' at row 1
```

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
