### PR TITLE
Prevent unrendered windows from attempting to sync shadows.

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -571,7 +571,9 @@ XDMoD.utils.trimOnBlur = function (thisField) {
 XDMoD.utils.syncWindowShadow = function (thisComponent) {
     thisComponent.bubble(function (currentComponent) {
         if (currentComponent instanceof Ext.Window) {
-            currentComponent.syncShadow();
+            if (currentComponent.rendered) {
+                currentComponent.syncShadow();
+            }
             return false;
         }
         return true;


### PR DESCRIPTION
This prevents windows from attempting to sync their shadows if they have not been rendered.

<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the "My Profile" window had a "Role Delegation" tab and was opened, there was a console error caused by the window being told to sync its window shadow before the window had been rendered.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Set up the test environment.
    1. New environment:
        1. Set up my port (9001) on `xdmod-dev` by running the script `update-open-xdmod-portal.php` with the branch `xdmod10.5-xsede`.
        1. Copy in the changed files from this Pull Request.
        1. Log in.
    1. Old environment:
        1. Spin up a Docker container from the image `tools-ext-01.ccr.xdmod.org/xdmod-10.0.0:centos7.9-0.6`.
        1. Upgrade to the latest Open XDMoD 10.5 version.
        1. Merge in the changed files.
        1. Run the `~/bin/services start` command and open a browser to `localhost:8080`.
        1. Log in using center director credentials.
1. Confirm that window shadows still appear properly and no console errors appear for each of the existing calls of `syncWindowShadow()` — for each of the fields in the following windows, erase the field and fill it back in:
      * "Contact Us" -> "Send Message"
      * "Sign In" -> "Don't have an account"
      * "Report Generator" -> "Save As"
      * "My Profile" -> "General"
      * (as center director) "My Profile" -> "Role Delegation" -> select staff member
      * (as admin) "Admin Dashboard" -> "User Management" -> "Create & Manage Users"

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request