### PR TITLE
Add ingestion by date range for Storage realm

### DIFF
--- a/bin/xdmod-ingestor
+++ b/bin/xdmod-ingestor
@@ -275,7 +275,7 @@ function main()
                 }
 
                 if ($datatypeValue == 'storage') {
-                    $dwi->ingestStorageData();
+                    $dwi->ingestStorageData($startDate, $endDate);
                 }
             }
 

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -335,7 +335,7 @@ class DataWarehouseInitializer
             'hpcdb-ingest-storage',
             'hpcdb-xdw-ingest-common'
         );
-        
+
         $params = [];
 
         if ($startDate !== null || $endDate !== null) {
@@ -345,7 +345,7 @@ class DataWarehouseInitializer
             if ($endDate !== null) {
                 $params['end-date'] = $endDate . ' 23:59:59';
             }
-            $pipeline[] = 'hpcdb-prep-xdw-storage-ingest-by-date-range';            
+            $pipeline[] = 'hpcdb-prep-xdw-storage-ingest-by-date-range';
         }
         else {
             $pipeline[] = 'hpcdb-prep-xdw-storage-ingest-by-new-usage';

--- a/classes/OpenXdmod/DataWarehouseInitializer.php
+++ b/classes/OpenXdmod/DataWarehouseInitializer.php
@@ -141,7 +141,7 @@ class DataWarehouseInitializer
         $this->ingestAllHpcdb($startDate, $endDate);
         $this->ingestCloudDataGeneric();
         $this->ingestCloudDataOpenStack();
-        $this->ingestStorageData();
+        $this->ingestStorageData($startDate, $endDate);
     }
 
     /**
@@ -322,23 +322,42 @@ class DataWarehouseInitializer
      *
      * If the storage realm is not enabled then do nothing.
      */
-    public function ingestStorageData()
+    public function ingestStorageData($startDate = null, $endDate = null)
     {
         if (!$this->isRealmEnabled('Storage')) {
             $this->logger->debug('Storage realm not enabled, not ingesting');
             return;
         }
 
+        $pipeline = array(
+            'staging-ingest-common',
+            'hpcdb-ingest-common',
+            'hpcdb-ingest-storage',
+            'hpcdb-xdw-ingest-common'
+        );
+        
+        $params = [];
+
+        if ($startDate !== null || $endDate !== null) {
+            if ($startDate !== null) {
+                $params['start-date'] = $startDate . ' 00:00:00';
+            }
+            if ($endDate !== null) {
+                $params['end-date'] = $endDate . ' 23:59:59';
+            }
+            $pipeline[] = 'hpcdb-prep-xdw-storage-ingest-by-date-range';            
+        }
+        else {
+            $pipeline[] = 'hpcdb-prep-xdw-storage-ingest-by-new-usage';
+        }
+
+        $pipeline[] = 'xdw-ingest-storage';
+
         $this->logger->notice('Ingesting storage data');
         Utilities::runEtlPipeline(
-            [
-                'staging-ingest-common',
-                'hpcdb-ingest-common',
-                'hpcdb-ingest-storage',
-                'hpcdb-xdw-ingest-common',
-                'xdw-ingest-storage',
-            ],
-            $this->logger
+            $pipeline,
+            $this->logger,
+            $params
         );
     }
 

--- a/configuration/etl/etl.d/hpcdb.json
+++ b/configuration/etl/etl.d/hpcdb.json
@@ -186,6 +186,22 @@
             "definition_file": "jobs/hpcdb/jobs-to-ingest-by-new-jobs.json"
         }
     ],
+    "hpcdb-prep-xdw-storage-ingest-by-date-range": [
+        {
+            "name": "storage-ingest-date-range",
+            "description": "Prepare storage usage to ingest using a date range",
+            "truncate_destination": true,
+            "definition_file": "storage/hpcdb/usage-to-ingest-date-range.json"
+        }
+    ],
+    "hpcdb-prep-xdw-storage-ingest-by-new-usage": [
+        {
+            "name": "storage-ingest-new-usage",
+            "description": "Prepare storage usage to ingest based on new usage information",
+            "truncate_destination": true,
+            "definition_file": "storage/hpcdb/usage-to-ingest-new-usage.json"
+        }
+    ],
     "hpcdb-ingest-storage": [
         {
             "name": "mountpoints",

--- a/configuration/etl/etl_action_defs.d/storage/hpcdb/usage-to-ingest-date-range.json
+++ b/configuration/etl/etl_action_defs.d/storage/hpcdb/usage-to-ingest-date-range.json
@@ -1,0 +1,22 @@
+{
+    "table_definition": {
+        "$ref": "${table_definition_dir}/storage/hpcdb/usage-to-ingest.json#/table_definition"
+    },
+    "source_query": {
+        "overseer_restrictions": {
+            "start_date": "UNIX_TIMESTAMP(su.dt) >= UNIX_TIMESTAMP(${VALUE})",
+            "end_date": "UNIX_TIMESTAMP(su.dt) <= UNIX_TIMESTAMP(${VALUE})"
+        },
+        "records": {
+            "storage_usage_id": "su.storage_usage_id"
+        },
+        "joins": [
+            {
+                "schema": "${DESTINATION_SCHEMA}",
+                "name": "hpcdb_storage_usage",
+                "alias": "su"
+            }
+
+        ]
+    }
+}

--- a/configuration/etl/etl_action_defs.d/storage/hpcdb/usage-to-ingest-new-usage.json
+++ b/configuration/etl/etl_action_defs.d/storage/hpcdb/usage-to-ingest-new-usage.json
@@ -1,0 +1,21 @@
+{
+    "table_definition": {
+        "$ref": "${table_definition_dir}/storage/hpcdb/usage-to-ingest.json#/table_definition"
+    },
+    "source_query": {
+        "records": {
+            "storage_usage_id": "su.storage_usage_id"
+        },
+        "joins": [
+            {
+                "schema": "${DESTINATION_SCHEMA}",
+                "name": "hpcdb_storage_usage",
+                "alias": "su"
+            }
+
+        ],
+        "where": [
+            "su.storage_usage_id > COALESCE((SELECT MAX(storage_usage_id) FROM modw.storagefact), 0)"
+        ]
+    }
+}

--- a/configuration/etl/etl_action_defs.d/storage/hpcdb/usage-to-ingest-new-usage.json
+++ b/configuration/etl/etl_action_defs.d/storage/hpcdb/usage-to-ingest-new-usage.json
@@ -15,7 +15,7 @@
 
         ],
         "where": [
-            "su.storage_usage_id > COALESCE((SELECT MAX(storage_usage_id) FROM modw.storagefact), 0)"
+            "su.storage_usage_id > COALESCE((SELECT MAX(id) FROM modw.storagefact), 0)"
         ]
     }
 }

--- a/configuration/etl/etl_action_defs.d/storage/xdw/storagefact.json
+++ b/configuration/etl/etl_action_defs.d/storage/xdw/storagefact.json
@@ -23,8 +23,15 @@
         "joins": [
             {
                 "schema": "${SOURCE_SCHEMA}",
+                "name": "hpcdb_storage_usage_to_ingest",
+                "alias": "su_ingest"
+            },
+            {
+                "schema": "${SOURCE_SCHEMA}",
                 "name": "hpcdb_storage_usage",
-                "alias": "su"
+                "alias": "su",
+                "type": "INNER",
+                "on": "su_ingest.storage_usage_id = su.storage_usage_id"
             },
             {
                 "schema": "${SOURCE_SCHEMA}",
@@ -54,9 +61,6 @@
                 "type": "INNER",
                 "on": "req.request_id = pi.request_id"
             }
-        ],
-        "where": [
-            "su.storage_usage_id > COALESCE((SELECT MAX(id) FROM ${DESTINATION_SCHEMA}.storagefact), 0)"
         ]
     }
 }

--- a/configuration/etl/etl_tables.d/storage/hpcdb/usage-to-ingest.json
+++ b/configuration/etl/etl_tables.d/storage/hpcdb/usage-to-ingest.json
@@ -1,0 +1,23 @@
+{
+    "table_definition": {
+        "name": "hpcdb_storage_usage_to_ingest",
+        "engine": "InnoDB",
+        "comment": "Storage usage data to ingest",
+        "columns": [
+            {
+                "name": "storage_usage_id",
+                "type": "int(11)",
+                "nullable": false,
+                "comment": "Storage usage record ID"
+            }
+        ],
+        "indexes": [
+            {
+                "name": "PRIMARY",
+                "columns": [
+                    "storage_usage_id"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
The Storage realm does not have the ability to ingest data by date range like the Jobs realm does. For the Storage realm, the command `xdmod-ingestor --start-date "2020-01-01" --end-date "2022-01-01"` does not ingest data for the specified time range. The Storage realm only ingests information that has not already been ingested into `modw.storagefact`. This allows the storage realm etl process to use the values supplied with the `--start-date` and `--end-date` flags.

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
