### PR TITLE
Add ability to specify an alternate group by.

### DIFF
--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -370,6 +370,7 @@ ETLProfile.prototype.getAggregationTables = function () {
                 category: agg.category,
 				def: agg.def || f.def,
                 dimension: agg.dimension || false,
+                alternate_group_by: agg.alternate_group_by || false,
                 show_all_dimension_values: agg.show_all_dimension_values || false
 			};
             newf.name = newf.name.replace(/\:field_name/g, field);
@@ -748,6 +749,9 @@ ETLProfile.prototype.integrateWithXDMoD = function () {
 
                     var itemAlias = tableColumns[tc].alias || tableColumns[tc].name;
                     xdmodInteg.addGroupBy(itemAlias, tableColumns[tc].roles);
+                    if (tableColumns[tc].alternate_group_by) {
+                        xdmodInteg.addGroupBy(tableColumns[tc].alternate_group_by, tableColumns[tc].roles);
+                    }
 
                     groupBys[itemAlias] = generateGroupBy(itemAlias, tableColumns[tc]);
 


### PR DESCRIPTION
This adds the ability to generate a roles entry for an
alternate group by for a dimension. This is used in
https://github.com/ubccr/xdmod-supremm/pull/295
to support the homogeneity and catastrophy group bys
(which are diffent 'views' of the same thing).