### PR TITLE
Fix Migration Class Warning Generation

### DIFF
--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -294,7 +294,7 @@ abstract class aStructuredFile extends File
 
         if ( null === $this->recordSeparator ) {
             while ( ! feof($fd) ) {
-                if (is_file($fd)) {
+                if (is_file($this->path)) {
                     $data = fread($fd, self::DEFAULT_READ_BYTES);
                     if ( false !== $data ) {
                         $buffer .= $data;

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -294,12 +294,10 @@ abstract class aStructuredFile extends File
 
         if ( null === $this->recordSeparator ) {
             while ( ! feof($fd) ) {
-                if (is_file($this->path)) {
-                    $data = fread($fd, self::DEFAULT_READ_BYTES);
-                    if ( false !== $data ) {
-                        $buffer .= $data;
-                        $totalBytesRead += strlen($data);
-                    }
+                $data = fread($fd, self::DEFAULT_READ_BYTES);
+                if ( false !== $data ) {
+                    $buffer .= $data;
+                    $totalBytesRead += strlen($data);
                 }
             }
         } else {

--- a/classes/ETL/DataEndpoint/aStructuredFile.php
+++ b/classes/ETL/DataEndpoint/aStructuredFile.php
@@ -294,10 +294,12 @@ abstract class aStructuredFile extends File
 
         if ( null === $this->recordSeparator ) {
             while ( ! feof($fd) ) {
-                $data = fread($fd, self::DEFAULT_READ_BYTES);
-                if ( false !== $data ) {
-                    $buffer .= $data;
-                    $totalBytesRead += strlen($data);
+                if (is_file($fd)) {
+                    $data = fread($fd, self::DEFAULT_READ_BYTES);
+                    if ( false !== $data ) {
+                        $buffer .= $data;
+                        $totalBytesRead += strlen($data);
+                    }
                 }
             }
         } else {

--- a/classes/OpenXdmod/Migration/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/ConfigFilesMigration.php
@@ -187,7 +187,7 @@ abstract class ConfigFilesMigration extends Migration
         $file = implode(
             DIRECTORY_SEPARATOR,
             array(
-                $this->baseDir,
+                CONFIG_DIR,
                 "$name.json"
             )
         );
@@ -249,7 +249,7 @@ abstract class ConfigFilesMigration extends Migration
         $file = implode(
             DIRECTORY_SEPARATOR,
             array(
-                $this->baseDir,
+                CONFIG_DIR,
                 "$name.json"
             )
         );

--- a/classes/OpenXdmod/Migration/ConfigFilesMigration.php
+++ b/classes/OpenXdmod/Migration/ConfigFilesMigration.php
@@ -187,7 +187,7 @@ abstract class ConfigFilesMigration extends Migration
         $file = implode(
             DIRECTORY_SEPARATOR,
             array(
-                $this->config->getBaseDir(),
+                $this->baseDir,
                 "$name.json"
             )
         );
@@ -249,7 +249,7 @@ abstract class ConfigFilesMigration extends Migration
         $file = implode(
             DIRECTORY_SEPARATOR,
             array(
-                $this->config->getBaseDir(),
+                $this->baseDir,
                 "$name.json"
             )
         );

--- a/classes/OpenXdmod/Migration/Migration.php
+++ b/classes/OpenXdmod/Migration/Migration.php
@@ -35,6 +35,8 @@ abstract class Migration
      */
     protected $config;
 
+    protected $baseDir;
+
     /**
      * Logger object.
      *
@@ -56,12 +58,7 @@ abstract class Migration
 
         $this->logger = Log::singleton('null');
 
-        $this->config = Configuration::factory(
-            ".",
-            CONFIG_DIR,
-            $this->logger
-        );
-
+        $this->baseDir = CONFIG_DIR;
     }
 
     /**

--- a/classes/OpenXdmod/Migration/Migration.php
+++ b/classes/OpenXdmod/Migration/Migration.php
@@ -29,15 +29,6 @@ abstract class Migration
     protected $newVersion;
 
     /**
-     * An empty default Configuration object.
-     *
-     * @var Configuration
-     */
-    protected $config;
-
-    protected $baseDir;
-
-    /**
      * Logger object.
      *
      * @var LoggerInterface
@@ -55,10 +46,7 @@ abstract class Migration
         $this->currentVersion = $currentVersion;
         $this->newVersion     = $newVersion;
 
-
         $this->logger = Log::singleton('null');
-
-        $this->baseDir = CONFIG_DIR;
     }
 
     /**


### PR DESCRIPTION
## Description
This code was causing warnings to be generated when testing with PHP 7.4. It turns out that trying to create a `Configuration` object for an entire directory will do that. Upon further investigation I found that the only time this property was used was to access it's `baseDir` value ( Which is always equal to the `CONFIG_DIR` class constant). I just updated the uses of this property to instead use `CONFIG_DIR` and removed the now unused `config` property. 

## Motivation and Context
Less warnings == less support tickets.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
