### PR TITLE
Escape double quotes when migrating portal settings.

### DIFF
--- a/classes/OpenXdmod/Migration/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/ConfigFilesMigration.php
@@ -138,7 +138,11 @@ abstract class ConfigFilesMigration extends Migration
         // portal_settings file.
         foreach ($data as $sectionName => $sectionData) {
             foreach ($sectionData as $key => $value) {
-                $settings[$sectionName . '_' . $key] = $value;
+                $settings[$sectionName . '_' . $key] = str_replace(
+                    '"',
+                    '\\"',
+                    $value
+                );
             }
         }
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR fixes a bug in which double quotes are not properly escaped when migrating portal settings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was noticed when testing the upgrade path for the `ondemand` module.

In `xdmod-ondemand`, in `configuration/portal_settings.d/ondemand.ini`, the value for `webserver_format_str` has backslash-escaped double quotes.

When running the test steps below (which are based on the CircleCI upgrade path for `xdmod-ondemand`) (and instead cloning `https://github.com/ubccr/xdmod` into `/xdmod`), after running the first set of commands, the file `/etc/xdmod/portal_settings.d/ondemand.ini` had unescaped quotes.

This is because when the file is parsed in `classes/OpenXdmod/Migration/ConfigFilesMigration.php` in the function `writeModulePortalSettingsFile` when it calls `parse_ini_file`, the backslashes are not preserved in the data, so they are not written back into the file.

Then, after running the second set of commands below, the web server log parser prints `Skip` for each of the lines in the example log file, so no data are loaded into the `modw_ondemand` database, because the double quotes in the format string are not being properly escaped in the regex used to parse the file.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a Docker container running `tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.3`:
1. Run the commands below:
    ```
    export COMPOSER_ALLOW_SUPERUSER=1
    export XDMOD_REALMS='jobs,storage,cloud'
    export XDMOD_IS_CORE=yes
    export XDMOD_INSTALL_DIR=/xdmod
    export XDMOD_TEST_MODE=upgrade
    export XDMOD_SRC_DIR=/xdmod
    git clone https://github.com/aaronweeden/xdmod -b portal-settings-migration-escape-quotes /xdmod
    git clone https://github.com/aaronweeden/xdmod-ondemand -b update-11.0 /xdmod-ondemand
    dnf module -y reset nodejs
    dnf module -y install nodejs:16
    cd /xdmod-ondemand
    ln -s `pwd` $XDMOD_SRC_DIR/open_xdmod/modules/ondemand
    composer install -d $XDMOD_SRC_DIR --no-progress
    export XDMOD_SOURCE_DIR=/xdmod
    pushd $XDMOD_SRC_DIR
    ~/bin/buildrpm xdmod ondemand
    popd
    $XDMOD_SRC_DIR/tests/ci/bootstrap.sh
    ```
1. Confirm the value `webserver_format_str` is the same for `/etc/xdmod/portal_settings.d/ondemand.ini` and `/xdmod/open_xdmod/modules/ondemand/configuration/portal_settings.d/ondemand.ini`.
1. Run the commands below (these come from `xdmod-ondemand` in `tests/scripts/bootstrap.sh`):
    ```
    expect ./tests/scripts/setup.tcl | col -b
    sudo -u xdmod xdmod-ingestor
    LOGPATH=/tmp/ondemand
    mkdir $LOGPATH
    cp ./tests/artifacts/*.log $LOGPATH
    sudo -u xdmod xdmod-ondemand-ingestor -d $LOGPATH -u https://localhost:3443 -r styx --debug
    ```
1. Confirm the parser did not print `Skip` for the lines in the example log file, and the `modw_ondemand` database has the expected data.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
