### PR TITLE
Add ability to for modules to specifiy report templates.

### DIFF
--- a/classes/ETL/Utilities.php
+++ b/classes/ETL/Utilities.php
@@ -229,7 +229,7 @@ class Utilities
         return $localVariableMap;
     }  // quoteVariables()
 
-    public static function runEtlPipeline(array $pipelines, $logger, array $params = array())
+    public static function runEtlPipeline(array $pipelines, $logger, array $params = array(), $module = 'xdmod')
     {
         $logger->debug(
             sprintf(
@@ -239,7 +239,7 @@ class Utilities
             )
         );
 
-        $configOptions = array('default_module_name' => 'xdmod');
+        $configOptions = array('default_module_name' => $module);
         if( array_key_exists('variable-overrides', $params) ){
             $configOptions['config_variables'] = $params['variable-overrides'];
         }
@@ -257,7 +257,7 @@ class Utilities
 
         $scriptOptions = array_merge(
             array(
-                'default-module-name' => 'xdmod',
+                'default-module-name' => $module,
                 'process-sections' => $pipelines,
             ),
             $params

--- a/configuration/etl/etl.d/acls-xdmod-management.json
+++ b/configuration/etl/etl.d/acls-xdmod-management.json
@@ -58,6 +58,26 @@
       "truncate_destination": true
     },
     {
+      "name": "report-template-acls-staging-submodules",
+      "namespace": "ETL\\Ingestor",
+      "class": "StructuredFileIngestor",
+      "options_class": "IngestorOptions",
+      "description": "Ingest the report template ACL settings for optional XDMoD modules",
+      "definition_file": "acls/report-template-acls-staging.json",
+      "endpoints": {
+        "source": {
+          "type": "directoryscanner",
+          "name": "report-template-acls-staging-submodules",
+          "path": "acls/report-template-acls-staging.d",
+          "file_pattern": "/\\.json$/",
+          "handler": {
+            "type": "jsonfile"
+          }
+        }
+      },
+      "truncate_destination": false
+    },
+    {
       "#": "AclStagingTableManagement should always be run after any changes have been made to the files ( tables ) found below.",
       "name": "AclStagingTableManagement",
       "class": "ManageTables",

--- a/html/controllers/report_builder/enum_templates.php
+++ b/html/controllers/report_builder/enum_templates.php
@@ -3,12 +3,14 @@
 try {
     $user = \xd_security\getLoggedInUser();
 
-    $templates = XDReportManager::enumerateReportTemplates($user->getRoles());
+    $orig_templates = XDReportManager::enumerateReportTemplates($user->getRoles());
 
-    // We do not want to show the "Dashboard Tab Reports"
-    foreach($templates as $key => $value){
-        if ($value['name'] === 'Dashboard Tab Report') {
-            unset($templates[$key]);
+    // We do not want to show the "Dashboard Tab Reports" - copy to a new array to ensure
+    // continuous indexes so it will be serialized to a json array not a json object.
+    $templates = [];
+    foreach($orig_templates as $key => $value){
+        if ($value['name'] !== 'Dashboard Tab Report') {
+            $templates[] = $value;
         }
     }
 


### PR DESCRIPTION
The report template acls were controlled by the contents of one file
 (`etc/etl/etl_data.d/acls/report-template-acls-staging.json`) and the
acl data base was loaded with the file contents each time acl-config was run. Since Open XDMoD modules cannot modify existing files, there was no mechanism for a module to add a new report template acl.

This adds a subdirectory (`report-template-acls-staging.d`) that is scanned for files that will be appended to the report acl templates table. Open XDMoD modules can just add their settings to a file in this directory and it will be loaded when acl-config runs.

It also fixes a problem with the enum_templates controlller endpoint where it would return a json object rather than a json array if the DashBoard report templates were not at the end of the list of templates. This situation will occur if a module is adding report templates since they get added at the end of the list (after the Dashboard reports).
