### PR TITLE
API changes to allow for public user.

### DIFF
--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -6,7 +6,6 @@ use Rest\Exceptions\BadTokenException;
 use Rest\Exceptions\EmptyTokenException;
 use DateTime;
 use Models\Services\Tokens;
-use MongoDB\Exception\BadMethodCallException;
 use Rest\Utilities\Authentication;
 use Rest\Utilities\Authorization;
 use Silex\Application;
@@ -207,8 +206,6 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      *                            'authorized'. If not specified, then only
      *                            whether or not the user is logged in will
      *                            be checked.
-     * @param bool $wantPublicUser Optional flag to indicate if public users are
-     *                             allowed. Defaults to false.
      * @return \XDUser The user that was checked and is authorized according to
      *                the given parameters.
      *
@@ -766,9 +763,9 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      * Attempt to authorize the the provided `$request` via an included API Token.
      *
      * @param Request $request
-     * @param bool $wantPublicUser An optional flag to return the public user when token is empty.
      * @return \XDUser
-     * @throws BadRequestHttpException if the provided token is empty, or there is not a provided token.
+     * @throws EmptyTokenException if the provided token is empty, or there is not a provided token.
+     * @throws BadTokenException if the provided token is in an invalid format.
      * @throws \Exception if the user's token from the db does not validate against the provided token.
      */
     protected function authenticateToken($request)

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -199,6 +199,8 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      *
      * @param Request $request A request containing user information
      *                         that is to be considered for authorization.
+     * @param bool $wantPublicUser Otional flag to indicate if public users are 
+     *                             allowed. Defaults to false.
      * @param array $requirements that a users' roles must satisfy to be
      *                            'authorized'. If not specified, then only
      *                            whether or not the user is logged in will
@@ -209,7 +211,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      * @throws  Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      *          Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
-    public function authorize(Request $request, array $requirements = array())
+    public function authorize(Request $request, bool $wantPublicUser = false, array $requirements = array())
     {
 
         $user = $this->getUserFromRequest($request);
@@ -218,6 +220,9 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
         // is that the user is not a public user.
         $isPublicUser = $user->isPublicUser();
         if (empty($requirements) && $isPublicUser) {
+            if ($wantPublicUser){
+                return $user;
+            }
             throw new UnauthorizedHttpException('xdmod', self::EXCEPTION_MESSAGE);
         }
 

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -199,19 +199,19 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      *
      * @param Request $request A request containing user information
      *                         that is to be considered for authorization.
-     * @param bool $wantPublicUser Optional flag to indicate if public users are 
-     *                             allowed. Defaults to false.
      * @param array $requirements that a users' roles must satisfy to be
      *                            'authorized'. If not specified, then only
      *                            whether or not the user is logged in will
      *                            be checked.
+     * @param bool $wantPublicUser Optional flag to indicate if public users are 
+     *                             allowed. Defaults to false.
      * @return \XDUser The user that was checked and is authorized according to
      *                the given parameters.
      *
      * @throws  Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException
      *          Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
      */
-    public function authorize(Request $request, bool $wantPublicUser = false, array $requirements = array())
+    public function authorize(Request $request, array $requirements = array(), bool $wantPublicUser = false)
     {
 
         $user = $this->getUserFromRequest($request);

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -795,9 +795,6 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
 
         // If it's still empty, then no token == no access.
         if (empty($rawToken)) {
-            // if ($wantPublicUser){
-            //     return $this->getUserFromRequest($request);
-            // } else {
             throw new EmptyTokenException(
                 Tokens::HEADER_KEY,
                 'No Token Provided.'

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -199,7 +199,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      *
      * @param Request $request A request containing user information
      *                         that is to be considered for authorization.
-     * @param bool $wantPublicUser Otional flag to indicate if public users are 
+     * @param bool $wantPublicUser Optional flag to indicate if public users are 
      *                             allowed. Defaults to false.
      * @param array $requirements that a users' roles must satisfy to be
      *                            'authorized'. If not specified, then only

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -764,11 +764,12 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      * Attempt to authorize the the provided `$request` via an included API Token.
      *
      * @param Request $request
+     * @param bool $wantPublicUser An optional flag to return the public user when token is empty.
      * @return \XDUser
      * @throws BadRequestHttpException if the provided token is empty, or there is not a provided token.
      * @throws \Exception if the user's token from the db does not validate against the provided token.
      */
-    protected function authenticateToken($request)
+    protected function authenticateToken($request, bool $wantPublicUser = false)
     {
         // NOTE: While we prefer token's to be pulled from the 'Authorization' header, we also support a fallback lookup
         // to the request's query params.
@@ -792,10 +793,14 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
 
         // If it's still empty, then no token == no access.
         if (empty($rawToken)) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                'No Token Provided.'
-            );
+            if ($wantPublicUser){
+                return $this->getUserFromRequest($request);
+            } else {
+                throw new UnauthorizedHttpException(
+                    Tokens::HEADER_KEY,
+                    'No Token Provided.'
+                );
+            }
         }
 
 

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -5,6 +5,7 @@ namespace Rest\Controllers;
 use CCR\DB;
 use CCR\Log;
 use Configuration\XdmodConfiguration;
+use DataWarehouse;
 use DataWarehouse\Data\BatchDataset;
 use DataWarehouse\Export\RealmManager;
 use DataWarehouse\Query\Exceptions\AccessDeniedException;
@@ -336,6 +337,9 @@ class WarehouseControllerProvider extends BaseControllerProvider
 
         $controller
             ->get("$root/raw-data", "$current::getRawData");
+
+        $controller
+            ->get("$root/search/dw_descripter", "$current::getDwDescipter");
     }
 
     /**
@@ -2494,4 +2498,151 @@ class WarehouseControllerProvider extends BaseControllerProvider
         $filterValuesArray = explode(',', $filterValuesStr);
         return $filterValuesArray;
     }
+
+
+    public function getDwDescipter (Request $request, Application $app)
+    {
+        $user = null;
+        try {
+            $user = $this->authenticateToken($request);
+        } catch (Exception $e) {
+            // NOOP
+        }
+
+        if ($user === null) {
+            $user = $this->authorize($request, [], true);
+        }
+
+        $roles = $user->getAllRoles(true);
+
+        $roleDescriptors = array();
+        foreach ($roles as $activeRole) {
+            $shortRole = $activeRole;
+            $us_pos = strpos($shortRole, '_');
+            if ($us_pos > 0)
+            {
+            $shortRole = substr($shortRole, 0, $us_pos);
+            }
+
+            if (array_key_exists($shortRole, $roleDescriptors)) {
+                continue;
+            }
+
+
+            $realms = array();
+            $groupByObjects = array();
+            $realmObjects = Realms::getRealmObjectsForUser($user);
+            $query_descripter_realms = Acls::getQueryDescripters($user);
+
+            foreach($query_descripter_realms as $query_descripter_realm => $query_descripter_groups)
+            {
+
+                $category = DataWarehouse::getCategoryForRealm($query_descripter_realm);
+                if ($category === null) {
+                    continue;
+                }
+
+                $seenstats = array();
+
+                $realmObject = $realmObjects[$query_descripter_realm];
+                $realmDisplay = $realmObject->getDisplay();
+                $realms[$query_descripter_realm] = array(
+                    'text' => $query_descripter_realm,
+                    'category' => $realmDisplay,
+                    'dimensions' => array(),
+                    'metrics' => array(),
+                );
+
+                foreach($query_descripter_groups as $query_descripter_group) {
+                    foreach ($query_descripter_group as $query_descripter) {
+                        if ($query_descripter->getDisableMenu()) {
+                            continue;
+                        }
+
+                        $groupByName = $query_descripter->getGroupByName();
+                        $group_by_object = $query_descripter->getGroupByInstance();
+                        $permittedStatistics = $group_by_object->getRealm()->getStatisticIds();
+
+                        $groupByObjects[$query_descripter_realm . '_' . $groupByName] = array(
+                            'object' => $group_by_object,
+                            'permittedStats' => $permittedStatistics);
+                        $realms[$query_descripter_realm]['dimensions'][$groupByName] = array(
+                            'text' => $groupByName == 'none' ? 'None' : $group_by_object->getName(),
+                            'info' => $group_by_object->getHtmlDescription()
+                        );
+
+                        $stats = array_diff($permittedStatistics, $seenstats);
+                        if (empty($stats)) {
+                            continue;
+                        }
+
+                        $statsObjects = $query_descripter->getStatisticsClasses($stats);
+                        foreach ($statsObjects as $realm_group_by_statistic => $statistic_object) {
+
+                            if ( ! $statistic_object->showInMetricCatalog() ) {
+                                continue;
+                            }
+
+                            $semStatId = \Realm\Realm::getStandardErrorStatisticFromStatistic(
+                                $realm_group_by_statistic
+                            );
+                            $realms[$query_descripter_realm]['metrics'][$realm_group_by_statistic] =
+                                array(
+                                    'text' => $statistic_object->getName(),
+                                    'info' => $statistic_object->getHtmlDescription(),
+                                    'std_err' => in_array($semStatId, $permittedStatistics),
+                                    'hidden_groupbys' => $statistic_object->getHiddenGroupBys()
+                                );
+                            $seenstats[] = $realm_group_by_statistic;
+                        }
+                    }
+                }
+
+                $texts = array();
+                foreach($realms[$query_descripter_realm]['metrics'] as $key => $row)
+                {
+                    $texts[$key] = $row['text'];
+                }
+                array_multisort($texts, SORT_ASC, $realms[$query_descripter_realm]['metrics']);
+            }
+            $texts = array();
+            foreach($realms as $key => $row)
+            {
+                $texts[$key] = $row['text'];
+            }
+            array_multisort($texts, SORT_ASC, $realms);
+
+            $roleDescriptors[$shortRole] = array('totalCount'=> 1, 'data' => array(array( 'realms' => $realms)));
+        }
+
+        $combinedRealmDescriptors = array();
+        foreach ($roleDescriptors as $roleDescriptor) {
+            foreach ($roleDescriptor['data'][0]['realms'] as $realm => $realmDescriptor) {
+                if (!isset($combinedRealmDescriptors[$realm])) {
+                    $combinedRealmDescriptors[$realm] = array(
+                        'metrics' => array(),
+                        'dimensions' => array(),
+                        'text' => $realmDescriptor['text'],
+                        'category' => $realmDescriptor['category'],
+                    );
+                }
+
+                $combinedRealmDescriptors[$realm]['metrics'] += $realmDescriptor['metrics'];
+                $combinedRealmDescriptors[$realm]['dimensions'] += $realmDescriptor['dimensions'];
+            }
+        }
+
+        return $app->json (
+            [
+                'totalCount' => 1,
+                'data' => array(
+                    array(
+                        'realms' => $combinedRealmDescriptors,
+                    ),
+                )
+            ]
+        );
+    }
 }
+
+

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -27,6 +27,9 @@ use DataWarehouse\Access\MetricExplorer;
 use DataWarehouse\Access\Usage;
 use stdClass;
 
+use Rest\Exceptions\BadTokenException;
+use Rest\Exceptions\EmptyTokenException;
+
 /**
  * @SuppressWarnings(PHPMD.StaticAccess)
  **/
@@ -2505,12 +2508,10 @@ class WarehouseControllerProvider extends BaseControllerProvider
         $user = null;
         try {
             $user = $this->authenticateToken($request);
+        } catch (EmptyTokenException $e) {
+            $user = $this->getUserFromRequest($request);
         } catch (Exception $e) {
-            // NOOP
-        }
-
-        if ($user === null) {
-            $user = $this->authorize($request, [], true);
+            throw new BadTokenException('xdmod', "An error was encountered while attempting to process the requested authorization procedure.");
         }
 
         $roles = $user->getAllRoles(true);
@@ -2633,13 +2634,13 @@ class WarehouseControllerProvider extends BaseControllerProvider
         }
 
         return $app->json (
-            [
+            [   'success' => true,
                 'totalCount' => 1,
                 'data' => array(
                     array(
                         'realms' => $combinedRealmDescriptors,
                     ),
-                )
+                ),
             ]
         );
     }

--- a/classes/Rest/Controllers/WarehouseExportControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseExportControllerProvider.php
@@ -96,13 +96,13 @@ class WarehouseExportControllerProvider extends BaseControllerProvider
         // We need to wrap the token authentication because we want the token authentication to be optional, proceeding
         // to the normal session authentication if a token is not provided.
         try {
-            $user = $this->authenticateToken($request);
+            $user = $this->authenticateToken($request, true);
         } catch (Exception $e) {
             // NOOP
         }
 
         if ($user === null) {
-            $user = $this->authorize($request, [], true);
+            $user = $this->authorize($request, []);
         }
 
         $config = RawStatisticsConfiguration::factory();

--- a/classes/Rest/Controllers/WarehouseExportControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseExportControllerProvider.php
@@ -102,7 +102,7 @@ class WarehouseExportControllerProvider extends BaseControllerProvider
         }
 
         if ($user === null) {
-            $user = $this->authorize($request, true);
+            $user = $this->authorize($request, [], true);
         }
 
         $config = RawStatisticsConfiguration::factory();

--- a/classes/Rest/Controllers/WarehouseExportControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseExportControllerProvider.php
@@ -102,9 +102,8 @@ class WarehouseExportControllerProvider extends BaseControllerProvider
         }
 
         if ($user === null) {
-            $user = $this->authorize($request);
+            $user = $this->authorize($request, true);
         }
-
 
         $config = RawStatisticsConfiguration::factory();
 

--- a/classes/Rest/Controllers/WarehouseExportControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseExportControllerProvider.php
@@ -4,6 +4,7 @@ namespace Rest\Controllers;
 
 use CCR\DB;
 use CCR\Log;
+use Rest\Exceptions\BadTokenException;
 use Rest\Exceptions\EmptyTokenException;
 use DataWarehouse\Data\RawStatisticsConfiguration;
 use DataWarehouse\Export\FileManager;
@@ -100,14 +101,9 @@ class WarehouseExportControllerProvider extends BaseControllerProvider
             $user = $this->authenticateToken($request);
         } catch (EmptyTokenException $e) {
             $user = $this->getUserFromRequest($request);
+        } catch (Exception $e) {
+            throw new BadTokenException('xdmod', "An error was encountered while attempting to process the requested authorization procedure.");
         }
-
-        // if ($user === null) {
-        //     $user = $this->authorize($request, []);
-        // }
-
-
-        // $user = $this->getUserFromRequest($request);
 
         $config = RawStatisticsConfiguration::factory();
 

--- a/classes/Rest/Controllers/WarehouseExportControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseExportControllerProvider.php
@@ -4,6 +4,7 @@ namespace Rest\Controllers;
 
 use CCR\DB;
 use CCR\Log;
+use Rest\Exceptions\EmptyTokenException;
 use DataWarehouse\Data\RawStatisticsConfiguration;
 use DataWarehouse\Export\FileManager;
 use DataWarehouse\Export\QueryHandler;
@@ -96,14 +97,17 @@ class WarehouseExportControllerProvider extends BaseControllerProvider
         // We need to wrap the token authentication because we want the token authentication to be optional, proceeding
         // to the normal session authentication if a token is not provided.
         try {
-            $user = $this->authenticateToken($request, true);
-        } catch (Exception $e) {
-            // NOOP
+            $user = $this->authenticateToken($request);
+        } catch (EmptyTokenException $e) {
+            $user = $this->getUserFromRequest($request);
         }
 
-        if ($user === null) {
-            $user = $this->authorize($request, []);
-        }
+        // if ($user === null) {
+        //     $user = $this->authorize($request, []);
+        // }
+
+
+        // $user = $this->getUserFromRequest($request);
 
         $config = RawStatisticsConfiguration::factory();
 

--- a/classes/Rest/Exceptions/BadTokenException.php
+++ b/classes/Rest/Exceptions/BadTokenException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rest\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class BadTokenException extends HttpException
+{
+    /**
+     * Constructor.
+     *
+     * @param string     $challenge WWW-Authenticate challenge string
+     * @param string     $message   The internal exception message
+     * @param \Exception $previous  The previous exception
+     * @param int        $code      The internal exception code
+     */
+    public function __construct($challenge, $message = null, \Exception $previous = null, $code = 0)
+    {
+        $headers = array('WWW-Authenticate' => $challenge);
+
+        parent::__construct(401, $message, $previous, $headers, $code);
+    }
+}
+

--- a/classes/Rest/Exceptions/EmptyTokenException.php
+++ b/classes/Rest/Exceptions/EmptyTokenException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rest\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class EmptyTokenException extends HttpException
+{
+    /**
+     * Constructor.
+     *
+     * @param string     $challenge WWW-Authenticate challenge string
+     * @param string     $message   The internal exception message
+     * @param \Exception $previous  The previous exception
+     * @param int        $code      The internal exception code
+     */
+    public function __construct($challenge, $message = null, \Exception $previous = null, $code = 0)
+    {
+        $headers = array('WWW-Authenticate' => $challenge);
+
+        parent::__construct(401, $message, $previous, $headers, $code);
+    }
+}
+

--- a/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
+++ b/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
@@ -884,28 +884,79 @@ class WarehouseControllerProviderTest extends TokenAuthTest
         );
     }
 
+    // public function provideGetDwDescriptor()
+    // {
+    //     $validInput = [
+    //         'path' => 'rest/warehouse/search/dw_descriptor',
+    //         'method' => 'get',
+    //         'params' => [],
+    //         'data' => null
+    //     ];
+
+    //     $expectedOutput = [
+    //         $this->validateSuccessResponse(function ($body, $assertMessage) {
+    //             $this->assertSame(3, $body['total'], $assertMessage);
+    //             $index = 0;
+    //             foreach (['Jobs', 'Cloud', 'ResourceSpecifications'] as $realmName) {
+    //                 $realm = $body['data'][$index];
+    //                 foreach (['id', 'name'] as $property) {
+    //                     $this->assertSame(
+    //                         $realmName,
+    //                         str_replace(' ', '', $realm[$property]),
+    //                         $assertMessage
+    //                     );
+    //                 }
+    //             }
+    //         }),
+    //     ];
+
+    //     $tests = [
+    //         [
+    //             'get_dw_descriptor_success',
+    //             'usr',
+    //             $validInput,
+    //             $expectedOutput
+    //         ]
+    //     ];
+
+    //     return $tests;
+    // }
+
+
     public function provideGetDwDescriptor()
-    {
-        $validInput = [
-            'path' => 'rest/warehouse/search/dw_descriptor',
-            'method' => 'get',
-            'params' => [],
-            'data' => null
-        ];
+{
+    $validInput = [
+        'path' => 'rest/warehouse/search/dw_descriptor',
+        'method' => 'get',
+        'params' => [],
+        'data' => null
+    ];
 
-        $expectedOutput = [
-            'status_code' => 200
-        ];
+    $expectedOutput = $this->validateSuccessResponse(function ($body, $assertMessage) {
+        $this->assertSame(3, $body['total'], $assertMessage);
+        $index = 0;
+        foreach (['Jobs', 'Cloud', 'ResourceSpecifications'] as $realmName) {
+            $realm = $body['data'][$index];
+            foreach (['id', 'name'] as $property) {
+                $this->assertSame(
+                    $realmName,
+                    str_replace(' ', '', $realm[$property]),
+                    $assertMessage
+                );
+            }
+            $index++;
+        }
+    });
 
-        $tests = [
-            [
-                'get_dw_descriptor_success',
-                'usr',
-                $validInput,
-                $expectedOutput
-            ]
-        ];
+    $tests = [
+        [
+            'get_dw_descriptor_success',
+            'usr',
+            $validInput,
+            $expectedOutput
+        ]
+    ];
 
-        return $tests;
-    }
+    return $tests;
+}
 }

--- a/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
+++ b/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
@@ -868,4 +868,44 @@ class WarehouseControllerProviderTest extends TokenAuthTest
         }
         return $tests;
     }
+
+//
+    /**
+     * @dataProvider provideGetDwDescriptor
+     */
+
+    public function testGetDwDescriptor($id, $role, $input, $output)
+    {
+        parent::authenticateRequestAndValidateJson(
+            self::$helper,
+            $role,
+            $input,
+            $output
+        );
+    }
+
+    public function provideGetDwDescriptor()
+    {
+        $validInput = [
+            'path' => 'rest/warehouse/search/dw_descriptor',
+            'method' => 'get',
+            'params' => [],
+            'data' => null
+        ];
+
+        $expectedOutput = [
+            'status_code' => 200
+        ];
+
+        $tests = [
+            [
+                'get_dw_descriptor_success',
+                'usr',
+                $validInput,
+                $expectedOutput
+            ]
+        ];
+
+        return $tests;
+    }
 }

--- a/tests/integration/lib/Rest/WarehouseExportControllerProviderTest.php
+++ b/tests/integration/lib/Rest/WarehouseExportControllerProviderTest.php
@@ -200,7 +200,8 @@ class WarehouseExportControllerProviderTest extends TokenAuthTest
                 'params' => null,
                 'data' => null,
                 'endpoint_type' => 'rest',
-                'authentication_type' => 'token_optional'
+                'authentication_type' => 'token_optional',
+                'wantPublicUser' => true
             ],
             parent::validateSuccessResponse(function ($body, $assertMessage) {
                 $this->assertSame(3, $body['total'], $assertMessage);

--- a/tests/integration/lib/TokenAuthTest.php
+++ b/tests/integration/lib/TokenAuthTest.php
@@ -150,7 +150,14 @@ abstract class TokenAuthTest extends BaseTest
                         )
                     ];
                 } elseif ('rest' === $input['endpoint_type']) {
-                    $output = parent::validateAuthorizationErrorResponse(401);
+                    // If token is empty and we want Public user, test that it returns a success response.
+                    if (true === $input['wantPublicUser'] && 'empty_token' === $tokenType)  {
+                        $output = $this->validateSuccessResponse(function ($body, $assertMessage) {
+                            parent::assertSame(true, $body['success'], $assertMessage);
+                        });
+                    } else {
+                        $output = parent::validateAuthorizationErrorResponse(401);
+                    }
                 } else {
                     throw new Exception(
                         "Unknown value for endpoint_type:"


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed --> 
Allows users without an authentication token to access the raw data API. Migrating the dw_descripter to the Rest stack through the route `/rest/v1/warehouse/search/dw_descripter`. Added new test cases for the new dw_descripter endpoint and modifying the test for the raw data endpoint to now pass for requests with empty token in accordance to the modifications. 

Two new exception classes were added for token authentication:
- `classes/Rest/Exceptions/BadTokenException.php`
- `classes/Rest/Exceptions/EmptyTokenException.php`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since the raw data endpoint is used for the data catalog, this would allow for public/non logged in users to view the entries available to them without a token. Migrating the dw_descripter endpoint allows for this same behavior and places it in the same place as the rest of the API functionality. Adding the new exception classes separates `UnauthorizedHttpException` for more nuanced behavior depending on empty or invalid token. 

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Automated tests. Modified tests to test for the changed functionality and added new test for the migrated endpoint. 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
