### PR TITLE
Update Gemfile Ruby Code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,8 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-gem 'github-pages', versions['github-pages']
+gem 'github-pages', 226
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do


### PR DESCRIPTION
## Description
*Replaced:*
`require 'json'`
`require 'open-uri'`
`versions = JSON.parse(open('https://pages.github.com/versions.json').read)`
`gem 'github-pages', versions['github-pages']`

*with:*
`gem 'github-pages', 226`

## Motivation and Context
1. `open-uri` depricated
2.  using 226 is more direct instead of parsing JSON data when accessing 'github-pages` gem
3. fixes `Net::OpenTimeout` error when trying to generate webpage with jekyll

## Tests performed
1. No longer had timeout error
2. Manually checked JSON data to ensure correct key-value pair of 'github-pages': '226'
3. Change was discussed between me and Joseph

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
