### PR TITLE
Include is_null check in RegressionTestHelper when checking json_decoded data

### DIFF
--- a/tests/regression/lib/TestHarness/RegressionTestHelper.php
+++ b/tests/regression/lib/TestHarness/RegressionTestHelper.php
@@ -383,7 +383,7 @@ class RegressionTestHelper extends XdmodTestHelper
             } else {
                 try {
                     $decodedCsv = json_decode($csvdata);
-                    if ($decodedCsv !== false) {
+                    if ($decodedCsv !== false && !is_null($decodedCsv)) {
                         $actualJson = json_encode($decodedCsv, JSON_PRETTY_PRINT);
                         $expectedJson = json_encode(json_decode($expected), JSON_PRETTY_PRINT);
 


### PR DESCRIPTION
This fixes a bug in the regression tests which give false positives for all tests that return csv data. `json_decode` return NULL when it cannot decode the data passed to it. Most of the regression test are csv data. The `json_decode` of this csv data returns NULL which passes the check in line 386 and line 390 and returns true, passing the test.

https://github.com/ubccr/xdmod/blob/c6f2e50231916a32d075bddb48285fbed76fd020/tests/regression/lib/TestHarness/RegressionTestHelper.php#L385-L392 

## Tests performed
Tested in docker by changing a regression test to fail before and after the change

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
