### PR TITLE
Updating node_utilization how-to to mention restarting php-fpm

### DIFF
--- a/docs/howto-node-utilization.md
+++ b/docs/howto-node-utilization.md
@@ -30,7 +30,8 @@ First add the statistic to the Jobs realm statistics configuration.
 }
 ```
 
-Next, run `acl-config` and restart your web server.
+Next, run `acl-config` and restart your web server. Note, depending on which Operating System you have XDMoD installed
+on you may need to restart `php-fpm` in addition to `httpd`.
 
 Reload the portal and the "Node Utilization" statistic will appear in the list
 of Job statistics.


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
Updated the text of the node_utilization How-To section to include language about needing to restart php-fpm in addition to httpd for changes to show up in the UI. 

## Motivation and Context
Recently had a conversation w/ somebody on the HPC Toolset Slack / XDMoD Channel that was attempting to use this How-To and wasn't seeing the `node_utilization` statistic show up after having run `acl-config` and restarting `httpd`. I realized that he would also need to restart `php-fpm`, so in an effort to help other people who may run into the same problem I've added the additional verbiage in this commit. 

## Tests performed
I read it? 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
