### PR TITLE
Add support for checking rpm install state in check-config

### DIFF
--- a/bin/xdmod-check-config
+++ b/bin/xdmod-check-config
@@ -50,6 +50,16 @@ try {
 
     echo "XDMoD $version\n\n";
 
+    if('__XDMOD_INSTALL_TYPE__' === 'rpm'){
+        $output = array('RPM Installed Packages:');
+        exec('rpm -qa xdmod\*', $output);
+        $output[] = 'File status:';
+        exec('rpm -qa --verify xdmod\*', $output);
+        foreach ($output as $line) {
+            echo "$line\n";
+        }
+    }
+
     echo "Required prerequisites\n\n";
 
     // Apache checks.

--- a/bin/xdmod-check-config
+++ b/bin/xdmod-check-config
@@ -51,13 +51,14 @@ try {
     echo "XDMoD $version\n\n";
 
     if('__XDMOD_INSTALL_TYPE__' === 'rpm'){
-        $output = array('RPM Installed Packages:');
+        $output = array("RPM Installed Packages:\n");
         exec('rpm -qa xdmod\*', $output);
-        $output[] = 'File status:';
+        $output[] = "File status:\n";
         exec('rpm -qa --verify xdmod\*', $output);
         foreach ($output as $line) {
             echo "$line\n";
         }
+        echo "\n";
     }
 
     echo "Required prerequisites\n\n";

--- a/open_xdmod/build_scripts/templates/install.template
+++ b/open_xdmod/build_scripts/templates/install.template
@@ -663,7 +663,7 @@ Options:
         (default: *prefix*/etc/cron.d).
 
     --rpm
-        This flag should be set when building an RPM package and ommited
+        This flag should be set when building an RPM package and omitted
         for a source code install.
 
 EOF;

--- a/open_xdmod/build_scripts/templates/install.template
+++ b/open_xdmod/build_scripts/templates/install.template
@@ -38,6 +38,7 @@ function main()
         array('',  'httpdconfdir:'),
         array('',  'logrotatedconfdir:'),
         array('',  'crondconfdir:'),
+        array('',  'rpm'),
     );
 
     $shortOptions = implode(
@@ -58,6 +59,7 @@ function main()
     $prefix = '/usr/local/xdmod';
 
     $dirs = array(
+        'installtype' => 'source',
         'src' => $srcDir,
     );
 
@@ -102,6 +104,9 @@ function main()
                 break;
             case 'crondconfdir':
                 $dirs['crond'] = $value;
+                break;
+            case 'rpm':
+                $dirs['installtype'] = 'rpm';
                 break;
             default:
                 fwrite(STDERR, "Unexpected argument '$key'\n");
@@ -552,6 +557,10 @@ function substitutePaths($dirs)
         '#/var/log/xdmod#'   => $dirs['log'],
         '#/etc/xdmod#'       => $dirs['conf'],
     ));
+
+    substituteInFile($destDir . $dirs['bin'] . '/xdmod-check-config', array(
+        '/__XDMOD_INSTALL_TYPE__/' => $dirs['installtype'],
+    ));
 }
 
 function substituteInDir($dir, array $subs)
@@ -653,6 +662,9 @@ Options:
         Copy the cron config file to this directory
         (default: *prefix*/etc/cron.d).
 
+    --rpm
+        This flag should be set when building an RPM package and ommited
+        for a source code install.
 
 EOF;
 }

--- a/open_xdmod/modules/xdmod/xdmod.spec.in
+++ b/open_xdmod/modules/xdmod/xdmod.spec.in
@@ -48,6 +48,7 @@ exit 0
 rm -rf $RPM_BUILD_ROOT
 DESTDIR=$RPM_BUILD_ROOT ./install \
     --quiet \
+    --rpm \
     --bindir=%{_bindir} \
     --libdir=%{_libdir}/%{name} \
     --sysconfdir=%{_sysconfdir}/%{name} \

--- a/tests/ci/validate.sh
+++ b/tests/ci/validate.sh
@@ -51,4 +51,11 @@ then
     exitcode=1
 fi
 
+# Confirm that xdmod-check-config finds the RPM installation details
+if ! xdmod-check-config | grep -q 'RPM Installed Packages'
+then
+    echo "Missing RPM information from xdmod-check-config"
+    exitcode=1
+fi
+
 exit $exitcode


### PR DESCRIPTION
Add an extra flag to the installer and new substituted string in the xdmod-check-config command so we can tell the difference between an rpm install and source code install. 

On an RPM -based install the check config script will list the installed xdmod rpms and output the results of the rpm verify command.

The additional output for an RPM install would look a bit like this:
```
RPM Installed Packages:

xdmod-10.5.0-1.0.el7.noarch

File status:

S.5....T.  c /etc/xdmod/hierarchy.json
S.5....T.  c /etc/xdmod/organization.json
S.5....T.  c /etc/xdmod/portal_settings.ini
S.5....T.  c /etc/xdmod/resource_specs.json
S.5....T.  c /etc/xdmod/resources.json
```