### PR TITLE
Fix API token expiration message.

### DIFF
--- a/html/gui/js/profile_editor/ProfileApiToken.js
+++ b/html/gui/js/profile_editor/ProfileApiToken.js
@@ -355,10 +355,7 @@ XDMoD.ProfileApiToken = Ext.extend(Ext.form.FormPanel, {
     },
 
     showReceivedToken: function () {
-        var isTokenExpired = (
-            new Date(this.creationDate)
-            >= new Date(this.expirationDate)
-        );
+        var isTokenExpired = (new Date() >= new Date(this.expirationDate));
         if (isTokenExpired) {
             this.showMsg(this.getExpiredTokenMsg());
         } else {


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
Currently, if someone has an expired API token, they see:
![Screen Shot 2024-02-05 at 2 30 40 PM](https://github.com/ubccr/xdmod/assets/31246768/af8b710f-a438-4213-bda5-13e76e630191)

Instead, they should see:
![Screen Shot 2024-02-05 at 2 32 06 PM](https://github.com/ubccr/xdmod/assets/31246768/df2baf7a-300a-45ad-823e-aa6fc8a2ea04)

There is already code to do this, but it was mistakenly using the creation date of the token rather than the current time to determine if a token is expired. This PR fixes it.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my port on `xdmod-dev`:
1. Before updating with the changes from this PR,
    1. Expire my current token manually in the database.
    1. Go to my XDMoD portal, click `My Profile`, and click `API Token`.
    1. Confirm it shows the wrong message.
1. Update my port with the changes from this PR, and repeat the same steps, confirming that it shows the right message.
1. Generate a new token, close the `My Profile` window, reopen it, and confirm the message is still correct.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
