### PR TITLE
Add check to sanitize job timeseries data of NAN values

### DIFF
--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -2501,5 +2501,4 @@ class WarehouseControllerProvider extends BaseControllerProvider
         }
         return $ret;
     }
-
 }

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -1999,6 +1999,8 @@ class WarehouseControllerProvider extends BaseControllerProvider
             throw new NotFoundException();
         }
 
+        $results['series'] = $this->sanitize($results['series']);
+
         $format = $this->getStringParam($request, 'format', false, 'json');
 
         if (!in_array($format, array('json', 'png', 'svg', 'pdf', 'csv'))) {
@@ -2475,4 +2477,29 @@ class WarehouseControllerProvider extends BaseControllerProvider
         $filterValuesArray = explode(',', $filterValuesStr);
         return $filterValuesArray;
     }
+
+    /**
+     *  Sanitize result data for charts. Replacing any non-numerical values from
+     *  the dataset result with the value of 0. It is expected that the series data
+     *  is passed in as sanitize($results['series']).
+     *
+     *  @param array $results['series']
+     *  TODO: Look into if this should be pass by reference instead
+     */
+    private function sanitize($results){
+        $ret = $results;
+        for ($i = 0; $i < count($ret); $i++) {
+            $trace = $ret[$i]['data'];
+            for ($j = 0; $j < count($trace); $j++) {
+                foreach ($trace[$j] as $key => $value) {
+                    // Found non-numeric value
+                    if (is_nan($value)) {
+                        $ret[$i]['data'][$j][$key] = 0;
+                    }
+                }
+            }
+        }
+        return $ret;
+    }
+
 }


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
Add check to sanitize job timeseries data of NAN values due to Symfony throwing double NAN error when json encoding. Added helper function which replaces any NAN values in the series data with 0. 

Note: This may need to be addressed in other areas. Need to find where else we are possibly letting NAN/null values through.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Charts with NAN data would return a null record.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Observed changes on xdmod-dev
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
