### PR TITLE
Remove test namespace linting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,24 +31,6 @@ jobs:
           name: Generate Certificate
           command: /usr/bin/openssl req -new -key /etc/pki/tls/private/localhost.key -x509 -sha256 -days 365 -set_serial $RANDOM -extensions v3_req -out /etc/pki/tls/certs/localhost.crt -subj "/C=XX/L=Default City/O=Default Company Ltd"
       - checkout
-      - run:
-          name: Make sure test namespaces are consistent
-          command: >
-            result=0;
-            for test_type in {unit,component,integration,regression}; do
-                for file in $(find tests/$test_type/lib -type f); do
-                    prefix="$(tr '[:lower:]' '[:upper:]' \<<< ${test_type:0:1})${test_type:1}Tests";
-                    expected_namespace="namespace $(dirname $file | sed "s/tests\/$test_type\/lib/$prefix/" | sed 's/\//\\/g');";
-                    actual_namespace="$(grep namespace $file)";
-                    if [[ "$expected_namespace" != "$actual_namespace" ]]; then
-                        echo -e "$file";
-                        echo -e "\tExpected: $expected_namespace";
-                        echo -e "\tActual: $actual_namespace";
-                        result=1;
-                    fi;
-                done;
-            done;
-            exit $result;
       # We need to update our acct before we can enable docker layer caching
       #- setup_remote_docker:
       #    docker_layer_caching: true


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
In conjunction with https://github.com/ubccr/xdmod-qa/pull/29, this PR moves the automated check of inconsistent test namespaces from https://github.com/ubccr/xdmod/pull/1795 out of the `xdmod` CircleCI config and into the `xdmod-qa` style tests for PHP files that have been added or changed. This way, the code does not have to be duplicated in the CircleCI config of each submodule of XDMoD, and it does not have to run for every file, only those that changed.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a Docker container running `tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.3`:
```
git clone https://github.com/ubccr/xdmod /xdmod
git clone https://github.com/aaronweeden/xdmod-qa -b lint-test-namespaces /xdmod-qa
cd /xdmod-qa
composer install
cd /xdmod
```
Change namespaces in the `tests` directories and confirm this outputs them and fails the style tests:
```
/xdmod-qa/scripts/build.sh --remote remotes/origin/xdmod11.0 -s
```

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
