### PR TITLE
Update `WebServerLogFile` parser to use `NA` instead of `unknown`.

### DIFF
--- a/classes/ETL/DataEndpoint/WebServerLogFile.php
+++ b/classes/ETL/DataEndpoint/WebServerLogFile.php
@@ -90,9 +90,9 @@ class WebServerLogFile extends aStructuredFile implements iStructuredFile
                 $result->{"country"} = $geoip->country->isoCode;
             }
             catch (\GeoIp2\Exception\AddressNotFoundException $e) {
-                $result->{"city"} = 'unknown';
-                $result->{"subdivision"} = 'unknown';
-                $result->{"country"} = 'unknown';
+                $result->{"city"} = 'NA';
+                $result->{"subdivision"} = 'NA';
+                $result->{"country"} = 'NA';
             }
             catch (\InvalidArgumentException $e) {
                 // leave at the default value of 'N/A'


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR updates the `WebServerLogFile` parser to consistently use `NA` for unknown geolocations instead of `unknown`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prior to this PR, the parser used `NA` if there was no GeoIP database file provided, and `unknown` if there was a file provided but an address was not found.

For the `xdmod-ondemand` module (which is currently the only place `WebServerLogFile` is used), there is an empty database file used by default. Thus, if a geolocation is unknown, it would use `unknown` for each of its city, state, and country.

However, as of https://github.com/ubccr/xdmod-ondemand/pull/50 (which will be included in the 11.0 release), [this line](https://github.com/ubccr/xdmod-ondemand/blob/main/configuration/etl/etl_action_defs.d/ood/dimensions.json#L42) of the `xdmod-ondemand` ETL configuration sets the name of the location to `Unknown` only if the city, state, and country are all `NA`. Thus, if they are all `unknown`, it sets the `name` to `unknown, unknown, unknown`, which is not desirable.

This PR fixes this by making the `WebServerLogFile` parser use `NA` consistently instead of `unknown`.

Existing installations of `xdmod-ondemand` may have a row in `modw_ondemand.location` with `unknown` for city, state, and country but with `Unknown` for the `name`, since https://github.com/ubccr/xdmod-ondemand/pull/50 has not been included in a release yet, and prior to that PR it set the `name` to `Unknown` if state and country were both `unknown`. [Upcoming xdmod-ondemand PR] adds a database migration that sets the city, state, and country columns all to `NA` if they are all `unknown`. This way, ingesting new logs will not cause there to be two rows with the name `Unknown` (one with `unknown` values and one with `NA` values).

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Test an upgrade in which database already contains `unknown` city, state, and country
1. Run a Docker container based on the image `tools-ext-01.ccr.xdmod.org/xdmod-ondemand:x86_64-rockylinux8.5-v10.5.0-1.0-01`.
1. `~/bin/services start`
1. Run the following in `mysql` and confirm the result:
    ```
    SELECT * FROM modw_ondemand.location;
    +----+---------+---------+---------+---------+----------+
    | id | city    | state   | country | name    | order_id |
    +----+---------+---------+---------+---------+----------+
    |  1 | unknown | unknown | unknown | Unknown |        2 |
    +----+---------+---------+---------+---------+----------+
    ```
    This shows the values of `unknown` before upgrading.
1. `~/bin/services stop`
1. Follow the steps in `xdmod-ondemand`'s `.circleci/config.yml` with `XDMOD_TEST_MODE` set to `upgrade`, cloning the branch from this PR into `/xdmod`, and cloning the branch from [upcoming xdmod-ondemand PR] into `/xdmod-ondemand`.
1. Run the following in `mysql` and confirm the result:
    ```
    SELECT * FROM modw_ondemand.location;
    +----+------+-------+---------+---------+----------+
    | id | city | state | country | name    | order_id |
    +----+------+-------+---------+---------+----------+
    |  1 | NA   | NA    | NA      | Unknown |        2 |
    +----+------+-------+---------+---------+----------+
    ```
   This shows the `Unknown` row has had its city, state, and country changed from `unknown` to `NA` after upgrading.
1. Clear the page impressions table in `mysql`. This way there will be no duplicates before ingesting the sample log again:
   ```
    DELETE FROM modw_ondemand.page_impressions;
   ```
1. Reingest the sample log:
   ```
   sudo -u xdmod xdmod-ondemand-ingestor -d /tmp/ondemand -r styx --debug
   ```
1. Run the following in `mysql` and confirm the result:
    ```
    SELECT * FROM modw_ondemand.location;
    +----+------+-------+---------+---------+----------+
    | id | city | state | country | name    | order_id |
    +----+------+-------+---------+---------+----------+
    |  1 | NA   | NA    | NA      | Unknown |        2 |
    +----+------+-------+---------+---------+----------+
    ```
    This shows there is still only a single `Unknown` value after upgrading and ingesting a new log.

### Test a fresh install of `xdmod-ondemand`
1. Run a Docker container based on the image `tools-ext-01.ccr.xdmod.org/xdmod-10.5.0-x86_64:rockylinux8.5-0.3`.
1. Follow the steps in `xdmod-ondemand`'s `.circleci/config.yml` with `XDMOD_TEST_MODE` set to `fresh_install`, cloning the branch from this PR into `/xdmod`, and cloning the branch from [upcoming xdmod-ondemand PR] into `/xdmod-ondemand`.
1. Run the following in `mysql` and confirm the result:
    ```
    SELECT * FROM modw_ondemand.location;
    +----+------+-------+---------+---------+----------+
    | id | city | state | country | name    | order_id |
    +----+------+-------+---------+---------+----------+
    |  1 | NA   | NA    | NA      | Unknown |        2 |
    +----+------+-------+---------+---------+----------+
    ```
    This shows that a brand new installation of `xdmod-ondemand` correctly uses `NA`.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
