### PR TITLE
Fix validation of REST array parameters.

### DIFF
--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -284,12 +284,25 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
             }
         }
 
+        // If the parameter is an array, throw an exception.
+        $invalidMessage = (
+            "Invalid value for $name. Must be a(n) $expectedValueType."
+        );
+        if (is_array($value)) {
+            throw new BadRequestHttpException($invalidMessage);
+        }
+
         // Run the found parameter value through the given filter.
+        if (array_key_exists('flags', $filterOptions)) {
+            $filterOptions['flags'] |= FILTER_NULL_ON_FAILURE;
+        } else {
+            $filterOptions['flags'] = FILTER_NULL_ON_FAILURE;
+        }
         $value = filter_var($value, $filterId, $filterOptions);
 
         // If the value is invalid, throw an exception.
         if ($value === null) {
-            throw new BadRequestHttpException("Invalid value for $name. Must be a(n) $expectedValueType.");
+            throw new BadRequestHttpException($invalidMessage);
         }
 
         // Return the filtered value.

--- a/classes/Rest/XdmodApplicationFactory.php
+++ b/classes/Rest/XdmodApplicationFactory.php
@@ -108,7 +108,11 @@ class XdmodApplicationFactory
             // Extracting any POST variables provided in the Request.
             $post = array();
             foreach($request->request->getIterator() as $key => $value) {
-                $post[$key] = json_decode($value, true);
+                $post[$key] = (
+                    is_string($value)
+                    ? json_decode($value, true)
+                    : null
+                );
             }
 
             // Calculate the amount of time that has elapsed serving this request.

--- a/tests/integration/lib/BaseTest.php
+++ b/tests/integration/lib/BaseTest.php
@@ -31,8 +31,10 @@ use IntegrationTests\TestHarness\XdmodTestHelper;
  * authentication failures give the correct response, failing to authorize as a
  * center director gives the correct response, requests in which the 'limit' or
  * 'start_date' parameters are missing give the correct response, and requests
- * in which the value of 'limit' is not a valid integer or 'start_date' is not
- * a valid ISO 8601 date give the correct response.
+ * give the correct response for which the value of 'limit' is not a valid
+ * integer, the values of 'realm' or 'dimension' are not valid strings, the
+ * value of 'ts' is not a valid Unix timestamp, or the value of 'start_date' is
+ * not a valid ISO 8601 date.
  *
  *   public function testGetData($id, $role, $input, $output)
  *   {
@@ -62,7 +64,9 @@ use IntegrationTests\TestHarness\XdmodTestHelper;
  *              'authentication' => true,
  *              'authorization' => 'cd',
  *              'int_params' => ['limit'],
- *              'date_params' => ['start_date']
+ *              'string_params' => ['realm', 'dimension'],
+ *              'unix_ts_params' => ['ts'],
+ *              'date_params' => ['start_date'],
  *          ]
  *      );
  *  }
@@ -394,6 +398,10 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      *                         need to be present for other tests here to succeed.
      *                       - 'int_params' — array of parameters that will each be tested for
      *                         invalid integer values.
+     *                       - 'string_params' — array of parameters that will each be tested for
+     *                         invalid string values.
+     *                       - 'unix_ts_params' — array of parameters that will each be tested for
+     *                         invalid Unix timestamp values.
      *                       - 'date_params' — array of parameters that will each be tested for
      *                         invalid ISO 8601 date values.
      * @return array of arrays of test data, each of which contains a string ID of the test, a
@@ -423,6 +431,11 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
                 $options['additional_params']
             );
         }
+        // Set up the custom error body validator.
+        $errorBodyValidator = null;
+        if (array_key_exists('error_body_validator', $options)) {
+            $errorBodyValidator = $options['error_body_validator'];
+        }
         $tests = [];
         // Provide authentication tests.
         if (
@@ -433,7 +446,10 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
                 'unauthenticated',
                 'pub',
                 $validInputWithAdditionalParams,
-                $this->validateAuthorizationErrorResponse(401)
+                $this->validateAuthorizationErrorResponse(
+                    401,
+                    $errorBodyValidator
+                )
             ];
         }
         // Provide authorization tests.
@@ -444,7 +460,10 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
                         'unauthorized',
                         $role,
                         $validInputWithAdditionalParams,
-                        $this->validateAuthorizationErrorResponse(403)
+                        $this->validateAuthorizationErrorResponse(
+                            403,
+                            $errorBodyValidator
+                        )
                     ];
                 }
             }
@@ -488,30 +507,48 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
             array_push(
                 $testData,
                 $input,
-                $this->validateMissingRequiredParameterResponse($param)
+                $this->validateMissingRequiredParameterResponse(
+                    $param,
+                    $errorBodyValidator
+                )
             );
             $tests[] = $testData;
         }
         // Provide tests of invalid parameters.
         $types = [
             'int_params' => 'integer',
+            'string_params' => 'string',
+            'unix_ts_params' => 'Unix timestamp',
             'date_params' => 'ISO 8601 Date'
+        ];
+        $values = [
+            'string' => 'foo',
+            'array' => ['foo' => 'bar']
         ];
         foreach ($types as $key => $type) {
             if (array_key_exists($key, $options)) {
                 foreach ($options[$key] as $param) {
                     $input = $validInputWithAdditionalParams;
-                    $input[$paramSource][$param] = 'foo';
-                    $testData = ["{$param}_string", $runAs];
-                    if ($tokenAuth) {
-                        $testData[] = 'valid_token';
+                    foreach ($values as $id => $value) {
+                        // Strings can be strings, so skip that test.
+                        if ('string_params' !== $key || 'string' !== $id) {
+                            $input[$paramSource][$param] = $value;
+                            $testData = ["{$param}_$id", $runAs];
+                            if ($tokenAuth) {
+                                $testData[] = 'valid_token';
+                            }
+                            array_push(
+                                $testData,
+                                $input,
+                                $this->validateInvalidParameterResponse(
+                                    $param,
+                                    $type,
+                                    $errorBodyValidator
+                                )
+                            );
+                            $tests[] = $testData;
+                        }
                     }
-                    array_push(
-                        $testData,
-                        $input,
-                        $this->validateInvalidParameterResponse($param, $type)
-                    );
-                    $tests[] = $testData;
                 }
             }
         }
@@ -524,13 +561,18 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      * the given name was not provided in the request.
      *
      * @param string $name
+     * @param callable|null $bodyValidator if provided, overrides the default
+     *                                     body validator.
      * @return array
      */
-    protected function validateMissingRequiredParameterResponse($name)
-    {
+    protected function validateMissingRequiredParameterResponse(
+        $name,
+        $bodyValidator = null
+    ) {
         return $this->validateBadRequestResponse(
             "$name is a required parameter.",
-            0
+            0,
+            $bodyValidator
         );
     }
 
@@ -541,13 +583,19 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $name
      * @param string $type
+     * @param callable|null $bodyValidator if provided, overrides the default
+     *                                     body validator.
      * @return array
      */
-    protected function validateInvalidParameterResponse($name, $type)
-    {
+    protected function validateInvalidParameterResponse(
+        $name,
+        $type,
+        $bodyValidator = null
+    ) {
         return $this->validateBadRequestResponse(
             "Invalid value for $name. Must be a(n) $type.",
-            0
+            0,
+            $bodyValidator
         );
     }
 
@@ -558,15 +606,21 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $message
      * @param int $code
+     * @param callable|null $bodyValidator if provided, overrides the default
+     *                                     body validator.
      * @return array
      */
-    protected function validateBadRequestResponse($message, $code)
-    {
+    protected function validateBadRequestResponse(
+        $message,
+        $code,
+        $bodyValidator = null
+    ) {
         return [
             'status_code' => 400,
             'body_validator' => $this->validateErrorResponseBody(
                 $message,
-                $code
+                $code,
+                $bodyValidator
             )
         ];
     }
@@ -576,10 +630,14 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      * validates authorization error responses with the given HTTP status code.
      *
      * @param int $statusCode
+     * @param callable|null $bodyValidator if provided, overrides the default
+     *                                     body validator.
      * @return array
      */
-    protected function validateAuthorizationErrorResponse($statusCode)
-    {
+    protected function validateAuthorizationErrorResponse(
+        $statusCode,
+        $bodyValidator = null
+    ) {
         return [
             'status_code' => $statusCode,
             'body_validator' => $this->validateErrorResponseBody(
@@ -587,7 +645,8 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
                     'An error was encountered while attempting to process the'
                     . ' requested authorization procedure.'
                 ),
-                0
+                0,
+                $bodyValidator
             )
         ];
     }
@@ -599,10 +658,18 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $message
      * @param int $code
+     * @param callable|null $bodyValidator if provided, overrides the default
+     *                                     body validator.
      * @return callable
      */
-    protected function validateErrorResponseBody($message, $code)
-    {
+    protected function validateErrorResponseBody(
+        $message,
+        $code,
+        $bodyValidator = null
+    ) {
+        if (!is_null($bodyValidator)) {
+            return $bodyValidator($message, $code);
+        }
         return function ($body, $assertMessage) use ($message, $code) {
             parent::assertEquals(
                 [

--- a/tests/integration/lib/BaseTest.php
+++ b/tests/integration/lib/BaseTest.php
@@ -146,7 +146,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      *                     - 'path': the URL path to the HTTP endpoint (e.g.,
      *                               '/rest/...').
      *                     - 'method': the HTTP method, either 'get', 'post',
-     *                                 'delete', or 'patch'.
+     *                                 'put', 'delete', or 'patch'.
      *                     - 'params': associative array of query parameters.
      *                     - 'data': associative array of request body data.
      * @return array element 0 is the response body, element 1 is the return of
@@ -169,6 +169,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
                 );
                 break;
             case 'post':
+            case 'put':
             case 'delete':
             case 'patch':
                 $response = $testHelper->$method(
@@ -363,8 +364,8 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      *                          'params' or 'data' key is mapped to an associative array in which
      *                          the keys are all of the required endpoint parameters, and the values
      *                          are valid values for those parameters. If the 'method' value is
-     *                          'post' or 'patch', the parameters will be pulled from the 'data'
-     *                          value; otherwise, they will be pulled from the 'params' value.
+     *                          'post', 'put', or 'patch', the parameters will be pulled from the
+     *                          'data' value; otherwise, they will be pulled from the 'params' value.
      * @param array $options an associative array that configures how this method should run.
      *                       The keys are all optional:
      *                       - 'authentication' — if the value is true, the return will include a
@@ -418,6 +419,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $paramSource = 'params';
         if (
             'post' === $validInput['method']
+            || 'put' === $validInput['method']
             || 'patch' === $validInput['method']
         ) {
             $paramSource = 'data';

--- a/tests/integration/lib/Controllers/MetricExplorerTest.php
+++ b/tests/integration/lib/Controllers/MetricExplorerTest.php
@@ -550,4 +550,122 @@ EOF;
             array($emptyChart)
         );
     }
+
+    /**
+     * @dataProvider provideCreateQueryParamValidation
+     */
+    public function testCreateQueryParamValidation(
+        $id,
+        $role,
+        $input,
+        $output
+    ) {
+        parent::authenticateRequestAndValidateJson(
+            $this->helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideCreateQueryParamValidation()
+    {
+        $validInput = [
+            'path' => 'rest/metrics/explorer/queries',
+            'method' => 'post',
+            'params' => null,
+            'data' => ['data' => 'foo']
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['data'],
+                'error_body_validator' => $this->validateQueryErrorBody(
+                    'creatQuery'
+                )
+            ]
+        );
+    }
+
+    private function validateQueryErrorBody($action)
+    {
+        // This function is passed to parent::provideRestEndpointTests().
+        return function ($message) use ($action) {
+            // This function is passed to parent::validateErrorResponseBody().
+            return function ($body, $assertMessage) use ($message, $action) {
+                return parent::assertEquals(
+                    [
+                        'success' => false,
+                        'message' => $message,
+                        'action' => $action
+                    ],
+                    $body,
+                    $assertMessage
+                );
+            };
+        };
+    }
+
+    /**
+     * @dataProvider provideUpdateQueryByIdParamValidation
+     */
+    public function testUpdateQueryByIdParamValidation(
+        $id,
+        $role,
+        $input,
+        $output
+    ) {
+        // Get a query ID.
+        $chartSettings = $this->chartDataProvider()[0][0];
+        $settings = [
+            'name' => 'test',
+            'ts' => microtime(true),
+            'config' => $chartSettings
+        ];
+        $this->helper->authenticate('usr');
+        $response = $this->helper->post(
+            'rest/metrics/explorer/queries',
+            null,
+            ['data' => json_encode($settings)]
+        );
+        $this->helper->logout();
+        $id = $response[0]['data']['recordid'];
+        $path = "rest/metrics/explorer/queries/$id";
+        $input['path'] .= $path;
+        // Run the test.
+        parent::authenticateRequestAndValidateJson(
+            $this->helper,
+            $role,
+            $input,
+            $output
+        );
+        // Delete the query ID.
+        $this->helper->authenticate('usr');
+        $this->helper->delete($path);
+        $this->helper->logout();
+    }
+
+    public function provideUpdateQueryByIdParamValidation()
+    {
+        $validInput = [
+            'path' => null, // set in provideUpdateQueryByIdParamValidation().
+            'method' => 'post',
+            'params' => null,
+            'data' => []
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['data', 'name', 'config'],
+                'unix_ts_params' => ['ts'],
+                'error_body_validator' => $this->validateQueryErrorBody(
+                    'updateQuery'
+                )
+            ]
+        );
+    }
 }

--- a/tests/integration/lib/Controllers/UserControllerProviderTest.php
+++ b/tests/integration/lib/Controllers/UserControllerProviderTest.php
@@ -120,6 +120,39 @@ class UserControllerProviderTest extends BaseUserAdminTest
     }
 
     /**
+     * @dataProvider provideUpdateCurrentUser
+     */
+    public function testUpdateCurrentUser($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            $this->helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideUpdateCurrentUser()
+    {
+        $validInput = [
+            'path' => 'rest/users/current',
+            'method' => 'patch',
+            'params' => null,
+            'data' => []
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            ['string_params' => [
+                'first_name',
+                'last_name',
+                'email_address',
+                'password'
+            ]]
+        );
+    }
+
+    /**
      * Test expected successes and failures at creating, getting, and revoking
      * API tokens.
      *

--- a/tests/integration/lib/Rest/AuthenticationControllerProviderTest.php
+++ b/tests/integration/lib/Rest/AuthenticationControllerProviderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace IntegrationTests\Rest;
+
+use IntegrationTests\BaseTest;
+use IntegrationTests\TestHarness\XdmodTestHelper;
+
+class AuthenticationControllerProviderTest extends BaseTest
+{
+    private static $helper;
+
+    public static function setUpBeforeClass()
+    {
+        self::$helper = new XdmodTestHelper();
+    }
+
+    /**
+     * @dataProvider provideGetIdpRedirect
+     */
+    public function testGetIdpRedirect($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            self::$helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideGetIdpRedirect()
+    {
+        $validInput = [
+            'path' => 'rest/auth/idpredirect',
+            'method' => 'get',
+            'params' => [],
+            'data' => null
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            ['string_params' => ['returnTo']]
+        );
+    }
+}

--- a/tests/integration/lib/Rest/DashboardControllerProviderTest.php
+++ b/tests/integration/lib/Rest/DashboardControllerProviderTest.php
@@ -9,6 +9,36 @@ use Models\Services\Realms;
 class DashboardControllerProviderTest extends BaseUserAdminTest
 {
     /**
+     * @dataProvider provideSetLayout
+     */
+    public function testSetLayout($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            $this->helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+    public function provideSetLayout()
+    {
+        $validInput = [
+            'path' => 'rest/dashboard/layout',
+            'method' => 'post',
+            'params' => null,
+            'data' => ['data' => 'foo']
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['data']
+            ]
+        );
+    }
+
+    /**
      * Exercises the `dashboard/statistics` REST endpoint.
      *
      * @dataProvider provideTestGetStatistics
@@ -119,6 +149,39 @@ class DashboardControllerProviderTest extends BaseUserAdminTest
     {
         return JSON::loadFile(
             $this->getTestFiles()->getFile('rest', 'get_statistics', 'input')
+        );
+    }
+
+    /**
+     * @dataProvider provideGetStatisticsParamValidation
+     */
+    public function testGetStatisticsParamValidation(
+        $id,
+        $role,
+        $input,
+        $output
+    ) {
+        parent::requestAndValidateJson($this->helper, $input, $output);
+    }
+
+    public function provideGetStatisticsParamValidation()
+    {
+        $validInput = [
+            'path' => 'rest/dashboard/statistics',
+            'method' => 'get',
+            'params' => [
+                'start_date' => 'foo',
+                'end_date' => 'foo'
+            ],
+            'data' => null
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'run_as' => 'pub',
+                'string_params' => ['start_date', 'end_date']
+            ]
         );
     }
 

--- a/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
+++ b/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
@@ -41,7 +41,8 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             $validInput,
             [
                 'authentication' => true,
-                'int_params' => ['nodeid', 'infoid', 'jobid', 'recordid']
+                'int_params' => ['nodeid', 'infoid', 'jobid', 'recordid'],
+                'string_params' => ['tsid', 'realm', 'title']
             ]
         );
     }
@@ -75,7 +76,135 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             $validInput,
             [
                 'authentication' => true,
-                'int_params' => ['recordid']
+                'int_params' => ['recordid'],
+                'string_params' => ['realm', 'data']
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider provideGetHistoryById
+     */
+    public function testGetHistoryById($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            self::$helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideGetHistoryById()
+    {
+        $validInput = [
+            'path' => 'rest/warehouse/search/history/0',
+            'method' => 'get',
+            'params' => ['realm' => 'Jobs'],
+            'data' => null
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['realm']
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider provideUpdateHistory
+     */
+    public function testUpdateHistory($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            self::$helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideUpdateHistory()
+    {
+        $validInput = [
+            'path' => 'rest/warehouse/search/history/0',
+            'method' => 'post',
+            'params' => null,
+            'data' => [
+                'realm' => 'Jobs',
+                'data' => '{"text":"foo"}'
+            ]
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['realm', 'data']
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider provideDeleteHistory
+     */
+    public function testDeleteHistory($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            self::$helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideDeleteHistory()
+    {
+        $validInput = [
+            'path' => 'rest/warehouse/search/history/0',
+            'method' => 'delete',
+            'params' => ['realm' => 'Jobs'],
+            'data' => null
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['realm']
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider provideDeleteAllHistory
+     */
+    public function testDeleteAllHistory($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            self::$helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideDeleteAllHistory()
+    {
+        $validInput = [
+            'path' => 'rest/warehouse/search/history',
+            'method' => 'delete',
+            'params' => ['realm' => 'Jobs'],
+            'data' => null
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['realm']
             ]
         );
     }
@@ -113,7 +242,13 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             $validInput,
             [
                 'authentication' => true,
-                'int_params' => ['start', 'limit']
+                'int_params' => ['start', 'limit'],
+                'string_params' => [
+                    'realm',
+                    'params',
+                    'start_date',
+                    'end_date'
+                ]
             ]
         );
     }
@@ -147,7 +282,8 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             $validInput,
             [
                 'authentication' => true,
-                'int_params' => ['jobid', 'start', 'limit']
+                'int_params' => ['jobid', 'start', 'limit'],
+                'string_params' => ['realm']
             ]
         );
     }
@@ -191,6 +327,13 @@ class WarehouseControllerProviderTest extends TokenAuthTest
                     'width',
                     'height',
                     'font_size'
+                ],
+                'string_params' => [
+                    'realm',
+                    'tsid',
+                    'format',
+                    'scale',
+                    'show_title'
                 ]
             ]
         );
@@ -267,7 +410,8 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             $validInput,
             [
                 'authentication' => true,
-                'int_params' => ['start', 'limit']
+                'int_params' => ['start', 'limit'],
+                'string_params' => ['config']
             ]
         );
         // Test bad request parameters.
@@ -398,6 +542,37 @@ class WarehouseControllerProviderTest extends TokenAuthTest
     }
 
     /**
+     * @dataProvider provideGetDimensions
+     */
+    public function testGetDimensions($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            self::$helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideGetDimensions()
+    {
+        $validInput = [
+            'path' => 'rest/warehouse/dimensions',
+            'method' => 'get',
+            'params' => [],
+            'data' => null
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['realm']
+            ]
+        );
+    }
+
+    /**
      * @dataProvider provideGetDimensionValues
      */
     public function testGetDimensionValues($id, $role, $input, $output)
@@ -423,7 +598,8 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             $validInput,
             [
                 'authentication' => true,
-                'int_params' => ['offset', 'limit']
+                'int_params' => ['offset', 'limit'],
+                'string_params' => ['search_text', 'realm']
             ]
         );
     }
@@ -464,6 +640,7 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             [
                 'token_auth' => true,
                 'int_params' => ['offset'],
+                'string_params' => ['realm', 'fields'],
                 'date_params' => ['start_date', 'end_date']
             ]
         );

--- a/tests/integration/lib/Rest/WarehouseExportControllerProviderTest.php
+++ b/tests/integration/lib/Rest/WarehouseExportControllerProviderTest.php
@@ -266,6 +266,41 @@ class WarehouseExportControllerProviderTest extends TokenAuthTest
     }
 
     /**
+     * @dataProvider provideCreateRequestParamValidation
+     */
+    public function testCreateRequestParamValidation(
+        $id,
+        $role,
+        $input,
+        $output
+    ) {
+        parent::requestAndValidateJson(self::$helpers[$role], $input, $output);
+    }
+
+    public function provideCreateRequestParamValidation()
+    {
+        $validInput = [
+            'path' => 'rest/warehouse/export/request',
+            'method' => 'post',
+            'params' => null,
+            'data' => [
+                'realm' => 'Jobs',
+                'start_date' => '2017-01-01',
+                'end_date' => '2017-01-01'
+            ]
+        ];
+        // Run some standard endpoint tests.
+        return parent::provideRestEndpointTests(
+            $validInput,
+            [
+                'authentication' => true,
+                'string_params' => ['realm', 'format'],
+                'date_params' => ['start_date', 'end_date']
+            ]
+        );
+    }
+
+    /**
      * Test getting the list of export requests.
      *
      * @param string $role Role to use during test.

--- a/tests/integration/lib/TestHarness/XdmodTestHelper.php
+++ b/tests/integration/lib/TestHarness/XdmodTestHelper.php
@@ -361,6 +361,35 @@ class XdmodTestHelper
         return $this->docurl();
     }
 
+    public function put($path, $params, $data, $isurl = false)
+    {
+        if ($isurl) {
+            $url = $path;
+        } else {
+            $url = $this->siteurl . $path;
+        }
+
+        if ($params !== null) {
+            $url .= "?" . http_build_query($params);
+        }
+        if (isset($this->verbose)) {
+            echo "$url\n";
+        }
+        curl_setopt($this->curl, CURLOPT_URL, $url);
+        curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, 'PUT');
+        $putData = '';
+        if (isset($data)) {
+            $putData = http_build_query($data);
+        }
+        curl_setopt($this->curl, CURLOPT_POSTFIELDS, $putData);
+        curl_setopt($this->curl, CURLOPT_HTTPHEADER, $this->getheaders());
+
+        $response = $this->docurl();
+        $this->resetCurlSession();
+
+        return $response;
+    }
+
     public function patch($path, $params = null, $data = null)
     {
         $url = $this->siteurl . $path;


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR fixes a bug in the validation of REST parameters in the `getParam()` method of `BaseControllerProvider` in which array parameters were not properly caught as being invalid. `filter_var()` was returning `false` but only being checked for `null`.

This PR also fixes a bug in `XdmodApplicationFactory` with processing array POST data that was exposed when testing the bug above; if non-string data was sent in a POST, it would still attempt to `json_decode` it. Now, instead, it decodes that data as null.

This PR also adds the ability to make `PUT` requests with `XdmodTestHelper`, which is needed by https://github.com/ubccr/xdmod-appkernels/pull/95.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR adds integration tests of array parameters for endpoints that call `getParam()`.

Additional integration tests are added in https://github.com/ubccr/xdmod-appkernels/pull/95 and https://github.com/ubccr/xdmod-supremm/pull/350.

I developed the tests incrementally while running in the `tools-ext-01.ccr.xdmod.org/xdmod10.0:rockylinux8.5-0.5` Docker container upgraded to the latest XDMoD. 

Also, in a Docker container running `tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.3`:
1. Run the following commands:
    ```
    export COMPOSER_ALLOW_SUPERUSER=1
    export XDMOD_REALMS='jobs,storage,cloud'
    export XDMOD_IS_CORE=yes
    export XDMOD_INSTALL_DIR=/xdmod
    export XDMOD_TEST_MODE=upgrade
    git clone https://github.com/ubccr/xdmod /xdmod
    cd /xdmod
    openssl genrsa -rand /proc/cpuinfo:/proc/dma:/proc/filesystems:/proc/interrupts:/proc/ioports:/proc/uptime 2048 > /etc/pki/tls/private/localhost.key
    /usr/bin/openssl req -new -key /etc/pki/tls/private/localhost.key -x509 -sha256 -days 365 -set_serial $RANDOM -extensions v3_req -out /etc/pki/tls/certs/localhost.crt -subj "/C=XX/L=Default City/O=Default Company Ltd"
    composer install
    mkdir ~/phpunit
    mkdir /tmp/screenshots
    ~/bin/buildrpm xdmod
    ./tests/ci/bootstrap.sh
    ./tests/ci/validate.sh
    composer install --no-progress
    mv ./configuration/organization.json ./configuration/organization.json.old
    mv ./configuration/portal_settings.ini ./configuration/portal_settings.ini.old
    cp /etc/xdmod/portal_settings.ini ./configuration/portal_settings.ini
    cp /etc/xdmod/organization.json ./configuration/organization.json
    ./tests/ci/scripts/qa-test-setup.sh
    ./tests/regression/runtests.sh
    cd tests/integration
    ../../vendor/bin/phpunit --testsuite default --group UserAdminTest.createUsers --debug > /before.txt
    ../../vendor/bin/phpunit --testsuite default --exclude-group UserAdminTest.createUsers --debug >> /before.txt
    git clone https://github.com/aaronweeden/xdmod -b fix-rest-array-param-validation /xdmod-new
    unalias rm
    rm -r lib
    cp -r /xdmod-new/tests/integration/lib .
    rm -r /usr/share/xdmod/classes/Rest
    cp -r {/xdmod-new,/usr/share/xdmod}/classes/Rest
    ../../vendor/bin/phpunit --testsuite default --group UserAdminTest.createUsers --debug > /after.txt
    ../../vendor/bin/phpunit --testsuite default --exclude-group UserAdminTest.createUsers --debug >> /after.txt
    ```
1. Compare `/before.txt` and `/after.txt` and make sure the differences are correct:
    1. Different random values for `ControllerTest::testEnumTargetAddresses`.
    1. New tests for:
        * `MetricExplorerTest::testCreateQueryParamValidation`.
        * `MetricExplorerTest::testUpdateQueryByIdParamValidation`.
        * `UserControllerProviderTest::testUpdateCurrentUser`.
        * `AuthenticationControllerProviderTest::testGetIdpRedirect`.
        * `DashboardControllerProviderTest::testSetLayout`.
        * `DashboardControllerProviderTest::testGetStatisticsParamValidation`.
        * `WarehouseControllerProviderTest::testCreateSearchHistory`.
        * `WarehouseControllerProviderTest::testGetHistoryById`.
        * `WarehouseControllerProviderTest::testUpdateHistory`.
        * `WarehouseControllerProviderTest::testDeleteHistory`.
        * `WarehouseControllerProviderTest::testDeleteAllHistory`.
        * `WarehouseControllerProviderTest::testGetDimensions`.
        * `WarehouseExportControllerProviderTest::testCreateRequestParamValidation`.
    1. New test arguments for:
        * `AdminControllerProviderTest::testResetUserTourViewed`.
        * `DashboardControllerProviderTest::testSetViewedUserTour`.
        * `WarehouseControllerProviderTest::testGetSearchHistory`.
        * `WarehouseControllerProviderTest::testSearchJobs`.
        * `WarehouseControllerProviderTest::testSearchJobsByPeers`.
        * `WarehouseControllerProviderTest::testSearchJobsByTimeseries`.
        * `WarehouseControllerProviderTest::testGetAggregateDataMalformedRequests`.
        * `WarehouseControllerProviderTest::testGetDimensionValues`.
        * `WarehouseControllerProviderTest::testGetRawData`.
    1. Last group of tests take about 0.25 min more and go from 784 tests -> 877 tests, 7141 assertions -> 7440 assertions.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
