### PR TITLE
Add `JsonReferenceWithFallbackTransformer`.

### DIFF
--- a/classes/CCR/Loggable.php
+++ b/classes/CCR/Loggable.php
@@ -135,7 +135,7 @@ class Loggable
             }
 
             if ( array_key_exists('log_level', $options) && ! empty($options['log_level']) ) {
-                $logLevel = $logMessage['log_level'];
+                $logLevel = $options['log_level'];
             }
         }
 

--- a/classes/Configuration/CommentTransformer.php
+++ b/classes/Configuration/CommentTransformer.php
@@ -46,7 +46,7 @@ class CommentTransformer extends Loggable implements iConfigFileKeyTransformer
      * ------------------------------------------------------------------------------------------
      */
 
-    public function transform(&$key, &$value, stdClass $obj, Configuration $config)
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config, $exceptionLogLevel)
     {
         $key = null;
         $value = null;

--- a/classes/Configuration/Configuration.php
+++ b/classes/Configuration/Configuration.php
@@ -64,6 +64,7 @@
 
 namespace Configuration;
 
+use CCR\Log;
 use CCR\Loggable;
 use ETL\DataEndpoint;
 use ETL\DataEndpoint\DataEndpointOptions;
@@ -698,6 +699,7 @@ class Configuration extends Loggable implements iConfiguration
     {
         $this->addKeyTransformer(new CommentTransformer($this->logger));
         $this->addKeyTransformer(new JsonReferenceTransformer($this->logger));
+        $this->addKeyTransformer(new JsonReferenceWithFallbackTransformer($this->logger));
         $this->addKeyTransformer(new JsonReferenceWithOverwriteTransformer($this->logger));
         $this->addKeyTransformer(new StripMergePrefixTransformer($this->logger));
         $this->addKeyTransformer(new IncludeTransformer($this->logger));
@@ -995,7 +997,7 @@ class Configuration extends Loggable implements iConfiguration
                 }
 
                 try {
-                    $stop = ( ! $transformer->transform($transformKey, $value, $obj, $this) );
+                    $stop = ( ! $transformer->transform($transformKey, $value, $obj, $this, Log::ERR) );
                 } catch ( Exception $e ) {
                     throw new Exception(sprintf("%s: %s", $this->filename, $e->getMessage()));
                 }

--- a/classes/Configuration/IncludeTransformer.php
+++ b/classes/Configuration/IncludeTransformer.php
@@ -6,6 +6,7 @@
 
 namespace Configuration;
 
+use CCR\Log;
 use stdClass;
 
 class IncludeTransformer extends aUrlTransformer implements iConfigFileKeyTransformer
@@ -29,17 +30,18 @@ class IncludeTransformer extends aUrlTransformer implements iConfigFileKeyTransf
      * ------------------------------------------------------------------------------------------
      */
 
-    public function transform(&$key, &$value, stdClass $obj, Configuration $config)
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config, $exceptionLogLevel)
     {
 
         if( count(get_object_vars($obj)) != 1 ) {
             $this->logAndThrowException(
-                sprintf('References cannot be mixed with other keys in an object: "%s": "%s"', $key, $value)
+                sprintf('References cannot be mixed with other keys in an object: "%s": "%s"', $key, $value),
+                array('log_level' => $exceptionLogLevel)
             );
         }
 
         $parsedUrl = null;
-        $contents = $this->getContentsFromUrl($value, $config);
+        $contents = $this->getContentsFromUrl($value, $config, $exceptionLogLevel);
         $key = null;
         $value = $contents;
 

--- a/classes/Configuration/JsonReferenceWithFallbackTransformer.php
+++ b/classes/Configuration/JsonReferenceWithFallbackTransformer.php
@@ -1,0 +1,86 @@
+<?php
+/** =========================================================================================
+ * This is the same as the JsonReferenceTransformer, but if the JSON pointer cannot be
+ * transformed, it will fall back to transforming a different JSON pointer, and if that fails,
+ * it will fall back to transforming a different JSON pointer, and so on.
+ * ==========================================================================================
+ */
+
+namespace Configuration;
+
+use CCR\Log;
+use Exception;
+use stdClass;
+
+class JsonReferenceWithFallbackTransformer extends JsonReferenceTransformer implements iConfigFileKeyTransformer
+{
+    const REFERENCE_KEY = '$ref-with-fallback';
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iConfigFileKeyTransformer::keyMatches()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function keyMatches($key)
+    {
+        return (self::REFERENCE_KEY == $key);
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * Transform the first JSON pointer in the array into the actual JSON that it references.
+     * If that fails, transform the next JSON pointer in the array into the actual JSON that it
+     * references. Keep trying until a JSON pointer is successfully transformed or the array
+     * of JSON pointers runs out (throw any exception caused by trying to transform the last
+     * pointer in the array).
+     *
+     * @see iConfigFileKeyTransformer::transform()
+     *
+     * @throws Exception if there are multiple keys in $obj or if $value is not a non-empty,
+     *                   non-associative array of strings.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config, $exceptionLogLevel)
+    {
+        if (1 !== count(get_object_vars($obj))) {
+            $this->logAndThrowException(
+                sprintf(
+                    'References cannot be mixed with other keys in an object: "%s"',
+                    $key
+                )
+            );
+        }
+        $exceptionMessage = sprintf(
+            'Value of "%s" must be a non-empty, non-associative array of strings',
+            $key
+        );
+        if (!is_array($value) || array_keys($value) !== range(0, count($value) - 1)) {
+            $this->logAndThrowException($exceptionMessage);
+        }
+        foreach ($value as $v) {
+            if (!is_string($v)) {
+                $this->logAndThrowException($exceptionMessage);
+            }
+        }
+        for ($i = 0; $i < count($value); $i++) {
+            try {
+                $keepGoing = parent::transform(
+                    $key,
+                    $value[$i],
+                    $obj,
+                    $config,
+                    Log::DEBUG
+                );
+                $value = $value[$i];
+                return $keepGoing;
+            } catch (Exception $e) {
+                if ($i === count($value) - 1) {
+                    $this->logAndThrowException($e->getMessage());
+                } else {
+                    $this->logger->debug('Falling back to next file');
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/classes/Configuration/JsonReferenceWithOverwriteTransformer.php
+++ b/classes/Configuration/JsonReferenceWithOverwriteTransformer.php
@@ -23,6 +23,7 @@
 
 namespace Configuration;
 
+use CCR\Log;
 use stdClass;
 
 class JsonReferenceWithOverwriteTransformer extends JsonReferenceTransformer implements iConfigFileKeyTransformer
@@ -44,7 +45,7 @@ class JsonReferenceWithOverwriteTransformer extends JsonReferenceTransformer imp
      * @see iConfigFileKeyTransformer::transform()
      */
 
-    public function transform(&$key, &$value, stdClass $obj, Configuration $config)
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config, $exceptionLogLevel)
     {
         $overwriteKey = '$overwrite';
         $overwriteDirectives = array();
@@ -59,11 +60,14 @@ class JsonReferenceWithOverwriteTransformer extends JsonReferenceTransformer imp
         } else {
             // If the reference with overwrite was specified, it must contain the overwrite
             // directive!
-            $this->logAndThrowException(sprintf("Expected '%s' directive not found", $overwriteKey));
+            $this->logAndThrowException(
+                sprintf("Expected '%s' directive not found", $overwriteKey),
+                array('log_level' => $exceptionLogLevel)
+            );
         }
 
         $jsonRefUrl = $value;
-        parent::transform($key, $value, $obj, $config);
+        parent::transform($key, $value, $obj, $config, $exceptionLogLevel);
 
         if ( ! is_object($value) ) {
             $this->logger->warning(

--- a/classes/Configuration/ModuleTransformer.php
+++ b/classes/Configuration/ModuleTransformer.php
@@ -30,7 +30,7 @@ class ModuleTransformer extends Loggable implements iConfigFileKeyTransformer
         return self::KEY === $key;
     }
 
-    public function transform(&$key, &$value, stdClass $obj, Configuration $config)
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config, $exceptionLogLevel)
     {
         if ($config instanceof ModuleConfiguration ) {
             $currentModule = $config->getModule();

--- a/classes/Configuration/StripMergePrefixTransformer.php
+++ b/classes/Configuration/StripMergePrefixTransformer.php
@@ -39,7 +39,7 @@ class StripMergePrefixTransformer extends Loggable implements iConfigFileKeyTran
     /**
      * @see iConfigFileKeyTransformer::transform()
      */
-    public function transform(&$key, &$value, stdClass $obj, Configuration $config)
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config, $exceptionLogLevel)
     {
         $key = substr($key, 1);
 

--- a/classes/Configuration/aUrlTransformer.php
+++ b/classes/Configuration/aUrlTransformer.php
@@ -7,6 +7,7 @@
 
 namespace Configuration;
 
+use CCR\Log;
 use CCR\Loggable;
 use Psr\Log\LoggerInterface;
 
@@ -60,13 +61,14 @@ abstract class aUrlTransformer extends Loggable
      *
      * @param string $url The URL to process
      * @param Configuration $config The Configuration object that called this method
+     * @param $exceptionLogLevel The level to use for logging any exceptions
      *
      * @return The contents of the file referenced by the URL
      * @throws Exception if there was an error parsing the URL or accessing the file
      * ------------------------------------------------------------------------------------------
      */
 
-    public function getContentsFromUrl($url, Configuration $config)
+    public function getContentsFromUrl($url, Configuration $config, $exceptionLogLevel)
     {
 
         $url = $config->getVariableStore()->substitute(
@@ -81,7 +83,8 @@ abstract class aUrlTransformer extends Loggable
 
         if ( empty($this->parsedUrl['path']) ) {
             $this->logAndThrowException(
-                sprintf("(%s) Unable to extract path from URL: %s", get_class($this), $url)
+                sprintf("(%s) Unable to extract path from URL: %s", get_class($this), $url),
+                array('log_level' => $exceptionLogLevel)
             );
         }
 
@@ -105,7 +108,8 @@ abstract class aUrlTransformer extends Loggable
         if ( false === $contents ) {
             $error = error_get_last();
             $this->logAndThrowException(
-                sprintf("Failed to open file '%s'%s", $path, (null !== $error ? ": " . $error['message'] : ""))
+                sprintf("Failed to open file '%s'%s", $path, (null !== $error ? ": " . $error['message'] : "")),
+                array('log_level' => $exceptionLogLevel)
             );
         }
 

--- a/classes/Configuration/iConfigFileKeyTransformer.php
+++ b/classes/Configuration/iConfigFileKeyTransformer.php
@@ -48,9 +48,10 @@ interface iConfigFileKeyTransformer
      * @param mixed $value Reference to the value (scalar, object, array), may be altered.
      * @param stdClass $obj The object where the key was found.
      * @param Configuration $config The Configuration object that called this method.
+     * @param int $exceptionLogLevel The level to use for logging exceptions.
      *
      * @return FALSE if transfomer processing should stop for this key, TRUE otherwise.
      * ------------------------------------------------------------------------------------------
      */
-    public function transform(&$key, &$value, stdClass $obj, Configuration $config);
+    public function transform(&$key, &$value, stdClass $obj, Configuration $config, $exceptionLogLevel);
 }  // interface iConfigFileKeyTransformer

--- a/docs/etl/json-references.md
+++ b/docs/etl/json-references.md
@@ -153,40 +153,6 @@ transformers to process matching keys will be used.
    3c. If a transformer returns `false` do not process any other transformers.
    3d. Recursively traverse keys in the returned JSON and apply transformers to the result.
 
-### Transformer Interface Definition
-
-Transformers must implement the `iConfigFileKeyTransformer` interface.
-
-```php
-interface iConfigFileKeyTransformer {
-    /* ------------------------------------------------------------------------------------------
-     * Return TRUE if the key is supported by this transformer
-     *
-     * @param string $key Key to check
-     *
-     * @return TRUE if they key is processed by this transformer
-     * ------------------------------------------------------------------------------------------
-     */
-
-    public function keyMatches($key);
-
-    /* ------------------------------------------------------------------------------------------
-     * Transform the data. Both the key and the value may be modified and will be returned
-     * by reference.
-     *
-     * @param string $key Reference to the key, may be altered.
-     * @param mixed $value Reference to the value (scalar, object, array), may be altered.
-     * @param stdClass $obj The object where the key was found.
-     * @param Configuration $config The Configuration object that called this method.
-     *
-     * @return FALSE if transfomer processing should stop for this key, TRUE otherwise.
-     * ------------------------------------------------------------------------------------------
-     */
-     
-    public function transform(&$key, &$value, stdClass $obj, Configuration $config);
-}
-```
-
 ### Comment Transformer
 
 The comment transformer strips comments from the JSON. Any key starting with a `#` is considered a

--- a/tests/unit/lib/ETL/Configuration/IncludeTest.php
+++ b/tests/unit/lib/ETL/Configuration/IncludeTest.php
@@ -51,7 +51,7 @@ class IncludeTest extends \PHPUnit\Framework\TestCase
         $key = '$include';
         $value = 'file_does_not_exist.txt';
         $obj = (object) array($key => $value);
-        self::$transformer->transform($key, $value, $obj, self::$config);
+        self::$transformer->transform($key, $value, $obj, self::$config, Log::ERR);
     }
 
     /**
@@ -66,7 +66,7 @@ class IncludeTest extends \PHPUnit\Framework\TestCase
         $key = '$include';
         $value = 'badscheme://string';
         $obj = (object) array($key => $value);
-        self::$transformer->transform($key, $value, $obj, self::$config);
+        self::$transformer->transform($key, $value, $obj, self::$config, Log::ERR);
     }
 
     /**
@@ -79,7 +79,7 @@ class IncludeTest extends \PHPUnit\Framework\TestCase
         $value = 'etl_sql.d/query.sql';
         $obj = (object) array($key => $value);
         $expected = file_get_contents(self::TEST_ARTIFACT_INPUT_PATH . '/' . $value);
-        self::$transformer->transform($key, $value, $obj, self::$config);
+        self::$transformer->transform($key, $value, $obj, self::$config, Log::ERR);
 
         // A null key means replace the entire value object with the transformed value
         $this->assertNull($key);
@@ -98,7 +98,7 @@ class IncludeTest extends \PHPUnit\Framework\TestCase
         $key = '$include';
         $value = '${SUBDIR}/${FILENAME}.sql';
         $obj = (object) array($key => $value);
-        self::$transformer->transform($key, $value, $obj, self::$config);
+        self::$transformer->transform($key, $value, $obj, self::$config, Log::ERR);
 
         $expected = file_get_contents(self::TEST_ARTIFACT_INPUT_PATH . '/etl_sql.d/query.sql');
         $this->assertNull($key);

--- a/tests/unit/lib/ETL/Configuration/JsonReferenceWithFallbackTest.php
+++ b/tests/unit/lib/ETL/Configuration/JsonReferenceWithFallbackTest.php
@@ -1,0 +1,174 @@
+<?php
+namespace UnitTests\ETL\Configuration;
+
+use CCR\Log;
+use Configuration\Configuration;
+use Configuration\JsonReferenceWithFallbackTransformer;
+
+class JsonReferenceWithFallbackTest extends \PHPUnit_Framework_TestCase
+{
+
+    const TEST_ARTIFACT_INPUT_PATH = "./../artifacts/xdmod/etlv2/configuration/input";
+    const TEST_ARTIFACT_OUTPUT_PATH = "./../artifacts/xdmod/etlv2/configuration/output";
+    const VALID_FILE = 'rfc6901.json';
+    const VALID_REFERENCE = self::VALID_FILE . '#/bar';
+    const VALID_REFERENCE_2 = self::VALID_FILE . '#/foo';
+
+    protected static $transformer = null;
+    protected static $config = null;
+
+    public static function setupBeforeClass()
+    {
+      // Set up a logger so we can get warnings and error messages from the ETL infrastructure
+        $conf = array(
+            'file' => false,
+            'db' => false,
+            'mail' => false,
+            'consoleLogLevel' => Log::EMERG
+        );
+        $logger = Log::factory('PHPUnit', $conf);
+
+        // Configuration is used in the transformer to qualify relative paths
+        self::$config = Configuration::factory(self::TEST_ARTIFACT_INPUT_PATH . '/sample_config.json');
+        self::$transformer = new JsonReferenceWithFallbackTransformer($logger);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage References cannot be mixed with other keys in an object: "$ref-with-fallback"
+     */
+    public function testMixedRefs()
+    {
+        $this->runTransformTest([self::VALID_FILE], null, ['foo' => 'bar']);
+    }
+
+    private function runTransformTest($value, $expected = null, $additionalKeys = [])
+    {
+        $key = JsonReferenceWithFallbackTransformer::REFERENCE_KEY;
+        $obj = (object)array_merge([$key => $value], $additionalKeys);
+        self::$transformer->transform($key, $value, $obj, self::$config, Log::ERR);
+        $this->assertNull($key);
+        $this->assertEquals($expected, $value);
+    }
+
+    /**
+     * @dataProvider provideInvalidValue
+     * @expectedException Exception
+     * @expectedExceptionMessage Value of "$ref-with-fallback" must be a non-empty, non-associative array of strings
+     */
+    public function testInvalidValue($value)
+    {
+        $this->runTransformTest($value);
+    }
+
+    public function provideInvalidValue()
+    {
+        return [
+            [2],
+            ['foo'],
+            [['foo' => 'bar']],
+            [[]],
+            [[2]],
+            [['foo', 2]],
+            [[['foo' => 'bar']]],
+            [[[]]]
+        ];
+    }
+
+    /**
+     * @dataProvider provideLastFileDNE
+     * @expectedException Exception
+     * @expectedExceptionMessageRegExp /Failed to open file '[^']+file_does_not_exist.txt': file_get_contents\([^)]+\): failed to open stream: No such file or directory/
+     */
+    public function testLastFileDNE($value)
+    {
+        $this->runTransformTest($value);
+    }
+
+    public function provideLastFileDNE()
+    {
+        return [
+            [['file_does_not_exist.txt']],
+            [['foo', 'file_does_not_exist.txt']],
+            [['foo', 'bar', 'file_does_not_exist.txt']]
+        ];
+    }
+
+    /**
+     * @dataProvider provideLastFileBadUrl
+     * @expectedException Exception
+     * @expectedExceptionMessage Unable to extract path from URL: badscheme://string
+     */
+    public function testLastFileBadUrl($value)
+    {
+        $this->runTransformTest($value);
+    }
+
+    public function provideLastFileBadUrl()
+    {
+        return [
+            [['badscheme://string']],
+            [['foo', 'badscheme://string']],
+            [['foo', 'bar', 'badscheme://string']]
+        ];
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage JSON pointer '/invalid_pointer' references a nonexistent value in file rfc6901.json
+     */
+    public function testInvalidPointer()
+    {
+        $this->runTransformTest([self::VALID_FILE . '#/invalid_pointer']);
+    }
+
+    /**
+     * @dataProvider provideSuccess
+     */
+    public function testSuccess($value, $expected)
+    {
+        $this->runTransformTest($value, $expected);
+    }
+
+    public function provideSuccess()
+    {
+        return [
+            [[self::VALID_REFERENCE], 99],
+            [['foo', self::VALID_REFERENCE], 99],
+            [['foo', self::VALID_REFERENCE, 'bar'], 99],
+            [['foo', self::VALID_REFERENCE, self::VALID_REFERENCE_2], 99],
+            [['foo', 'bar', self::VALID_REFERENCE], 99],
+            [
+                [self::VALID_FILE . '#/key1'],
+                json_decode(
+                    file_get_contents(
+                        self::TEST_ARTIFACT_OUTPUT_PATH
+                        . '/rfc6901_object.json'
+                    )
+                )
+            ],
+            [[self::VALID_FILE . '#/foo/1'], 'two'],
+            [[self::VALID_FILE . '#/key1/key2/key3/-'], 5],
+            [[self::VALID_FILE . '#/a~1b'], 'specialchar']
+        ];
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Undefined macros in URL reference: FILE_EXTENSION in string 'rfc6901.${FILE_EXTENSION}#/bar'
+     */
+    public function testUndefinedVariable()
+    {
+        self::$config->getVariableStore()->FILENAME = 'rfc6901';
+
+        $this->runTransformTest(['${FILENAME}.${FILE_EXTENSION}#/bar']);
+    }
+
+    public function testSuccessWithVariable()
+    {
+        self::$config->getVariableStore()->FILENAME = 'rfc6901';
+        self::$config->getVariableStore()->FILE_EXTENSION = 'json';
+
+        $this->runTransformTest(['${FILENAME}.${FILE_EXTENSION}#/bar'], 99);
+    }
+}

--- a/tests/unit/lib/ETL/Configuration/Rfc6901Test.php
+++ b/tests/unit/lib/ETL/Configuration/Rfc6901Test.php
@@ -9,6 +9,7 @@
 
 namespace UnitTests\ETL\Configuration;
 
+use CCR\Log;
 use Configuration\Configuration;
 use Configuration\JsonReferenceTransformer;
 use Exception;
@@ -41,7 +42,7 @@ class Rfc6901Test extends \PHPUnit\Framework\TestCase
         $key = '$ref';
         $value = 'rfc6901.json#/wehavenobananastoday';
         $obj = (object) array($key => $value);
-        $this->transformer->transform($key, $value, $obj, $this->config);
+        $this->transformer->transform($key, $value, $obj, $this->config, Log::ERR);
     }
 
     /**
@@ -53,7 +54,7 @@ class Rfc6901Test extends \PHPUnit\Framework\TestCase
         $key = '$ref';
         $value = 'rfc6901.json#/bar';
         $obj = (object) array($key => $value);
-        $this->transformer->transform($key, $value, $obj, $this->config);
+        $this->transformer->transform($key, $value, $obj, $this->config, Log::ERR);
 
         // A null key means replace the entire object with the transformed value
         $this->assertNull($key);
@@ -69,7 +70,7 @@ class Rfc6901Test extends \PHPUnit\Framework\TestCase
         $key = '$ref';
         $value = 'rfc6901.json#/key1';
         $obj = (object) array($key => $value);
-        $this->transformer->transform($key, $value, $obj, $this->config);
+        $this->transformer->transform($key, $value, $obj, $this->config, Log::ERR);
 
         // A null key means replace the entire object with the transformed value
         $this->assertNull($key);
@@ -86,7 +87,7 @@ class Rfc6901Test extends \PHPUnit\Framework\TestCase
         $key = '$ref';
         $value = 'rfc6901.json#/foo/1';
         $obj = (object) array($key => $value);
-        $this->transformer->transform($key, $value, $obj, $this->config);
+        $this->transformer->transform($key, $value, $obj, $this->config, Log::ERR);
 
         // A null key means replace the entire object with the transformed value
         $this->assertNull($key);
@@ -102,7 +103,7 @@ class Rfc6901Test extends \PHPUnit\Framework\TestCase
         $key = '$ref';
         $value = 'rfc6901.json#/key1/key2/key3/-';
         $obj = (object) array($key => $value);
-        $this->transformer->transform($key, $value, $obj, $this->config);
+        $this->transformer->transform($key, $value, $obj, $this->config, Log::ERR);
 
         // A null key means replace the entire object with the transformed value
         $this->assertNull($key);
@@ -118,7 +119,7 @@ class Rfc6901Test extends \PHPUnit\Framework\TestCase
         $key = '$ref';
         $value = 'rfc6901.json#/a~1b';
         $obj = (object) array($key => $value);
-        $this->transformer->transform($key, $value, $obj, $this->config);
+        $this->transformer->transform($key, $value, $obj, $this->config, Log::ERR);
 
         // A null key means replace the entire object with the transformed value
         $this->assertNull($key);
@@ -137,6 +138,6 @@ class Rfc6901Test extends \PHPUnit\Framework\TestCase
         $key = '$ref';
         $value = 'rfc6901.json#/does-not-exist';
         $obj = (object) array($key => $value);
-        $this->transformer->transform($key, $value, $obj, $this->config);
+        $this->transformer->transform($key, $value, $obj, $this->config, Log::ERR);
     }
 }  // class Rfc6901Test


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR adds an `JsonReferenceWithFallbackTransformer` that allows configuration files to contain a `$ref-with-fallback` key. This is similar to the `$ref` key, but instead of the value being a single JSON pointer, it is an array of JSON pointers. If there is an error transforming the first JSON pointer in the array, it tries the next JSON pointer in the array, and so on. If it fails to transform the last JSON pointer in the array, it raises an exception just as `$ref` would.

This PR adds an `$exceptionLogLevel` parameter to `getContentsFromUrl()` so that any `No such file or directory` errors are logged at the debug level instead of the error level. This change exposed a bug in `logAndThrowException()` in which the `log_level` option was not properly processed; this PR fixes that bug as well.

This PR also removes some code from `docs/etl/json-references.md` so it does not need to be maintained separately from the actual code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This enables https://github.com/ubccr/xdmod-ondemand/pull/50, specifically the ability to have resource-specific override files for `application-map.json` and/or `request-path-filter.json` without requiring all resources to have such files.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested ingesting logs on my port on `xdmod-dev` with the changes from https://github.com/ubccr/xdmod-ondemand/pull/50 and the PRs on which it depends. I also incrementally developed and tested the new unit tests in a Docker container.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
