### PR TITLE
Fix issues with swap XY axis.

### DIFF
--- a/classes/DataWarehouse/Visualization/AggregateChart.php
+++ b/classes/DataWarehouse/Visualization/AggregateChart.php
@@ -765,18 +765,40 @@ class AggregateChart
                     }
                 }
             }
+        }
 
-            // if we have just reset summarizeDatasets, recompute limit, xAxis, and yAxis
-            // with the new limit in place. Reset dataset _total to 1 to disable paging.
-            if ($summarizeDataseries)
+        if ($summarizeDataseries)
+        {
+            // disable ME paging by setting dataset size to 1
+            $this->_total = 1;
+            foreach($yAxisArray as $yAxisIndex => $yAxisObject)
             {
-                $yAxisArray = $this->setAxes($summarizeDataseries, $offset, $x_axis, $font_size);
-                $yAxisCount = count($yAxisArray);
+                foreach($yAxisObject->series as $data_description_index => $yAxisDataObjectAndDescription)
+                {
+                    $yAxisDataObject = $yAxisDataObjectAndDescription['yAxisDataObject'];
+                    $data_description = $yAxisDataObjectAndDescription['data_description'];
+                    $valuesCount = $yAxisDataObject->getCount(true);
 
-                // disable ME paging by setting dataset size to 1
-                $this->_total = 1;
+                    if($valuesCount - $this->limit >= 1)
+                    {
+                        // only compute average (2nd parameter) if not drawing pie chart
+                        $yAxisDataObject->truncate($this->limit, $data_description->display_type!=='pie');
+
+                        // now merge the x labels, if needed, from multiple datasets:
+                        $mergedlabels = $yAxisDataObject->getXValues();
+                        foreach( $mergedlabels as $idx => $label) {
+                            if ($label === null) {
+                                $tmp = $this->_xAxisDataObject->getValues();
+                                $mergedlabels[$idx] = $tmp[$idx];
+                            }
+                        }
+                        $this->_xAxisDataObject->setValues($mergedlabels);
+                        $this->_xAxisDataObject->getCount(true);
+                        $this->setXAxis($x_axis, $font_size);
+                    }
+                }
             }
-        } // !$summarizeDatasets
+        }
 
         // OK, now let's plot something...
         // Each of the yAxisObjects returned from getYAxis()
@@ -902,34 +924,6 @@ class AggregateChart
                 $semDecimals = $yAxisDataObjectAndDescription['semDecimals'];
                 $filterParametersTitle =  $yAxisDataObjectAndDescription['filterParametersTitle'];
 
-                // ============= truncate (e.g. take average, min, max, sum of remaining values) ==========
-
-                // Usage tab charts and ME pie charts will have their datasets summarized as follows:
-                $dataSeriesSummarized = false;
-                if ( $summarizeDataseries )
-                {
-                        $valuesCount = $yAxisDataObject->getCount(true);
-
-                    if($valuesCount - $this->limit >= 1)
-                        {
-                        // only compute average (2nd parameter) if not drawing pie chart
-                        $yAxisDataObject->truncate($this->limit, $data_description->display_type!=='pie');
-
-                        // now merge the x labels, if needed, from multiple datasets:
-                        $mergedlabels = $yAxisDataObject->getXValues();
-                        foreach( $mergedlabels as $idx => $label) {
-                            if ($label === null) {
-                                $tmp = $this->_xAxisDataObject->getValues();
-                                $mergedlabels[$idx] = $tmp[$idx];
-                            }
-                        }
-                        $this->_xAxisDataObject->setValues($mergedlabels);
-                        $this->_xAxisDataObject->getCount(true);
-                        $this->setXAxis($x_axis, $font_size);
-                        $dataSeriesSummarized = true;
-                    }
-                } // summarizeDataseries
-
                 //  ================ set color ================
 
                 // If the first data set in the series, pick up the yAxisColorValue.
@@ -962,13 +956,14 @@ class AggregateChart
                         $yValues[] = $value;
                         $colors[] = ($index == 0) ? $yAxisColor
                             : '#'.str_pad(dechex($this->_colorGenerator->getColor() ), 6, '0', STR_PAD_LEFT);
-                        $drillable[] = true;
+                        $drillId = $yAxisDataObject->getXId($index);
+                        $drillable[] = ($drillId > -9999);
                         // N.B.: These are drilldown labels.
                         // X axis labels will be the same, but are plotted
                         // from the x axis object instance variable.
                         // See setXAxis() and _xAxisDataObject.
                         $drilldown[] = array(
-                            'id' => $yAxisDataObject->getXId($index),
+                            'id' => $drillId,
                             'label' => $yAxisDataObject->getXValue($index)
                         );
 
@@ -1017,13 +1012,15 @@ class AggregateChart
                     // set the label for each value:
                     foreach( $yAxisDataObject->getValues() as $index => $value)
                     {
+                        $drillId = $yAxisDataObject->getXId($index);
                         $yValues[] = $value;
-                        $drillable[] = true;
+                        $drillable[] = ($drillId > -9999);
+
                         // N.B.: The following are drilldown labels.
                         // Labels on the x axis come from the x axis object
                         // (Though they are the same labels...)
                         $drilldown[] = array(
-                            'id' => $yAxisDataObject->getXId($index),
+                            'id' => $drillId,
                             'label' => $yAxisDataObject->getXValue($index)
                         );
 
@@ -1031,11 +1028,6 @@ class AggregateChart
                             $visiblePoints++;
                         }
                     }
-                }
-
-                $values_count = count($yValues);
-                if ($dataSeriesSummarized && $values_count > 0) {
-                    $drillable[$values_count - 1] = false;
                 }
 
                 $zIndex = isset($data_description->z_index) ? $data_description->z_index : $data_description_index;
@@ -1253,10 +1245,14 @@ class AggregateChart
                     $trace['xaxis'] = "x{$yIndex}";
 
                     if (!$swapXYDone) {
-                        $xtmp = $this->_chart['layout']['xaxis'];
-                        $ytmp = $this->_chart['layout']["{$yAxisName}"];
-                        $this->_chart['layout']['yaxis'] = $xtmp;
-                        $this->_chart['layout']["{$xAxisName}"] = $ytmp;
+                        if ($yIndex == 1) {
+                            $xtmp = $this->_chart['layout']["{$xAxisName}"];
+                            $this->_chart['layout']["{$xAxisName}"] = $this->_chart['layout']["{$yAxisName}"];
+                            $this->_chart['layout']["{$yAxisName}"] = $xtmp;
+                        } else {
+                            $this->_chart['layout']["{$xAxisName}"] = $this->_chart['layout']["{$yAxisName}"];
+                            unset($this->_chart['layout']["{$yAxisName}"]);
+                        }
 
                         $this->_chart['layout']["{$xAxisName}"]['side'] = ($yAxisIndex % 2 != 0) ? 'top' : 'bottom';
                         if ($this->_chart['layout']["{$xAxisName}"]['side'] == 'top') {


### PR DESCRIPTION
This pull request addresses multiple issues with swapping the X-Y axis.

1) Incorrect Y-axis legend configuration when there are multple datasets using different axes 
2) Corrupted x-axis legend configuration when "show remainder disable paging" is selected.

Before (note the wrong title on the y-axis and the vertical misalignment of the data, and the incorrect data ordering):

![image](https://github.com/user-attachments/assets/576413ae-920a-4932-a346-2413968798b8)

After:
![image](https://github.com/user-attachments/assets/1142d1d7-9b0d-47d8-afd3-f06e82624ab0)

Before (note the messed up x-axis): 

![image](https://github.com/user-attachments/assets/3a710a7d-e2b0-421a-bbf7-ca4b0af37fb0)

After:

![image](https://github.com/user-attachments/assets/b7c0f63c-9386-4e69-80a6-0a5f82a9bf02)


## Description

The change to fix problem (1) is to update the swap axis code to swap the correct axes!

The change for fix problem (2) involves moving the call to truncate the datasets to before the chart configuration is attempted. The chart truncate causes the categorical axis to be regenerated. When this was happening during the chart config with swap XY enabled then the chart layout config was getting corrupted.  There is no need to compute/store the `$dataSeriesSummarized` variable - you know whether a dataset can be drilled down based on the ID value.
