### PR TITLE
Disable db logging for etl_overseer

### DIFF
--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -385,7 +385,8 @@ foreach ( $argv as $index => $arg ) {
 
 $conf = array(
     'emailSubject' => gethostname() . ': XDMOD: Data Warehouse: Federated ETL Log',
-    'mail' => false
+    'mail' => false,
+    'db' => false
 );
 
 if ( null !== $scriptOptions['verbosity'] ) {


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

This allows etl_overseer.php to be used to bootstrap XDMOD instances where running xdmod-setup is not possible, like when running Puppet

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I use Puppet to bootstrap XDMOD and running 'xdmod-setup' isn't possible so I run commands like:

```
/usr/share/xdmod/tools/etl/etl_overseer.php -p xdb-bootstrap -p jobs-xdw-bootstrap -p xdw-bootstrap-storage -p shredder-bootstrap -p staging-bootstrap -p hpcdb-bootstrap -p acls-xdmod-management -p logger-bootstrap
```

This is failing without this change, examples:

```
[root@rocky-8 /]# /usr/share/xdmod/tools/etl/etl_overseer.php -l sections
PHP Fatal error:  Uncaught PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mod_logger.log_id_seq' doesn't exist in /usr/share/xdmod/classes/CCR/DB/PDODB.php:185
Stack trace:
#0 /usr/share/xdmod/classes/CCR/DB/PDODB.php(185): PDOStatement->execute(Array)
#1 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(100): CCR\DB\PDODB->execute('UPDATE mod_logg...')
#2 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(79): CCR\CCRDBHandler->getNextId()
#3 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(39): CCR\CCRDBHandler->write(Array)
#4 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(344): Monolog\Handler\AbstractProcessingHandler->handle(Array)
#5 /usr/share/xdmod/classes/CCR/Logger.php(37): Monolog\Logger->addRecord(200, '{"message":"Com...', Array)
#6 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(642): CCR\Logger->addRecord(200, 'Command: '/usr/...', Array)
#7 /usr/share/xdmod/tools/etl/etl_overseer.php(398): Monolog\Logger->info('Command: '/ in /usr/share/xdmod/classes/CCR/DB/PDODB.php on line 185
PHP Fatal error:  Uncaught PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mod_logger.log_id_seq' doesn't exist in /usr/share/xdmod/classes/CCR/DB/PDODB.php:185
Stack trace:
#0 /usr/share/xdmod/classes/CCR/DB/PDODB.php(185): PDOStatement->execute(Array)
#1 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(100): CCR\DB\PDODB->execute('UPDATE mod_logg...')
#2 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(79): CCR\CCRDBHandler->getNextId()
#3 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(39): CCR\CCRDBHandler->write(Array)
#4 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(344): Monolog\Handler\AbstractProcessingHandler->handle(Array)
#5 /usr/share/xdmod/classes/CCR/Logger.php(37): Monolog\Logger->addRecord(500, '{"message":"Unc...', Array)
#6 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(726): CCR\Logger->addRecord(500, Array, Array)
#7 /usr/share/xdmod/classes/CCR/Log.php(126): Monolog\Logger->crit(Array)
#8 [internal function]: CCR in /usr/share/xdmod/classes/CCR/DB/PDODB.php on line 185
```

```
[root@rocky-8 /]# /usr/share/xdmod/tools/etl/etl_overseer.php -p xdmod.logger-bootstrap
PHP Fatal error:  Uncaught PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mod_logger.log_id_seq' doesn't exist in /usr/share/xdmod/classes/CCR/DB/PDODB.php:185
Stack trace:
#0 /usr/share/xdmod/classes/CCR/DB/PDODB.php(185): PDOStatement->execute(Array)
#1 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(100): CCR\DB\PDODB->execute('UPDATE mod_logg...')
#2 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(79): CCR\CCRDBHandler->getNextId()
#3 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(39): CCR\CCRDBHandler->write(Array)
#4 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(344): Monolog\Handler\AbstractProcessingHandler->handle(Array)
#5 /usr/share/xdmod/classes/CCR/Logger.php(37): Monolog\Logger->addRecord(200, '{"message":"Com...', Array)
#6 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(642): CCR\Logger->addRecord(200, 'Command: '/usr/...', Array)
#7 /usr/share/xdmod/tools/etl/etl_overseer.php(398): Monolog\Logger->info('Command: '/ in /usr/share/xdmod/classes/CCR/DB/PDODB.php on line 185
PHP Fatal error:  Uncaught PDOException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'mod_logger.log_id_seq' doesn't exist in /usr/share/xdmod/classes/CCR/DB/PDODB.php:185
Stack trace:
#0 /usr/share/xdmod/classes/CCR/DB/PDODB.php(185): PDOStatement->execute(Array)
#1 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(100): CCR\DB\PDODB->execute('UPDATE mod_logg...')
#2 /usr/share/xdmod/classes/CCR/CCRDBHandler.php(79): CCR\CCRDBHandler->getNextId()
#3 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(39): CCR\CCRDBHandler->write(Array)
#4 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(344): Monolog\Handler\AbstractProcessingHandler->handle(Array)
#5 /usr/share/xdmod/classes/CCR/Logger.php(37): Monolog\Logger->addRecord(500, '{"message":"Unc...', Array)
#6 /usr/share/xdmod/vendor/monolog/monolog/src/Monolog/Logger.php(726): CCR\Logger->addRecord(500, Array, Array)
#7 /usr/share/xdmod/classes/CCR/Log.php(126): Monolog\Logger->crit(Array)
#8 [internal function]: CCR in /usr/share/xdmod/classes/CCR/DB/PDODB.php on line 185
```

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Inside Rocky 8 container I can bootstrap fresh XDMOD install with this change:

```
[root@rocky-8 /]# /usr/share/xdmod/tools/etl/etl_overseer.php -p xdb-bootstrap -p jobs-xdw-bootstrap -p xdw-bootstrap-storage -p shredder-bootstrap -p staging-bootstrap -p hpcdb-bootstrap -p acls-xdmod-management -p logger-bootstrap
2024-03-20 11:44:56 [notice] dw_extract_transform_load start (process_start_time: 2024-03-20 11:44:56)
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [warning] Cannot set ETL macro DW_ETL_LOG_RECIPIENT - XDMoD configuration option general.debug_recipient is not set or is empty.
2024-03-20 11:44:56 [notice] Start processing section 'xdmod.xdb-bootstrap'
2024-03-20 11:44:56 [notice] Table `moddb`.`AccountRequests` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`APIKeys` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`ChartPool` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`Colors` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`ExceptionEmailAddresses` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`ReportCharts` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`ReportTemplateCharts` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`ReportTemplates` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`Reports` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`RESTx509` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`SessionManager` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`Users` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`UserProfiles` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`UserTypes` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`VersionCheck` does not exist, creating.
2024-03-20 11:44:56 [notice] Table `moddb`.`batch_export_requests` does not exist, creating.
2024-03-20 11:44:56 [notice] (action: xdmod.xdb-bootstrap.xdb-table-create (ETL\Maintenance\ManageTables), start_time: 1710949496.7948, end_time: 1710949496.9845, elapsed_time: 0.18977)
2024-03-20 11:44:57 [notice] (action: xdmod.xdb-bootstrap.colors (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949496.9869, end_time: 1710949497.1464, elapsed_time: 0.15948, records_examined: 33, records_loaded: 33)
2024-03-20 11:44:57 [notice] (action: xdmod.xdb-bootstrap.report-templates-charts (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.147, end_time: 1710949497.2169, elapsed_time: 0.0699, records_examined: 28, records_loaded: 28)
2024-03-20 11:44:57 [notice] (action: xdmod.xdb-bootstrap.report-templates (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.2174, end_time: 1710949497.2558, elapsed_time: 0.03844, records_examined: 3, records_loaded: 3)
2024-03-20 11:44:57 [notice] (action: xdmod.xdb-bootstrap.user-types (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.2562, end_time: 1710949497.2898, elapsed_time: 0.0336, records_examined: 5, records_loaded: 5)
2024-03-20 11:44:57 [notice] Finished processing section 'xdmod.xdb-bootstrap'
2024-03-20 11:44:57 [notice] Start processing section 'xdmod.jobs-xdw-bootstrap'
2024-03-20 11:44:57 [notice] Table `modw`.`account` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`allocationbreakdown` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`allocationonresource` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`allocation` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`days` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`error_descriptions` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`federation_instances` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`fieldofscience_hierarchy` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`fieldofscience` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`gpu_buckets` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`hosts` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`job_records` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`job_tasks` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`job_times` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`job_wait_times` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`jobhosts` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`months` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`nodecount` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`organization` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`peopleunderpi` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`person` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`piperson` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`principalinvestigator` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`processor_buckets` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`quarters` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`queue` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`qos` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`request` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`resource_allocated` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`resourcefact` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`resourcespecs` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`resourcetype` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`serviceprovider` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`staging_jobhosts` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`systemaccount` does not exist, creating.
2024-03-20 11:44:57 [notice] Table `modw`.`years` does not exist, creating.
2024-03-20 11:44:57 [notice] (action: xdmod.jobs-xdw-bootstrap.table-create (ETL\Maintenance\ManageTables), start_time: 1710949497.2903, end_time: 1710949497.7234, elapsed_time: 0.4331)
2024-03-20 11:44:57 [notice] (action: xdmod.jobs-xdw-bootstrap.jobtimes (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.7238, end_time: 1710949497.7817, elapsed_time: 0.05785, records_examined: 8, records_loaded: 8)
2024-03-20 11:44:57 [notice] (action: xdmod.jobs-xdw-bootstrap.jobwaittimes (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.782, end_time: 1710949497.8228, elapsed_time: 0.04078, records_examined: 8, records_loaded: 8)
2024-03-20 11:44:57 [notice] (action: xdmod.jobs-xdw-bootstrap.error-descriptions (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.8233, end_time: 1710949497.8687, elapsed_time: 0.04541, records_examined: 16, records_loaded: 16)
2024-03-20 11:44:57 [notice] (action: xdmod.jobs-xdw-bootstrap.processorbuckets (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.8691, end_time: 1710949497.9125, elapsed_time: 0.04345, records_examined: 14, records_loaded: 14)
2024-03-20 11:44:57 [notice] (action: xdmod.jobs-xdw-bootstrap.gpu-buckets (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.9129, end_time: 1710949497.9594, elapsed_time: 0.04652, records_examined: 19, records_loaded: 19)
2024-03-20 11:44:57 [notice] (action: xdmod.jobs-xdw-bootstrap.account (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.9597, end_time: 1710949497.9935, elapsed_time: 0.03377, records_examined: 1, records_loaded: 1)
2024-03-20 11:44:58 [notice] (action: xdmod.jobs-xdw-bootstrap.person (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949497.9938, end_time: 1710949498.0311, elapsed_time: 0.03736, records_examined: 2, records_loaded: 2)
2024-03-20 11:44:58 [notice] (action: xdmod.jobs-xdw-bootstrap.pi-person (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949498.0315, end_time: 1710949498.0644, elapsed_time: 0.03288, records_examined: 1, records_loaded: 1)
2024-03-20 11:44:58 [notice] (action: xdmod.jobs-xdw-bootstrap.qos (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949498.0647, end_time: 1710949498.0985, elapsed_time: 0.03382, records_examined: 1, records_loaded: 1)
2024-03-20 11:44:58 [notice] (action: xdmod.jobs-xdw-bootstrap.organization (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949498.0989, end_time: 1710949498.1357, elapsed_time: 0.03685, records_examined: 1, records_loaded: 1)
2024-03-20 11:44:58 [notice] Finished processing section 'xdmod.jobs-xdw-bootstrap'
2024-03-20 11:44:58 [notice] Start processing section 'xdmod.xdw-bootstrap-storage'
2024-03-20 11:44:58 [notice] Table `modw`.`mountpoint` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `modw`.`storagefact` does not exist, creating.
2024-03-20 11:44:58 [notice] (action: xdmod.xdw-bootstrap-storage.create-tables (ETL\Maintenance\ManageTables), start_time: 1710949498.1363, end_time: 1710949498.1683, elapsed_time: 0.032)
2024-03-20 11:44:58 [notice] Finished processing section 'xdmod.xdw-bootstrap-storage'
2024-03-20 11:44:58 [notice] Start processing section 'xdmod.shredder-bootstrap'
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`shredded_job_lsf` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`shredded_job_pbs` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`shredded_job_sge` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`shredded_job` does not exist, creating.
2024-03-20 11:44:58 [notice] (action: xdmod.shredder-bootstrap.create-tables (ETL\Maintenance\ManageTables), start_time: 1710949498.1689, end_time: 1710949498.2214, elapsed_time: 0.05245)
2024-03-20 11:44:58 [notice] Processing SQL file '/etc/xdmod/etl/etl_sql.d/jobs/shredder/job-slurm.sql' using delimiter '//' containing 1 statements
2024-03-20 11:44:58 [notice] Finished Processing 1 SQL statements
2024-03-20 11:44:58 [notice] (action: xdmod.shredder-bootstrap.create-slurm-table (ETL\Maintenance\ExecuteSql), start_time: 1710949498.2217, end_time: 1710949498.2342, elapsed_time: 0.01256)
2024-03-20 11:44:58 [notice] Finished processing section 'xdmod.shredder-bootstrap'
2024-03-20 11:44:58 [notice] Start processing section 'xdmod.staging-bootstrap'
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_organization` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_pi_resource` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_pi` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_qos` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_resource_config` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_resource_spec` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_resource_type` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_resource` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_union_user_pi_resource` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_union_user_pi` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_user_pi_resource` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_job` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_storage_mountpoint` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_shredder`.`staging_storage_usage` does not exist, creating.
2024-03-20 11:44:58 [notice] (action: xdmod.staging-bootstrap.create-tables (ETL\Maintenance\ManageTables), start_time: 1710949498.2346, end_time: 1710949498.3811, elapsed_time: 0.14644)
2024-03-20 11:44:58 [notice] Finished processing section 'xdmod.staging-bootstrap'
2024-03-20 11:44:58 [notice] Start processing section 'xdmod.hpcdb-bootstrap'
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_accounts` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_organizations` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_resource_types` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_resources` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_allocations` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_people` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_allocation_breakdown` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_allocations_on_resources` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_email_addresses` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_fields_of_science` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_people_on_accounts_history` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_requests` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_principal_investigators` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_qos` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_resource_allocated` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_resource_specs` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_system_accounts` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_jobs` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_storage_mountpoints` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `mod_hpcdb`.`hpcdb_storage_usage` does not exist, creating.
2024-03-20 11:44:58 [notice] (action: xdmod.hpcdb-bootstrap.create-tables (ETL\Maintenance\ManageTables), start_time: 1710949498.3817, end_time: 1710949498.6169, elapsed_time: 0.23527)
2024-03-20 11:44:58 [notice] Processing SQL file '/etc/xdmod/etl/etl_sql.d/hpcdb/fields-of-science-hierarchy.sql' using delimiter '//' containing 1 statements
2024-03-20 11:44:58 [notice] Finished Processing 1 SQL statements
2024-03-20 11:44:58 [notice] (action: xdmod.hpcdb-bootstrap.create-views (ETL\Maintenance\ExecuteSql), start_time: 1710949498.6174, end_time: 1710949498.6251, elapsed_time: 0.00772)
2024-03-20 11:44:58 [notice] (action: xdmod.hpcdb-bootstrap.fields-of-science (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949498.6253, end_time: 1710949498.6777, elapsed_time: 0.05242, records_examined: 1, records_loaded: 1)
2024-03-20 11:44:58 [notice] Finished processing section 'xdmod.hpcdb-bootstrap'
2024-03-20 11:44:58 [notice] Start processing section 'xdmod.acls-xdmod-management'
2024-03-20 11:44:58 [notice] Altering table `moddb`.`module_versions`
2024-03-20 11:44:58 [notice] Table `moddb`.`user_acls` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `moddb`.`acl_group_bys` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `moddb`.`tabs` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `moddb`.`acl_tabs` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `moddb`.`user_acl_group_by_parameters` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `moddb`.`report_template_acls` does not exist, creating.
2024-03-20 11:44:58 [notice] Table `moddb`.`acl_dimensions` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`resource_type_realms` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`user_tokens` does not exist, creating.
2024-03-20 11:44:59 [notice] (action: xdmod.acls-xdmod-management.AclTableManagement (ETL\Maintenance\ManageTables), start_time: 1710949498.6783, end_time: 1710949499.0233, elapsed_time: 0.34502)
2024-03-20 11:44:59 [notice] Table `moddb`.`report_template_acls_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] (action: xdmod.acls-xdmod-management.report-template-acls-staging (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949499.0237, end_time: 1710949499.0389, elapsed_time: 0.01517, records_examined: 3, records_loaded: 3)
2024-03-20 11:44:59 [notice] (action: xdmod.acls-xdmod-management.report-template-acls-staging-submodules (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949499.0393, end_time: 1710949499.0785, elapsed_time: 0.03922, records_examined: 1, records_loaded: 1)
2024-03-20 11:44:59 [notice] Table `moddb`.`modules_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`realms_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`hierarchies_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`acl_types_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`acls_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`group_bys_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`statistics_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`acl_hierarchies_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`user_acls_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`acl_group_bys_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`tabs_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`acl_tabs_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`user_acl_group_by_parameters_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `moddb`.`acl_dimensions_staging` does not exist, creating.
2024-03-20 11:44:59 [notice] (action: xdmod.acls-xdmod-management.AclStagingTableManagement (ETL\Maintenance\ManageTables), start_time: 1710949499.0789, end_time: 1710949499.2679, elapsed_time: 0.18899)
2024-03-20 11:44:59 [notice] Finished processing section 'xdmod.acls-xdmod-management'
2024-03-20 11:44:59 [notice] Start processing section 'xdmod.logger-bootstrap'
2024-03-20 11:44:59 [notice] Table `mod_logger`.`log_id_seq` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `mod_logger`.`log_level` does not exist, creating.
2024-03-20 11:44:59 [notice] Table `mod_logger`.`log_table` does not exist, creating.
2024-03-20 11:44:59 [notice] (action: xdmod.logger-bootstrap.manage-tables (ETL\Maintenance\ManageTables), start_time: 1710949499.2684, end_time: 1710949499.2993, elapsed_time: 0.03082)
2024-03-20 11:44:59 [notice] (action: xdmod.logger-bootstrap.log_level (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949499.2996, end_time: 1710949499.3508, elapsed_time: 0.05121, records_examined: 9, records_loaded: 9)
2024-03-20 11:44:59 [notice] (action: xdmod.logger-bootstrap.log_id_seq (ETL\Ingestor\StructuredFileIngestor), start_time: 1710949499.3512, end_time: 1710949499.386, elapsed_time: 0.03474, records_examined: 1, records_loaded: 1)
2024-03-20 11:44:59 [notice] Finished processing section 'xdmod.logger-bootstrap'
2024-03-20 11:44:59 [notice] dw_extract_transform_load end (process_end_time: 2024-03-20 11:44:59)

[root@rocky-8 /]# mysql -e 'show databases'
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mod_hpcdb          |
| mod_logger         |
| mod_shredder       |
| moddb              |
| modw               |
| modw_aggregates    |
| modw_etl           |
| modw_filters       |
| modw_jobefficiency |
| modw_ondemand      |
| modw_supremm       |
| mysql              |
| performance_schema |
| test               |
+--------------------+
```

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
