### PR TITLE
Fixes for warnings generated with the supremm module tests

### DIFF
--- a/classes/DataWarehouse/Access/Common.php
+++ b/classes/DataWarehouse/Access/Common.php
@@ -45,6 +45,12 @@ class Common
 
     protected function checkDateParameters()
     {
+        if (!isset($this->request['start_date'])) {
+            throw new \DataWarehouse\Query\Exceptions\BadRequestException(
+                'missing required start_date parameter'
+            );
+        }
+
         $start_date_parsed = date_parse_from_format(
             'Y-m-d',
             $this->request['start_date']
@@ -53,6 +59,12 @@ class Common
         if ($start_date_parsed['error_count'] !== 0) {
             throw new \DataWarehouse\Query\Exceptions\BadRequestException(
                 'start_date param is not in the correct format of Y-m-d.'
+            );
+        }
+
+        if (!isset($this->request['end_date'])) {
+            throw new \DataWarehouse\Query\Exceptions\BadRequestException(
+                'missing required end_date parameter'
             );
         }
 
@@ -178,7 +190,7 @@ class Common
         return
             isset($this->request['font_size']) && $this->request['font_size'] != ''
             ? $this->request['font_size']
-            : 'default';
+            : '3';
     }
 
     protected function getTitle()

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -14,7 +14,7 @@ use DataWarehouse\RoleRestrictionsStringBuilder;
 use DataWarehouse\Query\Exceptions\AccessDeniedException;
 use DataWarehouse\Query\Exceptions\MissingFilterListTableException;
 use DataWarehouse\Query\Exceptions\UnknownGroupByException;
-use DataWarehouse\Query\Exceptions\BadRequestException;;
+use DataWarehouse\Query\Exceptions\BadRequestException;
 use FilterListHelper;
 use XDUser;
 

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -14,6 +14,7 @@ use DataWarehouse\RoleRestrictionsStringBuilder;
 use DataWarehouse\Query\Exceptions\AccessDeniedException;
 use DataWarehouse\Query\Exceptions\MissingFilterListTableException;
 use DataWarehouse\Query\Exceptions\UnknownGroupByException;
+use DataWarehouse\Query\Exceptions\BadRequestException;;
 use FilterListHelper;
 use XDUser;
 
@@ -410,6 +411,10 @@ class MetricExplorer extends Common
         $ret =  urldecode($this->request['data_series']);
 
         $jret = json_decode($ret);
+
+        if (!is_array($jret)) {
+            throw new BadRequestException('Invalid data_series specified');
+        }
 
         foreach ($jret as &$y) {
 

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -601,7 +601,6 @@ class WarehouseControllerProvider extends BaseControllerProvider
             array(
                 'success' => true,
                 'action' => $action,
-                'total' => count($history),
                 'results' => $result
             ),
             200

--- a/html/controllers/common_params.php
+++ b/html/controllers/common_params.php
@@ -2,6 +2,12 @@
 
 function checkDateParameters()
 {
+    if (!isset($_REQUEST['start_date'])) {
+        throw new Exception(
+            'missing required start_date parameter'
+        );
+    }
+
     $start_date_parsed = date_parse_from_format(
         'Y-m-d',
         $_REQUEST['start_date']
@@ -10,6 +16,12 @@ function checkDateParameters()
     if ($start_date_parsed['error_count'] !== 0) {
         throw new Exception(
             'start_date param is not in the correct format of Y-m-d.'
+        );
+    }
+
+    if (!isset($_REQUEST['end_date'])) {
+        throw new Exception(
+            'missing required end_date parameter'
         );
     }
 
@@ -130,14 +142,6 @@ function getLegendLocation()
         isset($_REQUEST['legend_type']) && $_REQUEST['legend_type'] != ''
         ? $_REQUEST['legend_type']
         : 'bottom_center';
-}
-
-function getFontSize()
-{
-    return
-        isset($_REQUEST['font_size']) && $_REQUEST['font_size'] != ''
-        ? $_REQUEST['font_size']
-        : 'default';
 }
 
 function getTitle()

--- a/html/controllers/metric_explorer/common.php
+++ b/html/controllers/metric_explorer/common.php
@@ -96,6 +96,10 @@ function getDataSeries()
 
     $jret = json_decode($ret);
 
+    if (!is_array($jret)) {
+        throw new Exception('Invalid data_series specified');
+    }
+
     foreach ($jret as &$y) {
 
         // Set values of new attribs for backward compatibility.

--- a/tests/integration/lib/Controllers/MetricExplorerTest.php
+++ b/tests/integration/lib/Controllers/MetricExplorerTest.php
@@ -73,6 +73,68 @@ class MetricExplorerTest extends TokenAuthTest
     }
 
     /**
+     * Check for correct handling of invalid or missing input parameters to the
+     * metric explorer charting controller
+     */
+    public function testInvalidRawDataRequests() {
+
+        $params = array(
+            'show_title' => 'y',
+            'timeseries' => 'y',
+            'aggregation_unit' => 'Auto',
+            'start_date' => '2013-06-08',
+            'end_date' => '2023-06-08',
+            'global_filters' => '%7B%22data%22%3A%5B%7B%22id%22%3A%22resource%3D2%22%2C%22value_id%22%3A%222%22%2C%22value_name%22%3A%22mortorq%22%2C%22dimension_id%22%3A%22resource%22%2C%22realms%22%3A%5B%22Cloud%22%2C%22Jobs%22%2C%22Storage%22%5D%2C%22checked%22%3Atrue%7D%5D%7D',
+            'title' => 'untitled query 1',
+            'show_filters' => 'true',
+            'show_warnings' => 'true',
+            'show_remainder' => 'false',
+            'start' => '0',
+            'limit' => '20',
+            'timeframe_label' => '10 year',
+            'operation' => 'get_rawdata',
+            'data_series' => '%5B%7B%22group_by%22%3A%22resource%22%2C%22color%22%3A%22auto%22%2C%22log_scale%22%3Afalse%2C%22std_err%22%3Afalse%2C%22value_labels%22%3Afalse%2C%22display_type%22%3A%22line%22%2C%22combine_type%22%3A%22side%22%2C%22sort_type%22%3A%22value_desc%22%2C%22ignore_global%22%3Afalse%2C%22long_legend%22%3Atrue%2C%22x_axis%22%3Afalse%2C%22has_std_err%22%3Afalse%2C%22trend_line%22%3Afalse%2C%22line_type%22%3A%22Solid%22%2C%22line_width%22%3A2%2C%22shadow%22%3Afalse%2C%22filters%22%3A%7B%22data%22%3A%5B%5D%2C%22total%22%3A0%7D%2C%22z_index%22%3A0%2C%22visibility%22%3Anull%2C%22enabled%22%3Atrue%2C%22metric%22%3A%22job_count%22%2C%22realm%22%3A%22Jobs%22%2C%22category%22%3A%22Jobs%22%2C%22id%22%3A-755536863343043%7D%5D',
+            'swap_xy' => 'false',
+            'share_y_axis' => 'false',
+            'hide_tooltip' => 'false',
+            'show_guide_lines' => 'y',
+            'showContextMenu' => 'y',
+            'scale' => '1',
+            'format' => 'jsonstore',
+            'width' => '1428',
+            'height' => '525',
+            'legend_type' => 'bottom_center',
+            'x_axis' => '%7B%7D',
+            'y_axis' => '%7B%7D',
+            'legend' => '%7B%7D',
+            'defaultDatasetConfig' => '%7B%7D',
+            'controller_module' => 'metric_explorer',
+            'inline' => 'n',
+            'datapoint' => '1475280000000',
+            'datasetId' => '-755536863343043'
+        );
+
+        $this->helper->authenticate('cd');
+
+        unset($params['start_date']);
+        $response = $this->helper->post('/controllers/metric_explorer.php', null, $params);
+        $this->assertFalse($response[0]['success']);
+        $this->assertEquals('missing required start_date parameter', $response[0]['message']);
+
+        $params['start_date'] = '2016-12-29';
+        unset($params['end_date']);
+        $response = $this->helper->post('/controllers/metric_explorer.php', null, $params);
+        $this->assertFalse($response[0]['success']);
+        $this->assertEquals('missing required end_date parameter', $response[0]['message']);
+
+        $params['end_date'] = '2016-12-29';
+        $params['data_series'] = '[object Object]';
+        $response = $this->helper->post('/controllers/metric_explorer.php', null, $params);
+        $this->assertFalse($response[0]['success']);
+        $this->assertEquals('Invalid data_series specified', $response[0]['message']);
+    }
+
+    /**
      * @dataProvider provideTokenAuthTestData
      */
     public function testGetDwDescripterTokenAuth($role, $tokenType) {

--- a/tests/integration/lib/Controllers/MetricExplorerTest.php
+++ b/tests/integration/lib/Controllers/MetricExplorerTest.php
@@ -18,6 +18,61 @@ class MetricExplorerTest extends TokenAuthTest
     }
 
     /**
+     * Check for correct handling of invalid or missing input parameters to the
+     * metric explorer charting controller
+     */
+    public function testInvalidChartRequests() {
+
+        $params = array(
+            "show_title" => "y",
+            "timeseries" => "y",
+            "aggregation_unit" => "Auto",
+            "start_date" => "2016-12-29",
+            "end_date" => "2017-01-01",
+            "global_filters" => "%7B%22data%22%3A%5B%5D%2C%22total%22%3A0%7D",
+            "title" => "untitled query 1",
+            "show_filters" => "true",
+            "show_warnings" => "true",
+            "show_remainder" => "false",
+            "start" => "0",
+            "limit" => "10",
+            "timeframe_label" => "User Defined",
+            "operation" => "get_data",
+            "data_series" => "%5B%7B%22group_by%22%3A%22none%22%2C%22color%22%3A%22auto%22%2C%22log_scale%22%3Afalse%2C%22std_err%22%3Afalse%2C%22value_labels%22%3Afalse%2C%22display_type%22%3A%22line%22%2C%22combine_type%22%3A%22side%22%2C%22sort_type%22%3A%22value_desc%22%2C%22ignore_global%22%3Afalse%2C%22long_legend%22%3Atrue%2C%22x_axis%22%3Afalse%2C%22has_std_err%22%3Afalse%2C%22trend_line%22%3Afalse%2C%22line_type%22%3A%22Solid%22%2C%22line_width%22%3A2%2C%22shadow%22%3Afalse%2C%22filters%22%3A%7B%22data%22%3A%5B%5D%2C%22total%22%3A0%7D%2C%22z_index%22%3A0%2C%22visibility%22%3Anull%2C%22enabled%22%3Atrue%2C%22metric%22%3A%22job_count%22%2C%22realm%22%3A%22Jobs%22%2C%22category%22%3A%22Jobs%22%2C%22id%22%3A2627927508440901%7D%5D",
+            "swap_xy" => "false",
+            "share_y_axis" => "false",
+            "hide_tooltip" => "false",
+            "show_guide_lines" => "y",
+            "showContextMenu" => "y",
+            "scale" => "1",
+            "format" => "hc_jsonstore",
+            "width" => "1500",
+            "height" => "626",
+            "legend_type" => "bottom_center",
+            "font_size" => "3",
+            "featured" => "false",
+            "trendLineEnabled" => "",
+            "x_axis" => "%7B%7D",
+            "y_axis" => "%7B%7D",
+            "legend" => "%7B%7D",
+            "defaultDatasetConfig" => "%7B%7D",
+            "controller_module" => "metric_explorer"
+        );
+
+        $this->helper->authenticate('cd');
+
+        unset($params['font_size']);
+
+        $response = $this->helper->post('/controllers/metric_explorer.php', null, $params);
+        $output = json_decode($response[0]);
+        $this->assertEquals($output->data[0]->title->style->fontSize, "19px");
+
+        $params['data_series'] = '[object Object]';
+        $response = $this->helper->post('/controllers/metric_explorer.php', null, $params);
+        $this->assertEquals(400, $response[1]['http_code']);
+    }
+
+    /**
      * @dataProvider provideTokenAuthTestData
      */
     public function testGetDwDescripterTokenAuth($role, $tokenType) {

--- a/tests/integration/lib/Controllers/UsageExplorerTest.php
+++ b/tests/integration/lib/Controllers/UsageExplorerTest.php
@@ -89,10 +89,18 @@ class UsageExplorerTest extends TokenAuthTest
             "controller_module"=> "user_interface"
         );
 
+        $view['start_date'] = null;
+        $tests[] = array($view, 'missing required start_date parameter');
+
+        $view['start_date'] = '2017-05-01';
         $view['end_date'] = null;
+        $tests[] = array($view, 'missing required end_date parameter');
+
+        $view['end_date'] = 'Yesterday';
         $tests[] = array($view, 'end_date param is not in the correct format of Y-m-d.');
 
-        $view['start_date'] = null;
+        $view['start_date'] = 'Tomorrow';
+        $view['end_date'] = '2017-05-01';
         $tests[] = array($view, 'start_date param is not in the correct format of Y-m-d.');
 
         $view['group_by'] = "elephants";

--- a/tests/integration/lib/Rest/JobViewerTest.php
+++ b/tests/integration/lib/Rest/JobViewerTest.php
@@ -491,6 +491,17 @@ class JobViewerTest extends BaseTest
         // get the record id
         $recordId = $result['results'][$result['results']['dtype']];
 
+        // update existing search
+        $input['text'] = 'Updated';
+        $response = $this->xdmodhelper->post(self::ENDPOINT . 'search/history/' . $recordId, array('realm' => 'Jobs'), array('data' => json_encode($input)));
+
+        $this->assertEquals(200, $response[1]['http_code']);
+        $result = $response[0];
+        $this->assertTrue($result['success']);
+        $this->assertEquals($input['searchterms'], $result['results']['searchterms']);
+        $this->assertEquals($input['results'], $result['results']['results']);
+        $this->assertEquals('Updated', $result['results']['text']);
+
         // remove the dummy saved search.
         $response = $this->xdmodhelper->delete(self::ENDPOINT . 'search/history/' . $recordId, array('realm' => 'Jobs'));
 


### PR DESCRIPTION
The xdmod-supremm module build has been updated to check for errors/warnings. Needless to say I found some.

The default value for the font size must be a numeric string - and not a text string. Also an error in the updateHistory rest endpoint. (these two changes have tests in the supremm module that check them).

Add some checks for data validity and hoy out an execption if the checks fail.

The corresponding pull request in the supremm module is https://github.com/ubccr/xdmod-supremm/pull/342