### PR TITLE
Backport JQuery Upgrade from main

### DIFF
--- a/composer-el7.json
+++ b/composer-el7.json
@@ -6,7 +6,7 @@
         "greenlion/php-sql-parser": "~4.2",
         "highsoft/highcharts": "^4.2.5",
         "ircmaxell/password-compat": "~1",
-        "jquery/jquery-min-file": "^1.12.4",
+        "jquery/jquery-min-file": "3.7.1",
         "justinrainbow/json-schema": "~5.2",
         "moment/moment-min-file": "^2.13.0",
         "moment/moment-timezone-min-file": "^0.5.4",
@@ -148,13 +148,13 @@
             "package": {
                 "name": "jquery/jquery-min-file",
                 "type": "vanilla-plugin",
-                "version": "1.12.4",
+                "version": "3.7.1",
                 "license": "MIT",
                 "homepage": "https://jquery.com",
                 "dist": {
-                    "url": "https://code.jquery.com/jquery-1.12.4.min.js",
+                    "url": "https://code.jquery.com/jquery-3.7.1.min.js",
                     "type": "file",
-                    "shasum": "5a9dcfbef655a2668e78baebeaa8dc6f41d8dabb"
+                    "shasum": "ee48592d1fff952fcf06ce0b666ed4785493afdc"
                 },
                 "require": {
                     "composer/installers": "~1.0"

--- a/composer-el7.lock
+++ b/composer-el7.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17fedb677e9a0759ac6e7dd79ad5ce89",
+    "content-hash": "cdd20bd2cff3efd05e153c476ae4d665",
     "packages": [
         {
             "name": "carlo/jquery-base64-file",
@@ -792,11 +792,11 @@
         },
         {
             "name": "jquery/jquery-min-file",
-            "version": "1.12.4",
+            "version": "3.7.1",
             "dist": {
                 "type": "file",
-                "url": "https://code.jquery.com/jquery-1.12.4.min.js",
-                "shasum": "5a9dcfbef655a2668e78baebeaa8dc6f41d8dabb"
+                "url": "https://code.jquery.com/jquery-3.7.1.min.js",
+                "shasum": "ee48592d1fff952fcf06ce0b666ed4785493afdc"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -4523,13 +4523,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "5.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer-el8.json
+++ b/composer-el8.json
@@ -7,7 +7,7 @@
         "greenlion/php-sql-parser": "~4.2",
         "highsoft/highcharts": "^4.2.5",
         "ircmaxell/password-compat": "~1",
-        "jquery/jquery-min-file": "^1.12.4",
+        "jquery/jquery-min-file": "^3.7.1",
         "justinrainbow/json-schema": "~5.2",
         "moment/moment-min-file": "^2.13.0",
         "moment/moment-timezone-min-file": "^0.5.4",
@@ -150,13 +150,13 @@
             "package": {
                 "name": "jquery/jquery-min-file",
                 "type": "vanilla-plugin",
-                "version": "1.12.4",
+                "version": "3.7.1",
                 "license": "MIT",
                 "homepage": "https://jquery.com",
                 "dist": {
-                    "url": "https://code.jquery.com/jquery-1.12.4.min.js",
+                    "url": "https://code.jquery.com/jquery-3.7.1.min.js",
                     "type": "file",
-                    "shasum": "5a9dcfbef655a2668e78baebeaa8dc6f41d8dabb"
+                    "shasum": "ee48592d1fff952fcf06ce0b666ed4785493afdc"
                 },
                 "require": {
                     "composer/installers": "~1.0"

--- a/composer-el8.lock
+++ b/composer-el8.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1aa2bd1eead6e666a7169bfd29500487",
+    "content-hash": "6763867ffbae38ce856d44bb6b5912df",
     "packages": [
         {
             "name": "carlo/jquery-base64-file",
@@ -867,11 +867,11 @@
         },
         {
             "name": "jquery/jquery-min-file",
-            "version": "1.12.4",
+            "version": "3.7.1",
             "dist": {
                 "type": "file",
-                "url": "https://code.jquery.com/jquery-1.12.4.min.js",
-                "shasum": "5a9dcfbef655a2668e78baebeaa8dc6f41d8dabb"
+                "url": "https://code.jquery.com/jquery-3.7.1.min.js",
+                "shasum": "ee48592d1fff952fcf06ce0b666ed4785493afdc"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -4738,12 +4738,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^5.4 || ^7.2"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/html/gui/js/AddDataPanel.js
+++ b/html/gui/js/AddDataPanel.js
@@ -82,8 +82,8 @@ Ext.apply(CCR.xdmod.ui.AddDataPanel, {
     },
     initRecord: function (store, config, selectedFilters, timeseries) {
         var conf = {};
-        jQuery.extend(true, conf, CCR.xdmod.ui.AddDataPanel.defaultConfig(timeseries));
-        if (config) jQuery.extend(true, conf, config);
+        XDMoD.utils.deepExtend(conf, CCR.xdmod.ui.AddDataPanel.defaultConfig(timeseries));
+        if (config) XDMoD.utils.deepExtend(conf, config);
         conf.id = CCR.randomInt(Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
         conf.z_index = store.getCount();
         conf.filters = selectedFilters ? selectedFilters : {
@@ -102,7 +102,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
         if (this.filtersStore) {
             this.filtersStore.each(
                 function (record) {
-                    var data = jQuery.extend({}, record.data);
+                    var data = {...{}, ...record.data}
                     ret.push(data);
                 });
         }
@@ -129,7 +129,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
             this.record = CCR.xdmod.ui.AddDataPanel.initRecord(this.store, this.config, this.getSelectedFilters(), this.timeseries);
         }
         this.originalData = {};
-        jQuery.extend(this.originalData, this.record.data);
+        this.originalData = {...this.originalData, ...this.record.data };
         this.filtersMenu = new Ext.menu.Menu({
             showSeparator: false,
             ignoreParentClicks: true
@@ -305,7 +305,7 @@ Ext.extend(CCR.xdmod.ui.AddDataPanel, Ext.Panel, {
             ])
         });
         if (this.record.data.filters) {
-            var currentFilters = jQuery.extend({}, this.record.data.filters);
+            var currentFilters = { ...{}, ...this.record.data.filters };
             this.filtersStore.loadData(currentFilters, false);
         }
         var selectAllButton = new Ext.Button({

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -686,6 +686,12 @@ XDMoD.utils.format = {
     }
 };
 
+// Taken from: https://github.com/HubSpot/YouMightNotNeedjQuery, which
+// is available under the MIT license.
+// Recommended by @versable on https://github.com/ubccr/xdmod/pull/1542
+XDMoD.utils.deepExtend = function extend(out, ...arguments_) {
+    return jQuery.extend(true, out, ...arguments_);
+};
 // =====================================================================
 
 Ext.Ajax.timeout = 86400000;

--- a/html/gui/js/HighChartPanel.js
+++ b/html/gui/js/HighChartPanel.js
@@ -14,7 +14,7 @@ CCR.xdmod.ui.HighChartPanel = function (config) {
 }; // CCR.xdmod.ui.HighChartPanel
 
 
-// Set options globally for all charts instantiated afterwards: 
+// Set options globally for all charts instantiated afterwards:
 Highcharts.setOptions ({
     lang: {
         // commas for thousands separators
@@ -39,7 +39,7 @@ Ext.extend(CCR.xdmod.ui.HighChartPanel, Ext.Panel, {
 
         var self = this;
 
-        this.baseChartOptions = jQuery.extend(true, {}, {
+        this.baseChartOptions = XDMoD.utils.deepExtend({}, {
             chart: {
                 renderTo: this.id,
                 width: this.width,
@@ -88,12 +88,7 @@ Ext.extend(CCR.xdmod.ui.HighChartPanel, Ext.Panel, {
                     if (t.getCount() <= 0) {
                         return;
                     }
-                    this.chartOptions = jQuery.extend(true, {}, this.baseChartOptions, t.getAt(0).data);
-
-                    this.chartOptions.exporting.enabled = (this.exporting === true);
-                    this.chartOptions.credits.enabled = (this.credits === true);
-
-                    this.chartOptions.title.text = this.highChartsTextEncode(this.chartOptions.title.text);
+                    this.highChartsTextEncode(this.chartOptions.title.text);
                     this.isEmpty = this.chartOptions.series && this.chartOptions.series.length === 0;
 
                     this.initNewChart.call(this);
@@ -127,9 +122,9 @@ Ext.extend(CCR.xdmod.ui.HighChartPanel, Ext.Panel, {
         }
         var finalChartOptions = {};
         if (chartOptions) {
-            jQuery.extend(true, finalChartOptions, this.baseChartOptions, chartOptions);
+            XDMoD.utils.deepExtend(this.baseChartOptions, chartOptions);
         } else {
-            jQuery.extend(true, finalChartOptions, this.baseChartOptions, this.chartOptions);
+            XDMoD.utils.deepExtend(finalChartOptions, this.baseChartOptions, this.chartOptions);
         }
         this.chart = XDMoD.utils.createChart(finalChartOptions);
     },

--- a/html/gui/js/HighChartWrapper.js
+++ b/html/gui/js/HighChartWrapper.js
@@ -168,7 +168,7 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
         }
     }
 
-    XDMoD.utils.deepExtend(baseChartOptions, chartOptions);
+    jQuery.extend(baseChartOptions, chartOptions);
 
     if (extraHandlers) {
         if (extraHandlers.loadHandlers) {

--- a/html/gui/js/HighChartWrapper.js
+++ b/html/gui/js/HighChartWrapper.js
@@ -168,7 +168,7 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
         }
     }
 
-    jQuery.extend(true, baseChartOptions, chartOptions);
+    XDMoD.utils.deepExtend(baseChartOptions, chartOptions);
 
     if (extraHandlers) {
         if (extraHandlers.loadHandlers) {

--- a/html/gui/js/modules/Usage.js
+++ b/html/gui/js/modules/Usage.js
@@ -1538,7 +1538,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
                                 if (chartRecords.length > 0) {
                                     chartOptions = chartRecords[0].get('hc_jsonstore');
                                 }
-                                jQuery.extend(true, chartOptions, baseChartOptions);
+                                XDMoD.utils.deepExtend(chartOptions, baseChartOptions);
 
                                 chartOptions.exporting.enabled = false;
                                 chartOptions.credits.enabled = false;
@@ -2753,7 +2753,7 @@ Ext.extend(XDMoD.Module.Usage, XDMoD.PortalModule, {
 
                             var chartOptions = r.get('hc_jsonstore');
 
-                            jQuery.extend(true, chartOptions, baseChartOptions);
+                            XDMoD.utils.deepExtend(chartOptions, baseChartOptions);
                             chartOptions.exporting.enabled = false;
                             chartOptions.credits.enabled = true;
 

--- a/html/gui/js/modules/dashboard/ChartComponent.js
+++ b/html/gui/js/modules/dashboard/ChartComponent.js
@@ -43,7 +43,7 @@ XDMoD.Module.Dashboard.ChartComponent = Ext.extend(CCR.xdmod.ui.Portlet, {
         this.title += ' - ' + this.config.chart.start_date + ' to ' + this.config.chart.end_date;
 
         var highchartConfig = {};
-        jQuery.extend(true, highchartConfig, this.config.chart);
+        XDMoD.utils.deepExtend(highchartConfig, this.config.chart);
         highchartConfig.title = '';
 
         this.store = new CCR.xdmod.CustomJsonStore({

--- a/html/gui/js/modules/job_viewer/ChartTab.js
+++ b/html/gui/js/modules/job_viewer/ChartTab.js
@@ -75,7 +75,7 @@ XDMoD.Module.JobViewer.ChartTab = Ext.extend(Ext.Panel, {
             }
         };
 
-        var storeSettings = jQuery.extend(true, {}, defaultStoreSettings, this.panelSettings.store);
+        var storeSettings = XDMoD.utils.deepExtend({}, defaultStoreSettings, this.panelSettings.store);
 
         this.store = new Ext.data.JsonStore(storeSettings);
 

--- a/html/gui/js/modules/metric_explorer/MetricExplorer.js
+++ b/html/gui/js/modules/metric_explorer/MetricExplorer.js
@@ -801,7 +801,7 @@ Ext.apply(XDMoD.Module.MetricExplorer, {
                                 if (datasetCount === 1) {
                                     instance.filtersStore.add(new instance.filtersStore.recordType(filter));
                                 } else if (datasetCount > 1) {
-                                    var filters = jQuery.extend(true, {}, record.get('filters')),
+                                    var filters = XDMoD.utils.deepExtend({}, record.get('filters')),
                                         found = false;
                                     for (var i = 0; i < filters.length; i++) {
                                         if (filters[i].id == filter.id) {
@@ -858,8 +858,8 @@ Ext.apply(XDMoD.Module.MetricExplorer, {
                                 metric: this.met,
                                 color: 'auto'
                             };
-                        jQuery.extend(config, record.data);
-                        jQuery.extend(config, defaultConfig);
+                        XDMoD.utils.deepExtend(config, record.data);
+                        XDMoD.utils.deepExtend(config, defaultConfig);
                         var newRecord = CCR.xdmod.ui.AddDataPanel.initRecord(
                             instance.datasetStore,
                             config,
@@ -1146,7 +1146,7 @@ Ext.apply(XDMoD.Module.MetricExplorer, {
             });
             if (dimension !== 'none') {
                 if (instance.filtersStore.getById(drillFilter.id) === undefined) {
-                    var filters = jQuery.extend(true, {}, record.get('filters')),
+                    var filters = XDMoD.utils.deepExtend({}, record.get('filters')),
                         found = false;
                     for (var k = 0; k < filters.length; k++) {
                         if (filters[k].id == drillFilter.id) {

--- a/html/highchart_template.html
+++ b/html/highchart_template.html
@@ -47,7 +47,7 @@
 
             };//chartOptions
 
-            jQuery.extend(true,inputChartOptions,chartOptions);
+            XDMoD.utils.deepExtend(inputChartOptions,chartOptions);
 
             // Needed to provide comma as thousands separator in export
             Highcharts.setOptions ({

--- a/html/highchart_template.html
+++ b/html/highchart_template.html
@@ -6,7 +6,7 @@
       <title>Highcharts Template</title>
 
       <style type="text/css">html,body{margin:0px;height:100%;}</style>
-      <script type="text/javascript" src="_html_dir_/gui/lib/jquery/jquery-1.12.4.min.js"></script>
+      <script type="text/javascript" src="_html_dir_/gui/lib/jquery/jquery-3.7.1.min.js"></script>
       <script type="text/javascript" src="_html_dir_/gui/js/StringExtensions.js"></script>
 
       <script type="text/javascript">
@@ -21,58 +21,54 @@
 
          // _ chartOptions _ is a macro that is substituted by \xd_charting\exportHighchart()
          var inputChartOptions = _chartOptions_;
-
-         $(document).ready(function() {
-
+        document.addEventListener('DOMContentLoaded', function() {
             var chartOptions = {
 
-               chart: {
-                  renderTo: 'container',
-                  animation: false
-               },
+                chart: {
+                    renderTo: 'container',
+                    animation: false
+                },
 
-               plotOptions: {
-                  series: {
-                     animation: false,
-                     turboThreshold: 0
-                  }
-               },
+                plotOptions: {
+                    series: {
+                        animation: false,
+                        turboThreshold: 0
+                    }
+                },
 
-               exporting: {
-                  width: _width_,
-                  height: _height_,
-                  sourceWidth: _width_,
-                  sourceHeight: _height_
-               }
+                exporting: {
+                    width: _width_,
+                    height: _height_,
+                    sourceWidth: _width_,
+                    sourceHeight: _height_
+                }
 
             };//chartOptions
 
-            XDMoD.utils.deepExtend(inputChartOptions,chartOptions);
+            jQuery.extend(inputChartOptions,chartOptions);
 
             // Needed to provide comma as thousands separator in export
             Highcharts.setOptions ({
-               lang: {
-                  thousandsSep: '\u002c' // the humble comma
-               }
+                lang: {
+                    thousandsSep: '\u002c' // the humble comma
+                }
             });
 
             var globalChartOptions = _globalChartOptions_;
             if (globalChartOptions) {
-               Highcharts.setOptions({
-                  global: globalChartOptions
-               });
+                Highcharts.setOptions({
+                    global: globalChartOptions
+                });
             }
 
             if (inputChartOptions.series.length == 0) {
-               inputChartOptions.title.text = 'No data available for the critera specified';
-               inputChartOptions.title.verticalAlign = 'middle';
-               inputChartOptions.title.floating = true;
-               inputChartOptions.title.style = { "color": "#333333", "fontSize": "40px" }
+                inputChartOptions.title.text = 'No data available for the critera specified';
+                inputChartOptions.title.verticalAlign = 'middle';
+                inputChartOptions.title.floating = true;
+                inputChartOptions.title.style = { "color": "#333333", "fontSize": "40px" }
             }
             chart = XDMoD.utils.createChart(inputChartOptions);
-
-         });//$(document).ready(...
-
+        });
       </script>
 
    </head>
@@ -85,6 +81,7 @@
       <script type="text/javascript" src="_html_dir_/gui/js/HighChartWrapper.js"></script>
 
       <!-- needed for getSVG() -->
+      <script type="text/javascript" src="_html_dir/gui/js/CCR.js"></script>
       <script type="text/javascript" src="_html_dir_/gui/lib/highcharts/js/modules/exporting.src.js"></script>
       <script type="text/javascript" src="_html_dir_/gui/lib/highcharts/js/highcharts-more.js"></script>
       <script type="text/javascript" src="_html_dir_/gui/lib/highchartsDottedLineNullPlot.src.js"></script>

--- a/html/index.php
+++ b/html/index.php
@@ -123,7 +123,7 @@ $page_title = xd_utilities\getConfiguration('general', 'title');
     ExtJS::loadSupportScripts('gui/lib');
     ?>
     <script type="text/javascript" src="gui/lib/ext-oldie-history-patch.js"></script>
-    <script type="text/javascript" src="gui/lib/jquery/jquery-1.12.4.min.js"></script>
+    <script type="text/javascript" src="gui/lib/jquery/jquery-3.7.1.min.js"></script>
     <?php if ($userLoggedIn): ?>
         <script type="text/javascript" src="gui/lib/jquery-plugins/base64/jquery.base64.js"></script>
     <?php endif; ?>

--- a/html/internal_dashboard/index.php
+++ b/html/internal_dashboard/index.php
@@ -28,7 +28,7 @@ require_once 'user_check.php';
   <script type="text/javascript" src="../gui/lib/internet-explorer-polyfills.js"></script>
   <?php ExtJS::loadSupportScripts('../gui/lib'); ?>
   <script type="text/javascript" src="../gui/lib/ext-oldie-history-patch.js"></script>
-  <script type="text/javascript" src="../gui/lib/jquery/jquery-1.12.4.min.js"></script>
+  <script type="text/javascript" src="../gui/lib/jquery/jquery-3.7.1.min.js"></script>
 
   <script type="text/javascript">
     jQuery.noConflict();

--- a/html/password_reset.php
+++ b/html/password_reset.php
@@ -7,7 +7,7 @@
    */
 
 	require_once dirname(__FILE__).'/../configuration/linker.php';
-	
+
 	$page_title = xd_utilities\getConfiguration('general', 'title');
 	$site_address = xd_utilities\getConfigurationUrlBase('general', 'site_address');
 
@@ -25,50 +25,50 @@ if ($rid === false) {
 
 
 	// -------------------------------
-   
+
    if ($validationCheck['status'] == INVALID) {
-   
+
 ?>
 <html>
 
    <head>
-				
+
       <link rel="shortcut icon" href="gui/icons/favicon_static.ico" />
-					
+
       <style type="text/css">
-			
+
          body, table {
-         
+
             font-family: helvetica;
             font-size: 12px;
-               
+
          }
-					    
+
       </style>
-		
+
       <title><?php print $page_title; ?></title>
-				
+
    </head>
-   
+
    <body bgcolor="#ffeeee">
-				
+
       <table width=100%>
-         <tr><td align=right><a href="index.php"><img src="gui/images/xdmod_mini.png" border=0></a></td></tr>   
+         <tr><td align=right><a href="index.php"><img src="gui/images/xdmod_mini.png" border=0></a></td></tr>
       </table>
-      
+
       <center>
-      
+
          <br><br>
-      
+
          <font color="#ff0000">The page you are trying to access has already expired.<br><br>
             If you still need to reset your password, visit the <a href="<?php print $site_address; ?>">login page</a> and click on <b>Problem Logging In?</b> below the login prompt.
          </font>
-         
+
       </center>
-					
+
    </body>
-   
-</html>		
+
+</html>
 <?php
 
       exit;
@@ -76,11 +76,11 @@ if ($rid === false) {
 		}//if (INVALID)
 
       $first_name = $validationCheck['user_first_name'];
-      
+
       $mode = ( isset($_GET['mode']) && ($_GET['mode'] == 'new') ) ? 'create' : 'reset';
-      
-      
-      
+
+
+
 ?>
 <html>
 
@@ -89,19 +89,19 @@ if ($rid === false) {
       <meta charset="UTF-8" />
 
       <link rel="shortcut icon" href="gui/icons/favicon_static.ico" />
-            
+
       <?php
          ExtJS::loadSupportScripts('gui/lib');
       ?>
-	  
-      <script type="text/javascript" src="gui/lib/jquery/jquery-1.12.4.min.js"></script>
+
+      <script type="text/javascript" src="gui/lib/jquery/jquery-3.7.1.min.js"></script>
       <script type="text/javascript" src="gui/lib/PasswordStrengthMeter.js"></script>
-      
+
       <link rel="stylesheet" type="text/css" href="gui/css/PasswordReset.css">
 
       <!--[if IE]>
       <style type="text/css">
-         
+
          .passStrength {
             padding-top: 2px;
          }
@@ -112,7 +112,7 @@ if ($rid === false) {
       <script language="JavaScript">
          var reset_id = <?php print json_encode($rid); ?>;
       </script>
-      
+
       <script type="text/javascript" src="gui/js/PasswordReset.js"></script>
 
       <title><?php print "$page_title: ".ucfirst($mode); ?> Password</title>
@@ -122,26 +122,26 @@ if ($rid === false) {
 	<body onload="initPage()">
 
       <table width=100%>
-      
+
          <tr>
             <td align=left><img src="gui/images/<?php print $mode; ?>_password.png"></td>
             <td align=right><a href="index.php"><img src="gui/images/xdmod_mini.png" border=0></a></td>
-         </tr>   
-         
+         </tr>
+
       </table>
-               
+
       <center>
-		
+
          <br><br>
          Welcome, <?php print $first_name; ?>. To <?php print $mode; ?> your password, supply a new password below and click on <b>Update</b>.<br><br>
-		
+
          <div class="splashContainer loginSection">
-                  
+
             <div>
                <table border=0 width=100%>
-               
-                  <tr><td align="center" colspan=3 style="padding-bottom: 7px"><b><?php print ucwords($mode); ?> Your Password</b></td></tr>  
-                  
+
+                  <tr><td align="center" colspan=3 style="padding-bottom: 7px"><b><?php print ucwords($mode); ?> Your Password</b></td></tr>
+
                   <tr>
                      <td align="left" width=100>Password:</td>
                      <td align="left">
@@ -149,7 +149,7 @@ if ($rid === false) {
                      </td>
                      <td align="left"><i><span id="stat_updated_password" class="fieldRestrictions">5 characters min.</span></i></td>
                   </tr>
-                  
+
                   <tr>
                      <td align="left">&nbsp</td>
                      <td align="left">
@@ -158,7 +158,7 @@ if ($rid === false) {
                            <td valign="middle"><div class="passStrength" id="strengthIndicator">password not specified</div></td>
                         </tr></table>
                      </td>
-                  </tr>                        
+                  </tr>
                   <tr>
                      <td align="left" width=100>Password Again:</td>
                      <td align="left">
@@ -166,18 +166,18 @@ if ($rid === false) {
                      </td>
                      <td align="left"><i><span id="stat_updated_password_repeat" class="fieldRestrictions">5 characters min.</span></i></td>
                   </tr>
-                  
+
                   <tr>
                      <td colspan="3" align="center" style="padding-top: 8px">
                         <input type="button" class="customButton" value="Update" onClick="performReset()">
                      </td>
                   </tr>
-                  
+
                </table>
-            </div>        
-                
-         </div>    
-          
+            </div>
+
+         </div>
+
 		</center>
 
    </body>


### PR DESCRIPTION
## Description
These changes backport a fix that's already been merged into `main` that updates jQuery to 3.7.1 so as to not be vulnerable to `CVE-2020-11023`.

## Motivation and Context
less vulnerabilities the better.

## Tests performed

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
