### PR TITLE
Updates to Allocations tab SQL for ACDB

### DIFF
--- a/classes/DataWarehouse.php
+++ b/classes/DataWarehouse.php
@@ -118,43 +118,41 @@ class DataWarehouse
         $pi = "";
 
         if (isset($config['is_pi_of_allocation'])) {
-             $pi = "and als.principalinvestigator_person_id ".($config['is_pi_of_allocation'] ? "" : "!")."= $person_id";
+            $pi = $config['is_pi_of_allocation'] ? "OR als.principalinvestigator_person_id = $person_id" : '';
         }
 
-
         $query = "SELECT DISTINCT
-				als.allocation_id,
-				als.principalinvestigator_person_id,
-				als.person_id,
-				als.charge_number,
-				als.project_title,
-				t.name as request_type,
-				als.resource_name,
-				als.base_allocation as base,
-				FORMAT(als.base_allocation,2) as base_formatted,
-				als.remaining_allocation as remaining,
-				FORMAT(als.remaining_allocation,2) as remaining_formatted,
-				als.pi_last_name,
-				als.pi_first_name,
-				als.project_title,
-				als.status,
-				als.initial_start_date as start,
-				als.end_date as end
-			FROM modw_aggregates.allocation_summary als, resourcefact re, person pti, allocation a, transactiontype t, request req
-			WHERE als.person_id = $person_id
-				AND als.resource_id = re.id
-				AND als.allocation_id = a.id
-				AND a.request_id = req.id
-				AND t.id = req.request_type_id
-				$pi
-				AND pti.id = als.person_id
-				".($allocation_id > -1 ? " " :" AND als.status = '".($showActive?'active':'expired')."' ")."
-				AND als.allocation_id ".($allocation_id > 0?" = ".$allocation_id:" > -1 ")."
-			GROUP BY
-				als.allocation_id
-			ORDER BY
-				end
-			DESC";
+                                als.allocation_id,
+                                als.principalinvestigator_person_id,
+                                als.person_id,
+                                als.charge_number,
+                                als.project_title,
+                                t.name as request_type,
+                                als.resource_name,
+                                als.base_allocation as base,
+                                FORMAT(als.base_allocation,2) as base_formatted,
+                                als.remaining_allocation as remaining,
+                                FORMAT(als.remaining_allocation,2) as remaining_formatted,
+                                als.pi_last_name,
+                                als.pi_first_name,
+                                als.project_title,
+                                als.status,
+                                als.initial_start_date as start,
+                                als.end_date as end
+                        FROM modw_aggregates.allocation_summary als, resourcefact re, person pti, allocation a, transactiontype t
+                        WHERE als.resource_id = re.id
+                                AND als.allocation_id = a.id
+                                AND (
+                                als.person_id = $person_id  $pi
+                                )
+                                AND pti.id = als.person_id
+                                ".($allocation_id > -1 ? " " :" AND als.status = '".($showActive?'active':'expired')."' ")."
+                                AND als.allocation_id ".($allocation_id > 0?" = ".$allocation_id:" > -1 ")."
+                        GROUP BY
+                                als.allocation_id
+                        ORDER BY
+                                end
+                        DESC";
 
         self::connect();
         $results = self::$db->query($query);


### PR DESCRIPTION
## Description
To accommodate the way that the ACDB models Allocations ( now called Request [for] Resources ) it is necessary to slightly reconfigure the way that the UI controls -> request parameters -> SQL WHERE clauses function. Previously the default where clauses were: 
```sql
WHERE als.person_id = :person_id AND als.principalinvestigator_person_id != :person_id 
```
This PR updates this to: 
```sql
WHERE 
(
  als.person_id = :person_id OR als.principalinvestigator_person_id = :person_id 
)
```
The reason being that with the original logic ( and current data layout ), PI's that have not run a job against an allocation would not see that allocation. 

There is a PR in the xdmod-xsede module that goes along with this one. https://github.com/ubccr/xdmod-xsede/pull/380 They will both need to be merged for the data in the Allocations tab to be displayed correctly. 

## Motivation and Context
- These changes are required for the Allocations tab to correctly handle data from the ACDB.

## Tests performed
Manual testing was performed. 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
