### PR TITLE
Update Gemfile - '226'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ ruby RUBY_VERSION
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 
-gem 'github-pages', 226
+gem 'github-pages', '226'
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do


### PR DESCRIPTION
Changed the 226 on line 13 to the string '226'

<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The change I had previously made to this file neglected the fact that the key-value pairs at https://pages.github.com/versions.json are strings. This change fixes that. Otherwise, the gem would not have been accessible.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I rebuilt the Open XDMoD website in my own test environment, which only generated after changing 226 into the string '226' in Gemfile.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
