### PR TITLE
Update styling of error message to match highcharts version.

### DIFF
--- a/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
+++ b/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
@@ -191,24 +191,25 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
                     align: 'left',
                     xref: 'paper',
                     yref: 'paper',
-                    sizex: 0.4,
-                    sizey: 0.4,
+                    sizex: 0.35,
+                    sizey: 0.35,
                     x: 0,
-                    y: 1.2
+                    y: 1.05
                 }
             ];
             this.chartOptions.images = errorImage;
             var errorText = [
                 {
-                    text: '<b>' + errorStr + '</b>',
+                    text: errorStr,
                     align: 'left',
                     xref: 'paper',
                     yref: 'paper',
                     font: {
-                        size: 11
+                        size: 12,
+                        family: 'Lucida Grande, Lucida Sans Unicode, Arial, Helvetica, sans-serif'
                     },
-                    x: 0.05,
-                    y: 1.2,
+                    x: 0.08,
+                    y: 1.1,
                     showarrow: false
                 }
             ];


### PR DESCRIPTION
Changes the icon to better match the original one remove the bold font and set the font size and face to match the original.
This does not address the word wrap (which will be in a different pull request).

HighCharts original version:
![image](https://github.com/ubccr/xdmod/assets/5342179/8140dab2-2fe3-468d-a849-be31ceb8fa27)

Ploty version with this code change:

![image](https://github.com/ubccr/xdmod/assets/5342179/c9567eb5-2fe1-4d50-be14-32bfd5cf232d)

Original plotly version:

![image](https://github.com/ubccr/xdmod/assets/5342179/b379dfec-3962-4ec7-9102-df293ddf4618)


