### PR TITLE
Fix how `pdoAggregator` logs the day that was aggregated.

### DIFF
--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1222,7 +1222,7 @@ class pdoAggregator extends aAggregator
             $periodDisplay = $periodId;
             if ( 'day' === $aggregationUnit ) {
                 $dayDateTime = \DateTime::createFromFormat('Y00z', $periodId - 1);
-                $periodDisplay .= ' ' . $dayDateTime->format('d m Y');
+                $periodDisplay .= ' ' . $dayDateTime->format('Y-m-d');
             }
             $this->logger->info("Aggregated $aggregationUnit ("
                                 . ( $numPeriodsProcessed + $aggregationPeriodOffset)

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1221,7 +1221,7 @@ class pdoAggregator extends aAggregator
             $numPeriodsProcessed++;
             $periodDisplay = $periodId;
             if ( 'day' === $aggregationUnit ) {
-                $dayDateTime = \DateTime::createFromFormat('Y00z', $periodId);
+                $dayDateTime = \DateTime::createFromFormat('Y00z', $periodId - 1);
                 $periodDisplay .= ' ' . $dayDateTime->format('d m Y');
             }
             $this->logger->info("Aggregated $aggregationUnit ("


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
Currently, if `pdoAggregator` is used to aggregate a single day, the day it displays in the log is off by one. I noticed this when manually aggregating a day (`2016-11-01`) of Gateways data:

```
sudo -u xdmod /data/www/xdmod/share/tools/etl/etl_overseer.php -v debug -a xsede.science-gateway.AggregationByDay -s '2016-11-01 00:00:00' -e '2016-11-01 23:59:59' -f
...
[info] Aggregated day (1/1) 201600306 02 11 2016
```

That should instead be `01 11 2016`.

This is because the `Y00z` format string counts days of the year starting at zero, but MySQL `DAYOFYEAR` counts starting at one.

This PR fixes how the day is displayed. It also changes the format to match what is used often elsewhere, `Y-m-d`.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by aggregating a day of Gateways records on `xdmod-dev` and confirming the displayed day is correct.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
