### PR TITLE
Handle REST exceptions for realms that are not configured to provide raw data.

### DIFF
--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -2126,8 +2126,9 @@ class WarehouseControllerProvider extends BaseControllerProvider
      *                                 not included; if an invalid start date,
      *                                 end date, realm, field alias, or filter
      *                                 key is provided; if the end date is
-     *                                 before the start date; or if the offset
-     *                                 is negative.
+     *                                 before the start date; if the offset is
+     *                                 negative; or if the requested realm is
+     *                                 not configured to provide raw data.
      */
     public function getRawData(Request $request, Application $app)
     {
@@ -2135,6 +2136,9 @@ class WarehouseControllerProvider extends BaseControllerProvider
         $params = $this->validateRawDataParams($request, $user);
         $realmManager = new RealmManager();
         $queryClass = $realmManager->getRawDataQueryClass($params['realm']);
+        if (!class_exists($queryClass)) {
+            throw new BadRequestHttpException('The requested realm is not configured to provide raw data.');
+        }
         $logger = $this->getRawDataLogger();
         $streamCallback = function () use (
             $user,

--- a/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
+++ b/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
@@ -831,6 +831,11 @@ class WarehouseControllerProviderTest extends TokenAuthTest
                 parent::validateBadRequestResponse('Invalid realm.')
             ],
             [
+                'realm_not_configured',
+                ['realm' => 'Storage'],
+                parent::validateBadRequestResponse('The requested realm is not configured to provide raw data.')
+            ],
+            [
                 'invalid_fields',
                 ['fields' => 'foo,bar;'],
                 parent::validateBadRequestResponse(


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR provides better exception handling for REST requests to the warehouse raw data endpoint when the realm has not been configured to provide raw data (e.g., the Storage realm).

For example, previously, this request: 
```
GET /rest/warehouse/raw-data?realm=Storage&start_date=2024-01-01&end_date=2024-01-01
```
would respond with `500 Internal Server Error` with no message. This PR changes it to respond with `400 Bad Request` with the message `The requested realm is not configured to provide raw data.`

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR adds an integration test to make sure that requests to the `Storage` realm, which is not configured for raw data, respond with the correct status code and message.

I also updated my port on `xdmod-dev` and tested to make sure requests for the `OnDemand` and `Requests` realms, which are not configured to provide raw data, respond correctly.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
