### PR TITLE
Fix MaxListenersExceededWarning warning.

### DIFF
--- a/html/gui/js/modules/job_viewer/ChartPanel.js
+++ b/html/gui/js/modules/job_viewer/ChartPanel.js
@@ -147,14 +147,11 @@ XDMoD.Module.JobViewer.ChartPanel = Ext.extend(Ext.Panel, {
 
                 if (panel.chart) {
                     Plotly.react(this.id, chartOptions.data, chartOptions.layout, { displayModeBar: false, doubleClick: 'reset' });
-                    this.chart = true;
                 } else {
                     Plotly.newPlot(this.id, chartOptions.data, chartOptions.layout, { displayModeBar: false, doubleClick: 'reset' });
-                    this.chart = true;
-                }
-                if (panel.chart) {
+
                     panel.chart = document.getElementById(this.id);
-                    panel.chart.once('plotly_click', function (data, event) {
+                    panel.chart.on('plotly_click', function (data, event) {
                         var userOptions = data.points[0].data.chartSeries;
                         if (!userOptions || !userOptions.dtype) {
                             return;


### PR DESCRIPTION
The event listener needs to only be added on a newPlot to readded to an existing one.

Tested on my port by repeatedly drilling down on a GPU timeseries plot. 