### PR TITLE
Fix syntax error in regression test

### DIFF
--- a/tests/regression/lib/Controllers/UsageChartsTest.php
+++ b/tests/regression/lib/Controllers/UsageChartsTest.php
@@ -114,7 +114,7 @@ class UsageChartsTest extends \PHPUnit_Framework_TestCase
             fclose($pipes[2]);
             $retval = proc_close($process);
             if (strlen($err) > 0 || $retval !== 0) {
-                throw new Exception("imagehash returned $retval stderr='$err'");
+                throw new \UnexpectedValueException("imagehash returned $retval stderr='$err'");
             }
         } else {
             $out = sha1($imageData);


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
This change fixes a syntax error in the Usage Charts regression test. It also updates the generic PHP `Exception` to the builtin `UnexpectedValueException` to pass the code quality tests.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes a bug originally introduced in https://github.com/ubccr/xdmod/pull/1699. I noticed this bug when I made some breaking changes to the imagehash installation that caused the Usage Charts regression test to fail. Instead of throwing an Exception when imagehash was unavailable on the system, the test reported a syntax error.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested in a docker container:
`$ docker run -it --rm -p 8443:443 tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.2 /bin/bash`

Inside the container clone the latest version of the upstream code:
`git clone https://github.com/ubccr/xdmod.git /root/scratch/xdmod`

Comment out the line from `bootstrap.sh` that installs `imagehash`:
`sed -i '/^pip3 install imagehash/ s/./#&/' tests/ci/bootstrap.sh`

Run the following script in the XDMoD source dir and verify that the tests break. After running this script, apply the changes from the PR and run the tests again. Verify the tests break but this time not due to the syntax error.
```sh
COMPOSER_ALLOW_SUPERUSER: 1
XDMOD_REALMS: 'jobs,storage,cloud'
XDMOD_IS_CORE: yes
XDMOD_INSTALL_DIR: /root/scratch/xdmod
XDMOD_TEST_MODE: 'upgrade'

# Generate OpenSSL Key
openssl genrsa -rand /proc/cpuinfo:/proc/dma:/proc/filesystems:/proc/interrupts:/proc/ioports:/proc/uptime 2048 > /etc/pki/tls/private/localhost.key

# Generate Certificate
/usr/bin/openssl req -new -key /etc/pki/tls/private/localhost.key -x509 -sha256 -days 365 -set_serial $RANDOM -extensions v3_req -out /etc/pki/tls/certs/localhost.crt -subj "/C=XX/L=Default City/O=Default Company Ltd"

# Install the composer dependencies
composer install

# Create Test Artifact Directories
mkdir ~/phpunit
mkdir /tmp/screenshots

# Build RPM
~/bin/buildrpm xdmod

# Install / Upgrade XDMoD from RPM
./tests/ci/bootstrap.sh

# Validate the newly installed / Upgraded XDMoD
./tests/ci/validate.sh
composer install --no-progress

# Setup & Run QA Tests
./tests/ci/scripts/qa-test-setup.sh

# Run regression tests
./tests/regression/runtests.sh
```
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
