### PR TITLE
Add index for qos_name ingestion

### DIFF
--- a/configuration/etl/etl.d/xdmod-migration-10_0_0-10_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-10_0_0-10_5_0.json
@@ -12,7 +12,8 @@
             "description": "Update mod_shredder tables",
             "class": "ManageTables",
             "definition_file_list": [
-                "jobs/shredder/job-sge.json"
+                "jobs/shredder/job-sge.json",
+                "jobs/shredder/job.json"
             ],
             "endpoints": {
                 "destination": {

--- a/configuration/etl/etl_tables.d/jobs/shredder/job.json
+++ b/configuration/etl/etl_tables.d/jobs/shredder/job.json
@@ -219,6 +219,12 @@
                     "resource_name",
                     "pi_name"
                 ]
+            },
+            {
+                "name": "qos_name",
+                "columns": [
+                    "qos_name"
+                ]
             }
         ]
     }

--- a/configuration/etl/etl_tables.d/jobs/shredder/job.json
+++ b/configuration/etl/etl_tables.d/jobs/shredder/job.json
@@ -224,7 +224,8 @@
                 "name": "qos_name",
                 "columns": [
                     "qos_name"
-                ]
+                ],
+                "type": "BTREE"
             }
         ]
     }


### PR DESCRIPTION
This adds an index to mod_shredder.shredded_job. The purpose is so speed up the ingestion action that ingests the qos_name field. This action takes about 3-4 minutes now and with an index it will likely be around a second or so.

## Motivation and Context
Speed up ingestion time.

## Tests performed
Tested in docker and on metrics-dev

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
