### PR TITLE
Backport docs changes from 11.0 to 10.5.

### DIFF
--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -10,7 +10,7 @@ See the [Software Requirements](software-requirements.html) for details.
 Install the RPM
 ---------------
 
-    # yum install xdmod-{{ page.sw_version }}-1.0.el7.noarch.rpm
+    # dnf install xdmod-{{ page.sw_version }}-1.0.el8.noarch.rpm
 
 Configure Open XDMoD
 --------------------

--- a/docs/openidc.md
+++ b/docs/openidc.md
@@ -1,0 +1,120 @@
+# OpenID Connect Setup
+
+This documentation will only cover the additional steps required to configure XDMoD to use OpenID Connect as an SSO identity
+provider. All the file paths included below assume that an RPM installation has been performed. If you have a source install
+of XDMoD then `/etc/xdmod` can be replaced with `/path/to/your/xdmod/install/etc`
+
+You will first need to modify `/etc/xdmod/simplesamlphp/metadata/saml20-idp-remote.php` according to the example below:
+
+*NOTE: in the following examples you will need to substitute your own values where `<< ... >>` is found. Each instance of `<< ... >>` will be detailed underneath the code block in which it is found. Some of these values will be referenced in other files, these values will be denoted by a <span style='color:red;font-size=20px'>\*</span>.*
+
+```injectablephp
+<?php
+$metadata['<<idp-remote-entity-id>>'] = array (
+    'metadata-set' => 'saml20-idp-hosted',
+    'entityid' => '<<idp-remote-entity-id>>',
+    'SingleSignOnService' => array (
+        0 =>
+            array (
+                'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                'Location' => 'https://<<your-xdmod-installs-web-address>>/simplesaml/saml2/idp/SSOService.php',
+            ),
+    ),
+    'SingleLogoutService' => array (
+        0 =>
+            array (
+                'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                'Location' => 'https://<<your-xdmod-installs-web-address>>/simplesaml/saml2/idp/SingleLogoutService.php',
+            ),
+    ),
+    'certData' => '<<contents-of-your-cert-file-minus-the-begin-and-end-certificate-blocks>>',
+    'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+    'contacts' => array (
+        0 =>
+            array (
+                'emailAddress' => '<<tech-support-email-address>>',
+                'contactType' => 'technical',
+                'givenName' => '<<display-name-for-email-address>>',
+            ),
+    ),
+    'icon' => '<<base64-encoded-png-icon-data-that-will-be-shown-in-the-xdmod-login-modal>>'
+);
+```
+
+- `<<idp-remote-entity-id>>`: <span style='color:red;font-size=20px'>*</span> This is a value selected by you, it will be referenced elsewhere in the configuration.
+- `<<your-xdmod-installation-web-address>>`: The external web address of your XDMoD Installation (which should contain the `host` property from your SP config in `authsources.php`), ex. `https://xdmod.example.com`.
+- `<<contents-of-your-cert-file-minus-the-begin-and-end-certificate-blocks>>`: This should be from the cert file your using for simplesamlphp. Location is based on the `certdir` property found in  `/etc/xdmod/simplesamlphp/config/config.php`.
+- `<<base64-encoded-png-icon-data-that-will-be-shown-in-the-xdmod-login-modal>>`: XDMoD supports displaying a custom image when users log in via SSO. This is where you would encode that image.
+
+Next, modify `/etc/xdmod/simplsamlphp/config/authsources.php` according to the example below:
+
+
+```injectablephp
+<?php
+$config = array(
+    '<<sp-id>>' => array(
+        'saml:SP',
+        'idp' => '<<idp-remote-entity-id>>'
+        /** Configuration from simplesSAMLphp general configuration **/
+    ),
+    '<<oidc-key-id>>'  => array(
+        'authoidcoauth2:OIDCOAuth2',
+        'entityID'            => '<<oidc-entity-id>>',
+        'auth_endpoint'       => '<<auth-endpoint-url>>',
+        'auth_path'           => '<<auth-path>>',
+        'api_endpoint'        => '<<api-endpoint-url>>',
+        'token_path'          => '<<token-path>>',
+        'user_info_path'      => '<<user-info-path>>',
+        'key'                 => '<<client-id-or-key>>',
+        'client_id'           => '<<client-id-or-key>>',
+        'client_secret'       => '<<client-secret>>',
+        'secret'              => '<<client-secret>>',
+        'scope'               => '<<oidc scope>>',
+        'response_type'       => 'code',
+        'use_header_for_auth' => false,
+        'redirect_uri'        => '<<your-xdmod-installation-web-address>>/simplesaml/module.php/authoidcoauth2/linkback.php',
+        'verify_ssl'          => 0
+    ),
+);
+```
+- `<<idp-remote-entity-id>>`: This is the `entityid` from `saml20-idp-remote.php`.
+- `<<oidc-key-id>>`: <span style='color:red;font-size=20px'>*</span> This is a value you select and will be referenced elsewhere in the configuration files.
+- `<<oidc-entity-id>>`: <span style='color:red;font-size=20px'>*</span> This is a value you select and will be referenced elsewhere in the configuration files.
+- `<<auth-endpoint-url>>`: The url that points to your authentication endpoint, ex. `https://cilogon.org`.
+- `<<auth-path>>`: The path element that will be appended to `<<auth-endpoint-url>>` when authorizing, ex. `/authorize`.
+- `<<api-endpoint>>`: The url that points to your OpenID Connect API endpoint ( often the same as `<<auth-endpoint-url>>` ), ex. `https://cilogon.org`.
+- `<<token-path>>`: The path element that will be appended to `<<auth-endpoint-url>>` when requesting a token, ex. `/oauth2/token`.
+- `<<user-info-path>>`: The path element that will be appended to `<<auth-endpoint-url>>` when requesting user information, ex. `/oauth2/userinfo`.
+- `<<client-id-or-key>>`: The key or client id from your IDP.
+- `<<client-secret>>`: The secret from your IDP.
+- `<<scope>>`: The information that will be returned from your IDP, ex. `email openid org.cilogon.userinfo profile`.
+- `<<your-xdmod-installation-web-address>>`: The external web address of your XDMoD Installation (which should match the `host` property in your SP config), ex. `https://xdmod.example.com`.
+
+and finally you will need to update `/etc/xdmod/simplesamlphp/metadata/saml20-idp-hosted.php`:
+
+```injectablephp
+<?php
+$metadata['<<idp-remote-entity-id>>'] = array(
+    /*
+     * The hostname for this IdP. This makes it possible to run multiple
+     * IdPs from the same configuration. '__DEFAULT__' means that this one
+     * should be used by default.
+     */
+    'host' => '__DEFAULT__',
+
+    /*
+     * The private key to use when signing responses.
+     * These are stored in the cert-directory.
+     */
+    'privatekey'  => '<<your-private-key-file-name>>',
+
+    /*
+     * The authentication source which should be used to authenticate the
+     * user. This must match one of the entries in config/authsources.php.
+     */
+    'auth' => '<<the-oidc-key-name-in-authsources>>',
+);
+```
+
+- `<<your-private-key-file-name>>`: The key file to be used by simplesamlphp. Location is based on the `certdir` property found in  `/etc/xdmod/simplesamlphp/config/config.php`.
+- `<<the-oidc-key-name-in-authsources>>`: <span style='color:red;font-size=20px'>*</span> The `<<oidc-key-id>>` used in `authsources.php`.

--- a/docs/simpleSAMLphp-ldap.md
+++ b/docs/simpleSAMLphp-ldap.md
@@ -206,5 +206,5 @@ You should now be able to go to the `Authentication` tab and test the `xdmod-sp`
 If you are using the forumsys example to test the username / password to use will be tesla / password
 
 [forumsys-ldap]: http://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/
-[ssp-idp]: https://simplesamlphp.org/docs/latest/simplesamlphp-idp.html
-[ssp-ldap]: https://simplesamlphp.org/docs/1.17/ldap/ldap.html
+[ssp-idp]: https://simplesamlphp.org/docs/stable/simplesamlphp-idp.html
+[ssp-ldap]: https://simplesamlphp.org/docs/contrib_modules/ldap/ldap.html

--- a/docs/simpleSAMLphp.md
+++ b/docs/simpleSAMLphp.md
@@ -33,6 +33,8 @@ More information on how to set these up can be found in the [SimpleSAMLphp Servi
 
 Information on how to set up SimpleSAMLphp to use Globus Auth can be found in the [simplesamlphp-module-authglobus documentation][ssp-globusconfig]
 
+Information on how to set up SimpleSAMLphp to use OpenID Connect can be found in the [OpenID Connect Configuration][ssp-openidc]
+
 You will need to modify the `config.php` file and make sure you modify the `metadata.sources` and the `certdir` keys to have the **full path** to directories containing the configurations:
 
 **note** make sure the file has opening `<?php`
@@ -267,8 +269,9 @@ see [Integrations][integrations] for more information
 
 [integrations]: integrations.html
 [ssp]: https://simplesamlphp.org/
-[ssp-config]: https://simplesamlphp.org/docs/latest/simplesamlphp-sp.html
+[ssp-config]: https://simplesamlphp.org/docs/stable/simplesamlphp-sp.html
 [ssp-globusconfig]: https://github.com/ubccr/simplesamlphp-module-authglobus
-[ssp-idp-remote]: https://simplesamlphp.org/docs/latest/simplesamlphp-reference-idp-remote.html
-[ssp-apache]: https://simplesamlphp.org/docs/latest/simplesamlphp-install.html#configuring-apache
+[ssp-openidc]: openidc.html
+[ssp-idp-remote]: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-remote.html
+[ssp-apache]: https://simplesamlphp.org/docs/stable/simplesamlphp-install.html#configuring-apache-section_4
 [saml-idp]: https://github.com/mcguinness/saml-idp/

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -18,8 +18,8 @@ General Upgrade Notes
   upgrade script.  The version number will be changed by the upgrade
   script.
 - If you have installed any additional Open XDMoD packages (e.g.
-  `xdmod-appkernels` or `xdmod-supremm`), upgrade those to the latest
-  version before running `xdmod-upgrade`.
+  `xdmod-appkernels`, `xdmod-supremm`, or `xdmod-ondemand`), upgrade those to
+  the latest version before running `xdmod-upgrade`.
 
 RPM Upgrade Process
 -------------------
@@ -32,8 +32,8 @@ Download available at [GitHub][github-latest-release].
 
     # yum install xdmod-{{ page.sw_version }}-1.0.el7.noarch.rpm
 
-Likewise, install the latest `xdmod-appkernels` or `xdmod-supremm` RPM
-files if you have those installed.
+Likewise, install the latest `xdmod-appkernels`, `xdmod-supremm`, and/or
+`xdmod-ondemand` RPM files if you have those modules installed.
 
 After upgrading the package you may need to manually merge any files
 that you have manually changed before the upgrade.  You do not need to
@@ -64,8 +64,8 @@ Download available at [GitHub][github-latest-release].
 
 ### Extract and Install Source Package
 
-    $ tar zxvf xdmod-{{ page.sw_version }}.tar.gz
-    $ cd xdmod-{{ page.sw_version }}
+    # tar zxvf xdmod-{{ page.sw_version }}.tar.gz
+    # cd xdmod-{{ page.sw_version }}
     # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 Likewise, install the latest `xdmod-appkernels` or `xdmod-supremm`

--- a/docs/xdmod-rest-schema.json
+++ b/docs/xdmod-rest-schema.json
@@ -1,3 +1,6 @@
+---
+layout: null
+---
 {
     "openapi": "3.0.3",
     "info": {
@@ -17,7 +20,7 @@
             "backgroundColor": "#FFFFFF",
             "altText": ""
         },
-        "version": "10.0.0"
+        "version": "{{ page.sw_version }}"
     },
     "servers": [
         {


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR backports documentation changes from the `xdmod11.0` branch to the `xdmod10.5` branch: OpenIDC documentation (https://github.com/ubccr/xdmod/pull/1810), broken link fixes (https://github.com/ubccr/xdmod/pull/1808), the version number fix in the REST API docs (https://github.com/ubccr/xdmod/pull/1784), and various other doc fixes (https://github.com/ubccr/xdmod/pull/1912).

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
