### PR TITLE
Change sql connection reuse strategy.

### DIFF
--- a/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
+++ b/classes/ETL/DataEndpoint/aRdbmsEndpoint.php
@@ -150,7 +150,8 @@ abstract class aRdbmsEndpoint extends aDataEndpoint
         // in the config file. You can, however, explicitly reference a schema in your query.
 
         try {
-            $this->handle = DB::factory($this->config);
+            $this->handle = DB::factory($this->config, false);
+            $this->handle->disconnect();
         } catch (Exception $e) {
             $msg = "Error connecting to data endpoint '" . $this->name . "'. " . $e->getMessage();
             $this->logAndThrowException($msg);

--- a/classes/ETL/Maintenance/ExecuteSql.php
+++ b/classes/ETL/Maintenance/ExecuteSql.php
@@ -267,6 +267,11 @@ class ExecuteSql extends aAction implements iAction
 
             $this->logger->notice("Finished Processing $numStatementsProcessed SQL statements");
 
+            // close the connection after each file if there are multiple files then
+            // a new connection will be created. This mitigates problems with long
+            // running queries.
+            $this->destinationEndpoint->disconnect();
+
         }  // foreach ( $this->options->sql_file_list as $sqlFile )
 
         $time_end = microtime(true);

--- a/classes/OpenXdmod/Migration/Version950To1000/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version950To1000/DatabasesMigration.php
@@ -15,53 +15,28 @@ use ETL\Utilities;
  */
 class DatabasesMigration extends AbstractDatabasesMigration
 {
-    /**
-     * Check whether a table exists in the datawarehouse. Note this creates (and destroys)
-     * a new connection for the check. This mitigates problems with a persistent connection
-     * timing out (which can happen if there is a long time between queries).
-     * @param string $tableName the name of the table to check.
-     * @return bool whether the table exists in the datawarehouse.
-     */
-    private function tableExists($tableName)
-    {
-        $dbh = DB::factory('datawarehouse');
-        $mysql_helper = \CCR\DB\MySQLHelper::factory($dbh);
-        $exists = $mysql_helper->tableExists($tableName);
-        $mysql_helper = null;
-        $dbh = null;
-        return $exists;
-    }
-
     public function execute()
     {
         parent::execute();
 
+        $dbh = DB::factory('datawarehouse');
+        $mysql_helper = \CCR\DB\MySQLHelper::factory($dbh);
         $console = Console::factory();
         $pipelinesToRun = [];
 
-        if ($this->tableExists('mod_shredder.staging_storage_usage')) {
-            Utilities::runEtlPipeline(
-                ['storage-table-definition-update-9-5-0_10-0-0'],
-                $this->logger,
-                ['last-modified-start-date' => '2017-01-01 00:00:00']
-            );
+        if ($mysql_helper->tableExists('mod_shredder.staging_storage_usage')) {
+            $pipelinesToRun[] = 'storage-table-definition-update-9-5-0_10-0-0';
         }
 
-        if ($this->tableExists('modw_cloud.event')) {
-            Utilities::runEtlPipeline(
-                ['cloud-migration-9-5-0_10-0-0'],
-                $this->logger,
-                [
-                    'last-modified-start-date' => '2017-01-01 00:00:00'
-                ]
-            );
+        if ($mysql_helper->tableExists('modw_cloud.event')) {
+            $pipelinesToRun[] = 'cloud-migration-9-5-0_10-0-0';
         }
 
-        if ($this->tableExists('modw_cloud.cloud_resource_specs')) {
+        if ($mysql_helper->tableExists('modw_cloud.cloud_resource_specs')) {
             $pipelinesToRun[] = 'cloud-resource-specs-migration-9-5-0_10-0-0';
         }
 
-        if ($this->tableExists('modw_cloud.event')) {
+        if ($mysql_helper->tableExists('modw_cloud.event')) {
             $pipelinesToRun[] = 'cloud-migration-innodb-9-5-0_10-0-0';
         }
 
@@ -70,10 +45,12 @@ This version of Open XDMoD converts any table with the MyISAM engine to InnoDB. 
 EOT
         );
 
-        Utilities::runEtlPipeline(
-            $pipelinesToRun,
-            $this->logger,
-            ['last-modified-start-date' => '2017-01-01 00:00:00']
-        );
+        foreach ($pipelinesToRun as $pipeline) {
+            Utilities::runEtlPipeline(
+                [$pipeline],
+                $this->logger,
+                ['last-modified-start-date' => '2017-01-01 00:00:00']
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

We were seeing database timeouts when running the upgrade procedure. It was thought that https://github.com/ubccr/xdmod/pull/1602 fixed some of the problems, but actually it didn't fix anything since the `DB::factory('datawarehouse');` function can return a stale database handle. Calling it multiple times will not result in a "fresh" handle, you just get the same one (which could be stale).

This commit has three changes:
- fix the DatabasesMigration to run the talbe existance checks first then run each migration step as a seperate EtlV2 run
- Change the EtlV2 data endpoint so that the initial connect call will guarantee to get a fresh database connection and not a stale existing one. (looking at the code design it may be that the original author expected the DB::factory() function to actually return a 'fresh' connection since the connection details are cached in the class).
- change the Maintenance/ExecuteSql.php to use a fresh connection for each file. The same connection is still reused for different statements within a file.

## Tests performed
These changes were tested as follows:

in the docker set then mysql timeout to 30s:
```
echo "wait_timeout = 30" >> /etc/my.cnf.d/server.cnf
```
then apply the following patch to deliberately make a couple of sql file runs
take a "long" time:

```
diff --git a/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_shredder/update_storage_datetimes.sql b/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_shredder/update_storage_datetimes.sql
index cb7c496a..28efba12 100644
--- a/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_shredder/update_storage_datetimes.sql
+++ b/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/mod_shredder/update_storage_datetimes.sql
@@ -2,3 +2,4 @@ UPDATE
        mod_shredder.staging_storage_usage
 SET
     dt = CONCAT(DATE(dt), 'T', TIME_FORMAT(dt, "%T"), 'Z');
+SELECT SLEEP(45);
diff --git a/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/modw_cloud/update_image_index.sql b/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/modw_cloud/update_image_index.sql
index 6b3cd725..b3cd67b2 100644
--- a/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/modw_cloud/update_image_index.sql
+++ b/configuration/etl/etl_sql.d/migrations/9.5.0-10.0.0/modw_cloud/update_image_index.sql
@@ -44,3 +44,4 @@ DROP INDEX image_resource_idx ON modw_cloud.image;
 DROP INDEX image_resource_idx ON modw_cloud.instance_data;

 UNLOCK TABLES;
+SELECT SLEEP(45);
```

when you run the original code you get the following error:
```
2022-02-01 21:00:26 [notice] Finished processing section 'xdmod.storage-table-definition-update-9-5-0_10-0-0'
SQLSTATE[HY000]: General error: 2006 MySQL server has gone away
```

and you don't see that error with this change in place.

Also as a different test set the database timeout to 10 seconds (and do not add the SLEEP(45) patch). The original code gives this error:
```
2022-02-01 21:56:45 [warning] Stopping ETL due to exception in xdmod.migration-9_5_0-10_0_0.alter-shredded_job_slurm (ETL\Maintenance\ExecuteSql)
xdmod.migration-9_5_0-10_0_0.alter-shredded_job_slurm (ETL\Maintenance\ExecuteSql): Error executing SQL Exception: 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away'
```
which is also not seen with this change in place.


