### PR TITLE
Extend support window for 10.5.

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -14,7 +14,7 @@ for 11.0.
 
 | Version | Release Date       | End of Support    |
 |---------|--------------------|-------------------|
-| 10.5    | September 03, 2023 | October 31, 2024* |
+| 10.5    | September 03, 2023 | March 31, 2025* |
 
 **\* Note: CentOS 7 officially reached end of life on June 30, 2024, and as such so did our official support for el7 XDMoD.**
 


### PR DESCRIPTION
This PR updates the support documentation to extend the support window for version 10.5 to March 31, 2025, to give people more of a transition period for upgrading to 11.0.