### PR TITLE
Adding migration pipeline to put dates in cloud resource specs and storage tables into correct format on upgrade

### DIFF
--- a/configuration/etl/etl.d/xdmod-migration-9_5_0-10_0_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-9_5_0-10_0_0.json
@@ -405,8 +405,20 @@
             "description": "Update modw_cloud tables to InnoDB",
             "class": "ManageTables",
             "definition_file_list": [
+                "cloud_common/raw_resource_specs.json",
                 "cloud_common/cloud_resource_specs.json"
               ]
+         },
+         {
+           "name": "UpdateCloudResourceSpecDatetimes",
+           "description": "Update datetimes in raw_resource_specs to correct format",
+           "class": "ExecuteSql",
+           "sql_file_list": [
+               {
+                   "delimiter": ";",
+                   "sql_file": "migrations/9.5.0-10.0.0/modw_cloud/update_cloud_resource_datetimes.sql"
+               }
+           ]
          }
     ],
     "storage-table-definition-update-9-5-0_10-0-0": [
@@ -425,6 +437,25 @@
                     "schema": "mod_shredder"
                 }
             }
+        },
+        {
+          "name": "UpdateStorageDatetimes",
+          "description": "Update datetimes in modw_shredder.staging_storage_usage to correct format",
+          "class": "ExecuteSql",
+          "sql_file_list": [
+              {
+                  "delimiter": ";",
+                  "sql_file": "migrations/9.5.0-10.0.0/mod_shredder/update_storage_datetimes.sql"
+              }
+          ],
+          "endpoints": {
+              "destination": {
+                  "type": "mysql",
+                  "name": "XDMoD Data Warehouse",
+                  "config": "database",
+                  "schema": "mod_shredder"
+              }
+          }
         }
     ],
     "cloud-migration-innodb-9-5-0_10-0-0": [
@@ -449,7 +480,6 @@
                 "cloud_common/instance.json",
                 "cloud_common/memory_buckets.json",
                 "cloud_common/processor_buckets.json",
-                "cloud_common/raw_resource_specs.json",
                 "cloud_common/record_type.json",
                 "cloud_common/session_records.json",
                 "cloud_common/staging_cloud_project_to_pi.json",

--- a/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_shredder/update_storage_datetimes.sql
+++ b/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_shredder/update_storage_datetimes.sql
@@ -1,0 +1,4 @@
+UPDATE
+	mod_shredder.staging_storage_usage
+SET
+    dt = CONCAT(DATE(dt), 'T', TIME_FORMAT(dt, "%T"), 'Z');

--- a/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/modw_cloud/update_cloud_resource_datetimes.sql
+++ b/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/modw_cloud/update_cloud_resource_datetimes.sql
@@ -1,0 +1,4 @@
+UPDATE
+	modw_cloud.raw_resource_specs
+SET
+	fact_date = CONCAT(DATE(fact_date), 'T', TIME_FORMAT(fact_date, "%T"), 'Z');

--- a/tests/ci/bootstrap.sh
+++ b/tests/ci/bootstrap.sh
@@ -132,8 +132,19 @@ then
     then
         sudo -u xdmod xdmod-shredder -r openstack -d $REF_DIR/openstack -f openstack -q
         sudo -u xdmod xdmod-shredder -r nutsetters -d $REF_DIR/nutsetters -f openstack -q
+        sudo -u xdmod xdmod-shredder -r openstack -d $REF_DIR/openstack_resource_specs -f cloudresourcespecs
         mysql -e "TRUNCATE TABLE modw_cloud.instance_type;"
         sudo -u xdmod xdmod-ingestor --last-modified-start-date="2017-01-01 00:00:00"
+    fi
+
+    if [[ "$XDMOD_REALMS" == *"storage"* ]];
+    then
+        for storage_dir in $REF_DIR/storage/*; do
+            sudo -u xdmod xdmod-shredder -f storage -r $(basename $storage_dir) -d $storage_dir
+        done
+        last_modified_start_date=$(date +'%F %T')
+        sudo -u xdmod xdmod-ingestor --datatype storage
+        sudo -u xdmod xdmod-ingestor --aggregate=storage --last-modified-start-date "$last_modified_start_date"
     fi
 fi
 


### PR DESCRIPTION
In #1592 column type changes were made to the `modw_cloud.cloud_resource_specs` and `mod_shredder.staging_storage_usage` tables to get rid of warnings that were being shown. That column change caused a change in format of the dates from `2021-01-01 12:00:00` to `2021-01-01T12:00:00Z`. There needs to be a migration pipeline that changes the existing dates in these columns to the correct format.

Ingesting the cloud resource specs and storage data again in the upgrade helps to test that this works.

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
