### PR TITLE
Add missing dependency for mongodb PHP Pear package

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -65,7 +65,7 @@ $ dnf module -y enable php:7.4
 
 Install PHP 7.4 and some require pre-reqs for PHP Pear packages
 ```shell
-$ dnf install -y php libzip-devel php-pear php-devel
+$ dnf install -y php make libzip-devel php-pear php-devel
 ```
 
 Some Notes:


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
`make` package is required to run `yes '' | pecl install mongodb-1.18.1`.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
