### PR TITLE
Fix range setting for job peers plots.

### DIFF
--- a/html/gui/js/modules/job_viewer/GanttChart.js
+++ b/html/gui/js/modules/job_viewer/GanttChart.js
@@ -101,7 +101,10 @@ XDMoD.Module.JobViewer.GanttChart = Ext.extend(XDMoD.Module.JobViewer.ChartTab, 
                     zeroline: false,
                     gridcolor: '#d8d8d8',
                     type: 'date',
-                    range: [record.data.series[0].data[0].low - (60 * 1000), record.data.series[0].data[0].high + (60 * 1000)]
+                    range: [
+                        moment.tz(record.data.series[0].data[0].low - (60 * 1000), record.data.schema.timezone).format('Y-MM-DD HH:mm:ss.SSS'),
+                        moment.tz(record.data.series[0].data[0].high + (60 * 1000), record.data.schema.timezone).format('Y-MM-DD HH:mm:ss.SSS')
+                    ]
                 },
                 yaxis: {
                     autorange: 'reversed',


### PR DESCRIPTION
The range values for job peers plots did not include the timezone so the plot range is incorrect for any resources that use a different timezone than the webbrowser timezone.

Before:

![image](https://github.com/ubccr/xdmod/assets/5342179/9825e645-6fea-487d-a750-8ad157bfb693)

After:

![image](https://github.com/ubccr/xdmod/assets/5342179/3d8f798c-d2ca-406a-8fb1-2447383f6ac4)
