### PR TITLE
Parse request method, URL, and protocol separately in web server logs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -317,8 +317,8 @@ configuration/aggregation_meta/
 # configuration/etl/*.json
 # configuration/etl/**/*.json
 
-# Include log files that are used for regression testing
-!tests/artifacts/xdmod-test-artifacts/xdmod/referencedata/*.log
+# Include log files that are used for CI testing
+!tests/artifacts/**/*.log
 
 # Include CCR Log Class
 !classes/Log

--- a/classes/ETL/DataEndpoint/WebServerLogFile.php
+++ b/classes/ETL/DataEndpoint/WebServerLogFile.php
@@ -54,6 +54,13 @@ class WebServerLogFile extends aStructuredFile implements iStructuredFile
         $this->web_parser->addPattern('%u', '(?P<user>(?:-|[\w\-\.@]+))');
 
         if (isset($options->log_format)) {
+            // Replace `%r` with `%m %U %H` so the request method, URL, and
+            // protocol can be parsed separately.
+            $options->log_format = str_replace(
+                '%r',
+                '%m %U %H',
+                $options->log_format
+            );
             $this->web_parser->setFormat($options->log_format);
         }
 

--- a/tests/artifacts/xdmod/etlv2/dataendpoint/input/webserverlogfile/test.log
+++ b/tests/artifacts/xdmod/etlv2/dataendpoint/input/webserverlogfile/test.log
@@ -1,0 +1,1 @@
+127.0.0.0 - testuser1 [01/Jul/2021:03:17:06 -0500] "GET /pun/sys/dashboard/apps/icon/jupyter_quantum_chem/sys/sys?foo=bar HTTP/1.1" 200 381 "https://ondemand.ccr.buffalo.edu/pun/sys/dashboard/batch_connect/sessions" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36"

--- a/tests/unit/lib/ETL/DataEndpoint/WebServerLogFileTest.php
+++ b/tests/unit/lib/ETL/DataEndpoint/WebServerLogFileTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace UnitTests\ETL\DataEndpoint;
+
+use CCR\Log;
+use ETL\DataEndpoint;
+use ETL\DataEndpoint\DataEndpointOptions;
+use Psr\Log\LoggerInterface;
+
+class WebServerLogFileTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_ARTIFACT_INPUT_PATH = "./../artifacts/xdmod/etlv2/dataendpoint/input/webserverlogfile";
+
+    /**
+     * @var LoggerInterface
+     */
+    private static $logger = null;
+
+    public static function setUpBeforeClass()
+    {
+        // Set up a logger so we can get warnings and error messages from the ETL
+        // infrastructure
+        $conf = array(
+            'file' => false,
+            'db' => false,
+            'mail' => false,
+            'consoleLogLevel' => Log::EMERG
+        );
+
+        self::$logger = Log::factory('PHPUnit', $conf);
+    }
+
+    /**
+     * @dataProvider provideWebServerLogFile
+     */
+    public function testWebServerLogFile($filename, $logFormat, $expected)
+    {
+        $config = [
+            'type' => 'directoryscanner',
+            'name' => 'Web Server Logs',
+            'path' => self::TEST_ARTIFACT_INPUT_PATH,
+            'file_pattern' => "/$filename/",
+            'handler' => (object)[
+                'type' => 'webserverlog',
+                'record_separator' => "\n",
+                'log_format' => $logFormat
+            ]
+        ];
+        $options = new DataEndpointOptions($config);
+        $endpoint = DataEndpoint::factory($options, self::$logger);
+        $endpoint->verify();
+        $endpoint->connect();
+        $numIterations = 0;
+        foreach ($endpoint as $record) {
+            $this->assertSame($expected[$numIterations], $record);
+            $numIterations++;
+        }
+        $this->assertSame(
+            count($expected),
+            $numIterations,
+            'Did not parse correct number of records.'
+        );
+    }
+
+    public function provideWebServerLogFile()
+    {
+        $logFormats = [
+            '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"',
+            '%h %l %u %t "%m %U %H" %>s %b "%{Referer}i" "%{User-Agent}i"'
+        ];
+        $tests = [];
+        foreach ($logFormats as $logFormat) {
+            array_push(
+                $tests,
+                [
+                    'test.log',
+                    $logFormat,
+                    [
+                        [
+                            'host' => '127.0.0.0',
+                            'logname' => '-',
+                            'user' => 'testuser1',
+                            'stamp' => 1625127426,
+                            'time' => '01/Jul/2021:03:17:06 -0500',
+                            'requestMethod' => 'GET',
+                            'URL' => '/pun/sys/dashboard/apps/icon/jupyter_quantum_chem/sys/sys?foo=bar',
+                            'requestProtocol' => 'HTTP/1.1',
+                            'status' => '200',
+                            'responseBytes' => '381',
+                            'HeaderReferer' => 'https://ondemand.ccr.buffalo.edu/pun/sys/dashboard/batch_connect/sessions',
+                            'HeaderUserAgent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
+                            'ua_family' => 'Chrome',
+                            'ua_major' => '91',
+                            'ua_minor' => '0',
+                            'ua_patch' => '4472',
+                            'ua_os_family' => 'Windows',
+                            'ua_os_major' => '10',
+                            'ua_os_minor' => null,
+                            'ua_os_patch' => null,
+                            'ua_device_family' => 'Other',
+                            'ua_device_brand' => null,
+                            'ua_device_model' => null,
+                            'geo_city_name' => 'NA',
+                            'geo_subdivision' => 'NA',
+                            'geo_country' => 'NA'
+                        ]
+                    ]
+                ]
+            );
+        }
+        return $tests;
+    }
+}


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR updates the web server log parser to split the request line (i.e., `%r`, e.g., `GET /index.html HTTP/1.1`) into its three parts (i.e., `%m %U %H`) so these can be parsed separately.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This enables https://github.com/ubccr/xdmod-ondemand/pull/50.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added unit tests to make sure a log is correctly parsed whether the format is `%r` or `%m %U %H`. I also tested ingesting logs on my port on `xdmod-dev` with the changes from https://github.com/ubccr/xdmod-ondemand/pull/50 and the PRs on which it depends.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
