### PR TITLE
Changing etlv2 endpoint config value used for migration etlv2 actions

### DIFF
--- a/configuration/etl/etl.d/xdmod-migration-10_5_0-11_0_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-10_5_0-11_0_0.json
@@ -30,7 +30,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }
@@ -61,7 +61,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }
@@ -75,13 +75,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }
@@ -116,7 +116,7 @@
                 "destination": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 }
             }
@@ -129,13 +129,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -153,13 +153,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -172,13 +172,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -192,13 +192,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -211,13 +211,13 @@
                 "source": {
                     "type": "mysql",
                     "name": "Shredder/Staging Database",
-                    "config": "shredder",
+                    "config": "database",
                     "schema": "mod_shredder"
                 },
                 "destination": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 }
             }
@@ -235,7 +235,7 @@
                 "source": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 },
                 "destination": {
@@ -254,7 +254,7 @@
                 "source": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 },
                 "destination": {
@@ -273,7 +273,7 @@
                 "source": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 },
                 "destination": {
@@ -292,7 +292,7 @@
                 "source": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 },
                 "destination": {
@@ -311,7 +311,7 @@
                 "source": {
                     "type": "mysql",
                     "name": "HPCDB",
-                    "config": "hpcdb",
+                    "config": "database",
                     "schema": "mod_hpcdb"
                 },
                 "destination": {


### PR DESCRIPTION
The endpoint config values for the etlv2 migrations should should match the config values used in other pipelines that use these tables, such as in `etc.d/staging.json` and `etl.d/hpcdb.json`.

## Tests performed
Tested locally in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
