### PR TITLE
Add explicit ordering for Job Viewer analytics panel.

### DIFF
--- a/html/gui/js/modules/job_viewer/JobPanel.js
+++ b/html/gui/js/modules/job_viewer/JobPanel.js
@@ -188,12 +188,29 @@ XDMoD.Module.JobViewer.JobPanel = Ext.extend(Ext.Panel, {
          */
         update_analytics: function (data) {
             var analyticsPanel = this.getComponent('analytics_container');
+            var metricOrder = [
+                'CPU User',
+                'Homogeneity',
+                'CPU User Balance',
+                'Memory Headroom',
+                'Walltime Accuracy'
+            ];
+            var sortedIndices;
             var i;
             var metricPanel;
 
             if (!analyticsPanel) {
                 return;
             }
+
+            // Sort metrics by expected order
+            sortedIndices = {};
+            for (i = 0; i < metricOrder.length; i++) {
+                sortedIndices[metricOrder[i]] = i;
+            }
+            data.sort(function (a, b) {
+                return sortedIndices[a.key] - sortedIndices[b.key];
+            });
 
             // Shrink panel to available metric count
             if (data.length < this.MAX_ANALYTICS) {


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR makes the Job Viewer's analytics panel explicitly display the metrics in the order they are currently displayed (1. `CPU User`, 2. `Homogeneity`, 3. `CPU User Balance`, 4. `Memory Headroom`, 5. `Walltime Accuracy`) rather than displaying them in whatever order they are returned by the `rest/warehouse/search/jobs/analytics` endpoint. This will be needed for https://github.com/ubccr/xdmod-supremm/pull/256 since that PR will cause the metrics to be in a different order when they are returned by the endpoint.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a Docker container running `tools-ext-01.ccr.xdmod.org/xdmod-job_performance-10.5.0:rockylinux8-0.1`:
1. Run the following commands:
    ```
    export COMPOSER_ALLOW_SUPERUSER=1
    export XDMOD_REALMS='jobs,storage,cloud,supremm,jobefficiency'
    export XDMOD_IS_CORE=yes
    export XDMOD_INSTALL_DIR=/xdmod
    export XDMOD_TEST_MODE=upgrade
    export XDMOD_SRC_DIR=./../xdmod
    git clone https://github.com/jtpalmer/xdmod-supremm -b jobdataset-analytics-fields /xdmod-supremm
    cd /xdmod-supremm
    dnf module -y reset nodejs
    dnf module -y install nodejs:16
    git clone https://github.com/ubccr/xdmod $XDMOD_SRC_DIR
    ln -s `pwd` $XDMOD_SRC_DIR/open_xdmod/modules/supremm
    ./tests/ci/scripts/install_mongo.sh
    composer install --no-progress
    composer config -g cache-files-ttl 315360000
    composer install -d $XDMOD_SRC_DIR --no-progress
    mkdir -p ~/phpunit
    mkdir -p /tmp/screenshots
    export XDMOD_SOURCE_DIR=/xdmod
    export SHIPPABLE_BUILD_DIR=/xdmod-supremm
    pushd $XDMOD_SRC_DIR
    ~/bin/buildrpm xdmod supremm
    popd
    ./tests/integration/scripts/bootstrap.sh
    ./tests/integration/scripts/validate.sh
    ```
1. In a web browser, browse to the localhost portal.
1. Sign in as `centerdirector`.
1. Go to the Metric Explorer.
1. Select `SUPREMM` > `CPU Hours Total` > `Application`.
1. Set the date range to `2016-12-01`–`2017-01-01`.
1. Select a data point and choose `Show Raw Data`.
1. Select a job in the list.
1. Confirm the order of the analytics metrics is incorrect.
1. Copy `html/gui/js/modules/job_viewer/JobPanel.js` from this PR to `/usr/share/xdmod/html/gui/js/modules/job_viewer/JobPanel.js`.
1. Refresh the browser and confirm the order of the analytics metrics is correct and there are no errors on the JavaScript console.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
