### PR TITLE
Add word wrap to job viewer analytics error messages

### DIFF
--- a/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
+++ b/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
@@ -191,24 +191,25 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
                     align: 'left',
                     xref: 'paper',
                     yref: 'paper',
-                    sizex: 0.4,
-                    sizey: 0.4,
+                    sizex: 0.35,
+                    sizey: 0.35,
                     x: 0,
-                    y: 1.2
+                    y: 1.05
                 }
             ];
             this.chartOptions.images = errorImage;
             var errorText = [
                 {
-                    text: '<b>' + errorStr + '</b>',
+                    text: errorStr,
                     align: 'left',
                     xref: 'paper',
                     yref: 'paper',
                     font: {
-                        size: 11
+                        size: 12,
+                        family: 'Lucida Grande, Lucida Sans Unicode, Arial, Helvetica, sans-serif'
                     },
-                    x: 0.05,
-                    y: 1.2,
+                    x: 0.08,
+                    y: 1.1,
                     showarrow: false
                 }
             ];

--- a/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
+++ b/html/gui/js/modules/job_viewer/AnalyticChartPanel.js
@@ -198,9 +198,11 @@ XDMoD.Module.JobViewer.AnalyticChartPanel = Ext.extend(Ext.Panel, {
                 }
             ];
             this.chartOptions.images = errorImage;
+            var max = Math.floor(this.chartOptions.width / 7);
+            var wordMatch = new RegExp('(?![^\\n]{1,' + max + '}$)([^\\n]{1,' + max + '})\\s', 'g');
             var errorText = [
                 {
-                    text: errorStr,
+                    text: errorStr.replace(wordMatch, '$1<br />'),
                     align: 'left',
                     xref: 'paper',
                     yref: 'paper',


### PR DESCRIPTION
Before:
![image](https://github.com/ubccr/xdmod/assets/5342179/5bb832ff-520f-4edd-a57e-d767d281687a)

After (this also includes the styling changes in #1739 
![image](https://github.com/ubccr/xdmod/assets/5342179/b304d020-4f84-42d4-b1e7-35d262724dbb)

Note this depends on a pull request in the xdmod-supremm repo that changes the error output to not add html entitires.