### PR TITLE
Update software requirements for Rocky 8

### DIFF
--- a/docs/software-requirements.md
+++ b/docs/software-requirements.md
@@ -90,6 +90,15 @@ start after a reboot unless you have configured them to do so.
 **NOTE**: APCu is optional, but highly recommended as it provides enhanced performance.
 
 ### Rocky 8+
+```sh
+dnf install -y epel-release
+
+dnf install -y httpd php php-cli php-mysqlnd php-gd php-pdo php-xml \
+            php-pear libreoffice nodejs \
+            mariadb-server mariadb cronie logrotate \
+            perl-Image-ExifTool php-mbstring php-pecl-apcu jq \
+            chromium-headless librsvg2-tools
+```
 
 **NOTE**: The nodejs version that is enabled by default in Rocky 8 is nodejs 10. Open
 XDMoD requires nodejs 16 which can be installed on Rocky 8 using the  nodejs 16 module
@@ -104,7 +113,7 @@ dnf module -y install nodejs:16
 need to run the following:
 ```shell
 dnf install -y php-devel
-pecl install mongodb
+pecl install mongodb-1.16.2
 echo "extension=mongodb.so" > /etc/php.d/40-mongodb.ini
 ```
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
These changes update the installation instructions for Rocky 8.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have received a couple tickets regarding the installation of the MongoDB PHP driver on Rocky 8. The current version `1.18.1` is not compatible with PHP 7.2. The current compatible version of the driver is `1.16.2`. The `php-mysql` package is also not available on Rocky 8 so I have updated the instructions to install `php-mysqlnd` instead (which is currently being used in our CI test images [here](https://github.com/ubccr/xdmod/blob/xdmod11.0/tests/ci/Docker/Dockerfile.rocky8.xdmod-base)) and `php-pear` to install the mechanism to install the MongoDB driver.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested in fresh `rockylinux:8` container using the updated installation instructions.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
