### PR TITLE
Changing Core hours statistic to CPU Hours with CPU Hour

### DIFF
--- a/configuration/datawarehouse.d/ref/Cloud-statistics.json
+++ b/configuration/datawarehouse.d/ref/Cloud-statistics.json
@@ -29,11 +29,11 @@
         "precision": 2
     },
     "cloud_core_time": {
-        "description_html": "The total number of Core Hours consumed by running sessions.<br/><b>Core Hours</b>: The product of the number of cores assigned to a VM and its wall time, in hours.<br/><b>Session:</b> A session is defined as a discrete run of a virtual machine (VM) on a cloud resource; i.e. any start and stop of a VM. For example, if a single VM is stopped and restarted ten times in a given day, this would be counted as ten sessions for that day.",
+        "description_html": "The total number of CPU Hours consumed by running sessions.<br/><b>CPU Hours</b>: The product of the number of cores assigned to a VM and its wall time, in hours.<br/><b>Session:</b> A session is defined as a discrete run of a virtual machine (VM) on a cloud resource; i.e. any start and stop of a VM. For example, if a single VM is stopped and restarted ten times in a given day, this would be counted as ten sessions for that day.",
         "formula": "COALESCE(SUM(agg.core_time) / 3600.0, 0)",
-        "name": "Core Hours: Total",
-        "precision": 0,
-        "unit": "Hours"
+        "name": "CPU Hours: Total",
+        "precision": 1,
+        "unit": "CPU Hour"
     },
     "cloud_num_sessions_ended": {
         "description_html": "The total number of sessions that were ended on a cloud resource. A session is ended when a VM is paused, shelved, stopped, or terminated on a cloud resource.<br/><b>Session:</b> A session is defined as a discrete run of a virtual machine (VM) on a cloud resource; i.e. any start and stop of a VM. For example, if a single VM is stopped and restarted ten times in a given day, this would be counted as ten sessions for that day.<br/><b>Start:</b> A session start event is defined as the initial creation, resume from pause/suspension, or unshelving of a VM. In the event that no such event has been collected, the first heartbeat event (e.g. a state report) is treated as the start of a new session.<br/><b>Stop:</b> A session stop event is defined as a pause, shelving, suspension, or termination event of a VM.",

--- a/tests/artifacts/xdmod/realm/datawarehouse.d/add-cloud-statistic.json
+++ b/tests/artifacts/xdmod/realm/datawarehouse.d/add-cloud-statistic.json
@@ -4,8 +4,8 @@
         "statistics": {
             "core_time": {
                 "formula": "COALESCE(SUM(agg.core_time) / 3600.0, 0)",
-                "name": "Core Hours: Total",
-                "description_html": "The total number of Core Hours consumed by running sessions.<br/><b>Core Hours</b>: The product of the number of cores assigned to a VM and its wall time, in hours.<br/><b>Session:</b> A session is defined as a discrete run of a virtual machine (VM) on a cloud resource; i.e. any start and stop of a VM. For example, if a single VM is stopped and restarted ten times in a given day, this would be counted as ten sessions for that day.",
+                "name": "CPU Hours: Total",
+                "description_html": "The total number of CPU Hours consumed by running sessions.<br/><b>CPU Hours</b>: The product of the number of cores assigned to a VM and its wall time, in hours.<br/><b>Session:</b> A session is defined as a discrete run of a virtual machine (VM) on a cloud resource; i.e. any start and stop of a VM. For example, if a single VM is stopped and restarted ten times in a given day, this would be counted as ten sessions for that day.",
                 "unit": "Hours",
                 "module": "cloud",
                 "order": 2

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Instance Type","Core Hours: Total"
+"Instance Type","CPU Hours: Total"
 c1.m4,904.6450
 c4.m16,423.1744
 c2.m4,419.2350

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Month-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Instance Type","Core Hours: Total"
+"Instance Type","CPU Hours: Total"
 c1.m4,904.6450
 c4.m16,423.1744
 c2.m4,419.2350

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Instance Type","Core Hours: Total"
+"Instance Type","CPU Hours: Total"
 c1.m4,904.6450
 c4.m16,423.1744
 c2.m4,419.2350

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/aggregate-Year-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Instance Type","Core Hours: Total"
+"Instance Type","CPU Hours: Total"
 c1.m4,904.6450
 c4.m16,423.1744
 c2.m4,419.2350

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[c1.m4] Core Hours: Total","[c4.m16] Core Hours: Total","[c2.m4] Core Hours: Total","[c1.m1] Core Hours: Total","[c2.m8] Core Hours: Total"
+Day,"[c1.m4] CPU Hours: Total","[c4.m16] CPU Hours: Total","[c2.m4] CPU Hours: Total","[c1.m1] CPU Hours: Total","[c2.m8] CPU Hours: Total"
 2018-04-18,32.5117,17.7044,1.4156,0.0150,0.4706
 2018-04-19,105.5942,0,31.5872,0.9328,0
 2018-04-20,49.0664,0,48.0000,0,0

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[c1.m4] Core Hours: Total","[c4.m16] Core Hours: Total","[c2.m4] Core Hours: Total","[c1.m1] Core Hours: Total","[c2.m8] Core Hours: Total"
+Month,"[c1.m4] CPU Hours: Total","[c4.m16] CPU Hours: Total","[c2.m4] CPU Hours: Total","[c1.m1] CPU Hours: Total","[c2.m8] CPU Hours: Total"
 2018-04,904.6450,423.1744,419.2350,6.6183,0.4706
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[c1.m4] Core Hours: Total","[c4.m16] Core Hours: Total","[c2.m4] Core Hours: Total","[c1.m1] Core Hours: Total","[c2.m8] Core Hours: Total"
+Quarter,"[c1.m4] CPU Hours: Total","[c4.m16] CPU Hours: Total","[c2.m4] CPU Hours: Total","[c1.m1] CPU Hours: Total","[c2.m8] CPU Hours: Total"
 "2018 Q2",904.6450,423.1744,419.2350,6.6183,0.4706
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/configuration/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Instance Type"
+"CPU Hours: Total: by Instance Type"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[c1.m4] Core Hours: Total","[c4.m16] Core Hours: Total","[c2.m4] Core Hours: Total","[c1.m1] Core Hours: Total","[c2.m8] Core Hours: Total"
+Year,"[c1.m4] CPU Hours: Total","[c4.m16] CPU Hours: Total","[c2.m4] CPU Hours: Total","[c1.m1] CPU Hours: Total","[c2.m8] CPU Hours: Total"
 2018,904.6450,423.1744,419.2350,6.6183,0.4706
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Domain,"Core Hours: Total"
+Domain,"CPU Hours: Total"
 Default,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Domain,"Core Hours: Total"
+Domain,"CPU Hours: Total"
 Default,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Domain,"Core Hours: Total"
+Domain,"CPU Hours: Total"
 Default,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Domain,"Core Hours: Total"
+Domain,"CPU Hours: Total"
 Default,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Default] Core Hours: Total"
+Day,"[Default] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Default] Core Hours: Total"
+Month,"[Default] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Default] Core Hours: Total"
+Quarter,"[Default] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/domain/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Domain"
+"CPU Hours: Total: by Domain"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Default] Core Hours: Total"
+Year,"[Default] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"PI Group","Core Hours: Total"
+"PI Group","CPU Hours: Total"
 "Mechanics and Materials",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"PI Group","Core Hours: Total"
+"PI Group","CPU Hours: Total"
 "Mechanics and Materials",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"PI Group","Core Hours: Total"
+"PI Group","CPU Hours: Total"
 "Mechanics and Materials",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"PI Group","Core Hours: Total"
+"PI Group","CPU Hours: Total"
 "Mechanics and Materials",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Mechanics and Materials] Core Hours: Total"
+Day,"[Mechanics and Materials] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Mechanics and Materials] Core Hours: Total"
+Month,"[Mechanics and Materials] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Mechanics and Materials] Core Hours: Total"
+Quarter,"[Mechanics and Materials] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/fieldofscience/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI Group"
+"CPU Hours: Total: by PI Group"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Mechanics and Materials] Core Hours: Total"
+Year,"[Mechanics and Materials] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Summary,"Core Hours: Total"
+Summary,"CPU Hours: Total"
 Screwdriver,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Summary,"Core Hours: Total"
+Summary,"CPU Hours: Total"
 Screwdriver,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Summary,"Core Hours: Total"
+Summary,"CPU Hours: Total"
 Screwdriver,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Summary,"Core Hours: Total"
+Summary,"CPU Hours: Total"
 Screwdriver,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Screwdriver] Core Hours: Total"
+Day,"[Screwdriver] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Screwdriver] Core Hours: Total"
+Month,"[Screwdriver] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Screwdriver] Core Hours: Total"
+Quarter,"[Screwdriver] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/none/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total"
+"CPU Hours: Total"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Screwdriver] Core Hours: Total"
+Year,"[Screwdriver] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Decanal Unit","Core Hours: Total"
+"Decanal Unit","CPU Hours: Total"
 Engineering,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Decanal Unit","Core Hours: Total"
+"Decanal Unit","CPU Hours: Total"
 Engineering,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Decanal Unit","Core Hours: Total"
+"Decanal Unit","CPU Hours: Total"
 Engineering,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Decanal Unit","Core Hours: Total"
+"Decanal Unit","CPU Hours: Total"
 Engineering,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Engineering] Core Hours: Total"
+Day,"[Engineering] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Engineering] Core Hours: Total"
+Month,"[Engineering] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Engineering] Core Hours: Total"
+Quarter,"[Engineering] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/nsfdirectorate/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Decanal Unit"
+"CPU Hours: Total: by Decanal Unit"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Engineering] Core Hours: Total"
+Year,"[Engineering] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Department,"Core Hours: Total"
+Department,"CPU Hours: Total"
 "Mechanical and Structural Systems",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Department,"Core Hours: Total"
+Department,"CPU Hours: Total"
 "Mechanical and Structural Systems",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Department,"Core Hours: Total"
+Department,"CPU Hours: Total"
 "Mechanical and Structural Systems",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Department,"Core Hours: Total"
+Department,"CPU Hours: Total"
 "Mechanical and Structural Systems",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Mechanical and Structural Systems] Core Hours: Total"
+Day,"[Mechanical and Structural Systems] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Mechanical and Structural Systems] Core Hours: Total"
+Month,"[Mechanical and Structural Systems] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Mechanical and Structural Systems] Core Hours: Total"
+Quarter,"[Mechanical and Structural Systems] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/parentscience/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Department"
+"CPU Hours: Total: by Department"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Mechanical and Structural Systems] Core Hours: Total"
+Year,"[Mechanical and Structural Systems] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-User,"Core Hours: Total"
+User,"CPU Hours: Total"
 "Warbler, Yellow-rumped",1308.4522
 "Warbler, Yellow",441.1944
 "Warbler, Blackburnian",4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Month-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-User,"Core Hours: Total"
+User,"CPU Hours: Total"
 "Warbler, Yellow-rumped",1308.4522
 "Warbler, Yellow",441.1944
 "Warbler, Blackburnian",4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-User,"Core Hours: Total"
+User,"CPU Hours: Total"
 "Warbler, Yellow-rumped",1308.4522
 "Warbler, Yellow",441.1944
 "Warbler, Blackburnian",4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/aggregate-Year-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-User,"Core Hours: Total"
+User,"CPU Hours: Total"
 "Warbler, Yellow-rumped",1308.4522
 "Warbler, Yellow",441.1944
 "Warbler, Blackburnian",4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Warbler, Yellow-rumped] Core Hours: Total","[Warbler, Yellow] Core Hours: Total","[Warbler, Blackburnian] Core Hours: Total"
+Day,"[Warbler, Yellow-rumped] CPU Hours: Total","[Warbler, Yellow] CPU Hours: Total","[Warbler, Blackburnian] CPU Hours: Total"
 2018-04-18,34.4128,17.7044,0
 2018-04-19,102.0303,31.5872,4.4967
 2018-04-20,49.0664,48.0000,0

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Warbler, Yellow-rumped] Core Hours: Total","[Warbler, Yellow] Core Hours: Total","[Warbler, Blackburnian] Core Hours: Total"
+Month,"[Warbler, Yellow-rumped] CPU Hours: Total","[Warbler, Yellow] CPU Hours: Total","[Warbler, Blackburnian] CPU Hours: Total"
 2018-04,1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Warbler, Yellow-rumped] Core Hours: Total","[Warbler, Yellow] Core Hours: Total","[Warbler, Blackburnian] Core Hours: Total"
+Quarter,"[Warbler, Yellow-rumped] CPU Hours: Total","[Warbler, Yellow] CPU Hours: Total","[Warbler, Blackburnian] CPU Hours: Total"
 "2018 Q2",1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/person/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by User"
+"CPU Hours: Total: by User"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Warbler, Yellow-rumped] Core Hours: Total","[Warbler, Yellow] Core Hours: Total","[Warbler, Blackburnian] Core Hours: Total"
+Year,"[Warbler, Yellow-rumped] CPU Hours: Total","[Warbler, Yellow] CPU Hours: Total","[Warbler, Blackburnian] CPU Hours: Total"
 2018,1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-PI,"Core Hours: Total"
+PI,"CPU Hours: Total"
 "Tern, Sandwich",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-PI,"Core Hours: Total"
+PI,"CPU Hours: Total"
 "Tern, Sandwich",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-PI,"Core Hours: Total"
+PI,"CPU Hours: Total"
 "Tern, Sandwich",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-PI,"Core Hours: Total"
+PI,"CPU Hours: Total"
 "Tern, Sandwich",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[Tern, Sandwich] Core Hours: Total"
+Day,"[Tern, Sandwich] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[Tern, Sandwich] Core Hours: Total"
+Month,"[Tern, Sandwich] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[Tern, Sandwich] Core Hours: Total"
+Quarter,"[Tern, Sandwich] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/pi/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by PI"
+"CPU Hours: Total: by PI"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[Tern, Sandwich] Core Hours: Total"
+Year,"[Tern, Sandwich] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Project,"Core Hours: Total"
+Project,"CPU Hours: Total"
 zealous,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Project,"Core Hours: Total"
+Project,"CPU Hours: Total"
 zealous,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Project,"Core Hours: Total"
+Project,"CPU Hours: Total"
 zealous,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Project,"Core Hours: Total"
+Project,"CPU Hours: Total"
 zealous,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[zealous] Core Hours: Total"
+Day,"[zealous] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[zealous] Core Hours: Total"
+Month,"[zealous] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[zealous] Core Hours: Total"
+Quarter,"[zealous] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/project/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Project"
+"CPU Hours: Total: by Project"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[zealous] Core Hours: Total"
+Year,"[zealous] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Provider,"Core Hours: Total"
+Provider,"CPU Hours: Total"
 "screw - Screwdriver",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Provider,"Core Hours: Total"
+Provider,"CPU Hours: Total"
 "screw - Screwdriver",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Provider,"Core Hours: Total"
+Provider,"CPU Hours: Total"
 "screw - Screwdriver",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Provider,"Core Hours: Total"
+Provider,"CPU Hours: Total"
 "screw - Screwdriver",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[screw - Screwdriver] Core Hours: Total"
+Day,"[screw - Screwdriver] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[screw - Screwdriver] Core Hours: Total"
+Month,"[screw - Screwdriver] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[screw - Screwdriver] Core Hours: Total"
+Quarter,"[screw - Screwdriver] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/provider/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Provider"
+"CPU Hours: Total: by Provider"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[screw - Screwdriver] Core Hours: Total"
+Year,"[screw - Screwdriver] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Resource,"Core Hours: Total"
+Resource,"CPU Hours: Total"
 openstack,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Resource,"Core Hours: Total"
+Resource,"CPU Hours: Total"
 openstack,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Resource,"Core Hours: Total"
+Resource,"CPU Hours: Total"
 openstack,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Resource,"Core Hours: Total"
+Resource,"CPU Hours: Total"
 openstack,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[openstack] Core Hours: Total"
+Day,"[openstack] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[openstack] Core Hours: Total"
+Month,"[openstack] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[openstack] Core Hours: Total"
+Quarter,"[openstack] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/resource/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Resource"
+"CPU Hours: Total: by Resource"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[openstack] Core Hours: Total"
+Year,"[openstack] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Day-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Submission Venue","Core Hours: Total"
+"Submission Venue","CPU Hours: Total"
 "OpenStack API",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Submission Venue","Core Hours: Total"
+"Submission Venue","CPU Hours: Total"
 "OpenStack API",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Submission Venue","Core Hours: Total"
+"Submission Venue","CPU Hours: Total"
 "OpenStack API",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/aggregate-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"Submission Venue","Core Hours: Total"
+"Submission Venue","CPU Hours: Total"
 "OpenStack API",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[OpenStack API] Core Hours: Total"
+Day,"[OpenStack API] CPU Hours: Total"
 2018-04-18,52.1172
 2018-04-19,138.1142
 2018-04-20,97.0664

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[OpenStack API] Core Hours: Total"
+Month,"[OpenStack API] CPU Hours: Total"
 2018-04,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[OpenStack API] Core Hours: Total"
+Quarter,"[OpenStack API] CPU Hours: Total"
 "2018 Q2",1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/submission_venue/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by Submission Venue"
+"CPU Hours: Total: by Submission Venue"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[OpenStack API] Core Hours: Total"
+Year,"[OpenStack API] CPU Hours: Total"
 2018,1754.1433
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-cd.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-cs.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-pi.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Day-usr.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-cd.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-cs.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-pi.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Month-usr.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-cd.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-cs.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-pi.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Quarter-usr.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-cd.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-cs.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 yerwa,1308.4522
 ylwwa,441.1944
 setusca,4.4967

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-pi.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/aggregate-Year-usr.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"
 start,end
 2018-04-18,2018-04-30
 ---------
-"System Username","Core Hours: Total"
+"System Username","CPU Hours: Total"
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-cd.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Day,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 2018-04-18,34.4128,17.7044,0
 2018-04-19,102.0303,31.5872,4.4967
 2018-04-20,49.0664,48.0000,0

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-cs.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Day,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 2018-04-18,34.4128,17.7044,0
 2018-04-19,102.0303,31.5872,4.4967
 2018-04-20,49.0664,48.0000,0

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-pi.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Day-usr.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-cd.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Month,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 2018-04,1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-cs.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Month,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 2018-04,1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-pi.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Month-usr.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-cd.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Quarter,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 "2018 Q2",1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-cs.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Quarter,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 "2018 Q2",1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-pi.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Quarter-usr.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-cd.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-cd.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Year,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 2018,1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-cs.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-cs.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[yerwa] Core Hours: Total","[ylwwa] Core Hours: Total","[setusca] Core Hours: Total"
+Year,"[yerwa] CPU Hours: Total","[ylwwa] CPU Hours: Total","[setusca] CPU Hours: Total"
 2018,1308.4522,441.1944,4.4967
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-pi.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-pi.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: PI = Tern, C OR User = Tern, C"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-usr.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/username/cloud_core_time/timeseries-Year-usr.csv
@@ -1,5 +1,5 @@
 title
-"Core Hours: Total: by System Username"
+"CPU Hours: Total: by System Username"
 parameters
 
 "*Restricted To: User = Whimbrel"

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Cores","Core Hours: Total"
+"VM Size: Cores","CPU Hours: Total"
 1,911.2633
 "2 - 3",419.7056
 "4 - 7",423.1744

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Month-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Cores","Core Hours: Total"
+"VM Size: Cores","CPU Hours: Total"
 1,911.2633
 "2 - 3",419.7056
 "4 - 7",423.1744

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Cores","Core Hours: Total"
+"VM Size: Cores","CPU Hours: Total"
 1,911.2633
 "2 - 3",419.7056
 "4 - 7",423.1744

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/aggregate-Year-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Cores","Core Hours: Total"
+"VM Size: Cores","CPU Hours: Total"
 1,911.2633
 "2 - 3",419.7056
 "4 - 7",423.1744

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[1] Core Hours: Total","[2 - 3] Core Hours: Total","[4 - 7] Core Hours: Total"
+Day,"[1] CPU Hours: Total","[2 - 3] CPU Hours: Total","[4 - 7] CPU Hours: Total"
 2018-04-18,32.5267,1.8861,17.7044
 2018-04-19,106.5269,31.5872,0
 2018-04-20,49.0664,48.0000,0

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[1] Core Hours: Total","[2 - 3] Core Hours: Total","[4 - 7] Core Hours: Total"
+Month,"[1] CPU Hours: Total","[2 - 3] CPU Hours: Total","[4 - 7] CPU Hours: Total"
 2018-04,911.2633,419.7056,423.1744
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[1] Core Hours: Total","[2 - 3] Core Hours: Total","[4 - 7] Core Hours: Total"
+Quarter,"[1] CPU Hours: Total","[2 - 3] CPU Hours: Total","[4 - 7] CPU Hours: Total"
 "2018 Q2",911.2633,419.7056,423.1744
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by VM Size: Cores"
+"CPU Hours: Total: by VM Size: Cores"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[1] Core Hours: Total","[2 - 3] Core Hours: Total","[4 - 7] Core Hours: Total"
+Year,"[1] CPU Hours: Total","[2 - 3] CPU Hours: Total","[4 - 7] CPU Hours: Total"
 2018,911.2633,419.7056,423.1744
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Memory","Core Hours: Total"
+"VM Size: Memory","CPU Hours: Total"
 "2 - 4 GB",1323.7597
 "8 - 16 GB",423.1744
 "< 2 GB",6.6183

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Month-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Memory","Core Hours: Total"
+"VM Size: Memory","CPU Hours: Total"
 "2 - 4 GB",1323.7597
 "8 - 16 GB",423.1744
 "< 2 GB",6.6183

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Quarter-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Memory","Core Hours: Total"
+"VM Size: Memory","CPU Hours: Total"
 "2 - 4 GB",1323.7597
 "8 - 16 GB",423.1744
 "< 2 GB",6.6183

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/aggregate-Year-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-"VM Size: Memory","Core Hours: Total"
+"VM Size: Memory","CPU Hours: Total"
 "2 - 4 GB",1323.7597
 "8 - 16 GB",423.1744
 "< 2 GB",6.6183

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Day-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Day-reference.csv
@@ -1,11 +1,11 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Day,"[2 - 4 GB] Core Hours: Total","[8 - 16 GB] Core Hours: Total","[< 2 GB] Core Hours: Total","[4 - 8 GB] Core Hours: Total","[32 - 64 GB] Core Hours: Total"
+Day,"[2 - 4 GB] CPU Hours: Total","[8 - 16 GB] CPU Hours: Total","[< 2 GB] CPU Hours: Total","[4 - 8 GB] CPU Hours: Total","[32 - 64 GB] CPU Hours: Total"
 2018-04-18,33.8069,17.7044,0.0150,0.4706,0.1203
 2018-04-19,137.1814,0,0.9328,0,0
 2018-04-20,97.0664,0,0,0,0

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Month-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Month-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Month,"[2 - 4 GB] Core Hours: Total","[8 - 16 GB] Core Hours: Total","[< 2 GB] Core Hours: Total","[4 - 8 GB] Core Hours: Total","[32 - 64 GB] Core Hours: Total"
+Month,"[2 - 4 GB] CPU Hours: Total","[8 - 16 GB] CPU Hours: Total","[< 2 GB] CPU Hours: Total","[4 - 8 GB] CPU Hours: Total","[32 - 64 GB] CPU Hours: Total"
 2018-04,1323.7597,423.1744,6.6183,0.4706,0.1203
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Quarter-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Quarter-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Quarter,"[2 - 4 GB] Core Hours: Total","[8 - 16 GB] Core Hours: Total","[< 2 GB] Core Hours: Total","[4 - 8 GB] Core Hours: Total","[32 - 64 GB] Core Hours: Total"
+Quarter,"[2 - 4 GB] CPU Hours: Total","[8 - 16 GB] CPU Hours: Total","[< 2 GB] CPU Hours: Total","[4 - 8 GB] CPU Hours: Total","[32 - 64 GB] CPU Hours: Total"
 "2018 Q2",1323.7597,423.1744,6.6183,0.4706,0.1203
 ---------

--- a/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Year-reference.csv
+++ b/tests/artifacts/xdmod/regression/current/expected/reference/Cloud/vm_size_memory/cloud_core_time/timeseries-Year-reference.csv
@@ -1,10 +1,10 @@
 title
-"Core Hours: Total: by VM Size: Memory"
+"CPU Hours: Total: by VM Size: Memory"
 parameters
 
 start,end
 2018-04-18,2018-04-30
 ---------
-Year,"[2 - 4 GB] Core Hours: Total","[8 - 16 GB] Core Hours: Total","[< 2 GB] Core Hours: Total","[4 - 8 GB] Core Hours: Total","[32 - 64 GB] Core Hours: Total"
+Year,"[2 - 4 GB] CPU Hours: Total","[8 - 16 GB] CPU Hours: Total","[< 2 GB] CPU Hours: Total","[4 - 8 GB] CPU Hours: Total","[32 - 64 GB] CPU Hours: Total"
 2018,1323.7597,423.1744,6.6183,0.4706,0.1203
 ---------

--- a/tests/artifacts/xdmod/user_controller/output/get_dw_descripter.json
+++ b/tests/artifacts/xdmod/user_controller/output/get_dw_descripter.json
@@ -26,8 +26,8 @@
                             "std_err": false
                         },
                         "cloud_core_time": {
-                            "text": "Core Hours: Total",
-                            "info": "The total number of Core Hours consumed by running sessions.<br\/><b>Core Hours<\/b>: The product of the number of cores assigned to a VM and its wall time, in hours.<br\/><b>Session:<\/b> A session is defined as a discrete run of a virtual machine (VM) on a cloud resource; i.e. any start and stop of a VM. For example, if a single VM is stopped and restarted ten times in a given day, this would be counted as ten sessions for that day.",
+                            "text": "CPU Hours: Total",
+                            "info": "The total number of CPU Hours consumed by running sessions.<br\/><b>CPU Hours<\/b>: The product of the number of cores assigned to a VM and its wall time, in hours.<br\/><b>Session:<\/b> A session is defined as a discrete run of a virtual machine (VM) on a cloud resource; i.e. any start and stop of a VM. For example, if a single VM is stopped and restarted ten times in a given day, this would be counted as ten sessions for that day.",
                             "std_err": false
                         },
                         "cloud_num_sessions_running": {

--- a/tests/unit/lib/Realm/RealmTest.php
+++ b/tests/unit/lib/Realm/RealmTest.php
@@ -134,7 +134,7 @@ class RealmTest extends \PHPUnit_Framework_TestCase
         $generated = $realm->getStatisticNames(); // Default sort order is SORT_ON_ORDER
         $expected = array(
             'cloud_num_sessions_running' => '${ORGANIZATION_NAME} Number of Active Sessions',
-            'core_time' => 'Core Hours: Total',
+            'core_time' => 'CPU Hours: Total',
             'alternate_statistic_class' => 'Alternate Statistic Class Example'
         );
         $this->assertEquals($expected, $generated, "getStatisticNames(SORT_ON_ORDER)");
@@ -142,7 +142,7 @@ class RealmTest extends \PHPUnit_Framework_TestCase
         $generated = $realm->getStatisticNames(Realm::SORT_ON_SHORT_ID);
         $expected = array(
             'alternate_statistic_class' => 'Alternate Statistic Class Example',
-            'core_time' => 'Core Hours: Total',
+            'core_time' => 'CPU Hours: Total',
             'cloud_num_sessions_running' => '${ORGANIZATION_NAME} Number of Active Sessions'
         );
         $this->assertEquals($expected, $generated, "getStatisticNames(SORT_ON_SHORT_ID)");
@@ -151,7 +151,7 @@ class RealmTest extends \PHPUnit_Framework_TestCase
         $expected = array(
             'cloud_num_sessions_running' => '${ORGANIZATION_NAME} Number of Active Sessions',
             'alternate_statistic_class' => 'Alternate Statistic Class Example',
-            'core_time' => 'Core Hours: Total'
+            'core_time' => 'CPU Hours: Total'
         );
         $this->assertEquals($expected, $generated, "getStatisticNames(SORT_ON_NAME)");
     }

--- a/tests/unit/lib/Realm/StatisticTest.php
+++ b/tests/unit/lib/Realm/StatisticTest.php
@@ -93,7 +93,7 @@ class StatisticTest extends \PHPUnit_Framework_TestCase
         }
         $expected = array(
             'alternate_statistic_class' => 'Alternate Statistic Class Example',
-            'core_time' => 'Core Hours: Total',
+            'core_time' => 'CPU Hours: Total',
             'cloud_num_sessions_running' => sprintf('%s Number of Active Sessions', ORGANIZATION_NAME)
         );
         $this->assertEquals($expected, $generated, "getStatisticObjects('Cloud'), SORT_ON_SHORT_ID");


### PR DESCRIPTION
Changing Core hours statistic to CPU Hours with CPU Hour to match the Jobs realm. This makes it so if you plot CPU Hours: Total in the Jobs and Cloud realm in the same chart only one axis is used since the units are the same.

## Tests performed
Tested in docker and on xdmod-dev

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
