### PR TITLE
Adding logic to catch invalid datetime values

### DIFF
--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -561,11 +561,18 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
                     $value_dt = \DateTime::createFromFormat('Y-m-d', $value);
 
                     $lastErrors = DateTime::getLastErrors();
-                    if ($lastErrors['warning_count'] > 0 || $lastErrors['error_count'] > 0) {
-                        throw new BadRequestHttpException("Invalid value for $name. Must be a(n) ISO 8601 Date.");
+
+                    // Depending on the version of PHP the value returned is different. This makes one less change needed
+                    // to support PHP 8.* in the future.
+                    // https://www.php.net/manual/en/datetimeimmutable.getlasterrors.php#refsect1-datetimeimmutable.getlasterrors-changelog
+                    if (version_compare(PHP_VERSION, '8.2.0') >= 0)
+                    {
+                        $hasWarningsOrErrors = $lastErrors;
+                    } else {
+                        $hasWarningsOrErrors = $lastErrors['warning_count'] > 0;
                     }
 
-                    if ($value_dt === false) {
+                    if ($value_dt === false || $hasWarningsOrErrors) {
                         return null;
                     }
                     return $value_dt;

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -814,9 +814,9 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      */
     private static function filterDate(string $value, string $format = 'Y-m-d'): ?DateTime
     {
-        $dateTime = \DateTime::createFromFormat($format, $value);
+        $dateTime = DateTime::createFromFormat($format, $value);
 
-        $lastErrors = \DateTime::getLastErrors();
+        $lastErrors = DateTime::getLastErrors();
 
         /* For PHP versions less than 8.2.0 $lastErrors will always be an array w/ the properties:
          * warning_count, warnings, error_count, and errors. For versions >= 8.2.0, it will return false if

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -565,8 +565,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
                     // Depending on the version of PHP the value returned is different. This makes one less change needed
                     // to support PHP 8.* in the future.
                     // https://www.php.net/manual/en/datetimeimmutable.getlasterrors.php#refsect1-datetimeimmutable.getlasterrors-changelog
-                    if (version_compare(PHP_VERSION, '8.2.0') >= 0)
-                    {
+                    if (version_compare(PHP_VERSION, '8.2.0') >= 0) {
                         $hasWarningsOrErrors = $lastErrors;
                     } else {
                         $hasWarningsOrErrors = $lastErrors['warning_count'] > 0;

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -812,7 +812,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      * @return DateTime|null If the creation of a DateTime was successful without warning then an instance of DateTime
      * will be returned, else null;
      */
-    private static function filterDate(string $value, string $format='Y-m-d'): ?DateTime
+    private static function filterDate(string $value, string $format = 'Y-m-d'): ?DateTime
     {
         $dateTime = \DateTime::createFromFormat($format, $value);
 

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -505,8 +505,14 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
             $default,
             FILTER_CALLBACK,
             array(
-                "options" => function ($value) {
+                "options" => function ($value) use ($name) {
                     $value_dt = DateTime::createFromFormat('U', $value);
+
+                    $lastErrors = DateTime::getLastErrors();
+                    if ($lastErrors['warning_count'] > 0 || $lastErrors['error_count'] > 0) {
+                        throw new BadRequestHttpException("Invalid value for $name. Must be a(n) Unix timestamp.");
+                    }
+
                     if ($value_dt === false) {
                         return null;
                     }
@@ -551,8 +557,14 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
             $default,
             FILTER_CALLBACK,
             [
-                'options' => function ($value) {
+                'options' => function ($value) use ($name) {
                     $value_dt = \DateTime::createFromFormat('Y-m-d', $value);
+
+                    $lastErrors = DateTime::getLastErrors();
+                    if ($lastErrors['warning_count'] > 0 || $lastErrors['error_count'] > 0) {
+                        throw new BadRequestHttpException("Invalid value for $name. Must be a(n) ISO 8601 Date.");
+                    }
+
                     if ($value_dt === false) {
                         return null;
                     }

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -505,18 +505,8 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
             $default,
             FILTER_CALLBACK,
             array(
-                "options" => function ($value) use ($name) {
-                    $value_dt = DateTime::createFromFormat('U', $value);
-
-                    $lastErrors = DateTime::getLastErrors();
-                    if ($lastErrors['warning_count'] > 0 || $lastErrors['error_count'] > 0) {
-                        throw new BadRequestHttpException("Invalid value for $name. Must be a(n) Unix timestamp.");
-                    }
-
-                    if ($value_dt === false) {
-                        return null;
-                    }
-                    return $value_dt;
+                "options" => function ($value) {
+                    return self::filterDate($value, 'U');
                 },
             ),
             "Unix timestamp"
@@ -558,34 +548,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
             FILTER_CALLBACK,
             [
                 'options' => function ($value) {
-                    $value_dt = \DateTime::createFromFormat('Y-m-d', $value);
-
-                    $lastErrors = DateTime::getLastErrors();
-
-                    /* For PHP versions less than 8.2.0 $lastErrors will always be an array w/ the properties:
-                     * warning_count, warnings, error_count, and errors. For versions >= 8.2.0, it will return false if
-                     * there are no errors else it will return as it did pre-8.2.0.
-                     *
-                     * The below `if` statement takes this into account by ensuring that we specifically check for when
-                     * $value_dt is not false ( i.e. is a DateTime object ) but we do have 1 or more warnings which
-                     * indicates that the value of $value_dt is most likely not what it's expected to be.
-                     *
-                     * Example: parsing the date `2024-01-99` results in a $value_dt of:
-                     * DateTime('2024-04-08')
-                     * and a $lastError of:
-                     * [
-                     *     'warning_count' => 1,
-                     *     'warnings' => [
-                     *         10 => 'The parsed date was invalid'
-                     *     ],
-                     *     'error_count' => 0,
-                     *     'errors' => []
-                     * ]
-                     */
-                    if ($value_dt === false || (is_array($lastErrors) && $lastErrors['warning_count'] > 0)) {
-                        return null;
-                    }
-                    return $value_dt;
+                    return self::filterDate($value);
                 },
             ],
             'ISO 8601 Date'
@@ -836,5 +799,48 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
         $token = substr($rawToken, $delimPosition + 1);
 
         return Tokens::authenticate($userId, $token);
+    }
+
+    /**
+     * Attempts to convert the provided $value into an instance of DateTime by using the provided $format. If $value is
+     * unable to be converted into a valid DateTime or if warnings are generated during the process it will be filtered
+     * and null returned.
+     *
+     * @param string $value the date to be validated against the provided $format. Ex: 2027-08-15
+     * @param string $format the format to be used when converting the string $value to an instance of DateTime
+     *
+     * @return DateTime|null If the creation of a DateTime was successful without warning then an instance of DateTime
+     * will be returned, else null;
+     */
+    private static function filterDate(string $value, string $format='Y-m-d'): ?DateTime
+    {
+        $dateTime = \DateTime::createFromFormat($format, $value);
+
+        $lastErrors = \DateTime::getLastErrors();
+
+        /* For PHP versions less than 8.2.0 $lastErrors will always be an array w/ the properties:
+         * warning_count, warnings, error_count, and errors. For versions >= 8.2.0, it will return false if
+         * there are no errors else it will return as it did pre-8.2.0.
+         *
+         * The below `if` statement takes this into account by ensuring that we specifically check for when
+         * $value_dt is not false ( i.e. is a DateTime object ) but we do have 1 or more warnings which
+         * indicates that the value of $value_dt is most likely not what it's expected to be.
+         *
+         * Example: parsing the date `2024-01-99` results in a $value_dt of:
+         * DateTime('2024-04-08')
+         * and a $lastError of:
+         * [
+         *     'warning_count' => 1,
+         *     'warnings' => [
+         *         10 => 'The parsed date was invalid'
+         *     ],
+         *     'error_count' => 0,
+         *     'errors' => []
+         * ]
+         */
+        if ($dateTime === false || (is_array($lastErrors) && $lastErrors['warning_count'] > 0)) {
+            return null;
+        }
+        return $dateTime;
     }
 }

--- a/tests/integration/lib/BaseTest.php
+++ b/tests/integration/lib/BaseTest.php
@@ -590,8 +590,8 @@ abstract class BaseTest extends \PHPUnit\Framework\TestCase
                         // We can skip tests:
                         //   - Strings can be strings, so skip that test.
                         //   - Invalid dates should only be tested on date params.
-                        if (('invalid_date' === $id && 'date_params' !== $key) ||
-                            ('string' === $id && 'string_params' === $key)) {
+                        if (('string' === $id && 'string_params' === $key) ||
+                            ('invalid_date' === $id && 'date_params' !== $key) ) {
                             continue;
                         }
 

--- a/tests/integration/lib/BaseTest.php
+++ b/tests/integration/lib/BaseTest.php
@@ -579,31 +579,37 @@ abstract class BaseTest extends \PHPUnit\Framework\TestCase
         ];
         $values = [
             'string' => 'foo',
-            'array' => ['foo' => 'bar']
+            'array' => ['foo' => 'bar'],
+            'invalid_date' => '2024-01-99'
         ];
         foreach ($types as $key => $type) {
             if (array_key_exists($key, $options)) {
                 foreach ($options[$key] as $param) {
                     $input = $validInputWithAdditionalParams;
                     foreach ($values as $id => $value) {
-                        // Strings can be strings, so skip that test.
-                        if ('string_params' !== $key || 'string' !== $id) {
-                            $input[$paramSource][$param] = $value;
-                            $testData = ["{$param}_$id", $runAs];
-                            if ($tokenAuth) {
-                                $testData[] = 'valid_token';
-                            }
-                            array_push(
-                                $testData,
-                                $input,
-                                $this->validateInvalidParameterResponse(
-                                    $param,
-                                    $type,
-                                    $errorBodyValidator
-                                )
-                            );
-                            $tests[] = $testData;
+                        // We can skip tests:
+                        //   - Strings can be strings, so skip that test.
+                        //   - Invalid dates should only be tested on date params.
+                        if (('invalid_date' === $id && 'date_params' !== $key) ||
+                            ('string' === $id && 'string_params' === $key)) {
+                            continue;
                         }
+
+                        $input[$paramSource][$param] = $value;
+                        $testData = ["{$param}_$id", $runAs];
+                        if ($tokenAuth) {
+                            $testData[] = 'valid_token';
+                        }
+                        array_push(
+                            $testData,
+                            $input,
+                            $this->validateInvalidParameterResponse(
+                                $param,
+                                $type,
+                                $errorBodyValidator
+                            )
+                        );
+                        $tests[] = $testData;
                     }
                 }
             }


### PR DESCRIPTION
## Description
Additional Validation of both ISO8601 Date & Unix Timestamp parameters REST parameters have been added. 

## Motivation and Context
Aaron noted in https://app.asana.com/0/159049597309611/1208001546005418/f that it seemed like invalid values ( ex. `2024-01-99`) were being accepted for date parameters provided to rest endpoints.

These changes add additional validation to both ISO8601 Date & Unix Timestamp parameters where `DateTime::getLastErrors()` is checked to see if there are any warnings or errors before possibly returning a value.

New tests were added per conversation with Aaron.

## Tests performed
All automated tests were run / passed. 

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
