### PR TITLE
Fix date in spec changelog.

### DIFF
--- a/open_xdmod/modules/xdmod/xdmod.spec.in
+++ b/open_xdmod/modules/xdmod/xdmod.spec.in
@@ -105,7 +105,7 @@ rm -rf $RPM_BUILD_ROOT
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
 - Release 10.5.0
 - Add support for checking rpm install state in check-config
-* Fri Aug 8 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.3-1.0
+* Fri Aug 4 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.3-1.0
 - Release 10.0.3
 * Mon Apr 3 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.2-1.0
 - Release 10.0.2


### PR DESCRIPTION
This PR fixes a date in the spec file's changelog. This fixes a warning when building the RPM: `warning: bogus date in %changelog`.