### PR TITLE
Fix comment removal in ETL SQL execution

### DIFF
--- a/classes/ETL/Maintenance/ExecuteSql.php
+++ b/classes/ETL/Maintenance/ExecuteSql.php
@@ -218,9 +218,9 @@ class ExecuteSql extends aAction implements iAction
 
                 $commentPatterns = array(
                     // Hash-style comments
-                    '/^\s*#.*[\r\n]+/',
+                    '/^\s*#.*[\r\n]+/m',
                     // Standard SQL comments.
-                    '/^\s*-- ?.*[\r\n]+/'
+                    '/^\s*-- ?.*[\r\n]+/m'
                     );
                 $sql = preg_replace($commentPatterns, "", $sql);
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adjusts regular expressions used to remove comments in SQL to use `PCRE_MULTILINE`.

From https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php:
By default, PCRE treats the subject string as consisting of a single "line" of characters (even if it actually contains several newlines).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this modifier only a single line is removed when there are multiple comments of the same style.  This produces confusing output in error messages.  Now all the comments will be removed.

See https://app.asana.com/0/1200028182662861/1201795993165108/f

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No new tests.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
