### PR TITLE
Fix Drilldown EventEmitter for Single Job Viewer

### DIFF
--- a/html/gui/js/modules/job_viewer/ChartPanel.js
+++ b/html/gui/js/modules/job_viewer/ChartPanel.js
@@ -154,7 +154,7 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
                 }
                 if (panel.chart) {
                     panel.chart = document.getElementById(this.id);
-                    panel.chart.on('plotly_click', function (data, event) {
+                    panel.chart.once('plotly_click', function (data, event) {
                         var userOptions = data.points[0].data.chartSeries;
                         if (!userOptions || !userOptions.dtype) {
                             return;


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
Drilling down on the same job repeatedly will eventually cause MaxListenersExceededWarning. You can reproduce this in the Job Viewer tab by the following:
1. Drilldown on a timeseries chart
2. Go back to original chart before drilldown
Repeat 1-2 until console warning appears.

NOTE: Not able to reproduce if you continually drilldown on different charts. Needs to be the same chart over and over again.

For Gantt Charts we may wish to use a flag instead of .once() due to the event listener never being re-added due to the existence of a cyclic drilldown. This is not an issue for timeseries charts because you can't drilldown in a cyclic manner.  

<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
