### PR TITLE
Change index on `mod_shredder.shredded_job` to improve performance

### DIFF
--- a/classes/OpenXdmod/Migration/Version1100To1150/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version1100To1150/DatabasesMigration.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Update database from version 11.0.0 to 11.5.0
+ */
+
+namespace OpenXdmod\Migration\Version1100To1150;
+
+use OpenXdmod\Migration\DatabasesMigration as AbstractDatabasesMigration;
+use CCR\DB;
+use CCR\DB\MySQLHelper;
+use ETL\Utilities;
+
+/**
+ * Migrate databases from version 11.0.0 to 11.5.0
+ */
+class DatabasesMigration extends AbstractDatabasesMigration
+{
+    public function execute()
+    {
+        parent::execute();
+    }
+}

--- a/classes/OpenXdmod/Migration/Version1100To1150/DatabasesMigration.php
+++ b/classes/OpenXdmod/Migration/Version1100To1150/DatabasesMigration.php
@@ -6,9 +6,6 @@
 namespace OpenXdmod\Migration\Version1100To1150;
 
 use OpenXdmod\Migration\DatabasesMigration as AbstractDatabasesMigration;
-use CCR\DB;
-use CCR\DB\MySQLHelper;
-use ETL\Utilities;
 
 /**
  * Migrate databases from version 11.0.0 to 11.5.0

--- a/configuration/etl/etl.d/xdmod-migration-11_0_0-11_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-11_0_0-11_5_0.json
@@ -9,7 +9,7 @@
     },
     "migration-11_0_0-11_5_0": [
         {
-            "name": "UpdateShreddeJobTable",
+            "name": "UpdateShredderJobTable",
             "description": "Update end_time index on mod_shredder.shredded_job.",
             "definition_file_list": [
                 "jobs/shredder/job.json"

--- a/configuration/etl/etl.d/xdmod-migration-11_0_0-11_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-11_0_0-11_5_0.json
@@ -10,7 +10,7 @@
     "migration-11_0_0-11_5_0": [
         {
             "name": "UpdateShreddeJobTable",
-            "description": "Update mod_shredder.shredded_job with new index.",
+            "description": "Update end_time index on mod_shredder.shredded_job.",
             "definition_file_list": [
                 "jobs/shredder/job.json"
             ],
@@ -23,7 +23,7 @@
                 },
                 "source": {
                     "type": "mysql",
-                    "name": "Shredder Databaes",
+                    "name": "Shredder Database",
                     "config": "shredder",
                     "schema": "mod_shredder"
                 }

--- a/configuration/etl/etl.d/xdmod-migration-11_0_0-11_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-11_0_0-11_5_0.json
@@ -1,0 +1,33 @@
+{
+    "module": "xdmod",
+    "defaults": {
+        "migration-11_0_0-11_5_0": {
+          "namespace": "ETL\\Maintenance",
+          "options_class": "MaintenanceOptions",
+          "class": "ManageTables"
+        }
+    },
+    "migration-11_0_0-11_5_0": [
+        {
+            "name": "UpdateShreddeJobTable",
+            "description": "Update mod_shredder.shredded_job with new index.",
+            "definition_file_list": [
+                "jobs/shredder/job.json"
+            ],
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "Shredder Database",
+                    "config": "shredder",
+                    "schema": "mod_shredder"
+                },
+                "source": {
+                    "type": "mysql",
+                    "name": "Shredder Databaes",
+                    "config": "shredder",
+                    "schema": "mod_shredder"
+                }
+            }
+        }
+    ]
+}

--- a/configuration/etl/etl_tables.d/jobs/shredder/job.json
+++ b/configuration/etl/etl_tables.d/jobs/shredder/job.json
@@ -195,8 +195,8 @@
             {
                 "name": "end_time",
                 "columns": [
-                    "end_time",
-                    "resource_name"
+                    "resource_name",
+                    "end_time"
                 ]
             },
             {


### PR DESCRIPTION
The `xdmod-slurm-helper` script runs the following query to try and find the time of the most recent job ingested in order to set the start time for the `sacct` command. Changing the order of the columns for the `end_time` index on `mod_shredder.shredded` provides a performance improvement. On `metrics-dev`, the query went from 6-8 minutes for the `ub-hpc` resource to around 30 seconds.

```
SELECT
  DATE_FORMAT(
    FROM_UNIXTIME(MAX(end_time)),
    '%Y-%m-%d %H:%i:%s'
   ) AS max_datetime
FROM shredded_job
WHERE resource_name = :resource
```

## Tests performed
Tested in docker and on `metrics-dev`

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
