### PR TITLE
Add ability to set character set for load data infile.

### DIFF
--- a/classes/ETL/Ingestor/IngestorOptions.php
+++ b/classes/ETL/Ingestor/IngestorOptions.php
@@ -95,6 +95,9 @@ class IngestorOptions extends aOptions
             // INFILE...REPLACE INTO instead.
             "force_load_data_infile_replace_into" => false,
 
+            // Character set override to use when loading data via a file.
+            "load_data_infile_character_set" => null,
+
             // Hide all SQL warnings returned by the database.
             "hide_sql_warnings" => false,
 


### PR DESCRIPTION
## Description
Trying to load utf8 data properly from xras. The mysql and mariadb docs claim that the [character_set_database](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_character_set_database) 
is used when load data infile. However I could not get it to work. The only thing that did work was explicitly setting the character set in the load data statement.

Note that the old-school ingestors supportted setting the character set in the load file statement and we use this capability in the classes/DB/PDODBUtf8MultiIngestor.php in the xsede module. It looks like an oversight that this support was not added to the ETLv2 code.

## Tests performed
Tested on NAIRR XDMoD:

Old code (note the `character_set_*` variables appear to be the correct values):

![image](https://github.com/user-attachments/assets/0ca9e4c5-d23a-4a37-8513-5dbd7ac3c003)


New code:

![image](https://github.com/user-attachments/assets/85384a78-7aff-40c8-919e-f70ebab1588a)
