### PR TITLE
Fix colour output in circle ci logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
         type: string
     executor: << parameters.os >>
     environment:
+      TERM: xterm
       COMPOSER_ALLOW_SUPERUSER: 1
       XDMOD_REALMS: 'jobs,storage,cloud'
       TRAVIS_COMMIT_RANGE: << pipeline.git.base_revision >>..<<pipeline.git.revision>>

--- a/open_xdmod/modules/xdmod/assets/setup.sh
+++ b/open_xdmod/modules/xdmod/assets/setup.sh
@@ -9,7 +9,7 @@ xdmod_dir="$module_dir/../../.."
 
 echo Installing composer managed dependencies
 cd $xdmod_dir
-composer install --no-dev --no-progress
+composer install --no-dev --no-progress --no-interaction
 
 echo Installing npm managed dependencies
 npm install --production --prefix etl/js

--- a/open_xdmod/modules/xdmod/assets/setup.sh
+++ b/open_xdmod/modules/xdmod/assets/setup.sh
@@ -9,7 +9,7 @@ xdmod_dir="$module_dir/../../.."
 
 echo Installing composer managed dependencies
 cd $xdmod_dir
-composer install --no-dev
+composer install --no-dev --no-progress
 
 echo Installing npm managed dependencies
 npm install --production --prefix etl/js

--- a/tests/ci/scripts/qa-test-setup.sh
+++ b/tests/ci/scripts/qa-test-setup.sh
@@ -9,7 +9,7 @@ set -e
 if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
 
     # Set default values for the environment variables we're going to use.
-    QA_BRANCH=${QA_BRANCH:-v2}
+    QA_BRANCH=${QA_BRANCH:-echo}
     QA_GIT_URL=${QA_GIT_URL:-https://github.com/ubccr/xdmod-qa.git}
 
     # Clone a current copy of the xdmod-qa repo.

--- a/tests/ci/scripts/qa-test-setup.sh
+++ b/tests/ci/scripts/qa-test-setup.sh
@@ -25,6 +25,7 @@ if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
     $HOME/.qa/scripts/install.sh
 
     # Run the xdmod-qa tests.
+    unset TERM
     $HOME/.qa/scripts/build.sh
 
     popd >/dev/null || exit 1

--- a/tests/ci/scripts/qa-test-setup.sh
+++ b/tests/ci/scripts/qa-test-setup.sh
@@ -25,7 +25,6 @@ if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
     $HOME/.qa/scripts/install.sh
 
     # Run the xdmod-qa tests.
-    unset TERM
     $HOME/.qa/scripts/build.sh
 
     popd >/dev/null || exit 1


### PR DESCRIPTION
This sets the TERM environment to `xterm`. This is compatible with the log parser in circle ci and fixes an issue where the terminal is not known to the `tput` command and it therefore cannot output a valid escape code:
```
tput: No value for $TERM and no -T specified
```
