### PR TITLE
Allow multiple columns in `RegexTransformIngestor`.

### DIFF
--- a/classes/ETL/Ingestor/RegexTransformIngestor.php
+++ b/classes/ETL/Ingestor/RegexTransformIngestor.php
@@ -2,26 +2,31 @@
 /* ==========================================================================================
  * RegexTransform. This ingestor transforms values using the preg_filter() function.
  *
- * The regular expressions, name of the source to split and the destination column
+ * The regular expressions, names of the sources to split and the destination columns
  * to populate are specified using configuration properties. All other source
- * columns are passed unmodified. If the regular expression does not match then
+ * columns are passed unmodified. If no regular expressions match then
  * the row is not passed by the ingestor.
  *
  * Configuration properties:
  *
- * - regex_column: defines the column in the source table to read and column name in the
+ * - regex_column: defines the columns in the source table to read and column names in the
  *                 output to use for the transformed data. For example:
- *                 { "source": "dest" } would read the data in column named "source" and
- *                 the transformed content of "source" would be written to "dest".
- * - regex_config: a json formatted string that contains regular expression and output
- *                 patterns. The the regex format is the one used by preg_filter().
+ *                 { "dest1": "source1", "dest2": "source2" } would read the data in column named
+ *                 "source1" and the transformed content of "source1" would be written to "dest1",
+ *                 then the transformed content of "source2" would be written to "dest2". If "dest1"
+ *                 and "source2" are the same, "dest2" will transform the old value of "source2"
+ *                 (old meaning before it was transformed from "source1" to "dest1").
+ * - regex_config: mapping of destination column names to json formatted strings that contain
+ *                 regular expression and output patterns. The regex format is the one used by
+ *                 preg_filter().
  *                 For example:
  *                     {
- *                         "#foo_([a-z]+)$#": "bar_$1"
+ *                         "dest": {
+ *                             ";foo_([a-z]+)$;": "bar_$1"
+ *                         }
  *                     }
  *                 defines a regex that matches foo_ and any lowercase letters and then transforms
- *                 it to bar_ with the same letters.
- *
+ *                 it to bar_ with the same letters, storing the result in the "dest" column.
  */
 namespace ETL\Ingestor;
 
@@ -33,19 +38,8 @@ use Psr\Log\LoggerInterface;
 
 class RegexTransformIngestor extends pdoIngestor implements iAction
 {
-    /**
-     * The name of the column in the source table to explode().
-     */
-    private $srcKey;
-    /**
-     * The name of the column in the destination table populate.
-     */
-    private $destKey;
-
-    /*
-     * Array of regular expressions to test.
-     */
-    private $regexconf;
+    private $regex_column;
+    private $dest_configs;
 
     /**
      * @see ETL\Ingestor\pdoIngestor::__construct()
@@ -54,38 +48,41 @@ class RegexTransformIngestor extends pdoIngestor implements iAction
     {
         parent::__construct($options, $etlConfig, $logger);
 
-        $this->verifyRequiredConfigKeys(array('regex_config', 'regex_column'), $options);
+        $this->verifyRequiredConfigKeys(array('regex_column', 'regex_config'), $options);
 
-        foreach($options->regex_column as $key => $value) {
-            $this->srcKey = $key;
-            $this->destKey = $value;
-            break;
+        $this->regex_column = $options->regex_column;
+        $this->dest_configs = array();
+        foreach ($options->regex_config as $dest => $config) {
+            $this->dest_configs[$dest] = get_object_vars($config);
         }
-
-        $rconf = json_decode($options->regex_config, true);
-
-        $this->patterns = array_keys($rconf);
-        $this->replacements = array_values($rconf);
     }
 
     /**
      * @see ETL\Ingestor\pdoIngestor::transform()
      */
-    protected function transform(array $srcRecord, $orderId)
+    protected function transform(array $srcRecord, &$orderId)
     {
         $transformedRecord = array();
+        $outdata = $srcRecord;
+        $ignored = true;
+        foreach ($this->dest_configs as $dest => $config) {
+            $srcColumn = $srcRecord[$this->regex_column->{$dest}];
+            $res = preg_filter(
+                array_keys($config),
+                array_values($config),
+                $srcColumn
+            );
 
-        $res = preg_filter($this->patterns, $this->replacements, $srcRecord[$this->srcKey]);
-
-        if ($res !== null) {
-            $outdata = $srcRecord;
-            $outdata[$this->destKey] = $res;
-
-            $transformedRecord[] = $outdata;
-        } else {
-            $this->logger->debug("Ignore " . $srcRecord[$this->srcKey]);
+            if (!is_null($res)) {
+                $outdata[$dest] = $res;
+                $ignored = false;
+            }
         }
-
+        if ($ignored) {
+            $this->logger->warning('RegexTransformIngestor ignoring ' . implode('|', $srcRecord));
+        } else {
+            $transformedRecord[] = $outdata;
+        }
         return $transformedRecord;
     }
 }


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->
_NOTE: This PR should not be merged unless https://github.com/ubccr/xdmod-ondemand/pull/50 is also merged; otherwise `xdmod-ondemand` ingestion will break._
## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR allows the `RegexTransformIngestor` to transform multiple columns.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This enables https://github.com/ubccr/xdmod-ondemand/pull/50, specifically the ability to transform `app`, `request_path`, `reverse_proxy_host`, and `reverse_proxy_port` in the same pipeline action (`ondemand.log-ingestion.normalize-staging`).

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested ingesting logs on my port on `xdmod-dev` with the changes from https://github.com/ubccr/xdmod-ondemand/pull/50 and the PRs on which it depends.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
