### PR TITLE
Add ability to add additional database migration classes.

### DIFF
--- a/classes/OpenXdmod/Migration/MigrationFactory.php
+++ b/classes/OpenXdmod/Migration/MigrationFactory.php
@@ -65,7 +65,7 @@ class MigrationFactory
                     $toVersion
                 );
 
-                // Run each of the other DatabasesMigration classes in the
+                // Add each of the other DatabasesMigration classes in the
                 // namespace.
                 $databasesMigrationClasses = array_filter(
                     get_declared_classes(),

--- a/classes/OpenXdmod/Migration/MigrationFactory.php
+++ b/classes/OpenXdmod/Migration/MigrationFactory.php
@@ -64,6 +64,18 @@ class MigrationFactory
                     $fromVersion,
                     $toVersion
                 );
+
+                foreach (['AppKernels', 'Supremm', 'OnDemand'] as $module) {
+                    $moduleDatabasesMigrationName = $ns . '\\' . $module . 'DatabasesMigration';
+                    if (class_exists($moduleDatabasesMigrationName)) {
+                        $msg = "Using databases migration '$moduleDatabasesMigrationName'";
+                        $logger->debug($msg);
+                        $migrations[] = new $moduleDatabasesMigrationName(
+                            $fromVersion,
+                            $toVersion
+                        );
+                    }
+                }
             }
             $migrations[] = new \OpenXdmod\Migration\Etlv2Migration($fromVersion, $toVersion);
         }

--- a/classes/OpenXdmod/Migration/MigrationFactory.php
+++ b/classes/OpenXdmod/Migration/MigrationFactory.php
@@ -67,12 +67,20 @@ class MigrationFactory
 
                 // Add each of the other DatabasesMigration classes in the
                 // namespace.
+                $classes = array_map(
+                    function($file) use ($ns) {
+                        return $ns . '\\' . rtrim(basename($file), '.php');
+                    },
+                    glob(__DIR__ . "/Version{$from}To$to/*.php")
+                );
                 $databasesMigrationClasses = array_filter(
-                    get_declared_classes(),
-                    function ($class) use ($ns, $databasesMigrationName) {
-                        return strpos("\\$class", $ns) === 0
-                            && substr("\\$class", -strlen('DatabasesMigration')) === 'DatabasesMigration'
-                            && "\\$class" !== $databasesMigrationName;
+                    $classes,
+                    function ($class) use ($databasesMigrationName) {
+                        return (
+                            substr($class, -strlen('DatabasesMigration')) === 'DatabasesMigration'
+                            && class_exists($class)
+                            && $class !== $databasesMigrationName
+                        );
                     }
                 );
                 sort($databasesMigrationClasses);

--- a/classes/OpenXdmod/Migration/MigrationFactory.php
+++ b/classes/OpenXdmod/Migration/MigrationFactory.php
@@ -68,7 +68,7 @@ class MigrationFactory
                 // Add each of the other DatabasesMigration classes in the
                 // namespace.
                 $classes = array_map(
-                    function($file) use ($ns) {
+                    function ($file) use ($ns) {
                         return $ns . '\\' . rtrim(basename($file), '.php');
                     },
                     glob(__DIR__ . "/Version{$from}To$to/*.php")


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR adds the ability to add additional database migration classes by defining them in the same namespace and ending their names with `DatabasesMigration`.

This is useful for, e.g., https://github.com/ubccr/xdmod-ondemand/pull/84.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested https://github.com/ubccr/xdmod-ondemand/pull/84 in tandem with this PR.