### PR TITLE
Use the portal's time zone for raw data query dates instead of UTC.

### DIFF
--- a/classes/DataWarehouse/Query/Cloud/JobDataset.php
+++ b/classes/DataWarehouse/Query/Cloud/JobDataset.php
@@ -56,7 +56,6 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
             $this->addPdoWhereCondition(new WhereCondition(new TableField($factTable, 'resource_id'), '=', $parameters['resource_id']));
             $this->addPdoWhereCondition(new WhereCondition(new TableField($factTable, 'provider_identifier'), '=', $parameters['job_identifier']));
         } elseif (isset($parameters['start_date']) && isset($parameters['end_date'])) {
-            date_default_timezone_set('UTC');
             $startDate = date_parse_from_format('Y-m-d', $parameters['start_date']);
             $startDateTs = mktime(0, 0, 0, $startDate['month'], $startDate['day'], $startDate['year']);
 

--- a/classes/DataWarehouse/Query/Gateways/JobDataset.php
+++ b/classes/DataWarehouse/Query/Gateways/JobDataset.php
@@ -68,7 +68,6 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
                 throw new Exception('invalid "job_identifier" query parameter');
             }
         } elseif (isset($parameters['start_date']) && isset($parameters['end_date'])) {
-            date_default_timezone_set('UTC');
             $startDate = date_parse_from_format('Y-m-d', $parameters['start_date']);
             $startDateTs = mktime(
                 0,

--- a/classes/DataWarehouse/Query/Jobs/JobDataset.php
+++ b/classes/DataWarehouse/Query/Jobs/JobDataset.php
@@ -68,7 +68,6 @@ class JobDataset extends \DataWarehouse\Query\RawQuery
                 throw new Exception('invalid "job_identifier" query parameter');
             }
         } elseif (isset($parameters['start_date']) && isset($parameters['end_date'])) {
-            date_default_timezone_set('UTC');
             $startDate = date_parse_from_format('Y-m-d', $parameters['start_date']);
             $startDateTs = mktime(
                 0,

--- a/docs/xdmod-rest-schema.json
+++ b/docs/xdmod-rest-schema.json
@@ -71,7 +71,7 @@ layout: null
                 "name": "start_date",
                 "in": "query",
                 "required": true,
-                "description": "Start date of requested data",
+                "description": "Start date of requested data in the portal's local time zone in YYYY-MM-DD format.",
                 "schema": {
                     "type": "string",
                     "format": "date"
@@ -81,7 +81,7 @@ layout: null
                 "name": "end_date",
                 "in": "query",
                 "required": true,
-                "description": "End date of requested data",
+                "description": "End date of requested data in the portal's local time zone in YYYY-MM-DD format.",
                 "schema": {
                     "type": "string",
                     "format": "date"


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->
## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR makes it so the warehouse raw data queries involving start and end dates use the portal's local time zone instead of UTC.

There are corresponding PRs for https://github.com/ubccr/xdmod-supremm/pull/356 and https://github.com/ubccr/xdmod-xsede/pull/439.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The rest of the XDMoD portal uses the portal's local time zone when dealing with date ranges. For consistency, this PR makes the raw data queries also use the portal's local time zone.

For the Jobs realm, this will have the added benefit of enabling https://github.com/ubccr/xdmod/pull/1780.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In addition to ensuring the regression tests still pass:
1. Run the script from https://github.com/ubccr/xdmod-xsede/pull/436.
1. For the differences in the `Cloud` realm:
    1. Copy the "only in old" lines into a file, run  `awk -F "', '" '{print $1}' old` to get the instance ID, and for a sample of the IDs, run the MySQL query below:
        ```
        SELECT i.instance_id, from_unixtime(start_time_ts), from_unixtime(end_time_ts)
        FROM modw_cloud.session_records s
        JOIN modw_cloud.instance i ON i.instance_id = s.instance_id
        WHERE provider_identifier = 'INSTANCE_ID_GOES_HERE';
        ```
        and confirm that some of the end dates occur after 7–8pm on the day before the given start date, indicating that these entries were in the date range when the query used UTC since Eastern Time is 4–5 hours behind UTC.
    1. Do the same for the "only in new" lines, but confirm that some of the start dates occur after 7–8pm on the given end date, showing that these entries were not in the date range when the query used UTC.
1. For the differences in the `Jobs` realm:
    1. Copy the "only in old" lines into a file, run  `awk -F "', '" '{print $1 ", " $18}' old` to get the job ID and resource name pairs, and for a sample of the pairs, run the MySQL query below:
        ```
        SELECT from_unixtime(start_time_ts), from_unixtime(end_time_ts)
        FROM modw.job_tasks j
        JOIN modw.resourcefact r ON j.resource_id = r.id
        WHERE j.local_jobid = 'JOB_ID_GOES_HERE'
        AND r.name = 'RESOURCE_NAME_GOES_HERE';
        ```
        and confirm that some of the end dates occur after 7–8pm on the day before the given start date, indicating that these entries were in the date range when the query used UTC.
    1. Do the same for the "only in new" lines, but confirm that some of the end dates occur after 7–8pm on the given end date, showing that these entries were not in the date range when the query used UTC.

To test the documentation changes, on my laptop:
1. [Make sure Jekyll is installed](https://jekyllrb.com/docs/installation/).
1. Change to the `docs` directory.
1. Run these commands:
    ```
    git clone https://github.com/ubccr/xdmod-jekyll-theme
    bundle install
    bundle add webrick
    bundle exec jekyll serve
    ```
1. In Chrome, browse to http://127.0.0.1:4000/rest.html and confirm the page changes look correct.
1. In Chrome, File -> Save Page As -> Webpage, Single File -> save as a temporary file `new.mht`.
1. Revert the changes to `docs/xdmod-rest-schema.json` and let the site regenerate.
1. In Chrome, refresh, File -> Save Page As -> Webpage, Single File -> save as a temporary file `old.mht`.
1. Diff `old.mht` and `new.mht` and confirm the only difference besides random IDs is the updates that were made in this PR.


## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
