### PR TITLE
Catch inconsistent test namespaces in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,24 @@ jobs:
           name: Generate Certificate
           command: /usr/bin/openssl req -new -key /etc/pki/tls/private/localhost.key -x509 -sha256 -days 365 -set_serial $RANDOM -extensions v3_req -out /etc/pki/tls/certs/localhost.crt -subj "/C=XX/L=Default City/O=Default Company Ltd"
       - checkout
+      - run:
+          name: Make sure test namespaces are consistent
+          command: >
+            result=0;
+            for test_type in {unit,component,integration,regression}; do
+                for file in $(find tests/$test_type/lib -type f); do
+                    prefix="$(tr '[:lower:]' '[:upper:]' \<<< ${test_type:0:1})${test_type:1}Tests";
+                    expected_namespace="namespace $(dirname $file | sed "s/tests\/$test_type\/lib/$prefix/" | sed 's/\//\\/g');";
+                    actual_namespace="$(grep namespace $file)";
+                    if [[ "$expected_namespace" != "$actual_namespace" ]]; then
+                        echo -e "$file";
+                        echo -e "\tExpected: $expected_namespace";
+                        echo -e "\tActual: $actual_namespace";
+                        result=1;
+                    fi;
+                done;
+            done;
+            exit $result;
       # We need to update our acct before we can enable docker layer caching
       #- setup_remote_docker:
       #    docker_layer_caching: true

--- a/tests/regression/lib/Rest/WarehouseRawDataTest.php
+++ b/tests/regression/lib/Rest/WarehouseRawDataTest.php
@@ -1,10 +1,6 @@
 <?php
-/**
- * @package OpenXdmod
- * @subpackage Tests
- */
 
-namespace Rest;
+namespace RegressionTests\Rest;
 
 use IntegrationTests\BaseTest;
 use RegressionTests\TestHarness\RegressionTestHelper;


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR adds a CircleCI step to automatically catch inconsistent test namespaces so that the manual test from https://github.com/ubccr/xdmod/pull/1789 doesn't need to be performed.

This PR also fixes the namespace of `tests/regression/lib/Rest/WarehouseRawDataTest.php` to be consistent with the other test files. That file was added in https://github.com/ubccr/xdmod/pull/1788 after https://github.com/ubccr/xdmod/pull/1789 had already been merged, so it was not caught when manually checking the namespaces for https://github.com/ubccr/xdmod/pull/1789.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To make sure the CircleCI step worked, I first committed just `.circleci/config.yml` to make sure it failed, then committed the change to `tests/regression/lib/Rest/WarehouseRawDataTest.php` to make sure it passed.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
