### PR TITLE
Allow `@` in remote user format string when parsing web server log files.

### DIFF
--- a/classes/ETL/DataEndpoint/WebServerLogFile.php
+++ b/classes/ETL/DataEndpoint/WebServerLogFile.php
@@ -47,6 +47,12 @@ class WebServerLogFile extends aStructuredFile implements iStructuredFile
         parent::__construct($options, $logger);
 
         $this->web_parser = new \Kassner\LogParser\LogParser();
+
+        // Allow "at" sign in remote user format string.
+        // This can be removed if Kassner LogParser is updated to
+        // version >2.1.1 (see note in composer.json).
+        $this->web_parser->addPattern('%u', '(?P<user>(?:-|[\w\-\.@]+))');
+
         if (isset($options->log_format)) {
             $this->web_parser->setFormat($options->log_format);
         }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+    "extra": {
+        "COMMENT": "If kassner/log-parser is updated to version >2.1.1, then the call to web_parser->addPattern in classes/ETL/DataEndpoint/WebServerLogFile.php (added in https://github.com/ubccr/xdmod/pull/1816) can be removed along with this 'extra' section."
+    },
     "require": {
         "php": "^5.4 || ^7.2",
         "carlo/jquery-base64-file": "^1.0",


### PR DESCRIPTION


<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR updates the web server log file parser to allow `@` in remote user values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remote user values are logged by some identity providers in the form `<user>@<domain>`. This PR makes sure that the log parser does not skip these lines. This is relevant for the `ondemand` module and was noticed when testing the upcoming OnDemand realm in ACCESS XDMoD.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by running `xdmod-ondemand-ingestor` on my port on `xdmod-dev` with log files containing user values containing `@`. Before the changes in this PR, the lines are skipped; after, they are ingested.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
