### PR TITLE
Fix timeseries x-axis tick overlap

### DIFF
--- a/classes/DataWarehouse/Visualization/TimeseriesChart.php
+++ b/classes/DataWarehouse/Visualization/TimeseriesChart.php
@@ -387,7 +387,6 @@ class TimeseriesChart extends AggregateChart
                         ),
                         'ticksuffix' => ' ',
                         'tickformat' => $this->getDateFormat(),
-                        'tickangle' => $xAxisData->getName() != 'Year' && $expectedDataPointCount > 25 ? -90 : 0,
                         'type' => 'date',
                         'rangemode' => 'tozero',
                         'hoverformat' => $this->getDateFormat(),
@@ -496,7 +495,6 @@ class TimeseriesChart extends AggregateChart
                             if($this->_swapXY)
                             {
                                 $trace['textangle'] = 90;
-                                $this->_chart['layout']['xaxis']['tickangle'] = 0;
                             } else {
                                 $trace['textangle'] = -90;
                             }
@@ -648,9 +646,6 @@ class TimeseriesChart extends AggregateChart
                         $value_count = count($xValues);
 
                         if (($this->_aggregationUnit == 'Day' || $this->_aggregationUnit == 'day')) {
-                            if ($value_count > 12) {
-                                $this->_chart['layout']['xaxis']['tickangle'] = -90;
-                            }
                             if ($value_count > 7) {
                                 $this->_chart['layout']['xaxis']['tickmode'] = 'auto';
 
@@ -692,7 +687,6 @@ class TimeseriesChart extends AggregateChart
                             if (!$swapXYDone) {
                                 $xAxis['type'] = $data_description->log_scale ? 'log' : '-';
                                 $xAxis['autorange'] = 'reversed';
-                                $xAxis['tickangle'] = 0;
                                 $yAxis['side'] = ($yAxisIndex % 2 != 0) ? 'top' : 'bottom';
                                 if ($yAxis['side'] == 'top') {
                                     $yAxis['title']['standoff'] = 0;


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
Improve timeseries x-axis tick angle by allowing Plotly JS to set it angle instead of manually setting it.
<!--- Include screenshots for GUI changes if appropriate -->
Before:
![overlap](https://github.com/user-attachments/assets/bbbdc980-0b3b-49ff-9c06-b7ff7a54c40c)

After:
![no_overlap](https://github.com/user-attachments/assets/2953d779-4994-4c9d-8947-f90bed38045f)

<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Improves readability especially when resizing the window to a smaller viewport.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested on dev port.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
