### PR TITLE
Add missing endpoint to exception message in `ExecuteSql`.

### DIFF
--- a/classes/ETL/Maintenance/ExecuteSql.php
+++ b/classes/ETL/Maintenance/ExecuteSql.php
@@ -252,7 +252,7 @@ class ExecuteSql extends aAction implements iAction
                 } catch ( PDOException $e ) {
                     $this->logAndThrowException(
                         "Error executing SQL",
-                        array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->sourceEndpoint)
+                        array('exception' => $e, 'sql' => $sql, 'endpoint' => $this->destinationEndpoint)
                     );
                 }
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
The ETL maintenance class `ExecuteSql` only uses `destinationEndpoint`, not `sourceEndpoint`. However, when exceptions are logged, it tries to report the `sourceEndpoint`. This PR fixes this to instead report the `destinationEndpoint`.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran an SQL query on my port on `xdmod-dev` that I knew was incorrect, and it reported the following (note that the endpoint is not reported):
```
xsede.migration-11_0_0p1-11_0_0p2.MapUnknownOodPeople (ETL\Maintenance\ExecuteSql): Error executing SQL Exception: 'SQLSTATE[42S02]: Base table or view not found: 1146 Table 'modw.page_impressions' doesn't exist'
```
Then I applied the fix, ran it again, and the endpoint is now reported in the exception:
```
xsede.migration-11_0_0p1-11_0_0p2.MapUnknownOodPeople (ETL\Maintenance\ExecuteSql): Error executing SQL Exception: 'SQLSTATE[42S02]: Base table or view not found: 1146 Table 'modw.page_impressions' doesn't exist' Using DataEndpoint: '('Database with Open OnDemand usage data', class=ETL\DataEndpoint\Mysql, config=datawarehouse, schema=modw_ondemand, host=mysql-dev.ccr.xdmod.org:3306, user=xdmod)'
```

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
