### PR TITLE
Bypass Login Modal for SSO

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1166,6 +1166,31 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
     //reset referer
     XDMoD.referer = document.location.hash;
 
+    // If we're using SSO and not using the login modal then start the auth process.
+    if (CCR.xdmod.SSODirectLink) {
+        Ext.Ajax.request({
+            url: '/rest/auth/idpredirect',
+            method: 'GET',
+            params: {
+                returnTo: '/gui/general/login.php' + document.location.hash
+            },
+            success: function (response) {
+                document.location = Ext.decode(response.responseText);
+            },
+            failure: function (response, opts) {
+                let message = 'Please contact the XDMoD administrator.';
+                if (response.responseText) {
+                    let decoded = Ext.decode(response.responseText);
+                    if (decoded.message) {
+                        message = decoded.message + '<br />' + message;
+                    }
+                }
+                Ext.Msg.alert('Error ' + response.status + ' ' + response.statusText, message);
+            }
+        });
+        return;
+    }
+
     var txtLoginUsername = new Ext.form.TextField({
         width: 184,
         height: 22,

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -1178,9 +1178,9 @@ CCR.xdmod.ui.actionLogin = function (config, animateTarget) {
                 document.location = Ext.decode(response.responseText);
             },
             failure: function (response, opts) {
-                let message = 'Please contact the XDMoD administrator.';
+                var message = 'Please contact the XDMoD administrator.';
                 if (response.responseText) {
-                    let decoded = Ext.decode(response.responseText);
+                    var decoded = Ext.decode(response.responseText);
                     if (decoded.message) {
                         message = decoded.message + '<br />' + message;
                     }

--- a/html/index.php
+++ b/html/index.php
@@ -329,6 +329,7 @@ JS;
             }
             if ($auth && $auth->isSamlConfigured()) {
                 $ssoShowLocalLogin = false;
+
                 try {
                     $ssoShowLocalLogin = filter_var(
                         xd_utilities\getConfiguration('sso', 'show_local_login'),
@@ -337,9 +338,19 @@ JS;
                 } catch (exception $ex) {
                 }
 
+                $ssoDirectLink = false;
+                try {
+                    $ssoDirectLink = filter_var(
+                        xd_utilities\getConfiguration('sso', 'direct_link'),
+                        FILTER_VALIDATE_BOOLEAN
+                    );
+                } catch (exception $ex) {
+                }
+
                 print "CCR.xdmod.isSSOConfigured = true;\n";
                 print "CCR.xdmod.SSOLoginLink = " . json_encode($auth->getLoginLink()) . ";\n";
-                print "CCR.xdmod.SSOShowLocalLogin = " . json_encode($ssoShowLocalLogin) . "\n";
+                print "CCR.xdmod.SSOShowLocalLogin = " . json_encode($ssoShowLocalLogin) . ";\n";
+                print "CCR.xdmod.SSODirectLink = " . json_encode($ssoDirectLink) . ";\n";
             } else {
                 print "CCR.xdmod.isSSOConfigured = false;\n";
             }


### PR DESCRIPTION
## Description
- Added an optional section/property in `portal_settings.ini` ( section `sso` and property `direct_link` ) that when set to a string that PHP evaluates to boolean true, allows for the bypassing of the normal login modal window and immediately begins the SSO login process. 
- index.php: Added a small section that reads the new `sso:direct_link` property from portal_settings and includes that as a javascript variable: `CCR.xdmod.SSODirectLink`. 
- CCR.js: Added a small section that immediately starts the SSO Login process if `CCR.xdmod.SSODirectLink` is present and true. 

## Motivation and Context
These changes make it possible to configure XDMoD to, when setup to use SSO,
bypass the normal login modal and for the auth process to begin
immediately upon clicking the `Sign In` link.

This feature came out of a desire to have external users of xdmod-dev ( and ultimately xdmod-prod ) only be able to authenticate via ACCESS SSO. 

## Tests performed
Manual testing performed

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
