### PR TITLE
Fix broken link to Storage documentation

### DIFF
--- a/docs/shredder.md
+++ b/docs/shredder.md
@@ -84,7 +84,7 @@ The convention for shredding cloud files is identical to job data:
 **Storage:**
 
 The shredder accepts one format for storage data.  See the [Storage
-Metrics](storage.md) documentation for an example.  The convention for
+Metrics](storage.html) documentation for an example.  The convention for
 shredding storage files is identical to job data:
 
     $ xdmod-shredder -f storage ...


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
Fixes a broken link which is currently to the source .md file instead of the built .html file.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently following the link in "See the [Storage Metrics](https://open.xdmod.org/10.0/storage.md) documentation for an example." leads to a 404.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
N/A

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
