### PR TITLE
Remove tick labels that are outside the selected date interval

### DIFF
--- a/classes/DataWarehouse/Visualization/TimeseriesChart.php
+++ b/classes/DataWarehouse/Visualization/TimeseriesChart.php
@@ -636,7 +636,6 @@ class TimeseriesChart extends AggregateChart
                         $value_count = count($xValues);
 
                         if (($this->_aggregationUnit == 'Day' || $this->_aggregationUnit == 'day')) {
-                            $this->_chart['layout']['xaxis']['type'] = 'category';
                             $this->_chart['layout']['xaxis']['tickmode'] = 'auto';
                         }
 

--- a/html/.eslintrc.json
+++ b/html/.eslintrc.json
@@ -24,6 +24,7 @@
     "DashboardStore": false,
     "grecaptcha": false,
     "StringUtilities": false,
-    "Plotly": false
+    "Plotly": false,
+    "removeExtraTimeseriesTickLabels": false
   }
 }

--- a/html/gui/js/PlotlyChartWrapper.js
+++ b/html/gui/js/PlotlyChartWrapper.js
@@ -130,11 +130,13 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
 
         if (baseChartOptions.layout.annotations.length === 0
            || (baseChartOptions.summary || baseChartOptions.dashboard || baseChartOptions.realmOverview)) {
+            removeExtraTimeseriesTickLabels(chartDiv, baseChartOptions);
             return;
         }
 
         const update = relayoutChart(chartDiv, baseChartOptions.layout.height, true);
         Plotly.relayout(baseChartOptions.renderTo, update);
+        removeExtraTimeseriesTickLabels(chartDiv, baseChartOptions);
     });
 
     return chart;

--- a/html/gui/js/PlotlyPanel.js
+++ b/html/gui/js/PlotlyPanel.js
@@ -253,6 +253,7 @@ Ext.extend(CCR.xdmod.ui.PlotlyPanel, Ext.Panel, {
                                         return false;
                                 }
                             });
+                            removeExtraTimeseriesTickLabels(chartDiv, this.chartOptions);
                         });
                         // Subtitle context menu
                         chartDiv.on('plotly_clickannotation', (evt) => {

--- a/html/gui/js/libraries/PlotlyUtilities.js
+++ b/html/gui/js/libraries/PlotlyUtilities.js
@@ -543,3 +543,29 @@ function overrideLegendEvent(chartDiv) {
 
     chartDiv.on('plotly_legenddoubleclick', (evt) => false);
 }
+/**
+ * Removes tick labels outside the selected time interval
+ * from the domain axis of the timeseries plot.
+ *
+ * @param {Object} chartDiv - Plotly JS chart div
+ * @param {Object} baseChartOptions - Object contain Plotly JS layout and data
+ */
+function removeExtraTimeseriesTickLabels(chartDiv, baseChartOptions) { // eslint-disable-line no-unused-vars
+    const axis = baseChartOptions.layout.swapXY ? 'yaxis' : 'xaxis';
+    const isEmpty = (!baseChartOptions.data) || (baseChartOptions.data && baseChartOptions.data.length === 0);
+    if (!isEmpty && baseChartOptions.layout[axis].timeseries) {
+        const xAxisTicks = chartDiv.getElementsByClassName(`${axis}layer-below`)[0];
+        const len = baseChartOptions.layout.swapXY ? baseChartOptions.data[0].y.length - 1 : baseChartOptions.data[0].x.length - 1;
+        const min = baseChartOptions.layout.swapXY ? baseChartOptions.data[0].y[0] : baseChartOptions.data[0].x[0];
+        const max = baseChartOptions.layout.swapXY ? baseChartOptions.data[0].y[len] : baseChartOptions.data[0].x[len];
+        const minString = moment(min).format('YYYY-MM-DD');
+        const maxString = moment(max).format('YYYY-MM-DD');
+        for (let i = 0; i < xAxisTicks.children.length; i++) {
+            const currTick = xAxisTicks.children[i];
+            const currDate = moment(currTick.__data__.text);
+            if (currDate.isBefore(minString) || currDate.isAfter(maxString)) {
+                currTick.remove();
+            }
+        }
+    }
+}

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -2592,6 +2592,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                     Plotly.relayout(this.chartId, { width: adjWidth, height: adjHeight });
                     const update = relayoutChart(chartDiv, adjHeight, false);
                     Plotly.relayout(this.chartId, update);
+                    removeExtraTimeseriesTickLabels(chartDiv, this.chartOptions);
                 }
             }
         } //onResize
@@ -2725,6 +2726,10 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                             this.chartId = id;
                             this.chartOptions = chartOptions;
                             var chartDiv = document.getElementById(baseChartOptions.renderTo);
+
+                            chartDiv.on('plotly_relayout', (evt) => {
+                                removeExtraTimeseriesTickLabels(chartDiv, this.chartOptions);
+                            });
 
                             chartDiv.on('plotly_click', (evt) => {
                                 let drillId;

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -6337,6 +6337,7 @@ Ext.extend(XDMoD.Module.MetricExplorer, XDMoD.PortalModule, {
                 Plotly.relayout(`plotly-panel${this.id}`, { width: adjWidth, height: adjHeight });
                 const update = relayoutChart(chartDiv, adjHeight, false);
                 Plotly.relayout(`plotly-panel${this.id}`, update);
+                removeExtraTimeseriesTickLabels(chartDiv, CCR.xdmod.ui.metricExplorer.plotlyPanel.chartOptions);
             }
         } //onResize
 

--- a/html/plotly_template.html
+++ b/html/plotly_template.html
@@ -115,7 +115,7 @@
                 }
                 const update = relayoutChart(chartDiv, chartOptions.layout.height, true, true);
                 Plotly.relayout('container', update);
-
+                removeExtraTimeseriesTickLabels(chartDiv, chartOptions);
             });
         });
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
The previous fix to address timeseries tick labels outside of the date range was in PR #1899, however, it was found that using 'category' axis type can cause timeseries plots to display data out of order if the series have varying date intervals.

This fix is for "Day" aggregation unit. The other units are handled by using a "linear" tickmode from PR #1899 

This refactor puts the work on Plotly to correctly order the axis by using the "date" axis type. To address the original issue of having date tick labels outside the date interval I decided to follow @jpwhite4 suggestions to remove tick labels that are outside the selected duration.

Plotly relayout events are tied to the Ext.js 'resize' event, but Plotly relayout events can happen outside of Ext.js 'resize' events (e.g. Zoom is a relayout event but not resize), therefore, I needed to add a listener to the Usage tab to ensure erroneous tick labels were removed on zooming (mainly resetting the zoom). The metric explorer tab already had a listener on the relayout event.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Out of order timeseries plots are very undesirable. Makes it impossible to accurately view the plot
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested on my dev-port on xdmod-dev
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
