### PR TITLE
Fix user update logic

### DIFF
--- a/classes/Models/Services/Organizations.php
+++ b/classes/Models/Services/Organizations.php
@@ -46,7 +46,7 @@ SQL;
      * $organizationName.
      *
      * @param string $organizationName the name of the organization to retrieve.
-     * @return int -1 if no record is found else the organization_id as an int.
+     * @return string '-1' if no record is found else the organization_id as a string.
      * @throws \Exception if there is a problem retrieving a db connection.
      * @throws \Exception if there is a problem executing the sql statement.
      */
@@ -57,7 +57,7 @@ SQL;
             "SELECT o.id FROM modw.organization o WHERE o.name = :organization_name;",
             array(':organization_name' => $organizationName)
         );
-        return !empty($rows) ? $rows[0]['id'] : -1;
+        return !empty($rows) ? $rows[0]['id'] : '-1';
     }
 
     /**
@@ -82,7 +82,7 @@ SQL;
      * Attempt to retrieve the organization_id for the specified person_id.
      *
      * @param int $personId
-     * @return int id of the organization or -1 if not found
+     * @return string id of the organization or '-1' if not found
      * @throws \Exception
      */
     public static function getOrganizationIdForPerson($personId)
@@ -95,6 +95,6 @@ SQL;
             )
         );
 
-        return count($rows) > 0 ? $rows[0]['organization_id'] : -1;
+        return count($rows) > 0 ? $rows[0]['organization_id'] : '-1';
     }
 }

--- a/classes/XDUser.php
+++ b/classes/XDUser.php
@@ -2469,7 +2469,7 @@ SQL;
 
         // If we have ssoAttrs available and this user's person's organization is 'Unknown' ( -1 ).
         // Then go ahead and lookup the organization value from sso.
-        if ($expectedOrganization == -1 && count($this->ssoAttrs) > 0) {
+        if ($expectedOrganization == -1 && isset($this->ssoAttrs['organization']) && count($this->ssoAttrs['organization']) > 0) {
             $expectedOrganization = Organizations::getIdByName($this->ssoAttrs['organization'][0]);
         }
 


### PR DESCRIPTION
## Description

Couple of clangers in the user organization update logic: The Organizations class functions `getIdByName()` and `getOrganizationIdForPerson()` claimed to return int values, but actually returned string values except if the database lookup failed in which case they did return strings. Turns out the organization_id values are stored as stings elsewhere in the code so changed these to return strings when the db lookup failed.

The guard logic in the XDUser class for SSO attributes was insufficient.