### PR TITLE
Update source install docs, port software requirement docs from 10.5 to 11.0.

### DIFF
--- a/docs/install-source.md
+++ b/docs/install-source.md
@@ -5,13 +5,14 @@ title: Source Installation Guide
 Install Source Package
 ----------------------
 
-    $ tar zxvf xdmod-{{ page.sw_version }}.tar.gz
-    $ cd xdmod-{{ page.sw_version }}
-    # ./install --prefix=/opt/xdmod
-
-Change the prefix as desired.  The default installation prefix is
+If installing from the `el7` source, replace `el8` with `el7` below. Change the
+installation prefix as desired.  The default installation prefix is
 `/usr/local/xdmod`.  These instructions assume you are installing Open
 XDMoD in `/opt/xdmod`.
+
+    # tar zxvf xdmod-{{ page.sw_version }}-el8.tar.gz
+    # cd xdmod-{{ page.sw_version }}
+    # ./install --prefix=/opt/xdmod
 
 Create Open XDMoD User And Group
 --------------------------------

--- a/docs/software-requirements.md
+++ b/docs/software-requirements.md
@@ -90,6 +90,15 @@ start after a reboot unless you have configured them to do so.
 **NOTE**: APCu is optional, but highly recommended as it provides enhanced performance.
 
 ### Rocky 8+
+```sh
+dnf install -y epel-release
+
+dnf install -y httpd php php-cli php-mysqlnd php-gd php-pdo php-xml \
+            php-pear libreoffice nodejs \
+            mariadb-server mariadb cronie logrotate \
+            perl-Image-ExifTool php-mbstring php-pecl-apcu jq \
+            chromium-headless librsvg2-tools
+```
 
 **NOTE**: The nodejs version that is enabled by default in Rocky 8 is nodejs 10. Open
 XDMoD requires nodejs 16 which can be installed on Rocky 8 using the  nodejs 16 module
@@ -104,7 +113,7 @@ dnf module -y install nodejs:16
 need to run the following:
 ```shell
 dnf install -y php-devel
-pecl install mongodb
+pecl install mongodb-1.16.2
 echo "extension=mongodb.so" > /etc/php.d/40-mongodb.ini
 ```
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR updates the source install documentation to:
- Move the instructions about changing the prefix to above the commands, to encourage reading the instructions before running the commands.
- Add in the proper `-el8` suffix to the source filename, with instructions to replace it with `-el7` if applicable.
- Use `#` as the terminal prompt symbol for all three commands, for consistency.

This PR also ports the changes from https://github.com/ubccr/xdmod/pull/1830 to the `xdmod11.0` branch.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my Mac with a cloned copy of the `gh-pages` branch of `xdmod` and Jekyll installed, I copied in the changes from this PR to the `10.5` directory, ran the commands below, and confirmed the output looks correct.
```
git submodule init
git submodule update --remote
sudo networksetup -setv6off 'Wi-Fi' # so the next commands don't hang
bundle update
bundle update --bundler
bundle install
bundle add webrick
sudo networksetup -setv6automatic 'Wi-Fi'
bundle exec jekyll serve
```

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
