### PR TITLE
Refactor REST warehouse raw data realm validation.

### DIFF
--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -2126,9 +2126,8 @@ class WarehouseControllerProvider extends BaseControllerProvider
      *                                 not included; if an invalid start date,
      *                                 end date, realm, field alias, or filter
      *                                 key is provided; if the end date is
-     *                                 before the start date; if the offset is
-     *                                 negative; or if the requested realm is
-     *                                 not configured to provide raw data.
+     *                                 before the start date; or if the offset
+     *                                 is negative.
      */
     public function getRawData(Request $request, Application $app)
     {
@@ -2136,9 +2135,6 @@ class WarehouseControllerProvider extends BaseControllerProvider
         $params = $this->validateRawDataParams($request, $user);
         $realmManager = new RealmManager();
         $queryClass = $realmManager->getRawDataQueryClass($params['realm']);
-        if (!class_exists($queryClass)) {
-            throw new BadRequestHttpException('The requested realm is not configured to provide raw data.');
-        }
         $logger = $this->getRawDataLogger();
         $streamCallback = function () use (
             $user,
@@ -2213,9 +2209,27 @@ class WarehouseControllerProvider extends BaseControllerProvider
             $params['start_date'], $params['end_date']
         ) = $this->validateRawDataDateParams($request);
         $params['realm'] = $this->getStringParam($request, 'realm', true);
+        $allRealmNames = self::getRealmNames(Realms::getRealms());
+        if (!in_array($params['realm'], $allRealmNames)) {
+            throw new BadRequestHttpException(
+                'No realm exists with the requested name.'
+            );
+        }
+        $realmManager = new RealmManager();
+        $allBatchExportRealms = self::getRealmNames(
+            $realmManager->getRealms()
+        );
+        if (!in_array($params['realm'], $allBatchExportRealms)) {
+            throw new BadRequestHttpException(
+                'The requested realm is not configured to provide raw data.'
+            );
+        }
         $queryDescripters = Acls::getQueryDescripters($user, $params['realm']);
         if (empty($queryDescripters)) {
-            throw new BadRequestHttpException('Invalid realm.');
+            throw new AccessDeniedException(
+                'Your user account does not have permission to get raw data'
+                . ' from the requested realm.'
+            );
         }
         $params['fields'] = $this->getRawDataFieldsArray($request);
         $params['filters'] = $this->validateRawDataFiltersParams(
@@ -2384,6 +2398,22 @@ class WarehouseControllerProvider extends BaseControllerProvider
             );
         }
         return [$startDate->format('Y-m-d'), $endDate->format('Y-m-d')];
+    }
+
+    /**
+     * Given an array of realms, return an array of just the names of the
+     * realms. Used for request parameter validation.
+     *
+     * @param array $realms array of Realm\Realm objects.
+     * @return array of string realm names.
+     */
+    private static function getRealmNames(array $realms) {
+        return array_map(
+            function ($realm) {
+                return $realm->getName();
+            },
+            $realms
+        );
     }
 
     /**

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -2128,6 +2128,8 @@ class WarehouseControllerProvider extends BaseControllerProvider
      *                                 key is provided; if the end date is
      *                                 before the start date; or if the offset
      *                                 is negative.
+     * @throws AccessDeniedException if the user does not have permission to
+     *                               get raw data from the requested realm.
      */
     public function getRawData(Request $request, Application $app)
     {
@@ -2201,6 +2203,8 @@ class WarehouseControllerProvider extends BaseControllerProvider
      * @param XDUser $user
      * @return array of validated parameter values.
      * @throws BadRequestHttpException if any of the parameters are invalid.
+     * @throws AccessDeniedException if the user does not have permission to
+     *                               get raw data from the requested realm.
      */
     private function validateRawDataParams($request, $user)
     {

--- a/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
+++ b/tests/integration/lib/Rest/WarehouseControllerProviderTest.php
@@ -828,7 +828,7 @@ class WarehouseControllerProviderTest extends TokenAuthTest
             [
                 'invalid_realm',
                 ['realm' => 'foo'],
-                parent::validateBadRequestResponse('Invalid realm.')
+                parent::validateBadRequestResponse('No realm exists with the requested name.')
             ],
             [
                 'realm_not_configured',


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR refactors the validation of the `realm` parameter for REST requests to the warehouse raw data endpoint.

Now, instead of responding with a message of `Invalid realm`, the message provides more information depending on the reason for the error:
* `No realm exists with the requested name.`
* `The requested realm is not configured to provide raw data.`
* `Your user account does not have permission to get raw data from the requested realm.`

In the last example above, it now responds with `403 Forbidden` instead of `400 Bad Request`.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In addition to updating the expected message in an integration test, I also updated my port on `xdmod-dev` and made sure the following tests passed with different roles and different realms, making the following request (replacing `<token>` with the user's token and `<realm>` with the realm):
```
GET https://xdmod-dev.ccr.xdmod.org:9001/rest/warehouse/raw-data?realm=<realm>&start_date=2024-01-01&end_date=2024-01-01&Bearer=<token>
```
| Top Role | Realm | Result |
| - | - | - |
| User | foo | No realm exists with the requested name. |
| User | Jobs | Success |
| User | Cloud | Success |
| User | Accounts | Success |
| User | Allocations | Success |
| User | ResourceAllocations | Your user account does not have permission to get raw data from the requested realm. |
| User | Requests | The requested realm is not configured to provide raw data. |
| User | Gateways | The requested realm is not configured to provide raw data. |
| User | SUPREMM | Success |
| User | JobEfficiency | The requested realm is not configured to provide raw data. |
| User | ResourceSpecifications | Success |
| User | Introspection | The requested realm is not configured to provide raw data. |
| User | PCPArchives | The requested realm is not configured to provide raw data. |
| User | OnDemand | The requested realm is not configured to provide raw data. |
| Program Officer | foo | No realm exists with the requested name. |
| Program Officer | Jobs | Success |
| Program Officer | Cloud | Success |
| Program Officer | Accounts | Success |
| Program Officer | Allocations | Success |
| Program Officer | ResourceAllocations | Success |
| Program Officer | Requests | The requested realm is not configured to provide raw data. |
| Program Officer | Gateways | The requested realm is not configured to provide raw data. |
| Program Officer | SUPREMM | Success |
| Program Officer | JobEfficiency | The requested realm is not configured to provide raw data. |
| Program Officer | ResourceSpecifications | Success |
| Program Officer | Introspection | The requested realm is not configured to provide raw data. |
| Program Officer | PCPArchives | The requested realm is not configured to provide raw data. |
| Program Officer | OnDemand | The requested realm is not configured to provide raw data. |

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
