### PR TITLE
Add default value for modw_cloud.instance_type_union table

### DIFF
--- a/classes/OpenXdmod/Migration/Version1050To1100/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version1050To1100/DatabasesMigration.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Update database from version 10.5.0 to 11.0.0
+ */
+
+namespace OpenXdmod\Migration\Version1050To1100;
+
+use OpenXdmod\Migration\DatabasesMigration as AbstractDatabasesMigration;
+use CCR\DB;
+use CCR\DB\MySQLHelper;
+use ETL\Utilities;
+
+/**
+ * Migrate databases from version 10.5.0 to 11.0.0
+ */
+class DatabasesMigration extends AbstractDatabasesMigration
+{
+    public function execute()
+    {
+        parent::execute();
+
+        $dbh = DB::factory('datawarehouse');
+        $mysql_helper = MySQLHelper::factory($dbh);
+
+        if ($mysql_helper->tableExists('modw_cloud.event')) {
+            Utilities::runEtlPipeline(
+                ['cloud-migration-10-5-0_11-0-0'],
+                $this->logger,
+                ['last-modified-start-date' => '2017-01-01 00:00:00']
+            );
+        }
+    }
+}

--- a/configuration/etl/etl.d/xdmod-migration-10_5_0-11_0_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-10_5_0-11_0_0.json
@@ -5,8 +5,36 @@
             "namespace": "ETL\\Ingestor",
             "class": "DatabaseIngestor",
             "options_class": "IngestorOptions"
+        },
+        "cloud-migration-10-5-0_11-0-0": {
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions",
+            "class": "ManageTables",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "Cloud Database",
+                    "config": "database",
+                    "schema": "modw_cloud"
+                },
+                "source": {
+                    "type": "mysql",
+                    "name": "Cloud Databaes",
+                    "config": "database",
+                    "schema": "modw_cloud"
+                }
+            }
         }
     },
+    "cloud-migration-10-5-0_11-0-0": [
+        {
+            "name": "UpdateInstanceTypeUnion",
+            "description": "Update instance type union table.",
+            "definition_file_list": [
+                "cloud_common/instance_type_union.json"
+            ]
+        }
+    ],
     "migration-10_5_0-11_0_0": [{
             "name": "resource-allocation-types",
             "description": "Ingest resource allocation types file",

--- a/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
@@ -16,7 +16,7 @@
             {
                 "name": "instance_type_id",
                 "type": "int(11)",
-                "default": -1,
+                "default": 1,
                 "nullable": true,
                 "comment": "Resource to which this type belongs"
             },

--- a/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
@@ -16,7 +16,7 @@
             {
                 "name": "instance_type_id",
                 "type": "int(11)",
-                "default": 1,
+                "default": null,
                 "nullable": true,
                 "comment": "Resource to which this type belongs"
             },

--- a/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
+++ b/configuration/etl/etl_tables.d/cloud_common/instance_type_union.json
@@ -16,6 +16,7 @@
             {
                 "name": "instance_type_id",
                 "type": "int(11)",
+                "default": -1,
                 "nullable": true,
                 "comment": "Resource to which this type belongs"
             },


### PR DESCRIPTION
Add default value for `modw_cloud.instance_type_union` table. This makes it so warning during ingestion do not happen. The `1` value is the Unknown value from `modw_cloud.instance_type`

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
