### PR TITLE
Remove XSEDE-specific code from base module.

### DIFF
--- a/html/gui/js/SignUpDialog.js
+++ b/html/gui/js/SignUpDialog.js
@@ -256,18 +256,6 @@ XDMoD.SignUpDialog = Ext.extend(Ext.Window, {
             signUpItems.push(captchaField);
         }
 
-        // Don't display XSEDE text in Open XDMoD.
-        if (CCR.xdmod.features.xsede) {
-            signUpItems.unshift(
-                new Ext.Panel({
-                    frame: true,
-                    title: 'Account Requirements',
-                    width: 550,
-                    html: '<p>Users affiliated with XSEDE do not need to request an XDMoD account; they should use their Globus credentials with a linked XSEDE account*. <br><br>Local accounts are created for users affiliated with XSEDE who do not have an XSEDE User Portal account <b>only with the express permission of XSEDE or NSF management</b>.</p><br><p>* Requires an active XSEDE User Portal account. See <a href="https://portal.xsede.org/software/globus" target="_blank" rel="noopener noreferrer">Add XSEDE to your Globus Profile</a> for more information.</p>'
-                })
-            );
-        }
-
         var signUpSection = new Ext.form.FormPanel({
             width: 310,
             autoHeight: true,

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -978,9 +978,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                         if (success) {
                             // If available, open the default statistic.
                             //
-                            // Open XDMoD Default: CPU Hours: Total
-                            // XDMoD Default: XD SUs Charged: Total
-                            var defaultStatistic = CCR.xdmod.features.xsede ? 'total_su' : 'total_cpu_hours';
+                            var defaultStatistic = 'total_cpu_hours';
                             var jobCountNode = child.findChild("statistic", defaultStatistic);
                             if (jobCountNode && !jobCountNode.disabled) {
                                 tree.getSelectionModel().select(jobCountNode);


### PR DESCRIPTION
These XSEDE-specific code paths are no longer needed.
