### PR TITLE
Added documentation for exporting saved Metric Explorer charts with the XDMoD API

### DIFF
--- a/docs/howto-api-image-export.md
+++ b/docs/howto-api-image-export.md
@@ -4,7 +4,12 @@ The following python script can be used to export your saved metric explorer cha
 
 `$ pip install python-dotenv`
 
-Running the script will export your saved metric explorer charts to the current working directory. The format of the exported image can be changed, the default used here is `svg`. Refer to the XDMoD Metric Explorer Tab Controller [API documentation](rest.html#tag/Metric-Explorer/paths/~1controllers~1metric_explorer.php/post) section for more information. The operation used here is `get_data`.
+Before running the script,
+
+1. Replace `YOUR_CENTER_URL` within the script with the appropriate information
+1. Create a `.env` file with your local XDMoD account credentials in the same directory as the script
+
+Running the script will export your saved metric explorer charts to the current working directory. The format of the exported image can be changed, the default used here is `svg`.
 
 ```python
 #!/usr/bin/env python3
@@ -55,6 +60,8 @@ for idx, chart in enumerate(saved_charts_data['data']):
         chart_json['operation'] = "get_data"
         chart_json['controller_module'] = "metric_explorer"
         chart_json['format'] = "svg"
+        chart_json['width'] = 916
+        chart_json['height'] = 484
 
         chart_response = session.post('YOUR_CENTER_URL/controllers/metric_explorer.php', data=chart_json, headers=header, cookies=session.cookies)
         chart_name = f"{chart['name']}.{chart_json['format']}" if ('name' in chart) else f"xdmod_API_export_{idx}.{chart_json['format']}"
@@ -62,3 +69,5 @@ for idx, chart in enumerate(saved_charts_data['data']):
         with open(chart_name, "w") as f:
             f.write(chart_response.text)
 ```
+
+The format of the exported image can be changed, the default used here is `svg`. Refer to the XDMoD [Metric Explorer Tab Controller API](rest.html#tag/Metric-Explorer/paths/~1controllers~1metric_explorer.php/post) `get_data` operation information on the request body schema.

--- a/docs/howto-api-image-export.md
+++ b/docs/howto-api-image-export.md
@@ -1,6 +1,6 @@
 You can use the XDMoD API to image export your saved metric explorer charts. A local XDMoD account is **required** to authenticate through the API.
 
-The following python script can be used to export your saved metric explorer charts. The `dotenv` library is recommend when authenticating through XDMoD API. You can install the `dotenv` library using:
+The following Python script will export your saved metric explorer charts. The `dotenv` library is recommended when authenticating through XDMoD API. You can install the `dotenv` library using:
 
 `$ pip install python-dotenv`
 
@@ -10,7 +10,7 @@ Before running the script,
 1. Declare `center_url` within the script with the appropriate information
 1. Confirm the `image_format` within the script.
 
-Running the script will export your saved metric explorer charts to the current working directory.
+The script will export your saved metric explorer charts to the current working directory.
 
 ```python
 #!/usr/bin/env python3
@@ -74,4 +74,4 @@ for idx, chart in enumerate(saved_charts_data['data']):
             f.write(chart_response.content)
 ```
 
-The defualt image format is `svg`, but `png` and `pdf` formats are also supported. Refer to the XDMoD [Metric Explorer Tab Controller API](rest.html#tag/Metric-Explorer/paths/~1controllers~1metric_explorer.php/post) `get_data` operation information on the request body schema.
+The default image format is `svg`, but `png` and `pdf` formats are also supported. Refer to the XDMoD [Metric Explorer Tab Controller API](rest.html#tag/Metric-Explorer/paths/~1controllers~1metric_explorer.php/post) `get_data` operation information on the request body schema.

--- a/docs/howto-api-image-export.md
+++ b/docs/howto-api-image-export.md
@@ -7,7 +7,7 @@ The following Python script will export your saved metric explorer charts. The `
 Before running the script,
 
 1. Create a `.env` file with your local XDMoD account credentials in the same directory as the script
-1. Declare `center_url` within the script with the appropriate information
+1. Update `site_address` within the script with site address associated with your XDMoD instance.
 1. Confirm the `image_format` within the script.
 
 The script will export your saved metric explorer charts to the current working directory.
@@ -24,12 +24,12 @@ load_dotenv()
 
 username = os.getenv('XDMOD_USERNAME')
 password = os.getenv('XDMOD_PASSWORD')
-center_url = ""
+site_address = ""
 image_format = "svg"
 
 session = requests.Session()
 
-auth_response = session.post(f'{center_url}/rest/auth/login', auth=(username, password))
+auth_response = session.post(f'{site_address}/rest/auth/login', auth=(username, password))
 
 if auth_response.status_code != 200:
     print('Authentication failed. Check provided credentials and check if you have a local XDMoD account')
@@ -43,7 +43,7 @@ header = {
   'Content-Type': 'application/x-www-form-urlencoded'
 }
 
-saved_charts = session.get(f'{center_url}/rest/v1/metrics/explorer/queries', headers=header, cookies=session.cookies)
+saved_charts = session.get(f'{site_address}/rest/v1/metrics/explorer/queries', headers=header, cookies=session.cookies)
 saved_charts_data = saved_charts.json()
 
 for idx, chart in enumerate(saved_charts_data['data']):
@@ -67,7 +67,7 @@ for idx, chart in enumerate(saved_charts_data['data']):
         chart_json['width'] = 916
         chart_json['height'] = 484
 
-        chart_response = session.post(f'{center_url}/controllers/metric_explorer.php', data=chart_json, headers=header, cookies=session.cookies)
+        chart_response = session.post(f'{site_address}/controllers/metric_explorer.php', data=chart_json, headers=header, cookies=session.cookies)
         chart_name = f"{chart['name']}.{image_format}" if ('name' in chart) else f"xdmod_API_export_{idx}.{image_format}"
 
         with open(chart_name, "wb") as f:

--- a/docs/howto-api-image-export.md
+++ b/docs/howto-api-image-export.md
@@ -1,9 +1,10 @@
-You can use the XDMoD API to export your saved metric explorer charts. A local XDMoD account is required to authenticate through the API.
+You can use the XDMoD API to image export your saved metric explorer charts. A local XDMoD account is **required** to authenticate through the API.
 
-The following python script can be used to export the saved metric explorer charts. The `dotenv` library is recommend when authenticating through XDMoD API. You can install the `dotenv` library using:
+The following python script can be used to export your saved metric explorer charts. The `dotenv` library is recommend when authenticating through XDMoD API. You can install the `dotenv` library using:
+
 `$ pip install python-dotenv`
 
-The script will write the images to the current working directory. The format of the returned image can be changed, the default used here is 'svg'.
+Running the script will export your saved metric explorer charts to the current working directory. The format of the exported image can be changed, the default used here is `svg`. Refer to the XDMoD Metric Explorer Tab Controller [API documentation](rest.html#tag/Metric-Explorer/paths/~1controllers~1metric_explorer.php/post) section for more information. The operation used here is `get_data`.
 
 ```python
 #!/usr/bin/env python3

--- a/docs/howto-api-image-export.md
+++ b/docs/howto-api-image-export.md
@@ -1,0 +1,63 @@
+You can use the XDMoD API to export your saved metric explorer charts. A local XDMoD account is required to authenticate through the API.
+
+The following python script can be used to export the saved metric explorer charts. The `dotenv` library is recommend when authenticating through XDMoD API. You can install the `dotenv` library using:
+`$ pip install python-dotenv`
+
+The script will write the images to the current working directory. The format of the returned image can be changed, the default used here is 'svg'.
+
+```python
+#!/usr/bin/env python3
+import os
+import requests
+import json
+import urllib
+from dotenv import load_dotenv
+
+load_dotenv()
+
+username = os.getenv('XDMOD_USERNAME')
+password = os.getenv('XDMOD_PASSWORD')
+
+session = requests.Session()
+
+auth_response = session.post('YOUR_CENTER_URL/rest/auth/login', auth=(username, password))
+
+if auth_response.status_code != 200:
+    print('Authentication failed. Check provided credentials and check if you have a local XDMoD account')
+    quit()
+
+auth_response = auth_response.json()
+
+header = {
+  'Token': auth_response['results']['token'],
+  'Authorization': auth_response['results']['token'],
+  'Content-Type': 'application/x-www-form-urlencoded'
+}
+
+saved_charts = session.get('YOUR_CENTER_URL/rest/v1/metrics/explorer/queries', headers=header, cookies=session.cookies)
+saved_charts_data = saved_charts.json()
+
+for idx, chart in enumerate(saved_charts_data['data']):
+    if 'config' in chart:
+        chart_json = json.loads(chart['config'])
+        for attribute in chart_json:
+            if (isinstance(chart_json[attribute], dict)):
+                if 'data' in attribute:
+                    encoded_str = urllib.parse.quote_plus(str(chart_json[attribute]['data']))
+                else:
+                    encoded_str = urllib.parse.quote_plus(str(chart_json[attribute]))
+                encoded_str = encoded_str.replace('%27','%22').replace('False', 'false').replace('True', 'true').replace('None', 'null')
+                chart_json[attribute] = encoded_str
+            if chart_json[attribute] in (True, False, None):
+                chart_json[attribute] = str(chart_json[attribute]).replace('False', 'false').replace('True', 'true').replace('None', 'null')
+
+        chart_json['operation'] = "get_data"
+        chart_json['controller_module'] = "metric_explorer"
+        chart_json['format'] = "svg"
+
+        chart_response = session.post('YOUR_CENTER_URL/controllers/metric_explorer.php', data=chart_json, headers=header, cookies=session.cookies)
+        chart_name = f"{chart['name']}.{chart_json['format']}" if ('name' in chart) else f"xdmod_API_export_{idx}.{chart_json['format']}"
+
+        with open(chart_name, "w") as f:
+            f.write(chart_response.text)
+```

--- a/docs/howto-api-image-export.md
+++ b/docs/howto-api-image-export.md
@@ -6,10 +6,11 @@ The following python script can be used to export your saved metric explorer cha
 
 Before running the script,
 
-1. Replace `YOUR_CENTER_URL` within the script with the appropriate information
 1. Create a `.env` file with your local XDMoD account credentials in the same directory as the script
+1. Declare `center_url` within the script with the appropriate information
+1. Confirm the `image_format` within the script.
 
-Running the script will export your saved metric explorer charts to the current working directory. The format of the exported image can be changed, the default used here is `svg`.
+Running the script will export your saved metric explorer charts to the current working directory.
 
 ```python
 #!/usr/bin/env python3
@@ -23,10 +24,12 @@ load_dotenv()
 
 username = os.getenv('XDMOD_USERNAME')
 password = os.getenv('XDMOD_PASSWORD')
+center_url = ""
+image_format = "svg"
 
 session = requests.Session()
 
-auth_response = session.post('YOUR_CENTER_URL/rest/auth/login', auth=(username, password))
+auth_response = session.post(f'{center_url}/rest/auth/login', auth=(username, password))
 
 if auth_response.status_code != 200:
     print('Authentication failed. Check provided credentials and check if you have a local XDMoD account')
@@ -40,7 +43,7 @@ header = {
   'Content-Type': 'application/x-www-form-urlencoded'
 }
 
-saved_charts = session.get('YOUR_CENTER_URL/rest/v1/metrics/explorer/queries', headers=header, cookies=session.cookies)
+saved_charts = session.get(f'{center_url}/rest/v1/metrics/explorer/queries', headers=header, cookies=session.cookies)
 saved_charts_data = saved_charts.json()
 
 for idx, chart in enumerate(saved_charts_data['data']):
@@ -59,15 +62,16 @@ for idx, chart in enumerate(saved_charts_data['data']):
 
         chart_json['operation'] = "get_data"
         chart_json['controller_module'] = "metric_explorer"
-        chart_json['format'] = "svg"
+        chart_json['show_title'] = "y"
+        chart_json['format'] = image_format
         chart_json['width'] = 916
         chart_json['height'] = 484
 
-        chart_response = session.post('YOUR_CENTER_URL/controllers/metric_explorer.php', data=chart_json, headers=header, cookies=session.cookies)
-        chart_name = f"{chart['name']}.{chart_json['format']}" if ('name' in chart) else f"xdmod_API_export_{idx}.{chart_json['format']}"
+        chart_response = session.post(f'{center_url}/controllers/metric_explorer.php', data=chart_json, headers=header, cookies=session.cookies)
+        chart_name = f"{chart['name']}.{image_format}" if ('name' in chart) else f"xdmod_API_export_{idx}.{image_format}"
 
-        with open(chart_name, "w") as f:
-            f.write(chart_response.text)
+        with open(chart_name, "wb") as f:
+            f.write(chart_response.content)
 ```
 
-The format of the exported image can be changed, the default used here is `svg`. Refer to the XDMoD [Metric Explorer Tab Controller API](rest.html#tag/Metric-Explorer/paths/~1controllers~1metric_explorer.php/post) `get_data` operation information on the request body schema.
+The defualt image format is `svg`, but `png` and `pdf` formats are also supported. Refer to the XDMoD [Metric Explorer Tab Controller API](rest.html#tag/Metric-Explorer/paths/~1controllers~1metric_explorer.php/post) `get_data` operation information on the request body schema.

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -8,3 +8,4 @@ The Open XDMoD HOWTOs are "how to" documents on specific subjects.
 - [Change Metric Explorer Colors](howto-colors.html)
 - [Enable Node Utilization Statistics](howto-node-utilization.html)
 - [Reconstruct Slurm Accounting Logs](howto-reconstruct-slurm.html)
+- [Export Saved Metric Explorer Charts Through the XDMOD API](howto-api-image-export.md)


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
This documentation contains a Python script that use the XDMoD API to authenticate with a local XDMoD account for the given credentials and site URL. Then the script will export the saved Metric Explorer charts into the current working directory. This documentation also describes how to edit certain parts of the script and where to find more information about the request schema for the request that exports the images.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We received a ticket asking about using the XDMoD API to export saved images for an Open XDMoD - Open OnDemand integration. This documentation will be used with the response and for future tickets that refer to this issue.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested script locally.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
