### PR TITLE
Fix sorting in regression tests of raw data.

### DIFF
--- a/tests/regression/lib/TestHarness/RegressionTestHelper.php
+++ b/tests/regression/lib/TestHarness/RegressionTestHelper.php
@@ -595,9 +595,9 @@ class RegressionTestHelper extends XdmodTestHelper
         );
         $data = str_replace("\x1e", '', $response[0]);
         if ($sort) {
-            $lines = explode("\n", $data);
+            $lines = explode("\n", rtrim($data));
             sort($lines);
-            $data = implode("\n", $lines);
+            $data = implode("\n", $lines) . "\n";
         }
         $data = preg_replace(self::$replaceRegex, self::$replacements, $data);
         if (getenv('REG_TEST_FORCE_GENERATION') === '1') {


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR fixes the regression tests of the `/warehouse/raw-data` endpoint such that, if the `sort` option is `true`, the last newline character of the sorted response text stays at the end rather than being moved to the beginning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes it easier to view and debug the expected test artifacts and actual responses for the tests in question. In addition, https://github.com/ubccr/xdmod-supremm/pull/381 depends on this PR.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a Docker container running `tools-ext-01.ccr.xdmod.org/xdmod-job_performance-10.5.0:rockylinux8-0.1`, I cloned copies of this branch and the branch from https://github.com/ubccr/xdmod-supremm/pull/381, manually followed the `upgrade` steps for CircleCI, and confirmed the regression tests all pass.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
