### PR TITLE
Additional php7 updates

### DIFF
--- a/classes/ETL/Ingestor/ExplodeTransformIngestor.php
+++ b/classes/ETL/Ingestor/ExplodeTransformIngestor.php
@@ -47,7 +47,7 @@ class ExplodeTransformIngestor extends pdoIngestor implements iAction
     /**
      * @see ETL\Ingestor\pdoIngestor::transform()
      */
-    protected function transform(array $srcRecord, $orderId)
+    protected function transform(array $srcRecord, &$orderId)
     {
         $transformedRecord = array();
         $items = explode(',', $srcRecord[$this->srcKey]);

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -1584,7 +1584,7 @@ class WarehouseControllerProvider extends BaseControllerProvider
         }
 
         return $app->json(
-            $this->arraytostore($execInfo),
+            $this->arraytostore(json_decode(json_encode($execInfo), true)),
             200
         );
     }


### PR DESCRIPTION

## Description
- ExplodeTransformIngestor: this function was causing a warning to be thrown during ingestion / aggregation w/ PHP7.2 on Rocky8 
- WarehouseControllerProvider: This update was found when testing the single job viewer and clicking on the executable information tab. This was missed when updating the PHP Mongo code to work w/ PHP7.2 & it's new mongodb library. Similar changes were made in `classes/DataWarehouse/Query/SUPREMM/JobMetadata.php::getJobSummary` line 129



## Motivation and Context
These changes fix issues found during testing for the hpc-toolset-tutorial.  

## Tests performed
Automated testing 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
