### PR TITLE
Updating Highcharts version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,9 +67,9 @@
                 ],
                 "homepage": "https://www.highcharts.com/products/highcharts",
                 "dist": {
-                    "url": "https://code.highcharts.com/zips/Highcharts-4.2.5.zip",
+                    "url": "https://code.highcharts.com/zips/Highcharts-4.2.7.zip",
                     "type": "zip",
-                    "shasum": "e4ad04f3a6c1b5042d25a8f960f62ce5aeb32777"
+                    "shasum": "d73108287fe8e34448e1dddda1558cf824be3d4d"
                 },
                 "require": {
                     "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -625,11 +625,11 @@
         },
         {
             "name": "highsoft/highcharts",
-            "version": "4.2.5",
+            "version": "4.2.7",
             "dist": {
                 "type": "zip",
-                "url": "https://code.highcharts.com/zips/Highcharts-4.2.5.zip",
-                "shasum": "e4ad04f3a6c1b5042d25a8f960f62ce5aeb32777"
+                "url": "https://code.highcharts.com/zips/Highcharts-4.2.7.zip",
+                "shasum": "d73108287fe8e34448e1dddda1558cf824be3d4d"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/tests/ui/test/specs/xdmod/usageTab.page.js
+++ b/tests/ui/test/specs/xdmod/usageTab.page.js
@@ -25,10 +25,11 @@ class Usage {
         };
         this.chart = '//div[@id="tg_usage"]//div[@class="highcharts-container"]//*[local-name() = "svg"]';
         this.chartByTitle = function (title) {
-            return module.exports.chart + '/*[name()="text" and contains(@class, "title")]/*[name()="tspan" and contains(text(),"' + title + '")]';
+            return module.exports.chart +'/*[name() = "text"]/*[contains(text(), "' + title +'")]';
         };
+        // //div[@id="tg_usage"]//div[@class="highcharts-container"]//*[local-name() = "svg"]/*[name() = "text"]/*[contains(text(), "CPU Hours: Total")]
         this.chartXAxisLabelByName = function (name) {
-            return module.exports.chart + '/*[name() = "g" and contains(@class, "highcharts-xaxis-labels")]/*[name() = "text" and text() = "' + name + '"]';
+            return module.exports.chart + '/*[name() = "g" and contains(@class, "highcharts-xaxis-labels")]//*[text() = "' + name + '"]';
         };
         this.durationButton = this.panel + '//button[contains(@class,"custom_date")]';
         this.durationMenu = '//div[contains(@class,"x-menu-floating")]';

--- a/tests/ui/test/specs/xdmod/usageTab.page.js
+++ b/tests/ui/test/specs/xdmod/usageTab.page.js
@@ -25,7 +25,7 @@ class Usage {
         };
         this.chart = '//div[@id="tg_usage"]//div[@class="highcharts-container"]//*[local-name() = "svg"]';
         this.chartByTitle = function (title) {
-            return module.exports.chart +'/*[name() = "text"]/*[contains(text(), "' + title +'")]';
+            return module.exports.chart + '/*[name() = "text"]/*[contains(text(), "' + title + '")]';
         };
         // //div[@id="tg_usage"]//div[@class="highcharts-container"]//*[local-name() = "svg"]/*[name() = "text"]/*[contains(text(), "CPU Hours: Total")]
         this.chartXAxisLabelByName = function (name) {


### PR DESCRIPTION


<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
These changes are due to issues we ran into while working on the metrics-dev
centos8 test box. I was unable to freshly download Highcharts 4.2.5 via composer
due to highcharts web server returning an invalid content-encoding value. This
hadn't been an issue before due to us either caching the downloaded zip file (
i.e. the current centos8 build ) or was downloading it on Centos7 which has an
old enough version of curl that it doesn't care if the server provides an
invalid content-encoding.

With the change in version there was a slight change in the way that Highcharts
constructs it's chart svg so this necessitated a slight modification to a few of
the UI test helper functions.

I have a ticket into highcharts github repo
https://github.com/highcharts/highcharts/issues/16926 that is, at the time of
writing, has been routed to the website team and is actively being worked on.

## Motivation and Context
These changes allow us to successfully install on OS's with newer versions of curl 

## Tests performed
UI tests were performed on both Centos7 & Centos8

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
