### PR TITLE
WIP: Debug `testChartSettings` regression test.

### DIFF
--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -119,7 +119,7 @@ function getSvgFromChromium($html, $width, $height){
         @unlink($tmpHtmlFile);
         throw new \Exception('Unable execute command: "'. $command . '". Details: ' . print_r(error_get_last(), true));
     }
-    fwrite($pipes[0], 'location.href');
+    fwrite($pipes[0], 'window');
     fclose($pipes[0]);
 
     $out = stream_get_contents($pipes[1]);
@@ -142,7 +142,7 @@ function getSvgFromChromium($html, $width, $height){
     }
 
     if ($chartSvg === null) {
-        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err . ' HTML: ' . $html);
+        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err);
     }
 
     return $chartSvg;

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -142,7 +142,7 @@ function getSvgFromChromium($html, $width, $height){
     }
 
     if ($chartSvg === null) {
-        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err);
+        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err . ' JSON data: ' . json_encode($jsondata));
     }
 
     return $chartSvg;

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -142,7 +142,7 @@ function getSvgFromChromium($html, $width, $height){
     }
 
     if ($chartSvg === null) {
-        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err);
+        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err . ' HTML: ' . $html);
     }
 
     return $chartSvg;

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -107,7 +107,7 @@ function getSvgFromChromium($html, $width, $height){
         '-repl',
         $tmpHtmlFile
     );
-    $command = "echo 'chart.getSVG(inputChartOptions);' | " . $chromiumPath . ' ' . implode(' ', $chromiumOptions);
+    $command = $chromiumPath . ' ' . implode(' ', $chromiumOptions);
     $pipes = array();
     $descriptor_spec = array(
         0 => array('pipe', 'r'),
@@ -119,6 +119,7 @@ function getSvgFromChromium($html, $width, $height){
         @unlink($tmpHtmlFile);
         throw new \Exception('Unable execute command: "'. $command . '". Details: ' . print_r(error_get_last(), true));
     }
+    fwrite($pipes[0], 'location.href');
     fclose($pipes[0]);
 
     $out = stream_get_contents($pipes[1]);

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -114,7 +114,7 @@ function getSvgFromChromium($html, $width, $height){
         1 => array('pipe', 'w'),
         2 => array('pipe', 'w'),
     );
-    $process = proc_open($command, $descriptor_spec, $pipes);
+    $process = proc_open('ls', $descriptor_spec, $pipes);
     if (!is_resource($process)) {
         @unlink($tmpHtmlFile);
         throw new \Exception('Unable execute command: "'. $command . '". Details: ' . print_r(error_get_last(), true));

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -104,7 +104,7 @@ function getSvgFromChromium($html, $width, $height){
         '--window-size=' . $width . ',' . $height,
         '--disable-extensions',
         '--incognito',
-        '-repl',
+        '--repl',
         $tmpHtmlFile
     );
     $command = $chromiumPath . ' ' . implode(' ', $chromiumOptions);
@@ -114,7 +114,7 @@ function getSvgFromChromium($html, $width, $height){
         1 => array('pipe', 'w'),
         2 => array('pipe', 'w'),
     );
-    $process = proc_open('ls', $descriptor_spec, $pipes);
+    $process = proc_open($command, $descriptor_spec, $pipes);
     if (!is_resource($process)) {
         @unlink($tmpHtmlFile);
         throw new \Exception('Unable execute command: "'. $command . '". Details: ' . print_r(error_get_last(), true));

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -107,14 +107,14 @@ function getSvgFromChromium($html, $width, $height){
         '-repl',
         $tmpHtmlFile
     );
-    $command = $chromiumPath . ' ' . implode(' ', $chromiumOptions);
+    $command = "echo 'chart.getSVG(inputChartOptions);' | " . $chromiumPath . ' ' . implode(' ', $chromiumOptions);
     $pipes = array();
     $descriptor_spec = array(
         0 => array('pipe', 'r'),
         1 => array('pipe', 'w'),
         2 => array('pipe', 'w'),
     );
-    $process = proc_open("echo 'chart.getSVG(inputChartOptions);' | " . $command, $descriptor_spec, $pipes);
+    $process = proc_open($command, $descriptor_spec, $pipes);
     if (!is_resource($process)) {
         @unlink($tmpHtmlFile);
         throw new \Exception('Unable execute command: "'. $command . '". Details: ' . print_r(error_get_last(), true));

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -114,12 +114,12 @@ function getSvgFromChromium($html, $width, $height){
         1 => array('pipe', 'w'),
         2 => array('pipe', 'w'),
     );
-    $process = proc_open($command, $descriptor_spec, $pipes);
+    $process = proc_open("echo 'chart.getSVG(inputChartOptions);' | " . $command, $descriptor_spec, $pipes);
     if (!is_resource($process)) {
         @unlink($tmpHtmlFile);
         throw new \Exception('Unable execute command: "'. $command . '". Details: ' . print_r(error_get_last(), true));
     }
-    fwrite($pipes[0], 'chart.getSVG(inputChartOptions);');
+    //fwrite($pipes[0], 'chart.getSVG(inputChartOptions);');
     fclose($pipes[0]);
 
     $out = stream_get_contents($pipes[1]);
@@ -142,7 +142,7 @@ function getSvgFromChromium($html, $width, $height){
     }
 
     if ($chartSvg === null) {
-        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err . ' JSON data: ' . json_encode($jsondata));
+        throw new \Exception('Error executing command: "'. $command . '". Details: ' . $return_value . " " . $out . ' Errors: ' . $err);
     }
 
     return $chartSvg;

--- a/libraries/charting.php
+++ b/libraries/charting.php
@@ -119,7 +119,6 @@ function getSvgFromChromium($html, $width, $height){
         @unlink($tmpHtmlFile);
         throw new \Exception('Unable execute command: "'. $command . '". Details: ' . print_r(error_get_last(), true));
     }
-    //fwrite($pipes[0], 'chart.getSVG(inputChartOptions);');
     fclose($pipes[0]);
 
     $out = stream_get_contents($pipes[1]);

--- a/tests/regression/lib/Controllers/UsageChartsTest.php
+++ b/tests/regression/lib/Controllers/UsageChartsTest.php
@@ -91,7 +91,9 @@ class UsageChartsTest extends \PHPUnit_Framework_TestCase
         $response = self::$helper->post('/controllers/user_interface.php', $postvars, $input);
 
         $imageData = $response[0];
-        var_dump($imageData);
+        if ('array' === gettype($imageData)) {
+            var_dump($imageData);
+        }
         $actualHash = sha1($imageData);
 
         if ($expectedHash === false || getenv('REG_TEST_FORCE_GENERATION') === '1') {

--- a/tests/regression/lib/Controllers/UsageChartsTest.php
+++ b/tests/regression/lib/Controllers/UsageChartsTest.php
@@ -91,9 +91,7 @@ class UsageChartsTest extends \PHPUnit_Framework_TestCase
         $response = self::$helper->post('/controllers/user_interface.php', $postvars, $input);
 
         $imageData = $response[0];
-        if ('array' === gettype($imageData)) {
-            var_dump($imageData);
-        }
+        var_dump($imageData);
         $actualHash = sha1($imageData);
 
         if ($expectedHash === false || getenv('REG_TEST_FORCE_GENERATION') === '1') {

--- a/tests/regression/lib/Controllers/UsageChartsTest.php
+++ b/tests/regression/lib/Controllers/UsageChartsTest.php
@@ -91,6 +91,7 @@ class UsageChartsTest extends \PHPUnit_Framework_TestCase
         $response = self::$helper->post('/controllers/user_interface.php', $postvars, $input);
 
         $imageData = $response[0];
+        var_dump($imageData);
         $actualHash = sha1($imageData);
 
         if ($expectedHash === false || getenv('REG_TEST_FORCE_GENERATION') === '1') {


### PR DESCRIPTION
This is not intended to be merged. It is for debugging the Rocky 8 CI build, which is failing on the `testChartSettings` regression test. The headless chromium command in `libraries/charting.php` appears not to be properly entering REPL mode. This will be fixed by a forthcoming update in another PR.