### PR TITLE
Add upgrade pipeline for person and PI organization in cloud realm

### DIFF
--- a/classes/OpenXdmod/Migration/Version1100To1101/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version1100To1101/DatabasesMigration.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Update database from version 11.0.0 to 11.0.1
+ */
+
+namespace OpenXdmod\Migration\Version1100To1101;
+
+use OpenXdmod\Migration\DatabasesMigration as AbstractDatabasesMigration;
+use CCR\DB;
+use CCR\DB\MySQLHelper;
+use ETL\Utilities;
+
+/**
+ * Migrate databases from version 11.0.0 to 11.0.1
+ */
+class DatabasesMigration extends AbstractDatabasesMigration
+{
+    public function execute()
+    {
+        parent::execute();
+
+        $dbh = DB::factory('datawarehouse');
+        $mysql_helper = MySQLHelper::factory($dbh);
+
+        if ($mysql_helper->tableExists('modw_cloud.event')) {
+            Utilities::runEtlPipeline(
+                ['cloud-migration-11-0-0_11-0-1','cloud-state-pipeline'],
+                $this->logger,
+                ['last-modified-start-date' => '2016-01-01 00:00:00']
+            );
+        }
+    }
+}

--- a/configuration/etl/etl.d/xdmod-migration-11_0_0-11_0_1.json
+++ b/configuration/etl/etl.d/xdmod-migration-11_0_0-11_0_1.json
@@ -24,7 +24,7 @@
     "cloud-migration-11-0-0_11-0-1": [
         {
             "name": "AddResourcePIOrganizationID",
-            "description": "Update instance type union table.",
+            "description": "Update modw_cloud.session_records table.",
             "definition_file_list": [
                 "cloud_common/session_records.json"
             ]

--- a/configuration/etl/etl.d/xdmod-migration-11_0_0-11_0_1.json
+++ b/configuration/etl/etl.d/xdmod-migration-11_0_0-11_0_1.json
@@ -1,0 +1,33 @@
+{
+    "module": "xdmod",
+    "defaults": {
+        "cloud-migration-11-0-0_11-0-1": {
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions",
+            "class": "ManageTables",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "Cloud Database",
+                    "config": "database",
+                    "schema": "modw_cloud"
+                },
+                "source": {
+                    "type": "mysql",
+                    "name": "Cloud Databaes",
+                    "config": "database",
+                    "schema": "modw_cloud"
+                }
+            }
+        }
+    },
+    "cloud-migration-11-0-0_11-0-1": [
+        {
+            "name": "AddResourcePIOrganizationID",
+            "description": "Update instance type union table.",
+            "definition_file_list": [
+                "cloud_common/session_records.json"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds the migration pipeline for the columns added in https://github.com/ubccr/xdmod/pull/1957. The cloud-state-pipeline etl pipeline has been added to the migration to re-aggregate the cloud realm so these columns are added and the columns are populated. These columns are used in the xsede module at this point in time.

This replaces #1936

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
