### PR TITLE
Improvements to xdmod-check-config

### DIFF
--- a/bin/xdmod-check-config
+++ b/bin/xdmod-check-config
@@ -216,6 +216,22 @@ try {
         $result,
         "sendmail executable installed"
     );
+
+    _debug('Checking for nodejs');
+    $output = null;
+    $returnVar = null;
+    $nodejs = exec('node --version 2>&1', $output, $returnVar);
+    displayResult(
+        $returnVar == 0,
+        "nodejs " . implode(' ', $output)
+    );
+
+    echo "\nOptional prerequisites\n\n";
+
+    _debug('Checking for a mongodb driver');
+    $result = class_exists('\MongoClient') || class_exists('\MongoDB\Client');
+    echo ' INFO     PHP MongoDB client driver ' . ($result ? 'installed' : 'not found') . "\n\n";
+
 } catch (Exception $e) {
     do {
         _error($e->getMessage());


### PR DESCRIPTION
Adds check for the (required) nodejs software. Also adds a check for the optional mongo driver.

Example of the output on a system with mongo driver and nodejs installed:
```
------------8<---------------
 OK       PHP Timezone set
 OK       Chromium configured
 OK       sendmail executable installed
 OK       nodejs v16.14.0

Optional prerequisites

 INFO     PHP MongoDB client driver installed
```

and similarly if node and mongo are absent:
```
------------8<---------------
 OK       PHP Timezone set
 OK       Chromium configured
 OK       sendmail executable installed
 NOT OK   nodejs sh: node: command not found

Optional prerequisites

 INFO     PHP MongoDB client driver not found
```

