### PR TITLE
Remove `jquery-base64` from NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -95,11 +95,6 @@ License: MIT License
 Author:  Mike Crawford, Ben Maurer
 Link:    https://developers.google.com/recaptcha/old/docs/php
 
-Name:    jquery-base64
-License: MIT License
-Author:  Carlo Zottmann
-Link:    https://github.com/carlo/jquery-base64
-
 Name:    Ext.ux.form.GroupComboBox
 License: "BSD"
 Author:  Robert B. Williams


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
jQuery was removed in PR #1756 along with `jquery-base64`.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make NOTICE accurate
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
