### PR TITLE
Add configuration setting for the ETL process log database output

### DIFF
--- a/tools/etl/etl_overseer.php
+++ b/tools/etl/etl_overseer.php
@@ -70,6 +70,8 @@ $scriptOptions = array(
     'lock-dir'          => null,
     // Optional ETL lock file prefix
     'lock-file-prefix'  => null,
+    // Whether the logger should write to the database
+    'log-to-database'   => true,
     // Previous number of days to ingest
     'number-of-days'    => null,
     // List of options to add to or override individual action options
@@ -144,7 +146,8 @@ $options = array(
     'x:'  => 'exclude-resource-codes:',
     'y:'  => 'last-modified-end-date:',
     ''    => 'lock-dir',
-    ''    => 'lock-file-prefix'
+    ''    => 'lock-file-prefix',
+    ''    => 'log-to-database:'
     );
 
 $args = getopt(implode('', array_keys($options)), $options);
@@ -349,6 +352,10 @@ foreach ($args as $arg => $value) {
             $scriptOptions['lock-prefix'] = $value;
             break;
 
+        case 'log-to-database':
+            $scriptOptions['log-to-database'] = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+            break;
+
         case 'h':
         case 'help':
             usage_and_exit();
@@ -386,7 +393,7 @@ foreach ( $argv as $index => $arg ) {
 $conf = array(
     'emailSubject' => gethostname() . ': XDMOD: Data Warehouse: Federated ETL Log',
     'mail' => false,
-    'db' => false
+    'db' => $scriptOptions['log-to-database']
 );
 
 if ( null !== $scriptOptions['verbosity'] ) {
@@ -689,6 +696,9 @@ Usage: {$argv[0]}
 
     -m, --last-modified-start-date
     ETL last modified start date, used by some actions. Defaults to the start of the ETL process (e.g., "now").
+
+        --log-to-database {yes, no}
+    Whether to enable writing the ETL process log to the database. Defaults to "yes".
 
     -n, --number-of-days
     Number of days that the action will operate on.


### PR DESCRIPTION
This is based on #1827 but makes it configurable (with the default being no change in behavour)

Tested manually by running:
```
./share/tools/etl/etl_overseer.php  -v debug
```
and then checking the database to see a log was written:
```
mysql mod_logger
> select * from log_table order by id desc limit 1;
```
then doing the same but with the `--log-to-database no` option (no write happened) and then same again but with the `--log-to-database yes` option (did write).