### PR TITLE
Update table definition for ReportTemplateCharts

### DIFF
--- a/configuration/etl/etl.d/xdmod-migration-10_0_0-10_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-10_0_0-10_5_0.json
@@ -22,6 +22,22 @@
                     "schema": "mod_shredder"
                 }
             }
+        },
+        {
+            "name": "update-report-template-tables",
+            "description": "Update report template tables",
+            "class": "ManageTables",
+            "definition_file_list": [
+                "xdb/report-template-charts.json"
+            ],
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "Database",
+                    "config": "database",
+                    "schema": "moddb"
+                }
+            }
         }
     ]
 }

--- a/configuration/etl/etl_tables.d/xdb/report-template-charts.json
+++ b/configuration/etl/etl_tables.d/xdb/report-template-charts.json
@@ -2,11 +2,13 @@
     "table_definition": {
         "name": "ReportTemplateCharts",
         "engine": "InnoDB",
+        "charset": "utf8mb4",
+        "collation": "utf8mb4_general_ci",
         "columns": [
             {
                 "name": "template_id",
                 "type": "int(11)",
-                "nullable": true
+                "nullable": false
             },
             {
                 "name": "chart_id",
@@ -16,7 +18,7 @@
             {
                 "name": "ordering",
                 "type": "int(11)",
-                "nullable": true
+                "nullable": false
             },
             {
                 "name": "chart_date_description",
@@ -39,7 +41,17 @@
                 "nullable": true
             }
         ],
-        "indexes": [],
+        "indexes": [
+            {
+                "name": "Unique",
+                "columns": [
+                    "template_id",
+                    "ordering"
+                ],
+                "type": "BTREE",
+                "is_unique": true
+            }
+        ],
         "triggers": []
     }
 }


### PR DESCRIPTION
There is no unique index on the report template charts which means that the normal etlv2 ingestion code cannot be used to sync the template definitions with the database. You would have to write custom SQL to update an existing row. Also if you run the existing ingestor more than once you'll get more than one copy of each chart in every report!

Also change the database charset and collation to be utf8mb4 so that non-latin characters can appear in the templates.


These changes are needed so that we can easily have xdmod modules install templates.