### PR TITLE
Update Contact Us button for ACCESS XDMoD

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -182,6 +182,19 @@ XDMoD.GlobalToolbar.Roadmap = {
 };
 
 XDMoD.GlobalToolbar.Contact = function () {
+    if (CCR.xdmod.support_url) {
+        return {
+            text: 'Contact Us',
+            tooltip: 'Contact Us',
+            scale: 'small',
+            iconCls: 'contact_16',
+            id: 'global-toolbar-contact-us',
+            handler: function() {
+                window.location.href = CCR.xdmod.support_url
+            };
+        };
+    }
+    
     var contactHandler = function(){
         XDMoD.TrackEvent('Portal', 'Contact Us -> ' + this.text + ' Button Clicked');
         switch(this.text){

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -191,7 +191,7 @@ XDMoD.GlobalToolbar.Contact = function () {
             id: 'global-toolbar-contact-us',
             handler: function() {
                 window.location.href = CCR.xdmod.support_url
-            };
+            }
         };
     }
     

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -190,7 +190,7 @@ XDMoD.GlobalToolbar.Contact = function () {
             iconCls: 'contact_16',
             id: 'global-toolbar-contact-us',
             handler: function () {
-                window.location.href = CCR.xdmod.support_url;
+                window.open(CCR.xdmod.support_url, "_blank");
             }
         };
     }

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -190,7 +190,7 @@ XDMoD.GlobalToolbar.Contact = function () {
             iconCls: 'contact_16',
             id: 'global-toolbar-contact-us',
             handler: function () {
-                window.open(CCR.xdmod.support_url, "_blank");
+                window.open(CCR.xdmod.support_url, '_blank');
             }
         };
     }

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -189,12 +189,12 @@ XDMoD.GlobalToolbar.Contact = function () {
             scale: 'small',
             iconCls: 'contact_16',
             id: 'global-toolbar-contact-us',
-            handler: function() {
-                window.location.href = CCR.xdmod.support_url
+            handler: function () {
+                window.location.href = CCR.xdmod.support_url;
             }
         };
     }
-    
+
     var contactHandler = function(){
         XDMoD.TrackEvent('Portal', 'Contact Us -> ' + this.text + ' Button Clicked');
         switch(this.text){

--- a/html/index.php
+++ b/html/index.php
@@ -268,7 +268,7 @@ JS;
             $tech_support_url = xd_utilities\getConfiguration('general', 'tech_support_url');
         } catch (exception $ex) {
         }
-        print "CCR.xdmod.support_url = CCR.xdmod.support_url = '$tech_support_url';\n";
+        print 'CCR.xdmod.support_url = ' . json_encode($tech_support_url) . ";\n";
 
         print "CCR.xdmod.version = '" . xd_versioning\getPortalVersion() . "';\n";
         print "CCR.xdmod.short_version = '" . xd_versioning\getPortalVersion(true) . "';\n";

--- a/html/index.php
+++ b/html/index.php
@@ -268,7 +268,7 @@ JS;
             $tech_support_url = xd_utilities\getConfiguration('general', 'tech_support_url');
         } catch (exception $ex) {
         }
-        print "CCR.xdmod.support_url = CCR.xdmod.support_url = '$tech_support_url';\n"
+        print "CCR.xdmod.support_url = CCR.xdmod.support_url = '$tech_support_url';\n";
 
         print "CCR.xdmod.version = '" . xd_versioning\getPortalVersion() . "';\n";
         print "CCR.xdmod.short_version = '" . xd_versioning\getPortalVersion(true) . "';\n";

--- a/html/index.php
+++ b/html/index.php
@@ -263,6 +263,13 @@ JS;
         $tech_support_recipient = xd_utilities\getConfiguration('general', 'tech_support_recipient');
         print "CCR.xdmod.tech_support_recipient = CCR.xdmod.support_email = '$tech_support_recipient';\n";
 
+        $tech_support_url = false;
+        try {
+            $tech_support_url = xd_utilities\getConfiguration('general', 'tech_support_url');
+        } catch (exception $ex) {
+        }
+        print "CCR.xdmod.support_url = CCR.xdmod.support_url = '$tech_support_url';\n"
+
         print "CCR.xdmod.version = '" . xd_versioning\getPortalVersion() . "';\n";
         print "CCR.xdmod.short_version = '" . xd_versioning\getPortalVersion(true) . "';\n";
 


### PR DESCRIPTION
This PR updates the Contact Us button to instead redirect to a configured URL for ACCESS tickets. This only works if the configured URL is present, else it will default to Open XDMoD's functionality.

<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
1.) Checks if 'tech_support_url' is set in configuration.
2.) If 'tech_support_url' is present, then the Contact Us button redirects to that site instead of the dropdown menu.
<!--- Include screenshots for GUI changes if appropriate -->
Without tech_support_url set:
![image](https://user-images.githubusercontent.com/51850219/186502018-d8120f50-fa3d-49e6-84f5-8426f43d202a.png)

With tech_support_url set:
![image](https://user-images.githubusercontent.com/51850219/186502344-179bf3d3-b75c-4d79-93c2-32853f8c17a8.png)
In the screenshot the Contact Us button will redirect to the configured URL.
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ACCESS XDMoD does not need the same dropdown menu for this button as Open XDMoD.
<!--- If it fixes an open issue, please link to the issue here. -->
https://app.asana.com/0/1202679277743034/1202840692396198

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested on my development port.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
