### PR TITLE
Updating the datasetid float comparison (PHP7.2)

### DIFF
--- a/html/controllers/metric_explorer/get_rawdata.php
+++ b/html/controllers/metric_explorer/get_rawdata.php
@@ -72,11 +72,13 @@ try {
 
     $datasetid = $_REQUEST['datasetId'];
 
+    // used to compare to floats, in this case the datasetId and the data_series->id
+    $epsilon = 0.00000000000001;
+
     // find requested dataset.
     $data_description = null;
-
     foreach ($all_data_series as $data_description_index => $data_series) {
-        if ("{$data_series->id}" == "$datasetid") {
+        if (abs($data_series->id - $datasetid) < $epsilon) {
             $data_description = $data_series;
             break;
         }

--- a/html/controllers/metric_explorer/get_rawdata.php
+++ b/html/controllers/metric_explorer/get_rawdata.php
@@ -75,6 +75,7 @@ try {
     // find requested dataset.
     $data_description = null;
     foreach ($all_data_series as $data_description_index => $data_series) {
+        // NOTE: this only works if the id's are not floats.
         if ("{$data_series->id}" == "$datasetid") {
             $data_description = $data_series;
             break;

--- a/html/controllers/metric_explorer/get_rawdata.php
+++ b/html/controllers/metric_explorer/get_rawdata.php
@@ -72,13 +72,10 @@ try {
 
     $datasetid = $_REQUEST['datasetId'];
 
-    // used to compare to floats, in this case the datasetId and the data_series->id
-    $epsilon = 0.00000000000001;
-
     // find requested dataset.
     $data_description = null;
     foreach ($all_data_series as $data_description_index => $data_series) {
-        if (abs($data_series->id - $datasetid) < $epsilon) {
+        if ("{$data_series->id}" == "$datasetid") {
             $data_description = $data_series;
             break;
         }

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -83,7 +83,7 @@ Ext.apply(CCR.xdmod.ui.AddDataPanel, {
         var conf = {};
         jQuery.extend(true, conf, CCR.xdmod.ui.AddDataPanel.defaultConfig(timeseries));
         if (config) jQuery.extend(true, conf, config);
-        conf.id = Math.random();
+        conf.id = CCR.randomInt(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
         conf.z_index = store.getCount();
         conf.filters = selectedFilters ? selectedFilters : {
             data: [],

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -55,6 +55,10 @@ Ext.apply(CCR.xdmod.ui.AddDataPanel, {
         ['label_asc', 'Labels Ascending'],
         ['label_desc', 'Labels Descending']
     ],
+    randomInt: function (min, max) {
+        // eslint-disable-next-line no-mixed-operators
+        return Math.floor(Math.random() * (max - min + 1) + min);
+    },
     defaultConfig: function (timeseries) {
         return {
             group_by: 'none',
@@ -83,7 +87,7 @@ Ext.apply(CCR.xdmod.ui.AddDataPanel, {
         var conf = {};
         jQuery.extend(true, conf, CCR.xdmod.ui.AddDataPanel.defaultConfig(timeseries));
         if (config) jQuery.extend(true, conf, config);
-        conf.id = CCR.randomInt(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+        conf.id = this.randomInt(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
         conf.z_index = store.getCount();
         conf.filters = selectedFilters ? selectedFilters : {
             data: [],

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1,8 +1,9 @@
-
 // Monkey patching in Date.now in case it's not here already
 // This is for IE8-. In IE9+ ( even IE9 w/ IE8 compatability mode on ) this works
 // just fine.
-Date.now = Date.now || function() { return +new Date; };
+Date.now = Date.now || function () {
+    return +new Date;
+};
 
 // JavaScript Document
 Ext.namespace('CCR', 'CCR.xdmod', 'CCR.xdmod.ui', 'CCR.xdmod.ui.dd', 'XDMoD', 'XDMoD.constants', 'XDMoD.Module', 'XDMoD.regex', 'XDMoD.validator', 'XDMoD.utils', 'CCR.xdmod.reporting');
@@ -176,15 +177,15 @@ XDMoD.GlobalToolbar.Roadmap = {
     text: 'Roadmap',
     iconCls: 'roadmap',
     id: 'global-toolbar-roadmap',
-    handler: function() {
+    handler: function () {
         Ext.History.add('#main_tab_panel:about_xdmod?Roadmap');
     }
 };
 
 XDMoD.GlobalToolbar.Contact = function () {
-    var contactHandler = function(){
+    var contactHandler = function () {
         XDMoD.TrackEvent('Portal', 'Contact Us -> ' + this.text + ' Button Clicked');
-        switch(this.text){
+        switch (this.text) {
             case 'Send Message':
                 new XDMoD.ContactDialog().show();
                 break;
@@ -210,18 +211,18 @@ XDMoD.GlobalToolbar.Contact = function () {
                 id: 'global-toolbar-contact-us-send-message',
                 handler: contactHandler
             },
-            {
-                text: 'Request Feature',
-                iconCls: 'bulb_16',
-                id: 'global-toolbar-contact-us-request-feature',
-                handler: contactHandler
-            },
-            {
-                text: 'Submit Support Request',
-                iconCls: 'help_16',
-                id: 'global-toolbar-contact-us-submit-support-request',
-                handler: contactHandler
-            }]
+                {
+                    text: 'Request Feature',
+                    iconCls: 'bulb_16',
+                    id: 'global-toolbar-contact-us-request-feature',
+                    handler: contactHandler
+                },
+                {
+                    text: 'Submit Support Request',
+                    iconCls: 'help_16',
+                    id: 'global-toolbar-contact-us-submit-support-request',
+                    handler: contactHandler
+                }]
         }) //menu
     };
 }; //XDMoD.GlobalToolbar.Contact
@@ -736,8 +737,8 @@ CCR.xdmod.ui.login_prompt = null;
 CCR.xdmod.ui.createUserManualLink = function (tags) {
 
     return '<div style="background-image: url(\'gui/images/user_manual.png\'); background-repeat: no-repeat; height: 36px; padding-left: 40px; padding-top: 10px">' +
-            'For more information, please refer to the <a href="javascript:void(0)" onClick="CCR.xdmod.ui.userManualNav(\'' + tags + '\')">User Manual</a>' +
-            '</div>';
+        'For more information, please refer to the <a href="javascript:void(0)" onClick="CCR.xdmod.ui.userManualNav(\'' + tags + '\')">User Manual</a>' +
+        '</div>';
 
 }; //CCR.xdmod.ui.createUserManualLink
 
@@ -797,8 +798,8 @@ CCR.safelyDecodeJSONResponse = function (response) {
     var responseObject = null;
     try {
         responseObject = Ext.decode(response.responseText);
+    } catch (e) {
     }
-    catch (e) {}
 
     return responseObject;
 };
@@ -814,8 +815,8 @@ CCR.checkDecodedJSONResponseSuccess = function (responseObject) {
     var responseSuccessful = false;
     try {
         responseSuccessful = responseObject.success === true;
+    } catch (e) {
     }
-    catch (e) {}
 
     return responseSuccessful;
 };
@@ -853,7 +854,7 @@ CCR.submitHiddenFormImmediately = function (url, method, params) {
     temp.style.display = "none";
 
     for (var param in params) {
-        if(params.hasOwnProperty(param)){
+        if (params.hasOwnProperty(param)) {
             var opt = document.createElement("textarea");
             opt.name = param;
             opt.value = params[param];
@@ -1053,10 +1054,9 @@ CCR.BrowserWindow = Ext.extend(Ext.Window, {
                 text: 'Close',
                 iconCls: 'general_btn_close',
                 handler: function () {
-                    if (self.closeAction == 'close'){
+                    if (self.closeAction == 'close') {
                         self.close();
-                    }
-                    else {
+                    } else {
                         self.hide();
                     }
                 }
@@ -1279,24 +1279,24 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
                 id: 'btn_sign_in',
                 handler: signInWithLocalAccount
             },
-            {
-                xtype: 'container',
-                autoEl: 'div',
-                autoWidth: true,
-                flex: 2,
-                height: 38,
-                id: 'assistancePrompt',
-                items: [{
-                    xtype: 'tbtext',
-                    html: '<a href="javascript:CCR.xdmod.ui.forgot_password()">Forgot your password?</a>',
-                    id: 'forgot_password_link'
-                },
                 {
-                    xtype: 'tbtext',
-                    html: '<a href="javascript:presentSignUpViaLoginPrompt()">Don\'t have an account?</a>',
-                    id: 'sign_up_link'
+                    xtype: 'container',
+                    autoEl: 'div',
+                    autoWidth: true,
+                    flex: 2,
+                    height: 38,
+                    id: 'assistancePrompt',
+                    items: [{
+                        xtype: 'tbtext',
+                        html: '<a href="javascript:CCR.xdmod.ui.forgot_password()">Forgot your password?</a>',
+                        id: 'forgot_password_link'
+                    },
+                        {
+                            xtype: 'tbtext',
+                            html: '<a href="javascript:presentSignUpViaLoginPrompt()">Don\'t have an account?</a>',
+                            id: 'sign_up_link'
+                        }]
                 }]
-            }]
         }
     ];
 
@@ -1548,8 +1548,7 @@ CCR.xdmod.initDashboard = function () {
         callback: function (options, success, response) {
             if (success && CCR.checkJSONResponseSuccess(response)) {
                 dashboardWindow.location.href = 'internal_dashboard';
-            }
-            else {
+            } else {
                 dashboardWindow.close();
                 window.focus();
                 CCR.xdmod.ui.presentFailureResponse(response, {
@@ -1702,13 +1701,13 @@ CCR.xdmod.ui.extractErrorMessageFromResponse = function (response, options) {
         if (response.responseText) {
             responseObject = Ext.decode(response.responseText);
         }
+    } catch (e) {
     }
-    catch (e) {}
 
     try {
         responseMessage = responseObject.message || responseObject.status || responseMessage;
+    } catch (e) {
     }
-    catch (e) {}
 
     if (options.htmlEncode) {
         responseMessage = Ext.util.Format.htmlEncode(responseMessage);
@@ -1804,7 +1803,7 @@ CCR.xdmod.ui.gridComboRenderer = function (combo) {
 };
 
 CCR.isBlank = function (value) {
-    return !value || value === 'undefined' || !value.trim() ? true: false;
+    return !value || value === 'undefined' || !value.trim() ? true : false;
 };
 
 CCR.Types = {};
@@ -1821,7 +1820,7 @@ CCR.isType = function (value, type) {
         return Object.prototype.toString.call(value) === type;
     } else {
         return Object.prototype.toString.call(value) ===
-                Object.prototype.toString.call(type);
+            Object.prototype.toString.call(type);
     }
 };
 
@@ -1838,12 +1837,12 @@ CCR.exists = function (value) {
 CCR.merge = function (obj1, obj2) {
     var obj3 = {};
     for (var attrname1 in obj1) {
-        if(obj1.hasOwnProperty(attrname1)){
+        if (obj1.hasOwnProperty(attrname1)) {
             obj3[attrname1] = obj1[attrname1];
         }
     }
     for (var attrname in obj2) {
-        if(obj2.hasOwnProperty(attrname)){
+        if (obj2.hasOwnProperty(attrname)) {
             obj3[attrname] = obj2[attrname];
         }
     }
@@ -1852,10 +1851,10 @@ CCR.merge = function (obj1, obj2) {
 CCR.getParameter = function (name, source) {
     name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
     var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-            results = regex.exec(source);
+        results = regex.exec(source);
     return results === null
-            ? ""
-            : decodeURIComponent(results[1].replace(/\+/g, " "));
+        ? ""
+        : decodeURIComponent(results[1].replace(/\+/g, " "));
 };
 /*
  * Process the location hash string. The string should have the form:
@@ -1869,8 +1868,8 @@ CCR.getParameter = function (name, source) {
  */
 CCR.tokenize = function (hash) {
     var raw = (typeof hash !== 'string')
-      ? String(hash)
-      : hash;
+        ? String(hash)
+        : hash;
 
     var matches = raw.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
 
@@ -1907,7 +1906,7 @@ CCR.tokenize = function (hash) {
  * @param {Array} delims
  * @returns {Array}
  */
-CCR.toArray = function(value, delims) {
+CCR.toArray = function (value, delims) {
     if (!CCR.exists(value) || !CCR.isType(value, CCR.Types.String) || value.length < 1) {
         return [];
     }
@@ -1934,20 +1933,20 @@ CCR.toArray = function(value, delims) {
     return results;
 };
 
-CCR.objectToArray = function(object) {
+CCR.objectToArray = function (object) {
     if (!CCR.exists(object)) {
         return [];
     }
     var results;
     for (var property in object) {
-        if(object.hasOwnProperty(property)) {
+        if (object.hasOwnProperty(property)) {
             results = [property, object[property]];
         }
     }
     return results;
 };
 
-CCR.join = function(values, joiners) {
+CCR.join = function (values, joiners) {
 
     if (!CCR.exists(values) || !CCR.isType(values, CCR.Types.Array)) {
         return "";
@@ -1965,7 +1964,7 @@ CCR.join = function(values, joiners) {
     var joinerIndex = 0;
     var result;
 
-    var joinValue = function(value, joiners, joinerIndex) {
+    var joinValue = function (value, joiners, joinerIndex) {
         var isArray = CCR.isType(value, CCR.Types.Array);
         var holdsArrays = isArray && value.length > 0 && CCR.isType(value[0], CCR.Types.Array);
         var result = [];
@@ -2015,7 +2014,7 @@ CCR.pad = function (str, len, pad, dir) {
     return str;
 };
 
-CCR.deepEncode = function(values, options) {
+CCR.deepEncode = function (values, options) {
     if (!CCR.exists(values)) {
         return '';
     }
@@ -2042,7 +2041,7 @@ CCR.deepEncode = function(values, options) {
     }
 };
 
-CCR._encodeArray = function(values, options) {
+CCR._encodeArray = function (values, options) {
     if (!CCR.exists(values)) {
         return JSON.stringify([]);
     }
@@ -2067,8 +2066,8 @@ CCR._encodeArray = function(values, options) {
     return (left + results.join(delim) + right).trim();
 };
 
-CCR._encodeObject = function(value, options) {
-    if (!CCR.exists(value)){
+CCR._encodeObject = function (value, options) {
+    if (!CCR.exists(value)) {
         return JSON.stringify({});
     }
     options = options || {};
@@ -2079,18 +2078,18 @@ CCR._encodeObject = function(value, options) {
     var separator = options.seperator || '=';
     var results = [];
 
-    for (var property in value ) {
-        if(value.hasOwnProperty(property)){
+    for (var property in value) {
+        if (value.hasOwnProperty(property)) {
             var propertyValue = value[property];
             if (CCR.isType(propertyValue, CCR.Types.Array)) {
                 results.push(property + '=' + encodeURIComponent(CCR._encodeArray(propertyValue, {
-                            wrap: true,
-                            seperator: ':'
-                        })));
+                    wrap: true,
+                    seperator: ':'
+                })));
             } else if (CCR.isType(propertyValue, CCR.Types.Object)) {
                 results.push(property + '=' + encodeURIComponent(CCR._encodeObject(propertyValue, {
-                            wrap: true
-                        })));
+                    wrap: true
+                })));
             } else {
                 var key = wrap ? '"' + property + '"' : property;
                 results.push(key + separator + propertyValue);
@@ -2113,8 +2112,8 @@ CCR.encode = function (values) {
                 var isArray = CCR.isType(values[property], CCR.Types.Array);
                 var isObject = CCR.isType(values[property], CCR.Types.Object);
                 var value = isArray || isObject
-                        ? encodeURIComponent(CCR.deepEncode(values[property]))
-                        : values[property];
+                    ? encodeURIComponent(CCR.deepEncode(values[property]))
+                    : values[property];
                 parameters.push(property + '=' + value);
             }
         }
@@ -2144,7 +2143,7 @@ CCR.apply = function (lhs, rhs) {
         for (property in rhs) {
             if (rhs.hasOwnProperty(property)) {
                 var rhsExists = rhs[property] !== undefined
-                        && rhs[property] !== null;
+                    && rhs[property] !== null;
                 if (rhsExists) {
                     results[property] = rhs[property];
                 }
@@ -2170,7 +2169,7 @@ CCR.toInt = function (value) {
 
 /**
  * Displays a MessageBox to the user with the error styling.
-  *
+ *
  * @param {String}   title   of the Error Dialog Box.
  * @param {String}   message that will be displayed to the user.
  * @param {Function} success function that will be executed if the user does not
@@ -2181,18 +2180,20 @@ CCR.toInt = function (value) {
  */
 CCR.error = function (title, message, success, failure, buttons) {
     buttons = buttons || Ext.MessageBox.OK;
-    success = success || function(){};
-    failure = failure || function(){};
+    success = success || function () {
+    };
+    failure = failure || function () {
+    };
 
     Ext.MessageBox.show({
         title: title,
         msg: message,
         buttons: buttons,
         icon: Ext.MessageBox.ERROR,
-        fn: function(buttonId, text, options) {
+        fn: function (buttonId, text, options) {
             var compare = CCR.compare;
             if (compare.strings(buttonId, Ext.MessageBox.buttonText['no'])
-                    || compare.strings(buttonId, Ext.MessageBox.buttonText['cancel'])) {
+                || compare.strings(buttonId, Ext.MessageBox.buttonText['cancel'])) {
                 failure(buttonId, text, options);
             } else {
                 success(buttonId, text, options);
@@ -2209,7 +2210,7 @@ CCR.compare = {
             None: 'toString'
         }
     },
-    strings: function(left, right, method) {
+    strings: function (left, right, method) {
         if (!CCR.exists(left) || !CCR.exists(right)) {
             return false;
         }
@@ -2244,11 +2245,11 @@ CCR.compare = {
  *             or an instance of 'classPath' instantiated with 'config'
  *             as a constructor argument.
  **/
-CCR.getInstance = function(instancePath, classPath, config) {
-    if ( !instancePath || typeof instancePath !== 'string' ) {
+CCR.getInstance = function (instancePath, classPath, config) {
+    if (!instancePath || typeof instancePath !== 'string') {
         return;
     }
-    if ( !classPath || typeof classPath !== 'string' ) {
+    if (!classPath || typeof classPath !== 'string') {
         return;
     }
 
@@ -2265,14 +2266,14 @@ CCR.getInstance = function(instancePath, classPath, config) {
      *
      * @return {*} the result of walking the provided 'path'.
      **/
-    var getReference = function(path, callback) {
-            callback = callback !== undefined
-                ? callback
-                : function(previous, current) {
-                    return previous[current];
-                };
+    var getReference = function (path, callback) {
+        callback = callback !== undefined
+            ? callback
+            : function (previous, current) {
+                return previous[current];
+            };
 
-        return path.split('.').reduce( callback, window );
+        return path.split('.').reduce(callback, window);
     };
 
     /**
@@ -2290,7 +2291,7 @@ CCR.getInstance = function(instancePath, classPath, config) {
      * @return {*} The return value of invoking 'classPath' or, failing that,
      *             the value of 'classPath'.
      **/
-    var instantiateClass = function(classPath, config) {
+    var instantiateClass = function (classPath, config) {
         var Class = getReference(classPath);
         return typeof Class === 'function' ? new Class(config) : Class;
     };
@@ -2299,8 +2300,8 @@ CCR.getInstance = function(instancePath, classPath, config) {
     if (!result) {
         result = getReference(
             instancePath,
-            function(previous, current) {
-                if ( previous[current] === undefined ) {
+            function (previous, current) {
+                if (previous[current] === undefined) {
                     return previous[current] = instantiateClass(classPath, config);
                 } else {
                     return previous[current];
@@ -2331,6 +2332,10 @@ CCR.intersect = function (left, right) {
     return found;
 };
 
+CCR.randomInt = function (min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min)
+};
+
 
 // override 3.4.0 to be able to restore column state
 Ext.override(Ext.grid.ColumnModel, {
@@ -2354,8 +2359,7 @@ Ext.override(Ext.form.TriggerField, {
         }
         if (this.rendered && !this.readOnly && this.editable && !this.el.getWidth()) {
             this.wrap.setWidth(w);
-        }
-        else {
+        } else {
             this.wrap.setWidth(this.el.getWidth() + tw);
         }
     }
@@ -2430,18 +2434,18 @@ Ext.override(Ext.ToolTip, {
 // override 3.4.0 to ensure that the grid stops editing if the view is refreshed
 // actual bug: removing grid lines with active lookup editor didn't hide editor
 Ext.grid.GridView.prototype.processRows =
-        Ext.grid.GridView.prototype.processRows.createInterceptor(function () {
-            if (this.grid) {
-                this.grid.stopEditing(true);
-            }
-        });
+    Ext.grid.GridView.prototype.processRows.createInterceptor(function () {
+        if (this.grid) {
+            this.grid.stopEditing(true);
+        }
+    });
 
 // override 3.4.0 to fix issue with chart labels losing their labelRenderer after hide/show
 Ext.override(Ext.chart.CartesianChart, {
     createAxis: function (axis, value) {
         var o = Ext.apply({}, value),
-                ref,
-                old;
+            ref,
+            old;
 
         if (this[axis]) {
             old = this[axis].labelFunction;
@@ -2479,7 +2483,7 @@ Ext.override(Ext.grid.RowSelectionModel, {
 
 // override to allow menu items to have a tooltip property
 Ext.override(Ext.menu.Item, {
-    onRender : function(container, position){
+    onRender: function (container, position) {
         if (!this.itemTpl) {
             this.itemTpl = Ext.menu.Item.prototype.itemTpl = new Ext.XTemplate(
                 '<a id="{id}" class="{cls} x-unselectable" hidefocus="true" unselectable="on" href="{href}"',
@@ -2490,7 +2494,7 @@ Ext.override(Ext.menu.Item, {
                 '<img src="{icon}" class="x-menu-item-icon {iconCls}"/>',
                 '<span class="x-menu-item-text">{text}</span>',
                 '</a>'
-                );
+            );
         }
         var a = this.getTemplateArgs();
         this.el = position ? this.itemTpl.insertBefore(position, a, true) : this.itemTpl.append(container, a, true);
@@ -2499,7 +2503,7 @@ Ext.override(Ext.menu.Item, {
         if (this.tooltip) {
             this.tooltip = new Ext.ToolTip(Ext.apply({
                 target: this.el
-            }, Ext.isObject(this.tooltip) ? this.toolTip : { html: this.tooltip }));
+            }, Ext.isObject(this.tooltip) ? this.toolTip : {html: this.tooltip}));
         }
         Ext.menu.Item.superclass.onRender.call(this, container, position);
     }

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -2,7 +2,7 @@
 // This is for IE8-. In IE9+ ( even IE9 w/ IE8 compatability mode on ) this works
 // just fine.
 Date.now = Date.now || function () {
-    return +new Date;
+    return Number(new Date());
 };
 
 // JavaScript Document
@@ -194,6 +194,8 @@ XDMoD.GlobalToolbar.Contact = function () {
                 break;
             case 'Submit Support Request':
                 new XDMoD.SupportDialog().show();
+                break;
+            default:
                 break;
         }
     };
@@ -799,6 +801,7 @@ CCR.safelyDecodeJSONResponse = function (response) {
     try {
         responseObject = Ext.decode(response.responseText);
     } catch (e) {
+        // NO-OP
     }
 
     return responseObject;
@@ -816,6 +819,7 @@ CCR.checkDecodedJSONResponseSuccess = function (responseObject) {
     try {
         responseSuccessful = responseObject.success === true;
     } catch (e) {
+        // NO-OP
     }
 
     return responseSuccessful;
@@ -1054,7 +1058,7 @@ CCR.BrowserWindow = Ext.extend(Ext.Window, {
                 text: 'Close',
                 iconCls: 'general_btn_close',
                 handler: function () {
-                    if (self.closeAction == 'close') {
+                    if (self.closeAction === 'close') {
                         self.close();
                     } else {
                         self.hide();
@@ -1702,11 +1706,13 @@ CCR.xdmod.ui.extractErrorMessageFromResponse = function (response, options) {
             responseObject = Ext.decode(response.responseText);
         }
     } catch (e) {
+        // NO-OP
     }
 
     try {
         responseMessage = responseObject.message || responseObject.status || responseMessage;
     } catch (e) {
+        // NO-OP
     }
 
     if (options.htmlEncode) {
@@ -1803,7 +1809,7 @@ CCR.xdmod.ui.gridComboRenderer = function (combo) {
 };
 
 CCR.isBlank = function (value) {
-    return !value || value === 'undefined' || !value.trim() ? true : false;
+    return !value || value === 'undefined' || !value.trim();
 };
 
 CCR.Types = {};
@@ -1849,12 +1855,12 @@ CCR.merge = function (obj1, obj2) {
     return obj3;
 };
 CCR.getParameter = function (name, source) {
-    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-        results = regex.exec(source);
+    var newName = name.replace(/[[]/, '\\[').replace(/[\]]/, '\\]');
+    var regex = new RegExp('[\\?&]' + newName + '=([^&#]*)');
+    var results = regex.exec(source);
     return results === null
-        ? ""
-        : decodeURIComponent(results[1].replace(/\+/g, " "));
+        ? ''
+        : decodeURIComponent(results[1].replace(/\+/g, ' '));
 };
 /*
  * Process the location hash string. The string should have the form:
@@ -1947,7 +1953,6 @@ CCR.objectToArray = function (object) {
 };
 
 CCR.join = function (values, joiners) {
-
     if (!CCR.exists(values) || !CCR.isType(values, CCR.Types.Array)) {
         return "";
     }
@@ -1961,9 +1966,10 @@ CCR.join = function (values, joiners) {
         return values.join('');
     }
 
-    var joinerIndex = 0;
+    var index = 0;
     var result;
 
+    // eslint-disable-next-line no-shadow
     var joinValue = function (value, joiners, joinerIndex) {
         var isArray = CCR.isType(value, CCR.Types.Array);
         var holdsArrays = isArray && value.length > 0 && CCR.isType(value[0], CCR.Types.Array);
@@ -1980,7 +1986,7 @@ CCR.join = function (values, joiners) {
         return result.join(joiners[joinerIndex]);
     };
 
-    result = joinValue(values, joiners, joinerIndex);
+    result = joinValue(values, joiners, index);
 
     return result;
 };
@@ -2135,17 +2141,17 @@ CCR.encode = function (values) {
 CCR.apply = function (lhs, rhs) {
     if (typeof lhs === 'object' && typeof rhs === 'object') {
         var results = {};
-        for (var property in lhs) {
-            if (lhs.hasOwnProperty(property)) {
-                results[property] = lhs[property];
+        for (var leftProperty in lhs) {
+            if (lhs.hasOwnProperty(leftProperty)) {
+                results[leftProperty] = lhs[leftProperty];
             }
         }
-        for (property in rhs) {
-            if (rhs.hasOwnProperty(property)) {
-                var rhsExists = rhs[property] !== undefined
-                    && rhs[property] !== null;
+        for (var rightProperty in rhs) {
+            if (rhs.hasOwnProperty(rightProperty)) {
+                var rhsExists = rhs[rightProperty] !== undefined
+                    && rhs[rightProperty] !== null;
                 if (rhsExists) {
-                    results[property] = rhs[property];
+                    results[rightProperty] = rhs[rightProperty];
                 }
             }
         }
@@ -2180,8 +2186,10 @@ CCR.toInt = function (value) {
  */
 CCR.error = function (title, message, success, failure, buttons) {
     buttons = buttons || Ext.MessageBox.OK;
+    // eslint-disable-next-line no-param-reassign
     success = success || function () {
     };
+    // eslint-disable-next-line no-param-reassign
     failure = failure || function () {
     };
 
@@ -2193,7 +2201,7 @@ CCR.error = function (title, message, success, failure, buttons) {
         fn: function (buttonId, text, options) {
             var compare = CCR.compare;
             if (compare.strings(buttonId, Ext.MessageBox.buttonText['no'])
-                || compare.strings(buttonId, Ext.MessageBox.buttonText['cancel'])) {
+                || compare.strings(buttonId, Ext.MessageBox.buttonText.cancel)) {
                 failure(buttonId, text, options);
             } else {
                 success(buttonId, text, options);
@@ -2267,6 +2275,7 @@ CCR.getInstance = function (instancePath, classPath, config) {
      * @return {*} the result of walking the provided 'path'.
      **/
     var getReference = function (path, callback) {
+        // eslint-disable-next-line no-param-reassign
         callback = callback !== undefined
             ? callback
             : function (previous, current) {
@@ -2282,18 +2291,18 @@ CCR.getInstance = function (instancePath, classPath, config) {
      * walking the 'classPath' is not a function then instead of invoking it
      * it is itself, returned.
      *
-     * @param {String} classPath          the '.' delimited string of the
+     * @param {String} innerClassPath          the '.' delimited string of the
      *                                    'class' that is to be instantiated.
-     * @param {Object} [config=undefined] an object that will be passed to the
+     * @param {Object} [innerConfig=undefined] an object that will be passed to the
      *                                    invocation of 'classPath' should it
      *                                    be found.
      *
      * @return {*} The return value of invoking 'classPath' or, failing that,
      *             the value of 'classPath'.
      **/
-    var instantiateClass = function (classPath, config) {
-        var Class = getReference(classPath);
-        return typeof Class === 'function' ? new Class(config) : Class;
+    var instantiateClass = function (innerClassPath, innerConfig) {
+        var Class = getReference(innerClassPath);
+        return typeof Class === 'function' ? new Class(innerConfig) : Class;
     };
 
     var result = getReference(instancePath);
@@ -2333,7 +2342,8 @@ CCR.intersect = function (left, right) {
 };
 
 CCR.randomInt = function (min, max) {
-    return Math.floor(Math.random() * (max - min + 1) + min)
+    // eslint-disable-next-line no-mixed-operators
+    return Math.floor(Math.random() * (max - min + 1) + min);
 };
 
 
@@ -2503,7 +2513,7 @@ Ext.override(Ext.menu.Item, {
         if (this.tooltip) {
             this.tooltip = new Ext.ToolTip(Ext.apply({
                 target: this.el
-            }, Ext.isObject(this.tooltip) ? this.toolTip : {html: this.tooltip}));
+            }, Ext.isObject(this.tooltip) ? this.toolTip : { html: this.tooltip }));
         }
         Ext.menu.Item.superclass.onRender.call(this, container, position);
     }

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1,9 +1,8 @@
+
 // Monkey patching in Date.now in case it's not here already
 // This is for IE8-. In IE9+ ( even IE9 w/ IE8 compatability mode on ) this works
 // just fine.
-Date.now = Date.now || function () {
-    return Number(new Date());
-};
+Date.now = Date.now || function() { return +new Date; };
 
 // JavaScript Document
 Ext.namespace('CCR', 'CCR.xdmod', 'CCR.xdmod.ui', 'CCR.xdmod.ui.dd', 'XDMoD', 'XDMoD.constants', 'XDMoD.Module', 'XDMoD.regex', 'XDMoD.validator', 'XDMoD.utils', 'CCR.xdmod.reporting');
@@ -177,15 +176,15 @@ XDMoD.GlobalToolbar.Roadmap = {
     text: 'Roadmap',
     iconCls: 'roadmap',
     id: 'global-toolbar-roadmap',
-    handler: function () {
+    handler: function() {
         Ext.History.add('#main_tab_panel:about_xdmod?Roadmap');
     }
 };
 
 XDMoD.GlobalToolbar.Contact = function () {
-    var contactHandler = function () {
+    var contactHandler = function(){
         XDMoD.TrackEvent('Portal', 'Contact Us -> ' + this.text + ' Button Clicked');
-        switch (this.text) {
+        switch(this.text){
             case 'Send Message':
                 new XDMoD.ContactDialog().show();
                 break;
@@ -194,8 +193,6 @@ XDMoD.GlobalToolbar.Contact = function () {
                 break;
             case 'Submit Support Request':
                 new XDMoD.SupportDialog().show();
-                break;
-            default:
                 break;
         }
     };
@@ -213,18 +210,18 @@ XDMoD.GlobalToolbar.Contact = function () {
                 id: 'global-toolbar-contact-us-send-message',
                 handler: contactHandler
             },
-                {
-                    text: 'Request Feature',
-                    iconCls: 'bulb_16',
-                    id: 'global-toolbar-contact-us-request-feature',
-                    handler: contactHandler
-                },
-                {
-                    text: 'Submit Support Request',
-                    iconCls: 'help_16',
-                    id: 'global-toolbar-contact-us-submit-support-request',
-                    handler: contactHandler
-                }]
+            {
+                text: 'Request Feature',
+                iconCls: 'bulb_16',
+                id: 'global-toolbar-contact-us-request-feature',
+                handler: contactHandler
+            },
+            {
+                text: 'Submit Support Request',
+                iconCls: 'help_16',
+                id: 'global-toolbar-contact-us-submit-support-request',
+                handler: contactHandler
+            }]
         }) //menu
     };
 }; //XDMoD.GlobalToolbar.Contact
@@ -739,8 +736,8 @@ CCR.xdmod.ui.login_prompt = null;
 CCR.xdmod.ui.createUserManualLink = function (tags) {
 
     return '<div style="background-image: url(\'gui/images/user_manual.png\'); background-repeat: no-repeat; height: 36px; padding-left: 40px; padding-top: 10px">' +
-        'For more information, please refer to the <a href="javascript:void(0)" onClick="CCR.xdmod.ui.userManualNav(\'' + tags + '\')">User Manual</a>' +
-        '</div>';
+            'For more information, please refer to the <a href="javascript:void(0)" onClick="CCR.xdmod.ui.userManualNav(\'' + tags + '\')">User Manual</a>' +
+            '</div>';
 
 }; //CCR.xdmod.ui.createUserManualLink
 
@@ -800,9 +797,8 @@ CCR.safelyDecodeJSONResponse = function (response) {
     var responseObject = null;
     try {
         responseObject = Ext.decode(response.responseText);
-    } catch (e) {
-        // NO-OP
     }
+    catch (e) {}
 
     return responseObject;
 };
@@ -818,9 +814,8 @@ CCR.checkDecodedJSONResponseSuccess = function (responseObject) {
     var responseSuccessful = false;
     try {
         responseSuccessful = responseObject.success === true;
-    } catch (e) {
-        // NO-OP
     }
+    catch (e) {}
 
     return responseSuccessful;
 };
@@ -858,7 +853,7 @@ CCR.submitHiddenFormImmediately = function (url, method, params) {
     temp.style.display = "none";
 
     for (var param in params) {
-        if (params.hasOwnProperty(param)) {
+        if(params.hasOwnProperty(param)){
             var opt = document.createElement("textarea");
             opt.name = param;
             opt.value = params[param];
@@ -1058,9 +1053,10 @@ CCR.BrowserWindow = Ext.extend(Ext.Window, {
                 text: 'Close',
                 iconCls: 'general_btn_close',
                 handler: function () {
-                    if (self.closeAction === 'close') {
+                    if (self.closeAction == 'close'){
                         self.close();
-                    } else {
+                    }
+                    else {
                         self.hide();
                     }
                 }
@@ -1283,24 +1279,24 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
                 id: 'btn_sign_in',
                 handler: signInWithLocalAccount
             },
+            {
+                xtype: 'container',
+                autoEl: 'div',
+                autoWidth: true,
+                flex: 2,
+                height: 38,
+                id: 'assistancePrompt',
+                items: [{
+                    xtype: 'tbtext',
+                    html: '<a href="javascript:CCR.xdmod.ui.forgot_password()">Forgot your password?</a>',
+                    id: 'forgot_password_link'
+                },
                 {
-                    xtype: 'container',
-                    autoEl: 'div',
-                    autoWidth: true,
-                    flex: 2,
-                    height: 38,
-                    id: 'assistancePrompt',
-                    items: [{
-                        xtype: 'tbtext',
-                        html: '<a href="javascript:CCR.xdmod.ui.forgot_password()">Forgot your password?</a>',
-                        id: 'forgot_password_link'
-                    },
-                        {
-                            xtype: 'tbtext',
-                            html: '<a href="javascript:presentSignUpViaLoginPrompt()">Don\'t have an account?</a>',
-                            id: 'sign_up_link'
-                        }]
+                    xtype: 'tbtext',
+                    html: '<a href="javascript:presentSignUpViaLoginPrompt()">Don\'t have an account?</a>',
+                    id: 'sign_up_link'
                 }]
+            }]
         }
     ];
 
@@ -1552,7 +1548,8 @@ CCR.xdmod.initDashboard = function () {
         callback: function (options, success, response) {
             if (success && CCR.checkJSONResponseSuccess(response)) {
                 dashboardWindow.location.href = 'internal_dashboard';
-            } else {
+            }
+            else {
                 dashboardWindow.close();
                 window.focus();
                 CCR.xdmod.ui.presentFailureResponse(response, {
@@ -1705,15 +1702,13 @@ CCR.xdmod.ui.extractErrorMessageFromResponse = function (response, options) {
         if (response.responseText) {
             responseObject = Ext.decode(response.responseText);
         }
-    } catch (e) {
-        // NO-OP
     }
+    catch (e) {}
 
     try {
         responseMessage = responseObject.message || responseObject.status || responseMessage;
-    } catch (e) {
-        // NO-OP
     }
+    catch (e) {}
 
     if (options.htmlEncode) {
         responseMessage = Ext.util.Format.htmlEncode(responseMessage);
@@ -1809,7 +1804,7 @@ CCR.xdmod.ui.gridComboRenderer = function (combo) {
 };
 
 CCR.isBlank = function (value) {
-    return !value || value === 'undefined' || !value.trim();
+    return !value || value === 'undefined' || !value.trim() ? true: false;
 };
 
 CCR.Types = {};
@@ -1826,7 +1821,7 @@ CCR.isType = function (value, type) {
         return Object.prototype.toString.call(value) === type;
     } else {
         return Object.prototype.toString.call(value) ===
-            Object.prototype.toString.call(type);
+                Object.prototype.toString.call(type);
     }
 };
 
@@ -1843,24 +1838,24 @@ CCR.exists = function (value) {
 CCR.merge = function (obj1, obj2) {
     var obj3 = {};
     for (var attrname1 in obj1) {
-        if (obj1.hasOwnProperty(attrname1)) {
+        if(obj1.hasOwnProperty(attrname1)){
             obj3[attrname1] = obj1[attrname1];
         }
     }
     for (var attrname in obj2) {
-        if (obj2.hasOwnProperty(attrname)) {
+        if(obj2.hasOwnProperty(attrname)){
             obj3[attrname] = obj2[attrname];
         }
     }
     return obj3;
 };
 CCR.getParameter = function (name, source) {
-    var newName = name.replace(/[[]/, '\\[').replace(/[\]]/, '\\]');
-    var regex = new RegExp('[\\?&]' + newName + '=([^&#]*)');
-    var results = regex.exec(source);
+    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+            results = regex.exec(source);
     return results === null
-        ? ''
-        : decodeURIComponent(results[1].replace(/\+/g, ' '));
+            ? ""
+            : decodeURIComponent(results[1].replace(/\+/g, " "));
 };
 /*
  * Process the location hash string. The string should have the form:
@@ -1874,8 +1869,8 @@ CCR.getParameter = function (name, source) {
  */
 CCR.tokenize = function (hash) {
     var raw = (typeof hash !== 'string')
-        ? String(hash)
-        : hash;
+      ? String(hash)
+      : hash;
 
     var matches = raw.match(/^#?(([^:\\?]*):?([^:\\?]*):?([^:\\?]*)\??(.*))/);
 
@@ -1912,7 +1907,7 @@ CCR.tokenize = function (hash) {
  * @param {Array} delims
  * @returns {Array}
  */
-CCR.toArray = function (value, delims) {
+CCR.toArray = function(value, delims) {
     if (!CCR.exists(value) || !CCR.isType(value, CCR.Types.String) || value.length < 1) {
         return [];
     }
@@ -1939,20 +1934,21 @@ CCR.toArray = function (value, delims) {
     return results;
 };
 
-CCR.objectToArray = function (object) {
+CCR.objectToArray = function(object) {
     if (!CCR.exists(object)) {
         return [];
     }
     var results;
     for (var property in object) {
-        if (object.hasOwnProperty(property)) {
+        if(object.hasOwnProperty(property)) {
             results = [property, object[property]];
         }
     }
     return results;
 };
 
-CCR.join = function (values, joiners) {
+CCR.join = function(values, joiners) {
+
     if (!CCR.exists(values) || !CCR.isType(values, CCR.Types.Array)) {
         return "";
     }
@@ -1966,11 +1962,10 @@ CCR.join = function (values, joiners) {
         return values.join('');
     }
 
-    var index = 0;
+    var joinerIndex = 0;
     var result;
 
-    // eslint-disable-next-line no-shadow
-    var joinValue = function (value, joiners, joinerIndex) {
+    var joinValue = function(value, joiners, joinerIndex) {
         var isArray = CCR.isType(value, CCR.Types.Array);
         var holdsArrays = isArray && value.length > 0 && CCR.isType(value[0], CCR.Types.Array);
         var result = [];
@@ -1986,7 +1981,7 @@ CCR.join = function (values, joiners) {
         return result.join(joiners[joinerIndex]);
     };
 
-    result = joinValue(values, joiners, index);
+    result = joinValue(values, joiners, joinerIndex);
 
     return result;
 };
@@ -2020,7 +2015,7 @@ CCR.pad = function (str, len, pad, dir) {
     return str;
 };
 
-CCR.deepEncode = function (values, options) {
+CCR.deepEncode = function(values, options) {
     if (!CCR.exists(values)) {
         return '';
     }
@@ -2047,7 +2042,7 @@ CCR.deepEncode = function (values, options) {
     }
 };
 
-CCR._encodeArray = function (values, options) {
+CCR._encodeArray = function(values, options) {
     if (!CCR.exists(values)) {
         return JSON.stringify([]);
     }
@@ -2072,8 +2067,8 @@ CCR._encodeArray = function (values, options) {
     return (left + results.join(delim) + right).trim();
 };
 
-CCR._encodeObject = function (value, options) {
-    if (!CCR.exists(value)) {
+CCR._encodeObject = function(value, options) {
+    if (!CCR.exists(value)){
         return JSON.stringify({});
     }
     options = options || {};
@@ -2084,18 +2079,18 @@ CCR._encodeObject = function (value, options) {
     var separator = options.seperator || '=';
     var results = [];
 
-    for (var property in value) {
-        if (value.hasOwnProperty(property)) {
+    for (var property in value ) {
+        if(value.hasOwnProperty(property)){
             var propertyValue = value[property];
             if (CCR.isType(propertyValue, CCR.Types.Array)) {
                 results.push(property + '=' + encodeURIComponent(CCR._encodeArray(propertyValue, {
-                    wrap: true,
-                    seperator: ':'
-                })));
+                            wrap: true,
+                            seperator: ':'
+                        })));
             } else if (CCR.isType(propertyValue, CCR.Types.Object)) {
                 results.push(property + '=' + encodeURIComponent(CCR._encodeObject(propertyValue, {
-                    wrap: true
-                })));
+                            wrap: true
+                        })));
             } else {
                 var key = wrap ? '"' + property + '"' : property;
                 results.push(key + separator + propertyValue);
@@ -2118,8 +2113,8 @@ CCR.encode = function (values) {
                 var isArray = CCR.isType(values[property], CCR.Types.Array);
                 var isObject = CCR.isType(values[property], CCR.Types.Object);
                 var value = isArray || isObject
-                    ? encodeURIComponent(CCR.deepEncode(values[property]))
-                    : values[property];
+                        ? encodeURIComponent(CCR.deepEncode(values[property]))
+                        : values[property];
                 parameters.push(property + '=' + value);
             }
         }
@@ -2141,17 +2136,17 @@ CCR.encode = function (values) {
 CCR.apply = function (lhs, rhs) {
     if (typeof lhs === 'object' && typeof rhs === 'object') {
         var results = {};
-        for (var leftProperty in lhs) {
-            if (lhs.hasOwnProperty(leftProperty)) {
-                results[leftProperty] = lhs[leftProperty];
+        for (var property in lhs) {
+            if (lhs.hasOwnProperty(property)) {
+                results[property] = lhs[property];
             }
         }
-        for (var rightProperty in rhs) {
-            if (rhs.hasOwnProperty(rightProperty)) {
-                var rhsExists = rhs[rightProperty] !== undefined
-                    && rhs[rightProperty] !== null;
+        for (property in rhs) {
+            if (rhs.hasOwnProperty(property)) {
+                var rhsExists = rhs[property] !== undefined
+                        && rhs[property] !== null;
                 if (rhsExists) {
-                    results[rightProperty] = rhs[rightProperty];
+                    results[property] = rhs[property];
                 }
             }
         }
@@ -2175,7 +2170,7 @@ CCR.toInt = function (value) {
 
 /**
  * Displays a MessageBox to the user with the error styling.
- *
+  *
  * @param {String}   title   of the Error Dialog Box.
  * @param {String}   message that will be displayed to the user.
  * @param {Function} success function that will be executed if the user does not
@@ -2186,22 +2181,18 @@ CCR.toInt = function (value) {
  */
 CCR.error = function (title, message, success, failure, buttons) {
     buttons = buttons || Ext.MessageBox.OK;
-    // eslint-disable-next-line no-param-reassign
-    success = success || function () {
-    };
-    // eslint-disable-next-line no-param-reassign
-    failure = failure || function () {
-    };
+    success = success || function(){};
+    failure = failure || function(){};
 
     Ext.MessageBox.show({
         title: title,
         msg: message,
         buttons: buttons,
         icon: Ext.MessageBox.ERROR,
-        fn: function (buttonId, text, options) {
+        fn: function(buttonId, text, options) {
             var compare = CCR.compare;
             if (compare.strings(buttonId, Ext.MessageBox.buttonText['no'])
-                || compare.strings(buttonId, Ext.MessageBox.buttonText.cancel)) {
+                    || compare.strings(buttonId, Ext.MessageBox.buttonText['cancel'])) {
                 failure(buttonId, text, options);
             } else {
                 success(buttonId, text, options);
@@ -2218,7 +2209,7 @@ CCR.compare = {
             None: 'toString'
         }
     },
-    strings: function (left, right, method) {
+    strings: function(left, right, method) {
         if (!CCR.exists(left) || !CCR.exists(right)) {
             return false;
         }
@@ -2253,11 +2244,11 @@ CCR.compare = {
  *             or an instance of 'classPath' instantiated with 'config'
  *             as a constructor argument.
  **/
-CCR.getInstance = function (instancePath, classPath, config) {
-    if (!instancePath || typeof instancePath !== 'string') {
+CCR.getInstance = function(instancePath, classPath, config) {
+    if ( !instancePath || typeof instancePath !== 'string' ) {
         return;
     }
-    if (!classPath || typeof classPath !== 'string') {
+    if ( !classPath || typeof classPath !== 'string' ) {
         return;
     }
 
@@ -2274,15 +2265,14 @@ CCR.getInstance = function (instancePath, classPath, config) {
      *
      * @return {*} the result of walking the provided 'path'.
      **/
-    var getReference = function (path, callback) {
-        // eslint-disable-next-line no-param-reassign
-        callback = callback !== undefined
-            ? callback
-            : function (previous, current) {
-                return previous[current];
-            };
+    var getReference = function(path, callback) {
+            callback = callback !== undefined
+                ? callback
+                : function(previous, current) {
+                    return previous[current];
+                };
 
-        return path.split('.').reduce(callback, window);
+        return path.split('.').reduce( callback, window );
     };
 
     /**
@@ -2291,26 +2281,26 @@ CCR.getInstance = function (instancePath, classPath, config) {
      * walking the 'classPath' is not a function then instead of invoking it
      * it is itself, returned.
      *
-     * @param {String} innerClassPath          the '.' delimited string of the
+     * @param {String} classPath          the '.' delimited string of the
      *                                    'class' that is to be instantiated.
-     * @param {Object} [innerConfig=undefined] an object that will be passed to the
+     * @param {Object} [config=undefined] an object that will be passed to the
      *                                    invocation of 'classPath' should it
      *                                    be found.
      *
      * @return {*} The return value of invoking 'classPath' or, failing that,
      *             the value of 'classPath'.
      **/
-    var instantiateClass = function (innerClassPath, innerConfig) {
-        var Class = getReference(innerClassPath);
-        return typeof Class === 'function' ? new Class(innerConfig) : Class;
+    var instantiateClass = function(classPath, config) {
+        var Class = getReference(classPath);
+        return typeof Class === 'function' ? new Class(config) : Class;
     };
 
     var result = getReference(instancePath);
     if (!result) {
         result = getReference(
             instancePath,
-            function (previous, current) {
-                if (previous[current] === undefined) {
+            function(previous, current) {
+                if ( previous[current] === undefined ) {
                     return previous[current] = instantiateClass(classPath, config);
                 } else {
                     return previous[current];
@@ -2341,11 +2331,6 @@ CCR.intersect = function (left, right) {
     return found;
 };
 
-CCR.randomInt = function (min, max) {
-    // eslint-disable-next-line no-mixed-operators
-    return Math.floor(Math.random() * (max - min + 1) + min);
-};
-
 
 // override 3.4.0 to be able to restore column state
 Ext.override(Ext.grid.ColumnModel, {
@@ -2369,7 +2354,8 @@ Ext.override(Ext.form.TriggerField, {
         }
         if (this.rendered && !this.readOnly && this.editable && !this.el.getWidth()) {
             this.wrap.setWidth(w);
-        } else {
+        }
+        else {
             this.wrap.setWidth(this.el.getWidth() + tw);
         }
     }
@@ -2444,18 +2430,18 @@ Ext.override(Ext.ToolTip, {
 // override 3.4.0 to ensure that the grid stops editing if the view is refreshed
 // actual bug: removing grid lines with active lookup editor didn't hide editor
 Ext.grid.GridView.prototype.processRows =
-    Ext.grid.GridView.prototype.processRows.createInterceptor(function () {
-        if (this.grid) {
-            this.grid.stopEditing(true);
-        }
-    });
+        Ext.grid.GridView.prototype.processRows.createInterceptor(function () {
+            if (this.grid) {
+                this.grid.stopEditing(true);
+            }
+        });
 
 // override 3.4.0 to fix issue with chart labels losing their labelRenderer after hide/show
 Ext.override(Ext.chart.CartesianChart, {
     createAxis: function (axis, value) {
         var o = Ext.apply({}, value),
-            ref,
-            old;
+                ref,
+                old;
 
         if (this[axis]) {
             old = this[axis].labelFunction;
@@ -2493,7 +2479,7 @@ Ext.override(Ext.grid.RowSelectionModel, {
 
 // override to allow menu items to have a tooltip property
 Ext.override(Ext.menu.Item, {
-    onRender: function (container, position) {
+    onRender : function(container, position){
         if (!this.itemTpl) {
             this.itemTpl = Ext.menu.Item.prototype.itemTpl = new Ext.XTemplate(
                 '<a id="{id}" class="{cls} x-unselectable" hidefocus="true" unselectable="on" href="{href}"',
@@ -2504,7 +2490,7 @@ Ext.override(Ext.menu.Item, {
                 '<img src="{icon}" class="x-menu-item-icon {iconCls}"/>',
                 '<span class="x-menu-item-text">{text}</span>',
                 '</a>'
-            );
+                );
         }
         var a = this.getTemplateArgs();
         this.el = position ? this.itemTpl.insertBefore(position, a, true) : this.itemTpl.append(container, a, true);


### PR DESCRIPTION
## Description
Comparing floats as strings is not desirable due to the way they are represented
internally. Per [https://www.php.net/manual/en/language.types.float.php](https://www.php.net/manual/en/language.types.float.php) they
should be compared to within a certain number of digits. This was found by
investigating an error where the "Show Raw Data" context menu item was not
showing the associated jobs. It turns out that the id's being compared were the
following:
- 0.22694672549385309
- 0.22694672549385

The latter number having been truncated after 14 digits, which was a problem
as they were being compared as strings, not floats. By comparing them as floats
we can mitigate this type of rounding / truncating error in the future.

## Motivation and Context
This was found as part of manual on testing XDMoD & SUPREMM on CentOS8. 

## Tests performed
Manual Testing on the metrics-dev-centos8 exploratory machine. 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
