### PR TITLE
Update log table sql migration query to be more efficient

### DIFF
--- a/configuration/etl/etl_sql.d/migration/cleanup_log_table.sql
+++ b/configuration/etl/etl_sql.d/migration/cleanup_log_table.sql
@@ -6,11 +6,8 @@ UPDATE mod_logger.log_table as lt JOIN (SELECT
                                         FROM mod_logger.log_table as l2
                                         WHERE
                                               l2.ident IN ('rest.logger.db', 'controller.log')
-                                          AND l2.priority = 6) AS data JOIN moddb.SessionManager sm ON sm.session_token = data.token JOIN moddb.Users u ON u.id = sm.user_id
+                                          AND l2.priority = 6) AS data on data.id = lt.id JOIN moddb.SessionManager sm ON sm.session_token = data.token JOIN moddb.Users u ON u.id = sm.user_id
 SET lt.message = JSON_REPLACE(lt.message, '$.data.username', u.username)
-WHERE
-      lt.ident IN ('rest.logger.db', 'controller.log')
-  AND lt.priority = 6;
 //
 /* backfill for removing the extra escaping for the other ident types */
 UPDATE mod_logger.log_table lt


### PR DESCRIPTION
This query can take a very, very long time when the `mod_logger.log_table` is large, changing to use a `ON` condition decreases the time the query takes to run from days in some cases to minutes.

## Tests performed
Tested on staging servers where query went from taking days to taking under a minute to run.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
