### PR TITLE
Update docs.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,8 +36,10 @@ defaults:
       type: "pages"
     values:
       layout: "page"
+      version: "11.0"
       prev_sw_version: "10.5.1"
       sw_version: "11.0.1"
+      rpm_version: "11.0.1-1"
       style: "effervescence"
       tocversion: "v11_0toc"
 

--- a/docs/dev-code-organization.md
+++ b/docs/dev-code-organization.md
@@ -15,7 +15,7 @@ installed files.
 
 [fhs]: http://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
 
-The "Source Installation" paths listed below assume that `/opt/xdmod`
+The "Source Installation" paths listed below assume that `/opt/xdmod-{{ page.sw_version }}`
 has been used as the installation prefix.
 
 Non-User Executables
@@ -23,28 +23,28 @@ Non-User Executables
 
 - Source Tarball: `background_scripts/`
 - RPM Installation: `/usr/lib/xdmod/`
-- Source Installation: `/opt/xdmod/lib/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/lib/`
 
 User Executables
 -----------------
 
 - Source Tarball: `bin/`
 - RPM Installation: `/usr/bin/`
-- Source Installation: `/opt/xdmod/bin/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/bin/`
 
 PHP Classes
 -----------
 
 - Source Tarball: `classes/`
 - RPM Installation: `/usr/share/xdmod/classes/`
-- Source Installation: `/opt/xdmod/share/classes/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/classes/`
 
 Configuration Files
 -------------------
 
 - Source Tarball: `configuration/`
 - RPM Installation: `/etc/xdmod`
-- Source Installation: `/opt/xdmod/etc/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/etc/`
 
 The following configuration files are also installed by the RPM:
 
@@ -59,7 +59,7 @@ Database schema files, data files and database migrations.
 
 - Source Tarball: `db/`
 - RPM Installation: `/usr/share/xdmod/db/`
-- Source Installation: `/opt/xdmod/share/db/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/db/`
 
 Documentation
 -------------
@@ -69,7 +69,7 @@ files.
 
 - Source Tarball: `docs/`
 - RPM Installation: `/usr/share/doc/xdmod-{{ page.sw_version }}/`
-- Source Installation: `/opt/xdmod/share/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/`
 
 External Libraries
 ------------------
@@ -78,7 +78,7 @@ Various open source libraries used by Open XDMoD.
 
 - Source Tarball: `external_libraries/`
 - RPM Installation: `/usr/share/xdmod/external_libraries/`
-- Source Installation: `/opt/xdmod/share/external_libraries/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/external_libraries/`
 
 HTML
 ----
@@ -87,7 +87,7 @@ HTML files used by the Open XDMoD portal.
 
 - Source Tarball: `html/`
 - RPM Installation: `/usr/share/xdmod/html/`
-- Source Installation: `/opt/xdmod/share/html/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/html/`
 
 Open XDMoD Libraries
 --------------------
@@ -96,21 +96,21 @@ Non-class PHP code.
 
 - Source Tarball: `libraries/`
 - RPM Installation: `/usr/share/xdmod/libraries/`
-- Source Installation: `/opt/xdmod/share/libraries/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/libraries/`
 
 Log Files
 ---------
 
 - Source Tarball: `logs/`
 - RPM Installation: `/var/log/xdmod/`
-- Source Installation: `/opt/xdmod/logs/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/logs/`
 
 Report Generator Code
 ---------------------
 
 - Source Tarball: `reporting/`
 - RPM Installation: `/usr/share/xdmod/reporting/`
-- Source Installation: `/opt/xdmod/share/reporting/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/reporting/`
 
 Configuration Templates
 ------------------------
@@ -119,4 +119,4 @@ Template files used by `xdmod-setup` to generate config files.
 
 - Source Tarball: `templates/`
 - RPM Installation: `/usr/share/xdmod/templates/`
-- Source Installation: `/opt/xdmod/share/templates/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/templates/`

--- a/docs/docs-conventions.md
+++ b/docs/docs-conventions.md
@@ -15,7 +15,7 @@ prefixed with a dollar sign (`$`). e.g.:
 Examples of commands that must be run with root privileges are prefixed
 with a number sign (`#`). e.g.:
 
-    # ./install --prefix=/opt/xdmod
+    # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 These commands may be run with `sudo` or `su`.
 
@@ -27,9 +27,9 @@ is not the case. For example, the following:
 
 Would need to be changed to:
 
-    # /opt/xdmod/bin/xdmod-setup
+    # /opt/xdmod-{{ page.sw_version }}/bin/xdmod-setup
 
-If you installed Open XDMoD in `/opt/xdmod`.
+If you installed Open XDMoD in `/opt/xdmod-{{ page.sw_version }}`.
 
 If you installed the Open XDMoD RPM package, these commands will be
 placed in `/usr/bin` which is most likely already in your `PATH`.

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -10,6 +10,9 @@ See the [Software Requirements](software-requirements.html) for details.
 Install the RPM
 ---------------
 
+The RPM package can be downloaded from
+[GitHub](https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}).
+
     # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 
 Configure Open XDMoD

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -10,7 +10,7 @@ See the [Software Requirements](software-requirements.html) for details.
 Install the RPM
 ---------------
 
-    # dnf install xdmod-{{ page.sw_version }}-1.el8.noarch.rpm
+    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 
 Configure Open XDMoD
 --------------------

--- a/docs/install-source.md
+++ b/docs/install-source.md
@@ -7,11 +7,11 @@ Install Source Package
 
 Change the installation prefix as desired.  The default installation prefix is
 `/usr/local/xdmod`.  These instructions assume you are installing Open
-XDMoD in `/opt/xdmod`.
+XDMoD in `/opt/xdmod-{{ page.sw_version }}`.
 
     # tar zxvf xdmod-{{ page.sw_version }}-el8.tar.gz
     # cd xdmod-{{ page.sw_version }}
-    # ./install --prefix=/opt/xdmod
+    # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 Create Open XDMoD User And Group
 --------------------------------
@@ -20,12 +20,12 @@ For improved security, create an Open XDMoD user and group that will have
 access to sensitive data:
 
     # groupadd -r xdmod
-    # useradd -r -M -c "Open XDMoD" -g xdmod -d /opt/xdmod/lib -s /sbin/nologin xdmod
+    # useradd -r -M -c "Open XDMoD" -g xdmod -d /opt/xdmod-{{ page.sw_version }}/lib -s /sbin/nologin xdmod
 
 Secure the file containing database passwords:
 
-    # chmod 440 /opt/xdmod/etc/portal_settings.ini
-    # chown apache:xdmod /opt/xdmod/etc/portal_settings.ini
+    # chmod 440 /opt/xdmod-{{ page.sw_version }}/etc/portal_settings.ini
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/etc/portal_settings.ini
 
 **NOTE**: The `portal_settings.ini` file must be readable by Apache and any
 user that will run the Open XDMoD commands.  Replace the Apache username
@@ -40,26 +40,26 @@ out of your system and log back in for this change to take effect.
 
 Update log directory and file ownership and permissions:
 
-    # chmod 770 /opt/xdmod/logs
-    # chown apache:xdmod /opt/xdmod/logs
-    # touch /opt/xdmod/logs/exceptions.log
-    # chmod 660 /opt/xdmod/logs/exceptions.log
-    # chown apache:xdmod /opt/xdmod/logs/exceptions.log
-    # touch /opt/xdmod/logs/query.log
-    # chmod 660 /opt/xdmod/logs/query.log
-    # chown apache:xdmod /opt/xdmod/logs/query.log
+    # chmod 770 /opt/xdmod-{{ page.sw_version }}/logs
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/logs
+    # touch /opt/xdmod-{{ page.sw_version }}/logs/exceptions.log
+    # chmod 660 /opt/xdmod-{{ page.sw_version }}/logs/exceptions.log
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/logs/exceptions.log
+    # touch /opt/xdmod-{{ page.sw_version }}/logs/query.log
+    # chmod 660 /opt/xdmod-{{ page.sw_version }}/logs/query.log
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/logs/query.log
 
 The `exceptions.log` and `query.log` may be written to by both Apache and Open
 XDMoD commands.
 
 Update the bin directory permissions so that only users with the `xdmod` group can run Open XDMoD commands:
 
-    # chmod 750 /opt/xdmod/bin/*
+    # chmod 750 /opt/xdmod-{{ page.sw_version }}/bin/*
 
 Run Configuration Script
 ------------------------
 
-    # /opt/xdmod/bin/xdmod-setup
+    # /opt/xdmod-{{ page.sw_version }}/bin/xdmod-setup
 
 Complete each setup section with the required information.
 
@@ -68,11 +68,11 @@ See the [Configuration Guide](configuration.html) for more details.
 Copy Configuration Files
 ------------------------
 
-    # cp /opt/xdmod/share/templates/apache.conf /etc/apache2/conf.d/xdmod.conf
+    # cp /opt/xdmod-{{ page.sw_version }}/share/templates/apache.conf /etc/apache2/conf.d/xdmod.conf
 
-    # cp /opt/xdmod/etc/cron.d/xdmod /etc/cron.d/xdmod
+    # cp /opt/xdmod-{{ page.sw_version }}/etc/cron.d/xdmod /etc/cron.d/xdmod
 
-    # cp /opt/xdmod/etc/logrotate.d/xdmod /etc/logrotate.d/xdmod
+    # cp /opt/xdmod-{{ page.sw_version }}/etc/logrotate.d/xdmod /etc/logrotate.d/xdmod
 
 The directories where these files are needed may differ depending on
 your operating system.
@@ -97,13 +97,13 @@ PBS stores its accounting logs in a directory where the name of each
 file corresponds to the end date of the jobs it contains.  A directory
 such as this can be specified using the `-d` option:
 
-    $ /opt/xdmod/bin/xdmod-shredder -v -r *resource* -f pbs \
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-shredder -v -r *resource* -f pbs \
           -d /var/spool/pbs/server_priv/accounting
 
 SGE stores its accounting logs in a single file so the `-i` (input)
 option should be used:
 
-    $ /opt/xdmod/bin/xdmod-shredder -v -r *resource* -f sge \
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-shredder -v -r *resource* -f sge \
           -i /var/lib/gridengine/default/common/accounting
 
 Slurm stores its accounting logs in a database that can be queried using
@@ -111,7 +111,7 @@ the `sacct` command.  Since the accounting data is not directly
 accessible in files Open XDMoD provides a helper script that writes the
 data to a file and then shreds that file:
 
-    $ /opt/xdmod/bin/xdmod-slurm-helper -v -r *resource*
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-slurm-helper -v -r *resource*
 
 The resource name here must match the one supplied to the setup script.
 
@@ -123,7 +123,7 @@ using `ssh` with a public key to run the command on another machine).
 Ingest Data
 -----------
 
-    $ /opt/xdmod/bin/xdmod-ingestor -v
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-ingestor -v
 
 See the [Ingestor Guide](ingestor.html) for more details.
 

--- a/docs/install-source.md
+++ b/docs/install-source.md
@@ -5,11 +5,16 @@ title: Source Installation Guide
 Install Source Package
 ----------------------
 
-Change the installation prefix as desired.  The default installation prefix is
-`/usr/local/xdmod`.  These instructions assume you are installing Open
-XDMoD in `/opt/xdmod-{{ page.sw_version }}`.
+The source package can be downloaded from
+[GitHub](https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}).
+Make sure to download `xdmod-{{ page.sw_version }}.tar.gz`, not the
+GitHub-generated "Source code" files.
 
-    # tar zxvf xdmod-{{ page.sw_version }}-el8.tar.gz
+These instructions assume you are installing Open XDMoD in `/opt/xdmod-{{
+page.sw_version }}`. Change the installation prefix as desired. The default
+installation prefix is `/usr/local/xdmod`.
+
+    # tar zxvf xdmod-{{ page.sw_version }}.tar.gz
     # cd xdmod-{{ page.sw_version }}
     # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -33,9 +33,9 @@ General Upgrade Notes
   there may be version-specific upgrade notes. If you have installed any of the
   optional modules for Open XDMoD, they may have their own version-specific
   upgrade notes as well, see:
-    - [Application Kernels](https://appkernels.xdmod.org/ak-upgrade.html)
-    - [Job Performance (SUPReMM)](https://supremm.xdmod.org/supremm-upgrade.html)
-    - [OnDemand](https://ondemand.xdmod.org/upgrade.html)
+    - [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
+    - [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
+    - [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
 
 ## !!! XDMoD 11.0 Upgrade Process Changes !!!
 
@@ -121,8 +121,11 @@ Download available at [GitHub][github-release].
 
     # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 
-Likewise, install the latest `xdmod-appkernels`, `xdmod-supremm`, and/or
-`xdmod-ondemand` RPM files if you have those modules installed.
+If you have installed any of the optional modules for Open XDMoD, download and
+install their RPMs, too:
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-rpm.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
 
 After upgrading the package you may need to manually merge any files
 that you have manually changed before the upgrade.  You do not need to
@@ -363,5 +366,5 @@ will have the following columns added:
 
 Then, the Cloud realm will be reaggregated.
 
-[github-release]: https://github.com/ubccr/xdmod/releases/{{ page.rpm_version }}
+[github-release]: https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}
 [mysql-config]: configuration.md#mysql-configuration

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -33,14 +33,11 @@ General Upgrade Notes
   there may be version-specific upgrade notes. If you have installed any of the
   optional modules for Open XDMoD, they may have their own version-specific
   upgrade notes as well, see:
-    - [`xdmod-appkernels`](https://appkernels.xdmod.org/ak-upgrade.html)
-    - [`xdmod-supremm`](https://supremm.xdmod.org/supremm-upgrade.html)
-    - [`xdmod-ondemand`](https://ondemand.xdmod.org/upgrade.html)
+    - [Application Kernels](https://appkernels.xdmod.org/ak-upgrade.html)
+    - [Job Performance (SUPReMM)](https://supremm.xdmod.org/supremm-upgrade.html)
+    - [OnDemand](https://ondemand.xdmod.org/upgrade.html)
 
-RPM Upgrade Process
--------------------
-
-# !!! XDMoD 11.0 Upgrade Process Changes !!!
+## !!! XDMoD 11.0 Upgrade Process Changes !!!
 
 XDMoD 11.0 no longer supports the obsolete Centos 7 OS. XDMoD 11.0 is supported on
 Rocky 8 with the PHP version 7.4 that [is supported until May 2029](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle#rhel8_full_life_application_streams).
@@ -52,28 +49,32 @@ We support the following upgrade paths:
 If you run into any problems during your upgrade process, please submit a
 ticket to `ccr-xdmod-help@buffalo.edu` and we will do our best to help.
 
-
 ### Server: EL7, XDMoD: 10.5, PHP: 5.4, MySQL or MariaDB 5.5
+
 If you are using CentOS 7 and will upgrade to XDMoD 11.0 on Rocky 8, please follow the steps below.
 
 At the end of this process you should expect to have a working XDMoD 10.5 installation on a Rocky 8 server that
 contains all of your current data. After which you can then follow the upgrade procedure that immediately follows this
 section which starts at `Server: EL8, XDMoD: 10.5, PHP: 7.2`.
 
-1. Install a fresh copy of XDMoD 10.5 on a new Rocky 8 server [via RPM](10.5/install-rpm.md) or [from source](10.5/install-source.md).
+1. Install a fresh copy of XDMoD 10.5 on a new Rocky 8 server from
+   [RPM](../10.5/install-rpm.html) or [source](../10.5/install-source.html).
    1. Instead of running `xdmod-setup` do steps 2 & 3 below.
 2. Copy the contents of `/etc/xdmod` (or if you have a source install the contents of `/path/to/your/xdmod/etc/`) from the CentOS 7
    server to the Rocky 8 server.
     1. <span style="color: orange;">***NOTE:***</span>If the database host has changed then on the Rocky 8 Server,
        update the `host = ` entries in `/etc/xdmod/portal_settings.ini` to reflect this.
 3. Export the database from the CentOS 7 installation and transfer the files to the Rocky 8 server.
-    1. For example, `mysqldump --databases mod_hpcdb mod_logger moddb modw modw_aggregates modw_cloud modw_filters > backup.sql`
+    1. For example (noting that if you have the `xdmod-supremm` module
+       installed to add `modw_supremm` to the list of databases and if you have
+       the `xdmod-ondemand` module installed to add `modw_ondemand` to the list
+       of databases): `mysqldump --databases mod_hpcdb mod_logger moddb modw modw_aggregates modw_cloud modw_filters > backup.sql`
        1. To make the process of importing the data less error-prone, please update the following sed snippet with your installations MySQL user (`` `user`@`host` ``) and run it against the dumped sql file(s).
           ``sed -i 's|DEFINER=`xdmod`@`localhost`||g' backup.sql``
 4. Import the CentOS 7 exported database files into the Rocky 8 server's database.
     1. `mysql < backup.sql`
 5. **NOTE:** MariaDB / MySQL users are defined as `'username'@'hostname'` so if the hostname of the new Rocky 8 web server is different than the hostname of the old CentOS 7 web server, you will need to make sure that this change is reflected in the database.
-    1. Run the following from an account that has db admin privileges to ensure the XDMoD user is correct: `mysql -e "UPDATE mysql.user SET Host = '<insert new XDMoD web server hostname here>' WHERE username = 'xdmod';"`
+    1. Run the following from an account that has db admin privileges to ensure the XDMoD user is correct: `mysql -e "UPDATE mysql.user SET Host = '<insert new XDMoD web server hostname here>' WHERE username = 'xdmod'"`
 6. Restart the web server / database on the Rocky 8 server and confirm that everything is working as expected.
 7. Next, follow the upgrade process detailed below on the Rocky 8 Server.
 
@@ -93,14 +94,14 @@ $ dnf install -y php make libzip-devel php-pear php-devel
 ```
 
 Some Notes:
-- If you run the above command and dnf tells you that the packages are already installed, double-check the contents of
-  `/etc/dnf/dnf.conf` if `best=False` is present then change it to `best=True`. Re-run the command above, and it should
+- If you run the above command and `dnf` tells you that the packages are already installed, double-check the contents of
+  `/etc/dnf/dnf.conf`; if `best=False` is present then change it to `best=True` and re-run the command above, and it should
   now find / install the 7.4 version of the packages.
 - You may also see some `PHP: Warning` messages during this process, specifically:
 ```
 PHP Warning:  PHP Startup: Unable to load dynamic library 'mongodb.so' (tried: /usr/lib64/php/modules/mongodb.so (/usr/lib64/php/modules/mongodb.so: undefined symbol: _zval_ptr_dtor), /usr/lib64/php/modules/mongodb.so.so (/usr/lib64/php/modules/mongodb.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
 ```
-*Not to worry, this will be resolved by the next step*
+*Not to worry, this will be resolved by the next step.*
 
 Install the mongodb PHP Pear package
 ```shell
@@ -108,6 +109,9 @@ $ yes '' | pecl install mongodb-1.18.1
 ```
 
 You may now continue with the standard upgrade steps below.
+
+RPM Upgrade Process
+-------------------
 
 ### Download Latest Open XDMoD RPM package
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -18,9 +18,9 @@ General Upgrade Notes
       from 10.5.1 to 11.0.1, etc.).
 - If you need to jump more than one major release, you must incrementally
   upgrade to each of the intermediate major releases (or a minor release
-  thereof), e.g., if you want to upgrade from 9.5.0 to 11.5.0, then you must
+  thereof), e.g., if you want to upgrade from 9.5.0 to 11.0.0, then you must
   upgrade from 9.5.0 to 10.0.\*, then from 10.0.\* to 10.5.\*, then from
-  10.5.\* to 11.5.0.
+  10.5.\* to 11.0.0.
 - Make a backup of your Open XDMoD configuration files before running
   the upgrade script. The upgrade script may overwrite your current
   configuration files.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -7,8 +7,8 @@ General Upgrade Notes
 
 - Open XDMoD release numbers are of the form X.Y.Z.
     - New minor releases increment Z by 1, e.g., 10.0.0, 10.0.1, 10.0.2, etc.
-    - New major releases increment X.Y by 0.5 and reset Z to 0, e.g., 9.0.0,
-      9.5.0, 10.0.0, 10.5.0, etc.
+    - New major releases increment X.Y (usually by 0.5) and reset Z to 0, e.g.,
+      9.0.0, 9.5.0, 10.0.0, 10.5.0, etc.
 - Unless otherwise noted below, Open XDMoD only supports upgrades to:
     - Minor releases of the same major release (e.g., from 9.5.0 to 9.5.1,
       from 10.0.0 to 10.0.3, etc.),
@@ -21,11 +21,9 @@ General Upgrade Notes
   thereof), e.g., if you want to upgrade from 9.5.1 to 11.0.2, then you must
   upgrade from 9.5.1 to 10.0.\*, then from 10.0.\* to 10.5.\*, then from
   10.5.\* to 11.0.2.
-- Make a backup of your Open XDMoD configuration files before running
-  the upgrade script. The upgrade script may overwrite your current
-  configuration files.
-- If the upgrade includes database schema changes (see version-specific notes
-  further down on this page), you should back up all your data.
+- Make backups of your Open XDMoD configuration files and databases before
+  running the upgrade script. The upgrade script may overwrite your current
+  configuration files and data.
 - Do not change the version in `portal_settings.ini` before running the
   upgrade script. The version number will be changed by the upgrade
   script.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -154,7 +154,9 @@ in a different directory than your existing version.
 
 ### Download Open XDMoD Source Package
 
-Download available at [GitHub][github-release].
+Download available at [GitHub][github-release]. Make sure to download
+`xdmod-{{ page.sw_version }}.tar.gz`, not the GitHub-generated "Source code"
+files.
 
 ### Extract and Install Source Package
 
@@ -162,8 +164,11 @@ Download available at [GitHub][github-release].
     # cd xdmod-{{ page.sw_version }}
     # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
-Likewise, install the latest `xdmod-appkernels`, `xdmod-supremm`, and/or
-`xdmod-ondemand` tarballs if you have those installed.
+If you have installed any of the optional modules for Open XDMoD, download,
+extract, and install their source packages, too:
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-source.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
 
 ### Copy Current Config Files
 
@@ -369,4 +374,4 @@ will have the following columns added:
 Then, the Cloud realm will be reaggregated.
 
 [github-release]: https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}
-[mysql-config]: configuration.md#mysql-configuration
+[mysql-config]: configuration.html#mariadb-configuration

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -54,13 +54,13 @@ ticket to `ccr-xdmod-help@buffalo.edu` and we will do our best to help.
 
 
 ### Server: EL7, XDMoD: 10.5, PHP: 5.4, MySQL or MariaDB 5.5
-If you are using CentOS 7 and will upgrade to XDMoD 11.0 on Rocky or Alma 8, please follow the steps below.
+If you are using CentOS 7 and will upgrade to XDMoD 11.0 on Rocky 8, please follow the steps below.
 
 At the end of this process you should expect to have a working XDMoD 10.5 installation on a Rocky 8 server that
 contains all of your current data. After which you can then follow the upgrade procedure that immediately follows this
 section which starts at `Server: EL8, XDMoD: 10.5, PHP: 7.2`.
 
-1. Install a fresh copy of XDMoD 10.5 on a new Rocky 8 server [https://open.xdmod.org/10.5/install-rpm.html](https://open.xdmod.org/10.5/install-rpm.html)
+1. Install a fresh copy of XDMoD 10.5 on a new Rocky 8 server [via RPM](10.5/install-rpm.md) or [from source](10.5/install-source.md).
    1. Instead of running `xdmod-setup` do steps 2 & 3 below.
 2. Copy the contents of `/etc/xdmod` (or if you have a source install the contents of `/path/to/your/xdmod/etc/`) from the CentOS 7
    server to the Rocky 8 server.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -113,13 +113,13 @@ You may now continue with the standard upgrade steps below.
 RPM Upgrade Process
 -------------------
 
-### Download Latest Open XDMoD RPM package
+### Download Open XDMoD RPM package
 
-Download available at [GitHub][github-latest-release].
+Download available at [GitHub][github-release].
 
 ### Install the RPM
 
-    # dnf install xdmod-{{ page.sw_version }}-1.el8.noarch.rpm
+    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 
 Likewise, install the latest `xdmod-appkernels`, `xdmod-supremm`, and/or
 `xdmod-ondemand` RPM files if you have those modules installed.
@@ -147,9 +147,9 @@ This example assumes that your previous version of Open XDMoD is installed at
 `/opt/xdmod-{{ page.sw_version }}`.  It is recommended to install the new version of Open XDMoD
 in a different directory than your existing version.
 
-### Download Latest Open XDMoD Source Package
+### Download Open XDMoD Source Package
 
-Download available at [GitHub][github-latest-release].
+Download available at [GitHub][github-release].
 
 ### Extract and Install Source Package
 
@@ -363,5 +363,5 @@ will have the following columns added:
 
 Then, the Cloud realm will be reaggregated.
 
-[github-latest-release]: https://github.com/ubccr/xdmod/releases/latest
+[github-release]: https://github.com/ubccr/xdmod/releases/{{ page.rpm_version }}
 [mysql-config]: configuration.md#mysql-configuration

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -5,19 +5,23 @@ title: Upgrade Guide
 General Upgrade Notes
 ---------------------
 
-- Open XDMoD release numbers are of the form X.Y.Z.
-    - New minor releases increment Z by 1, e.g., 10.0.0, 10.0.1, 10.0.2, etc.
-    - New major releases increment X.Y (usually by 0.5) and reset Z to 0, e.g.,
-      9.0.0, 9.5.0, 10.0.0, 10.5.0, etc.
+- Open XDMoD version numbers are of the form X.Y.Z, where X.Y is the major
+  version number and Z is the minor version number.
+    - Software changes for minor versions include security updates and bug
+      fixes.
+    - Software changes for major versions usually have new features added,
+      database structure changes, and non-backwards compatible changes.
+    - Major version numbers usually (but not always) increment by 0.5, e.g.,
+      9.0, 9.5, 10.0, 10.5, etc.
 - Unless otherwise noted below, Open XDMoD only supports upgrades to:
-    - Minor releases of the same major release (e.g., from 9.5.0 to 9.5.1,
+    - Minor versions of the same major version (e.g., from 9.5.0 to 9.5.1,
       from 10.0.0 to 10.0.3, etc.),
-    - The next major release (e.g., from 9.5.0 to 10.0.0, from 10.0.2 to
+    - The next major version (e.g., from 9.5.0 to 10.0.0, from 10.0.2 to
       11.0.0, etc.), or
-    - Minor releases of the next major release (e.g., from 9.5.0 to 10.0.1,
+    - Minor versions of the next major version (e.g., from 9.5.0 to 10.0.1,
       from 10.5.1 to 11.0.1, etc.).
-- If you need to jump more than one major release, you must incrementally
-  upgrade to each of the intermediate major releases (or a minor release
+- If you need to jump more than one major version, you must incrementally
+  upgrade to each of the intermediate major versions (or a minor version
   thereof), e.g., if you want to upgrade from 9.5.1 to 11.0.2, then you must
   upgrade from 9.5.1 to 10.0.\*, then from 10.0.\* to 10.5.\*, then from
   10.5.\* to 11.0.2.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -18,9 +18,9 @@ General Upgrade Notes
       from 10.5.1 to 11.0.1, etc.).
 - If you need to jump more than one major release, you must incrementally
   upgrade to each of the intermediate major releases (or a minor release
-  thereof), e.g., if you want to upgrade from 9.5.0 to 11.0.0, then you must
-  upgrade from 9.5.0 to 10.0.\*, then from 10.0.\* to 10.5.\*, then from
-  10.5.\* to 11.0.0.
+  thereof), e.g., if you want to upgrade from 9.5.1 to 11.0.2, then you must
+  upgrade from 9.5.1 to 10.0.\*, then from 10.0.\* to 10.5.\*, then from
+  10.5.\* to 11.0.2.
 - Make a backup of your Open XDMoD configuration files before running
   the upgrade script. The upgrade script may overwrite your current
   configuration files.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -5,21 +5,37 @@ title: Upgrade Guide
 General Upgrade Notes
 ---------------------
 
-- Open XDMoD only supports upgrading to a new version from the version that
-  directly precedes it unless otherwise noted below.  If you need to upgrade
-  from an older version you must upgrade through all the intermediate versions
-  or perform a clean installation.
+- Open XDMoD release numbers are of the form X.Y.Z.
+    - New minor releases increment Z by 1, e.g., 10.0.0, 10.0.1, 10.0.2, etc.
+    - New major releases increment X.Y by 0.5 and reset Z to 0, e.g., 9.0.0,
+      9.5.0, 10.0.0, 10.5.0, etc.
+- Unless otherwise noted below, Open XDMoD only supports upgrades to:
+    - Minor releases of the same major release (e.g., from 9.5.0 to 9.5.1,
+      from 10.0.0 to 10.0.3, etc.),
+    - The next major release (e.g., from 9.5.0 to 10.0.0, from 10.0.2 to
+      11.0.0, etc.), or
+    - Minor releases of the next major release (e.g., from 9.5.0 to 10.0.1,
+      from 10.5.1 to 11.0.1, etc.).
+- If you need to jump more than one major release, you must incrementally
+  upgrade to each of the intermediate major releases (or a minor release
+  thereof), e.g., if you want to upgrade from 9.5.0 to 11.5.0, then you must
+  upgrade from 9.5.0 to 10.0.\*, then from 10.0.\* to 10.5.\*, then from
+  10.5.\* to 11.5.0.
 - Make a backup of your Open XDMoD configuration files before running
-  the upgrade script.  The upgrade script may overwrite your current
+  the upgrade script. The upgrade script may overwrite your current
   configuration files.
-- If the upgrade includes database schema changes (see notes at the
-  bottom of this page), you should backup all your data.
+- If the upgrade includes database schema changes (see version-specific notes
+  further down on this page), you should back up all your data.
 - Do not change the version in `portal_settings.ini` before running the
-  upgrade script.  The version number will be changed by the upgrade
+  upgrade script. The version number will be changed by the upgrade
   script.
-- If you have installed any additional Open XDMoD packages (e.g.
-  `xdmod-appkernels`, `xdmod-supremm`, or `xdmod-ondemand`), upgrade those to
-  the latest version before running `xdmod-upgrade`.
+- Make sure to follow the instructions below in the proper order, and note that
+  there may be version-specific upgrade notes. If you have installed any of the
+  optional modules for Open XDMoD, they may have their own version-specific
+  upgrade notes as well, see:
+    - [`xdmod-appkernels`](https://appkernels.xdmod.org/ak-upgrade.html)
+    - [`xdmod-supremm`](https://supremm.xdmod.org/supremm-upgrade.html)
+    - [`xdmod-ondemand`](https://ondemand.xdmod.org/upgrade.html)
 
 RPM Upgrade Process
 -------------------
@@ -106,7 +122,7 @@ Likewise, install the latest `xdmod-appkernels`, `xdmod-supremm`, and/or
 
 After upgrading the package you may need to manually merge any files
 that you have manually changed before the upgrade.  You do not need to
-merge `portal_settings.ini`.  This file will be updated by the upgrade
+merge `portal_settings.ini`. This file will be updated by the upgrade
 script.  If you have manually edited this file, you should create a
 backup and merge any changes after running the upgrade script.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -196,6 +196,11 @@ the recommended values listed in the [Configuration Guide][mysql-config].
 
     # /opt/xdmod-{{ page.sw_version }}/bin/xdmod-upgrade
 
+### Update Apache Configuration
+
+Make sure to update `/etc/httpd/conf.d/xdmod.conf` to change
+`/opt/xdmod-{{ page.prev_sw_version }}` to `/opt/xdmod-{{ page.sw_version }}`.
+
 Additional 11.0.0 Upgrade Notes
 -------------------
 


### PR DESCRIPTION
This PR makes the following documentation updates:
- Use a variable that will be added in https://github.com/ubccr/xdmod/pull/2015 for the GitHub Pages site that stores the RPM version (e.g., `11.0.1-1`) so that this can be changed in one place if it needs to be updated (e.g., if we need to release new RPM(s) for `11.0.1-2`).
- Consistently use `/opt/xdmod-{{ page.sw_version }}` instead of `/opt/xdmod` for all examples of source code installation.
- Add GitHub links to the RPM and source install pages.
- Update the upgrade guide to:
    - Clarify how releases are numbered, which upgrades are supported, and where to find upgrade notes for the modules.
    - Remove reference to Alma 8.
    - Update the GitHub download link to point to the latest release of the major version being documented instead of the overall latest release.
- Specify not to download the GitHub "Source code" links since we have had tickets from users confused by this.
- Specify in source code installation that Apache conf needs to be updated if installing to a new directory.

I tested the changes on my laptop running Jekyll.