### PR TITLE
Make `Ctrl-C` interrupt regression test subprocesses.

### DIFF
--- a/tests/regression/runtests.sh
+++ b/tests/regression/runtests.sh
@@ -43,6 +43,12 @@ if [ "$REG_TEST_ALL" = "1" ]; then
 else
     pids=()
 
+    # Make Ctrl-C interrupt all subprocesses.
+    function interrupt_all_subprocesses {
+        kill ${pids[@]}
+    }
+    trap interrupt_all_subprocesses SIGINT
+
     if [[ "$XDMOD_REALMS" == *"jobs"* ]];
     then
         $phpunit $(log_opts "regression-subset" "Charts-pub") --filter ChartsTest . & #TODO: Implement UsageChartsTest for Cloud and Storage realms


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This makes it so that, when running the regression tests, `Ctrl-C` (`SIGINT`) interrupts all subprocesses.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When manually running `runtests.sh` and typing `Ctrl-C`, the main process would interrupt, but the subprocesses would continue running. This was inconvenient when testing new edits to the regression tests.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. In a Docker container running `tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.3`:
    1. Run the following.
        ```
        ~/bin/services start
        git clone https://github.com/ubccr/xdmod /xdmod
        cd /xdmod
        composer install
        cd tests/regression
        XDMOD_REALMS=jobs,storage,cloud ./runtests.sh
        ```
    1. Type `Ctrl-C` and confirm subprocesses continue running and producing output.
    1. Once the output finishes, run the following.
        ```
        git clone https://github.com/aaronweeden/xdmod -b regression-ctrl-c /aaronweeden-xdmod-regression-ctrl-c
        cd /aaronweeden-xdmod-regression-ctrl-c
        composer install
        cd tests/regression
        XDMOD_REALMS=jobs,storage,cloud ./runtests.sh
        ```
    1. Type `Ctrl-C` and confirm all subprocesses stop producing output.
1. Make sure there are no differences between the CircleCI checks for this PR and the CircleCI checks of the most recent commit to the `xdmod11.0` branch, specifically the section `./tests/regression/runtests.sh`.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
