### PR TITLE
Add sorting functionality to raw data regression tests.

### DIFF
--- a/tests/regression/lib/TestHarness/RegressionTestHelper.php
+++ b/tests/regression/lib/TestHarness/RegressionTestHelper.php
@@ -528,8 +528,8 @@ class RegressionTestHelper extends XdmodTestHelper
                 // reorders some of them from the Posidriv resource, producing
                 // differently-ordered results than in upgrade mode. To work
                 // around this, each mode has its own artifact file for the
-                // Jobs and SUPREMM realms.
-                if ('jobs' === $realm || 'supremm' === $realm) {
+                // Jobs realm.
+                if ('jobs' === $realm) {
                     $testFileName = "$realm-$testMode.json";
                 }
                 $testParams[] = [
@@ -539,13 +539,8 @@ class RegressionTestHelper extends XdmodTestHelper
                         ['params' => $params['base']]
                     )
                 ];
-                // See above.
-                $testFileName = "$realm-fields-and-filters.json";
-                if ('supremm' === $realm) {
-                    $testFileName = "$realm-$testMode-fields-and-filters.json";
-                }
                 $testParams[] = [
-                    $testFileName,
+                    "$realm-fields-and-filters.json",
                     array_merge(
                         $baseInput,
                         ['params' => array_merge(
@@ -568,6 +563,8 @@ class RegressionTestHelper extends XdmodTestHelper
      *                         `.json` extension.
      * @param array $input describes the HTTP request,
      *                     @see BaseTest::makeHttpRequest().
+     * @param bool $sort whether to sort the result before saving or comparing
+     *                   it.
      * @return bool true if the test artifact file already exists and
      *              contains the response body from the HTTP request.
      * @throws \PHPUnit_Framework_SkippedTestError if REG_TEST_USER_ROLE is
@@ -583,7 +580,7 @@ class RegressionTestHelper extends XdmodTestHelper
      *                                             the contents of the test
      *                                             artifact file.
      */
-    public function checkRawData($testName, array $input)
+    public function checkRawData($testName, array $input, $sort = false)
     {
         $role = self::getEnvUserrole();
         if ('public' === $role) {
@@ -596,6 +593,13 @@ class RegressionTestHelper extends XdmodTestHelper
             $input,
             $role
         );
+        if ($sort) {
+            array_multisort(
+                array_column($response[0]['data'], 0),
+                SORT_ASC,
+                $response[0]['data']
+            );
+        }
         $data = json_encode($response[0]) . "\n";
         $data = preg_replace(self::$replaceRegex, self::$replacements, $data);
         if (getenv('REG_TEST_FORCE_GENERATION') === '1') {


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR adds functionality to allow the raw data requested in the regression tests to be sorted before it is saved to or compared against a test artifact file. This is useful for the `SUPREMM` realm in the `fresh_install` test mode, since in this case the order of the results returned is nondeterministic across multiple CI runs. This also means there do not need to be separate test artifacts in the `SUPREMM` realm for `fresh_install` and `upgrade` test modes, so this PR also removes the code that separates those.

This PR allows the regression tests in https://github.com/ubccr/xdmod-supremm/pull/354 to pass.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I confirmed the CI tests still pass for this PR, and I ran the manual tests described in https://github.com/ubccr/xdmod-supremm/pull/354.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
