### PR TITLE
Add missing variable substitutions

### DIFF
--- a/classes/DataWarehouse/Data/RawStatisticsConfiguration.php
+++ b/classes/DataWarehouse/Data/RawStatisticsConfiguration.php
@@ -176,8 +176,10 @@ class RawStatisticsConfiguration
         $vs = $this->variableStore;
         return array_map(
             function ($field) use ($vs) {
-                foreach (['name', 'documentation'] as $key) {
-                    $field[$key] = $vs->substitute($field[$key]);
+                foreach (['name', 'documentation', 'alias'] as $key) {
+                    if (array_key_exists($key, $field)) {
+                        $field[$key] = $vs->substitute($field[$key]);
+                    }
                 }
                 return $field;
             },

--- a/classes/ETL/aAction.php
+++ b/classes/ETL/aAction.php
@@ -353,7 +353,7 @@ abstract class aAction extends aEtlObject
     }  // setOverseerRestrictionOverrides()
 
     /** -----------------------------------------------------------------------------------------
-     * Initialize the variable map based on ETL settings in the overseer options.
+     * Initialize the variable map based on ETL settings in the overseer options and constants.
      *
      * @return This object to support method chaining.
      * ------------------------------------------------------------------------------------------
@@ -361,6 +361,9 @@ abstract class aAction extends aEtlObject
 
     private function initializeVariableStore()
     {
+        // Constants used in substitutions.
+        $this->variableStore->HIERARCHY_BOTTOM_LEVEL_INFO = HIERARCHY_BOTTOM_LEVEL_INFO;
+
         if ( null === $this->etlOverseerOptions ) {
             return;
         }


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

Adds variable substitution for hierarchy info used in ETL table definitions (see ubccr/xdmod-supremm#255) and `alias` configuration used in the raw statistics configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes table comment fields and aliases used in generated queries.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually using `mysqldump` to check tables and checking the query log for aliases used in generated SQL queries.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
