### PR TITLE
Temporary Fix for Centos8 repo change

### DIFF
--- a/tests/ci/bootstrap.sh
+++ b/tests/ci/bootstrap.sh
@@ -22,6 +22,16 @@ cp -r $REF_SOURCE /var/tmp/
 set -e
 set -o pipefail
 
+# Detect what version of CentOS we're running in, if it's 8 then we need to do some rejiggering of the yum repos to
+# make things work. From: https://stackoverflow.com/questions/70926799/centos-through-vm-no-urls-in-mirrorlist
+OS_VERSION=$(grep VERSION_ID < /etc/os-release  | cut -d"=" -f 2 | tr -d '"')
+case "$OS_VERSION" in
+    "8")
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+        ;;
+esac
+
 if [ "$XDMOD_TEST_MODE" = "fresh_install" ];
 then
     rpm -qa | grep ^xdmod | xargs yum -y remove || true


### PR DESCRIPTION
## Description
Redhat moved the centos8 repos to vault today. These changes allow our
Centos8 builds to work while we move towards supporting Rocky.

## Motivation and Context
To get our Centos8 builds working long enough for us to move to Rocky.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
