### PR TITLE
Patch for symfony/http-foundation: CVE-2019-10913

### DIFF
--- a/open_xdmod/modules/xdmod/assets/setup.sh
+++ b/open_xdmod/modules/xdmod/assets/setup.sh
@@ -7,10 +7,8 @@ assets_dir="$(
 module_dir="$assets_dir/.."
 xdmod_dir="$module_dir/../../.."
 
-echo Installing composer managed dependencies
-cd $xdmod_dir
-composer install --no-dev
-
+pushd "$xdmod_dir" || exit
 echo Installing npm managed dependencies
 npm install --production --prefix etl/js
 npm install --production --prefix background_scripts/chrome-helper
+popd || exit

--- a/open_xdmod/modules/xdmod/assets/symfony_http-foundation_CVE-2019-10913.patch
+++ b/open_xdmod/modules/xdmod/assets/symfony_http-foundation_CVE-2019-10913.patch
@@ -1,0 +1,44 @@
+1275,1284c1275,1276
+<         if (null === $this->method) {
+<             $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
+< 
+<             if ('POST' === $this->method) {
+<                 if ($method = $this->headers->get('X-HTTP-METHOD-OVERRIDE')) {
+<                     $this->method = strtoupper($method);
+<                 } elseif (self::$httpMethodParameterOverride) {
+<                     $this->method = strtoupper($this->request->get('_method', $this->query->get('_method', 'POST')));
+<                 }
+<             }
+---
+>         if (null !== $this->method) {
+>             return $this->method;
+1287c1279,1305
+<         return $this->method;
+---
+>         $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
+> 
+>         if ('POST' !== $this->method) {
+>             return $this->method;
+>         }
+> 
+>         $method = $this->headers->get('X-HTTP-METHOD-OVERRIDE');
+> 
+>         if (!$method && self::$httpMethodParameterOverride) {
+>             $method = $this->request->get('_method', $this->query->get('_method', 'POST'));
+>         }
+> 
+>         if (!\is_string($method)) {
+>             return $this->method;
+>         }
+> 
+>         $method = strtoupper($method);
+> 
+>         if (\in_array($method, ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'PATCH', 'PURGE', 'TRACE'], true)) {
+>             return $this->method = $method;
+>         }
+> 
+>         if (!preg_match('/^[A-Z]++$/D', $method)) {
+>             throw new \UnexpectedValueException(sprintf('Invalid method override "%s".', $method));
+>         }
+> 
+>         return $this->method = $method;

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -103,7 +103,10 @@
     },
     "commands": {
         "pre_build": [
+            "rm -rf vendor/",
+            "composer install",
             "sed -i 's/SimpleSAML_Error_Assertion::installHandler();//g' vendor/simplesamlphp/simplesamlphp/www/_include.php",
+            "patch vendor/symfony/http-foundation/Request.php < open_xdmod/modules/xdmod/assets/symfony_http-foundation_CVE-2019-10913.patch.patch",
             "user_manual_builder/setup.sh",
             "user_manual_builder/build_user_manual.sh --builddir user_manual_builder/ --destdir html/user_manual/"
         ]

--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -106,7 +106,7 @@
             "rm -rf vendor/",
             "composer install",
             "sed -i 's/SimpleSAML_Error_Assertion::installHandler();//g' vendor/simplesamlphp/simplesamlphp/www/_include.php",
-            "patch vendor/symfony/http-foundation/Request.php < open_xdmod/modules/xdmod/assets/symfony_http-foundation_CVE-2019-10913.patch.patch",
+            "patch vendor/symfony/http-foundation/Request.php < open_xdmod/modules/xdmod/assets/symfony_http-foundation_CVE-2019-10913.patch",
             "user_manual_builder/setup.sh",
             "user_manual_builder/build_user_manual.sh --builddir user_manual_builder/ --destdir html/user_manual/"
         ]

--- a/tests/ci/scripts/qa-test-setup.sh
+++ b/tests/ci/scripts/qa-test-setup.sh
@@ -18,11 +18,17 @@ if [[ "$XDMOD_TEST_MODE" == "upgrade" ]]; then
     # Switch to the repo root
     pushd $XDMOD_SOURCE_DIR >/dev/null || exit 1
 
+    # Capture the current value of $COMPOSER so that we can reset it after the install script runs.
+    OLD_COMPOSER="$COMPOSER"
+
     # Specify composer.json for xdmod-qa so xdmod dev-dependencies aren't removed.
     export COMPOSER="$HOME/.qa/composer.json"
 
     # Setup the xdmod-qa environment / requirements.
     $HOME/.qa/scripts/install.sh
+
+    # Reset the value of COMPOSER so we don't mess with any other script that runs downstream.
+    export COMPOSER="$OLD_COMPOSER"
 
     # Run the xdmod-qa tests.
     $HOME/.qa/scripts/build.sh


### PR DESCRIPTION
This patch sets up the patch pipeline in `build.json` and updates a few files that will cause issues during the CI / QA tests / build process. These changes originated in https://github.com/ubccr/xdmod/pull/1891 ( which will be merged in 11.5 ).

<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
- `open_xdmod/modules/xdmod/assets/setup.sh`:
  - Removed the Composer Install section as this + the dangling `cd` was causing the composer dependencies of `qa` to be installed in the xdmod directory. This probably wasn't a problem or caught before because we were not previously patching files.
  - Changed the `cd $xdmod_dir`to a `pushd | popd` so that we reset the cwd after the script runs.
- `open_xdmod/modules/xdmod/build.json`
  - added entries to support patching files. This necessitated adding the `rm -rf vendor/` and `composer install` due to the build step occurring twice in the CI process. 
- `tests/ci/scripts/qa-test-setup.sh`:
  - Taking care of the other part of the **Case of the Mysterious Disappearing Dependencies**. Just made sure to save the existing `$COMPOSER` env variable so that we can restore it after we're done installing the qa dependencies. 

## Motivation and Context
Less holes == more good. 

## Tests performed
All Automated Tests passed. 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
