### PR TITLE
fix: Use correct scope when calling method

### DIFF
--- a/classes/DataWarehouse.php
+++ b/classes/DataWarehouse.php
@@ -57,7 +57,7 @@ class DataWarehouse
 	 */
     public function __destruct()
     {
-        destroy();
+        $this->destroy();
     }
 
     /**


### PR DESCRIPTION
Use correct scope when calling destroy() method

## Description
Change the scope from a global function to local class method.

## Motivation and Context
`__destruct`  method referenced a seemingly nonexistent global `destroy()` function. It should have been calling its own class' `destroy()` method.
