### PR TITLE
Add explicit transactions to the StructuredFile ingestor

### DIFF
--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -298,6 +298,8 @@ class StructuredFileIngestor extends aIngestor implements iAction
 
         $warnings = array();
 
+        $this->destinationHandle->beginTransaction();
+
         foreach ( $this->sourceEndpoint as $sourceRecord ) {
 
             // The same source record may be used in multiple tables.
@@ -335,6 +337,13 @@ class StructuredFileIngestor extends aIngestor implements iAction
                 }
             }
             $numRecords++;
+        }
+
+        try {
+            $this->destinationHandle->commit();
+        } catch (PDOException $e) {
+            $this->logger->warning('Trouble commiting transaction. Rolling back');
+            $this->destinationHandle->rollback();
         }
 
         foreach ( $warnings as $table => $message) {


### PR DESCRIPTION
This adds an explicit transaction for the StructuredFile Ingestor. By default, PDO is set to auto-commit mode meaning that every query that run has its own implicit transaction. If the files you are ingesting has a lot rows there can be significant performance hit because it is writing to the commit log for each insert as well as the database. By setting the transaction before the inserts start auto commit is turned off and when commit is called it will write to the commit log once, providing significant performance improvement of ingestion. 

Many of the changes here are existing code moving to a different line or indenting of existing code because of the addition of a try catch statement.

## Motivation and Context
This change provides significant performance improvements. In testing with some cloud logs the insert time for a file with ~20,000 records went from ~2 minutes to ~10-20 seconds.

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
