### PR TITLE
Update RPM install/upgrade instructions.

### DIFF
--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -7,11 +7,17 @@ Install Prerequisites
 
 See the [Software Requirements](software-requirements.html) for details.
 
-Install the RPM
+Install the RPM package
 ---------------
 
-The RPM package can be downloaded from
-[GitHub](https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}).
+If your web server can reach GitHub via HTTPS, you can install the RPM package
+directly:
+
+    # dnf install https://github.com/ubccr/xdmod/releases/download/v{{ page.rpm_version }}/xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+
+Otherwise, you can download the RPM file from the
+[GitHub page for the release](https://github.com/ubccr/xdmod/releases/tag/v{{
+page.rpm_version }}) and install it:
 
     # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -121,7 +121,7 @@ Note that if you have installed any of the optional modules for Open XDMoD, you
 should also include their new RPM file(s) on the same `dnf install` command
 line below that you use to install the new Open XDMoD RPM file. The upgrade
 guides for each of the optional modules are linked below; these each contain a
-link to the GitHub page for the module release, which has the link for their
+link to the GitHub page for the module release, which has the link to their
 RPM file.
 
 - [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
@@ -179,7 +179,10 @@ files.
     # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 If you have installed any of the optional modules for Open XDMoD, download,
-extract, and install their source packages, too:
+extract, and install their source packages, too. The upgrade guides for
+each of the optional modules are linked below; these each contain a link to
+the GitHub page for the module release, which has the link to their source
+package.
 
 - [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
 - [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -117,23 +117,27 @@ RPM Upgrade Process
 
 ### Install RPM package(s)
 
-Note that if you have installed any of the optional modules for Open XDMoD
-(whose upgrade guides are linked below), you should also include their new
-RPM file(s) on the same `dnf install` command line below that you use to
-install the new Open XDMoD RPM file.
+Note that if you have installed any of the optional modules for Open XDMoD, you
+should also include their new RPM file(s) on the same `dnf install` command
+line below that you use to install the new Open XDMoD RPM file. The upgrade
+guides for each of the optional modules are linked below; these each contain a
+link to the GitHub page for the module release, which has the link for their
+RPM file.
+
 - [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
 - [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
 - [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
 
-If your web server can reach GitHub via HTTPS, you can install the RPM package
-directly:
+If your web server can reach GitHub via HTTPS, you can install the RPM
+package(s) directly:
 
-    # dnf install https://github.com/ubccr/xdmod/releases/download/v{{ page.rpm_version }}/xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+    # dnf install https://github.com/ubccr/xdmod/releases/download/v{{ page.rpm_version }}/xdmod-{{ page.rpm_version }}.el8.noarch.rpm [optional module RPMs]
 
 Otherwise, you can download the RPM file from the [GitHub page for the
-release][github-release] and install it:
+release][github-release] and install it (along with any of the optional modules
+you have installed as explained above):
 
-    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm [optional module RPMs]
 
 After installing the RPM(s), you may need to manually merge changes to any
 files that you had previously manually changed in your Open XDMoD installation.
@@ -176,9 +180,10 @@ files.
 
 If you have installed any of the optional modules for Open XDMoD, download,
 extract, and install their source packages, too:
-- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-source.html)
-- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
-- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
+
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
 
 ### Copy Current Config Files
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -115,27 +115,35 @@ You may now continue with the standard upgrade steps below.
 RPM Upgrade Process
 -------------------
 
-### Download and install Open XDMoD RPM package
+### Install RPM package(s)
 
-Download available at [GitHub][github-release].
+Note that if you have installed any of the optional modules for Open XDMoD
+(whose upgrade guides are linked below), you should also include their new
+RPM file(s) on the same `dnf install` command line below that you use to
+install the new Open XDMoD RPM file.
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
 
-If you have installed any of the optional modules for Open XDMoD:
+If your web server can reach GitHub via HTTPS, you can install the RPM package
+directly:
 
-1. Download their RPMs, too; download links and additional notes are available
-   in their upgrade guides:
-    - [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
-    - [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
-    - [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
-1. Add the module RPMs to the end of the command below.
+    # dnf install https://github.com/ubccr/xdmod/releases/download/v{{ page.rpm_version }}/xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 
-```
-# dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
-```
+Otherwise, you can download the RPM file from the [GitHub page for the
+release][github-release] and install it:
 
-You may need to manually merge any files that you had manually changed. You do
-not need to merge `portal_settings.ini`. This file will be updated by the
-upgrade script. If you have manually edited this file, you should create a
-backup and merge any changes after running the upgrade script.
+    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+
+After installing the RPM(s), you may need to manually merge changes to any
+files that you had previously manually changed in your Open XDMoD installation.
+Any such files will have extensions of `.rpmnew` or `.rpmsave` and can be
+located with the following command. The exception to this is
+`portal_settings.ini`; this file will be updated by the `xdmod-upgrade` command
+later; any manual changes you want to merge to this file should be merged after
+running the `xdmod-upgrade` command in a later step below.
+
+    # find /etc/xdmod /usr/bin /usr/lib64/xdmod /usr/share/xdmod -regextype sed -regex '.*\.rpm\(new\|save\)$'
 
 ### Verify Server Configuration Settings
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -115,24 +115,26 @@ You may now continue with the standard upgrade steps below.
 RPM Upgrade Process
 -------------------
 
-### Download Open XDMoD RPM package
+### Download and install Open XDMoD RPM package
 
 Download available at [GitHub][github-release].
 
-### Install the RPM
+If you have installed any of the optional modules for Open XDMoD:
 
-    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+1. Download their RPMs, too; download links and additional notes are available
+   in their upgrade guides:
+    - [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
+    - [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
+    - [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
+1. Add the module RPMs to the end of the command below.
 
-If you have installed any of the optional modules for Open XDMoD, download and
-install their RPMs, too:
-- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-rpm.html)
-- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
-- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
+```
+# dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+```
 
-After upgrading the package you may need to manually merge any files
-that you have manually changed before the upgrade.  You do not need to
-merge `portal_settings.ini`. This file will be updated by the upgrade
-script.  If you have manually edited this file, you should create a
+You may need to manually merge any files that you had manually changed. You do
+not need to merge `portal_settings.ini`. This file will be updated by the
+upgrade script. If you have manually edited this file, you should create a
 backup and merge any changes after running the upgrade script.
 
 ### Verify Server Configuration Settings


### PR DESCRIPTION
This PR updates the docs as follows:
* Explain that when upgrading via RPM, the GitHub URL can be directly installed via `dnf`, and if modules are installed, their RPMs need to be installed in the same `dnf install` line.
* Mention to be aware of `.rpmnew` and `.rpmsave` files.
* Make sure the source upgrade instructions link to the module upgrade pages instead of their install pages.