### PR TITLE
Added Usage tab link loading for statistics link

### DIFF
--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -965,6 +965,57 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
             var root = tree.getRootNode();
 
+             //Try grab url and load chart accordingly, otherwise load default
+            const url = window.location.href;
+            if (url) {
+                 const substringToRemove = /https:\/\/[^\/]+\/#tg_usage\?node=/;
+                 let chartSettings = url.replace(substringToRemove, '');
+                 if( chartSettings.includes('statistic_')){
+                 const realmsMetric = root.childNodes;
+                 let selectedRealmMetric = null;
+
+                 for (let realm of realmsMetric) {
+                     let transformedId = realm.id.replace('group_by_', 'statistic_');
+                     if (chartSettings.includes(transformedId)) {
+                         selectedRealmMetric = realm;
+                         chartSettings = chartSettings.replace(transformedId+'_', '');
+                         break;
+                     }
+                }
+                if (selectedRealmMetric){
+                    tree.expandPath(selectedRealmMetric.getPath(), null, function (success) {
+                            if (success) {
+                            var jobCountNode = selectedRealmMetric.findChild("statistic", chartSettings);
+                            if (jobCountNode && !jobCountNode.disabled) {
+                                tree.getSelectionModel().select(jobCountNode);
+                                return;
+                            }
+                        }
+                    });
+                }
+                }
+                else{
+                    defaultSelectFirstNode();
+                }
+            } else if (root.hasChildNodes()) {
+
+                defaultSelectFirstNode();
+
+            } //if (root.hasChildNodes())
+
+        } //selectFirstNode
+
+        // ---------------------------------------------------------
+
+        function defaultSelectFirstNode() {
+            updateDisabledMenus.call(this, true);
+
+            var node = tree.getSelectionModel().getSelectedNode();
+
+            if (node != null) return;
+
+            var root = tree.getRootNode();
+
             if (root.hasChildNodes()) {
 
                 var child = root.findChildBy(function (n) {
@@ -1004,8 +1055,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                 } //if(child)
 
             } //if (root.hasChildNodes())
-
-        } //selectFirstNode
+        } //defaultSelectFirstNode
 
         // ---------------------------------------------------------
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->
Added capability so that when you load a chart link from the usage tab ie https://xdmod.access-ci.org/index.php#tg_usage?node=statistic_Jobs_nodecount_utilization the usage tab will load that chart, instead of loading the default chart configuration

Note - this does not handle the case for group charts ie https://xdmod.access-ci.org/index.php#tg_usage?node=group_by_Jobs_nodecount which are handled like the old case and just load the default chart instead.


## Motivation and Context
This allows users to share usage tab charts, as well as adds the production effort in creating an XDMod Chatbot


