### PR TITLE
Adding index to nodecount column

### DIFF
--- a/configuration/etl/etl_tables.d/jobs/hpcdb/jobs.json
+++ b/configuration/etl/etl_tables.d/jobs/hpcdb/jobs.json
@@ -254,6 +254,12 @@
                 "columns": [
                     "qos_id"
                 ]
+            },
+            {
+                "name": "nodecount_idx",
+                "columns": [
+                    "nodecount"
+                ]
             }
         ],
         "foreign_key_constraints": [


### PR DESCRIPTION
Adding an index to the nodecount column speeds up the `hpcdb-xdm-ingest-jobs.node-count` action. When using this index the action takes less than 10 seconds where before it would take around 5 minutes on our development server. This was supposed to be part of #1579 but was missed.

## Motivation and Context
We would like ingestion to be as quick as possible.

## Tests performed
Tested in docker and on metrics-dev

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
