### PR TITLE
Improving transaction error handling in StructuredFileIngestor

### DIFF
--- a/classes/ETL/Ingestor/StructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/StructuredFileIngestor.php
@@ -346,12 +346,12 @@ class StructuredFileIngestor extends aIngestor implements iAction
             }
 
             $this->destinationHandle->commit();
-        } catch (PDOException $e) {
+        } catch (Exception $e) {
+            $this->destinationHandle->rollback();
             $this->logAndThrowException(
                 "Error committing transaction. Rolling back transactions.",
                 array('exception' => $e, 'endpoint' => $this)
             );
-            $this->destinationHandle->rollback();
         }
 
         foreach ( $warnings as $table => $message) {


### PR DESCRIPTION
The call to rollback needs to be before the `logAndThrowException` call and it should catch all exceptions not just PDOException so that it can catch exceptions thrown on line 329.

## Tests performed
Tested in docker by adding a `throw new PDOException` in the try catch on line 323 and in the for loop on line 313

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
