### PR TITLE
Allowing group bys to be hidden for a specific statistic

### DIFF
--- a/bin/acl-config
+++ b/bin/acl-config
@@ -1491,9 +1491,12 @@ SQL;
 
             $id = "[ $module, $realm, $acl, $groupByName, $statisticId ]";
             $visible = 1;
-            if (!$realmData['show_in_catalog'] || !$statisticData->showInMetricCatalog()) {
+            $hiddenGroupBys = $statisticData->getHiddenGroupBys();
+
+            if (!$realmData['show_in_catalog'] || !$statisticData->showInMetricCatalog() || in_array($groupByName, $hiddenGroupBys)) {
                 $visible = 0;
             }
+
             $params = array(
                 ':module_name' => $module,
                 ':realm_name' => $realm,

--- a/classes/DataWarehouse/Access/Usage.php
+++ b/classes/DataWarehouse/Access/Usage.php
@@ -817,7 +817,7 @@ class Usage extends Common
                     $usageGroupBy,
                     $meRequestMetric->getId()
                 );
-                $drillTargets = $queryDescripter->getDrillTargets();
+                $drillTargets = $queryDescripter->getDrillTargets($meRequestMetric->getHiddenGroupBys());
                 $drillDowns = array_map(
                     function ($drillTarget) {
                         return explode('-', $drillTarget, 2);

--- a/classes/Realm/Realm.php
+++ b/classes/Realm/Realm.php
@@ -799,7 +799,7 @@ class Realm extends \CCR\Loggable implements iRealm
      * @see iRealm::getDrillTargets()
      */
 
-    public function getDrillTargets($groupById, $order = self::SORT_ON_ORDER)
+    public function getDrillTargets($groupById, $hiddenGroupBys=array(), $order = self::SORT_ON_ORDER)
     {
         $drillTargets = array();
         $groupByObjects = $this->getGroupByObjects($order);
@@ -807,7 +807,7 @@ class Realm extends \CCR\Loggable implements iRealm
         foreach ( $groupByObjects as $gId => $groupByObj ) {
             // Don't include the current group by or any group bys that are not available for drill
             // down.
-            if ( $gId == $groupById || ! $groupByObj->showInMetricCatalog() ) {
+            if ( $gId == $groupById || ! $groupByObj->showInMetricCatalog() || in_array($gId, $hiddenGroupBys) ) {
                 continue;
             }
             $drillTargets[] = sprintf('%s-%s', $gId, $groupByObj->getName());

--- a/classes/Realm/Realm.php
+++ b/classes/Realm/Realm.php
@@ -799,7 +799,7 @@ class Realm extends \CCR\Loggable implements iRealm
      * @see iRealm::getDrillTargets()
      */
 
-    public function getDrillTargets($groupById, $hiddenGroupBys=array(), $order = self::SORT_ON_ORDER)
+    public function getDrillTargets($groupById, $hiddenGroupBys = array(), $order = self::SORT_ON_ORDER)
     {
         $drillTargets = array();
         $groupByObjects = $this->getGroupByObjects($order);

--- a/classes/Realm/Statistic.php
+++ b/classes/Realm/Statistic.php
@@ -130,6 +130,11 @@ class Statistic extends \CCR\Loggable implements iStatistic
     protected $variableStore = null;
 
     /**
+     * @var array Group By names that should be hidden for this statistic.
+     */
+    protected $hiddenGroupBys = [];
+
+    /**
      * @see iStatistic::factory()
      */
 
@@ -267,6 +272,11 @@ class Statistic extends \CCR\Loggable implements iStatistic
                     break;
                 case 'weight_statistic_id':
                     $this->weightStatisticId = trim($value);
+                    break;
+                case 'hidden_groupbys':
+                    if(is_array($value)) {
+                        $this->hiddenGroupBys = $value;
+                    }
                     break;
                 default:
                     $this->logger->notice(
@@ -483,6 +493,15 @@ class Statistic extends \CCR\Loggable implements iStatistic
     public function showInMetricCatalog()
     {
         return $this->showInCatalog;
+    }
+
+    /**
+     * @see iStatistic::getHiddenGroupBys()
+     */
+
+    public function getHiddenGroupBys()
+    {
+        return $this->hiddenGroupBys;
     }
 
     /**

--- a/classes/Realm/iStatistic.php
+++ b/classes/Realm/iStatistic.php
@@ -175,6 +175,11 @@ interface iStatistic
     public function showInMetricCatalog();
 
     /**
+     * @return array Returns array of group by names that should be hidden for this statistic.
+     */
+    public function getHiddenGroupBys();
+
+    /**
      * Generate a string representation of the object
      */
 

--- a/classes/User/Elements/QueryDescripter.php
+++ b/classes/User/Elements/QueryDescripter.php
@@ -75,10 +75,11 @@ class QueryDescripter
         $this->_disable_menu = false;
     }
 
-    public function getDrillTargets()
+    public function getDrillTargets($hiddenGroupBys=array())
     {
         return $this->realm->getDrillTargets(
             $this->_group_by_name,
+            $hiddenGroupBys,
             \Realm\Realm::SORT_ON_NAME
         );
     }

--- a/classes/User/Elements/QueryDescripter.php
+++ b/classes/User/Elements/QueryDescripter.php
@@ -75,7 +75,7 @@ class QueryDescripter
         $this->_disable_menu = false;
     }
 
-    public function getDrillTargets($hiddenGroupBys=array())
+    public function getDrillTargets($hiddenGroupBys = array())
     {
         return $this->realm->getDrillTargets(
             $this->_group_by_name,

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -105,7 +105,8 @@ foreach ($roles as $activeRole) {
                             array(
                                 'text' => $statistic_object->getName(),
                                 'info' => $statistic_object->getHtmlDescription(),
-                                'std_err' => in_array($semStatId, $permittedStatistics)
+                                'std_err' => in_array($semStatId, $permittedStatistics),
+                                'hidden_groupbys' => $statistic_object->getHiddenGroupBys()
                             );
                         $seenstats[] = $realm_group_by_statistic;
                     }

--- a/html/controllers/user_interface/get_menus.php
+++ b/html/controllers/user_interface/get_menus.php
@@ -192,7 +192,7 @@ try {
                     foreach ($query_descripter->getPermittedStatistics() as $realm_group_by_statistic) {
                         $statistic_object = $query_descripter->getStatistic($realm_group_by_statistic);
 
-                        if ( ! $statistic_object->showInMetricCatalog() ) {
+                        if ( ! $statistic_object->showInMetricCatalog() || in_array($group_by_name, $statistic_object->getHiddenGroupBys())) {
                             continue;
                         }
 

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -155,7 +155,9 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
           var filterMap = {};
 
           for (var x in realm_dimensions) {
-              if (x === 'none' || realm_dimensions[x].text === undefined || hidden_groupbys.includes(x)) { continue };
+              if (x === 'none' || realm_dimensions[x].text === undefined || hidden_groupbys.includes(x)) {
+                continue;
+              }
               if (filterMap[x] === undefined) {
                   filterMap[x] = filterItems.length;
                   filterItems.push({
@@ -169,10 +171,8 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
                           filterButtonHandler.call(b.scope, b.dimension, b.text, b.realms);
                       }
                   });
-              } else {
-                  if (filterItems[filterMap[x]].realms.indexOf(this.record.data.realm) == -1) {
-                      filterItems[filterMap[x]].realms.push(this.record.data.realm);
-                  }
+              } else if (filterItems[filterMap[x]].realms.indexOf(this.record.data.realm) === -1) {
+                    filterItems[filterMap[x]].realms.push(this.record.data.realm);
               }
           }
 
@@ -180,18 +180,18 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
               function (a, b) {
                   var nameA = a.text.toLowerCase();
                   var nameB = b.text.toLowerCase();
-                  if (nameA < nameB) { //sort string ascending
+                  if (nameA < nameB) { // sort string ascending
                       return -1;
                   }
                   if (nameA > nameB) {
                       return 1;
                   }
-                  return 0; //default return value (no sorting)
+                  return 0; // default return value (no sorting)
               }
           );
 
           return filterItems;
-        }
+        };
 
         this.filtersMenu.addItem(this.filterItemsList());
         filterButtonHandler = function (dim_id, dim_label, realms) {

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -155,7 +155,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
           var filterItems = [];
           var filterMap = {};
 
-          Object.entries(realm_dimensions).forEach( function (item, key, value) {
+          Object.entries(realm_dimensions).forEach(function (item, key, value) {
               var dimension_name = item[0];
               if (dimension_name === 'none' || item[1].text === undefined || hidden_groupbys.includes(dimension_name)) {
                 return;

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -150,31 +150,33 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
         var realm_dimensions = this.realms[this.record.data.realm]['dimensions'];
 
         this.filterItemsList = function () {
-          var hidden_groupbys = this.realms[this.record.data.realm]['metrics'][this.record.data.metric].hidden_groupbys;
+          var recordData = this.record.data;
+          var hidden_groupbys = this.realms[recordData.realm]['metrics'][recordData.metric].hidden_groupbys;
           var filterItems = [];
           var filterMap = {};
 
-          for (var x in realm_dimensions) {
-              if (x === 'none' || realm_dimensions[x].text === undefined || hidden_groupbys.includes(x)) {
-                continue;
+          Object.entries(realm_dimensions).forEach( function (item, key, value) {
+              var dimension_name = item[0];
+              if (dimension_name === 'none' || item[1].text === undefined || hidden_groupbys.includes(dimension_name)) {
+                return;
               }
-              if (filterMap[x] === undefined) {
-                  filterMap[x] = filterItems.length;
+              if (filterMap[dimension_name] === undefined) {
+                  filterMap[dimension_name] = filterItems.length;
                   filterItems.push({
-                      text: realm_dimensions[x].text,
+                      text: item[1].text,
                       iconCls: 'menu',
-                      realms: [this.record.data.realm],
-                      dimension: x,
+                      realms: [recordData.realm],
+                      dimension: dimension_name,
                       scope: this,
                       handler: function (b, e) {
                           XDMoD.TrackEvent('Metric Explorer', 'Data Series Definition -> Selected filter from menu', b.text);
                           filterButtonHandler.call(b.scope, b.dimension, b.text, b.realms);
                       }
                   });
-              } else if (filterItems[filterMap[x]].realms.indexOf(this.record.data.realm) === -1) {
-                    filterItems[filterMap[x]].realms.push(this.record.data.realm);
+              } else if (filterItems[filterMap[dimension_name]].realms.indexOf(recordData.realm) === -1) {
+                  filterItems[filterMap[dimension_name]].realms.push(recordData.realm);
               }
-          }
+          });
 
           filterItems.sort(
               function (a, b) {
@@ -251,7 +253,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
             }
 
             return metricData;
-        }
+        };
 
         this.dimensionDataList = function () {
             var hidden_groupbys = this.realms[this.record.data.realm]['metrics'][this.record.data.metric].hidden_groupbys;
@@ -264,7 +266,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
             }
 
             return dimensionData;
-        }
+        };
 
         var activeFilterCheckColumn = new Ext.grid.CheckColumn({
             id: 'checked',

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -151,7 +151,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
 
         this.filterItemsList = function () {
           var recordData = this.record.data;
-          var hidden_groupbys = this.realms[recordData.realm]['metrics'][recordData.metric].hidden_groupbys;
+          var hidden_groupbys = this.realms[recordData.realm].metrics[recordData.metric].hidden_groupbys;
           var filterItems = [];
           var filterMap = {};
 
@@ -246,9 +246,9 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
         this.metricsDataList = function () {
             var metricData = [];
 
-            for (var metric in this.realms[this.record.data.realm]['metrics']) {
-                if (this.realms[this.record.data.realm]['metrics'][metric].hidden_groupbys.includes(this.record.data.group_by) === false) {
-                  metricData.push([metric, this.realms[this.record.data.realm]['metrics'][metric].text]);
+            for (var metric in this.realms[this.record.data.realm].metrics) {
+                if (this.realms[this.record.data.realm].metrics[metric].hidden_groupbys.includes(this.record.data.group_by) === false) {
+                  metricData.push([metric, this.realms[this.record.data.realm].metrics[metric].text]);
                 }
             }
 
@@ -256,12 +256,12 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
         };
 
         this.dimensionDataList = function () {
-            var hidden_groupbys = this.realms[this.record.data.realm]['metrics'][this.record.data.metric].hidden_groupbys;
+            var hidden_groupbys = this.realms[this.record.data.realm].metrics[this.record.data.metric].hidden_groupbys;
             var dimensionData = [];
 
-            for (var dimension in this.realms[this.record.data.realm]['dimensions']) {
+            for (var dimension in this.realms[this.record.data.realm].dimensions) {
                 if (hidden_groupbys.includes(dimension) === false) {
-                    dimensionData.push([dimension, this.realms[this.record.data.realm]['dimensions'][dimension].text]);
+                    dimensionData.push([dimension, this.realms[this.record.data.realm].dimensions[dimension].text]);
                 }
             }
 
@@ -511,7 +511,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
                       XDMoD.TrackEvent('Metric Explorer', 'Data Series Definition -> Selected ' + combo.fieldLabel + ' using drop-down menu', record.get('id'));
                       var metric = record.get('id');
                       this.record.set('metric', metric);
-                      var has_std_err = this.realms[this.record.data.realm]['metrics'][metric].std_err;
+                      var has_std_err = this.realms[this.record.data.realm].metrics[metric].std_err;
                       this.record.set('has_std_err', has_std_err);
                       this.stdErrorCheckBox.setDisabled(!has_std_err || this.record.data.log_scale);
                       this.stdErrorLabelsCheckBox.setDisabled(!has_std_err || this.record.data.log_scale);

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -149,14 +149,14 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
 
         var realm_dimensions = this.realms[this.record.data.realm]['dimensions'];
 
-        this.filterItemsList = function(){
+        this.filterItemsList = function () {
           var hidden_groupbys = this.realms[this.record.data.realm]['metrics'][this.record.data.metric].hidden_groupbys;
           var filterItems = [];
           var filterMap = {};
 
-          for (x in realm_dimensions) {
-              if (x == 'none' || realm_dimensions[x].text == undefined || hidden_groupbys.includes(x)) continue;
-              if (filterMap[x] == undefined) {
+          for (var x in realm_dimensions) {
+              if (x === 'none' || realm_dimensions[x].text === undefined || hidden_groupbys.includes(x)) { continue };
+              if (filterMap[x] === undefined) {
                   filterMap[x] = filterItems.length;
                   filterItems.push({
                       text: realm_dimensions[x].text,
@@ -178,12 +178,14 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
 
           filterItems.sort(
               function (a, b) {
-                  var nameA = a.text.toLowerCase(),
-                      nameB = b.text.toLowerCase();
-                  if (nameA < nameB) //sort string ascending
+                  var nameA = a.text.toLowerCase();
+                  var nameB = b.text.toLowerCase();
+                  if (nameA < nameB) { //sort string ascending
                       return -1;
-                  if (nameA > nameB)
+                  }
+                  if (nameA > nameB) {
                       return 1;
+                  }
                   return 0; //default return value (no sorting)
               }
           );
@@ -239,11 +241,11 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
             realmData.push([realm]);
         }
 
-        this.metricsDataList = function(){
+        this.metricsDataList = function () {
             var metricData = [];
 
-            for (metric in this.realms[this.record.data.realm]['metrics']) {
-                if(this.realms[this.record.data.realm]['metrics'][metric].hidden_groupbys.includes(this.record.data.group_by) === false){
+            for (var metric in this.realms[this.record.data.realm]['metrics']) {
+                if (this.realms[this.record.data.realm]['metrics'][metric].hidden_groupbys.includes(this.record.data.group_by) === false) {
                   metricData.push([metric, this.realms[this.record.data.realm]['metrics'][metric].text]);
                 }
             }
@@ -251,17 +253,17 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
             return metricData;
         }
 
-        this.dimensionDataList = function(){
+        this.dimensionDataList = function () {
             var hidden_groupbys = this.realms[this.record.data.realm]['metrics'][this.record.data.metric].hidden_groupbys;
             var dimensionData = [];
 
-            for (dimension in this.realms[this.record.data.realm]['dimensions']) {
+            for (var dimension in this.realms[this.record.data.realm]['dimensions']) {
                 if (hidden_groupbys.includes(dimension) === false) {
                     dimensionData.push([dimension, this.realms[this.record.data.realm]['dimensions'][dimension].text]);
                 }
             }
 
-            return dimensionData
+            return dimensionData;
         }
 
         var activeFilterCheckColumn = new Ext.grid.CheckColumn({
@@ -503,7 +505,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
               triggerAction: 'all',
               listeners: {
                   scope: this,
-                  'select': function (combo, record, index) {
+                  select: function (combo, record, index) {
                       XDMoD.TrackEvent('Metric Explorer', 'Data Series Definition -> Selected ' + combo.fieldLabel + ' using drop-down menu', record.get('id'));
                       var metric = record.get('id');
                       this.record.set('metric', metric);
@@ -541,7 +543,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
               triggerAction: 'all',
               listeners: {
                   scope: this,
-                  'select': function (combo, record, index) {
+                  select: function (combo, record, index) {
                       XDMoD.TrackEvent('Metric Explorer', 'Data Series Definition -> Selected ' + combo.fieldLabel + ' using drop-down menu', record.get('id'));
                       this.record.set('group_by', record.get('id'));
                       this.metricsComboBox.store.removeAll();

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -517,7 +517,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
                       this.filtersMenu.addItem(this.filterItemsList());
                   }
               }
-          },
+          }
         );
 
         this.dimensionComboBox = new Ext.form.ComboBox({

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -126,7 +126,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
     },
     initComponent: function () {
         var filterButtonHandler;
-        var _self = this;
+        var that = this;
 
         if (!this.record && this.store) {
             this.record = CCR.xdmod.ui.AddDataPanel.initRecord(this.store, this.config, this.getSelectedFilters(), this.timeseries);
@@ -168,7 +168,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
                       iconCls: 'menu',
                       realms: [recordData.realm],
                       dimension: dimension_name,
-                      scope: _self,
+                      scope: that,
                       handler: function (b, e) {
                           XDMoD.TrackEvent('Metric Explorer', 'Data Series Definition -> Selected filter from menu', b.text);
                           filterButtonHandler.call(b.scope, b.dimension, b.text, b.realms);

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -126,7 +126,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
     },
     initComponent: function () {
         var filterButtonHandler;
-        var that = this;
+        var self = this;
 
         if (!this.record && this.store) {
             this.record = CCR.xdmod.ui.AddDataPanel.initRecord(this.store, this.config, this.getSelectedFilters(), this.timeseries);
@@ -168,7 +168,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
                       iconCls: 'menu',
                       realms: [recordData.realm],
                       dimension: dimension_name,
-                      scope: that,
+                      scope: self,
                       handler: function (b, e) {
                           XDMoD.TrackEvent('Metric Explorer', 'Data Series Definition -> Selected filter from menu', b.text);
                           filterButtonHandler.call(b.scope, b.dimension, b.text, b.realms);

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -126,6 +126,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
     },
     initComponent: function () {
         var filterButtonHandler;
+        var _self = this;
 
         if (!this.record && this.store) {
             this.record = CCR.xdmod.ui.AddDataPanel.initRecord(this.store, this.config, this.getSelectedFilters(), this.timeseries);
@@ -167,7 +168,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
                       iconCls: 'menu',
                       realms: [recordData.realm],
                       dimension: dimension_name,
-                      scope: this,
+                      scope: _self,
                       handler: function (b, e) {
                           XDMoD.TrackEvent('Metric Explorer', 'Data Series Definition -> Selected filter from menu', b.text);
                           filterButtonHandler.call(b.scope, b.dimension, b.text, b.realms);

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -5310,7 +5310,6 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
 
             // for each item in the filtersMenu,
             this.filtersMenu.items.each(function (item) {
-
                 // Get the item's realms array, if it exists.
                 var iRealms = item.realms;
                 if (iRealms === undefined) {

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -2838,7 +2838,6 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                                     type: 'metric',
                                     text: realm_metrics[rm].text,
                                     has_std_err: realm_metrics[rm].std_err,
-                                    hidden_groupbys: realm_metrics[rm].hidden_groupbys,
                                     iconCls: 'chart',
                                     category: category,
                                     realm: realm,

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -781,7 +781,7 @@ Ext.apply(XDMoD.Module.MetricExplorer, {
 
         var dimensions = instance.realms[realm]['dimensions'];
         var drilldownItems = ['<span class="menu-title">' + (dimensions[dimension].text !== drillLabel ? (dimension !== 'none' ? 'For ' + dimensions[dimension].text + ' = ' + drillLabel + ', ' : '') : '') + 'Drilldown to:</span><br/>'];
-        var metrics = instance.realms[realm]['metrics'];
+        var metrics = instance.realms[realm].metrics;
 
         if (drillId && drillLabel) {
             for (var dim in dimensions) {
@@ -5305,7 +5305,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
             var instance = CCR.xdmod.ui.metricExplorer;
 
             this.datasetStore.each(function (record) {
-              hidden_groupbys[record.get('realm')] = instance.realms[record.get('realm')]['metrics'][record.get('metric')].hidden_groupbys;
+              hidden_groupbys[record.get('realm')] = instance.realms[record.get('realm')].metrics[record.get('metric')].hidden_groupbys;
             });
 
             // for each item in the filtersMenu,

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -2823,8 +2823,8 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                                     continue;
                                 }
 
-                                metric_dimensions = {};
-                                for(var dimension in realm_dimensions) {
+                                var metric_dimensions = {};
+                                for (var dimension in realm_dimensions) {
                                     if (!realm_metrics[rm].hidden_groupbys.includes(dimension)) {
                                         metric_dimensions[dimension] = realm_dimensions[dimension];
                                     }
@@ -5301,16 +5301,15 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
             // get a list of the currently plotted realms:
             var enabledRealms = this.getEnabledRealmsList();
 
-            hidden_groupbys = [];
-            instance = CCR.xdmod.ui.metricExplorer;
+            var hidden_groupbys = [];
+            var instance = CCR.xdmod.ui.metricExplorer;
 
-            this.datasetStore.each(function(record) {
-              var metric = record.get('metric');
+            this.datasetStore.each(function (record) {
               hidden_groupbys[record.get('realm')] = instance.realms[record.get('realm')]['metrics'][record.get('metric')].hidden_groupbys;
             });
 
             // for each item in the filtersMenu,
-            this.filtersMenu.items.each(function(item) {
+            this.filtersMenu.items.each(function (item) {
 
                 // Get the item's realms array, if it exists.
                 var iRealms = item.realms;


### PR DESCRIPTION
This PR contains changes to allow group by's to be hidden for a specific statistic instead of a whole realm. To denote the hidden group by's for a statistic a field `hidden_groupby` can be added to a statistic definition in the config files in `datawarehouse.d`.

Example: 
```
"active_person_count": {
        "description_html": "The total number of users that used ${ORGANIZATION_NAME} resources.",
        "formula": "COUNT(DISTINCT(agg.person_id))",
        "name": "Number of Users: Active",
        "precision": 0,
        "unit": "Number of Users",
        "hidden_groupbys": ["resource", "pi"]
    }
```

Changes were made to `acl-config` to make sure the `visibility` fields was set correctly in the appropriate acl role tables. A `hidden_groupby` property was added to the `classes/Realm/Statitstic.php` class and in `html/controllers/metric_explorer/get_dw_descipters.php` to make sure any hidden groupby's are returned for each statistic.

For JS related changes, changes were made for the metric explorer to the catalog, dropdown menus, Edit Dataset dialog box and `Add Filter` button. Changes were also make in the Usage tab for the Usage catalog and dropdown menus. 

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
