### PR TITLE
Adding default values for modw_cloud.instance_type_union table

### DIFF
--- a/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
@@ -16,8 +16,7 @@
             {
                 "name": "instance_type_id",
                 "type": "int(11)",
-                "nullable": false,
-                "default": -1,
+                "nullable": true,
                 "comment": "Resource to which this type belongs"
             },
             {

--- a/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
@@ -10,24 +10,28 @@
                 "name": "resource_id",
                 "type": "int(11)",
                 "nullable": false,
+                "default": -1,
                 "comment": "Resource to which this type belongs"
             },
             {
                 "name": "instance_type_id",
                 "type": "int(11)",
                 "nullable": false,
+                "default": -1,
                 "comment": "Resource to which this type belongs"
             },
             {
                 "name": "instance_type",
                 "type": "varchar(64)",
                 "nullable": false,
+                "default": "Unknown",
                 "comment": "Short version or abbrev"
             },
             {
                 "name": "display",
                 "type": "varchar(256)",
                 "nullable": false,
+                "default": "Unknown",
                 "comment": "What to show the user"
             },
             {


### PR DESCRIPTION
Adding default values for modw_cloud.instance_type_union table prevents the following warning

```
[warning] Warning 1364 Field 'instance_type_id' doesn't have a default value
```
## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
