### PR TITLE
Update docs.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,8 +36,10 @@ defaults:
       type: "pages"
     values:
       layout: "page"
-      prev_sw_version: "10.0.2"
-      sw_version: "10.5.0"
+      version: "10.5"
+      prev_sw_version: "10.0.3"
+      sw_version: "10.5.1"
+      rpm_version: "10.5.1-1"
       style: "effervescence"
       tocversion: "toc"
 

--- a/docs/dev-code-organization.md
+++ b/docs/dev-code-organization.md
@@ -15,7 +15,7 @@ installed files.
 
 [fhs]: http://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
 
-The "Source Installation" paths listed below assume that `/opt/xdmod`
+The "Source Installation" paths listed below assume that `/opt/xdmod-{{ page.sw_version }}`
 has been used as the installation prefix.
 
 Non-User Executables
@@ -23,28 +23,28 @@ Non-User Executables
 
 - Source Tarball: `background_scripts/`
 - RPM Installation: `/usr/lib/xdmod/`
-- Source Installation: `/opt/xdmod/lib/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/lib/`
 
 User Executables
 -----------------
 
 - Source Tarball: `bin/`
 - RPM Installation: `/usr/bin/`
-- Source Installation: `/opt/xdmod/bin/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/bin/`
 
 PHP Classes
 -----------
 
 - Source Tarball: `classes/`
 - RPM Installation: `/usr/share/xdmod/classes/`
-- Source Installation: `/opt/xdmod/share/classes/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/classes/`
 
 Configuration Files
 -------------------
 
 - Source Tarball: `configuration/`
 - RPM Installation: `/etc/xdmod`
-- Source Installation: `/opt/xdmod/etc/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/etc/`
 
 The following configuration files are also installed by the RPM:
 
@@ -59,7 +59,7 @@ Database schema files, data files and database migrations.
 
 - Source Tarball: `db/`
 - RPM Installation: `/usr/share/xdmod/db/`
-- Source Installation: `/opt/xdmod/share/db/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/db/`
 
 Documentation
 -------------
@@ -69,7 +69,7 @@ files.
 
 - Source Tarball: `docs/`
 - RPM Installation: `/usr/share/doc/xdmod-{{ page.sw_version }}/`
-- Source Installation: `/opt/xdmod/share/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/`
 
 External Libraries
 ------------------
@@ -78,7 +78,7 @@ Various open source libraries used by Open XDMoD.
 
 - Source Tarball: `external_libraries/`
 - RPM Installation: `/usr/share/xdmod/external_libraries/`
-- Source Installation: `/opt/xdmod/share/external_libraries/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/external_libraries/`
 
 HTML
 ----
@@ -87,7 +87,7 @@ HTML files used by the Open XDMoD portal.
 
 - Source Tarball: `html/`
 - RPM Installation: `/usr/share/xdmod/html/`
-- Source Installation: `/opt/xdmod/share/html/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/html/`
 
 Open XDMoD Libraries
 --------------------
@@ -96,21 +96,21 @@ Non-class PHP code.
 
 - Source Tarball: `libraries/`
 - RPM Installation: `/usr/share/xdmod/libraries/`
-- Source Installation: `/opt/xdmod/share/libraries/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/libraries/`
 
 Log Files
 ---------
 
 - Source Tarball: `logs/`
 - RPM Installation: `/var/log/xdmod/`
-- Source Installation: `/opt/xdmod/logs/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/logs/`
 
 Report Generator Code
 ---------------------
 
 - Source Tarball: `reporting/`
 - RPM Installation: `/usr/share/xdmod/reporting/`
-- Source Installation: `/opt/xdmod/share/reporting/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/reporting/`
 
 Configuration Templates
 ------------------------
@@ -119,4 +119,4 @@ Template files used by `xdmod-setup` to generate config files.
 
 - Source Tarball: `templates/`
 - RPM Installation: `/usr/share/xdmod/templates/`
-- Source Installation: `/opt/xdmod/share/templates/`
+- Source Installation: `/opt/xdmod-{{ page.sw_version }}/share/templates/`

--- a/docs/docs-conventions.md
+++ b/docs/docs-conventions.md
@@ -15,7 +15,7 @@ prefixed with a dollar sign (`$`). e.g.:
 Examples of commands that must be run with root privileges are prefixed
 with a number sign (`#`). e.g.:
 
-    # ./install --prefix=/opt/xdmod
+    # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 These commands may be run with `sudo` or `su`.
 
@@ -27,9 +27,9 @@ is not the case. For example, the following:
 
 Would need to be changed to:
 
-    # /opt/xdmod/bin/xdmod-setup
+    # /opt/xdmod-{{ page.sw_version }}/bin/xdmod-setup
 
-If you installed Open XDMoD in `/opt/xdmod`.
+If you installed Open XDMoD in `/opt/xdmod-{{ page.sw_version }}`.
 
 If you installed the Open XDMoD RPM package, these commands will be
 placed in `/usr/bin` which is most likely already in your `PATH`.

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -7,11 +7,17 @@ Install Prerequisites
 
 See the [Software Requirements](software-requirements.html) for details.
 
-Install the RPM
+Install the RPM package
 ---------------
 
-The RPM package can be downloaded from
-[GitHub](https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}).
+If your web server can reach GitHub via HTTPS, you can install the RPM package
+directly:
+
+    # dnf install https://github.com/ubccr/xdmod/releases/download/v{{ page.rpm_version }}/xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+
+Otherwise, you can download the RPM file from the
+[GitHub page for the release](https://github.com/ubccr/xdmod/releases/tag/v{{
+page.rpm_version }}) and install it:
 
     # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 

--- a/docs/install-rpm.md
+++ b/docs/install-rpm.md
@@ -10,7 +10,10 @@ See the [Software Requirements](software-requirements.html) for details.
 Install the RPM
 ---------------
 
-    # dnf install xdmod-{{ page.sw_version }}-1.0.el8.noarch.rpm
+The RPM package can be downloaded from
+[GitHub](https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}).
+
+    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 
 Configure Open XDMoD
 --------------------

--- a/docs/install-source.md
+++ b/docs/install-source.md
@@ -5,14 +5,18 @@ title: Source Installation Guide
 Install Source Package
 ----------------------
 
-If installing from the `el7` source, replace `el8` with `el7` below. Change the
-installation prefix as desired.  The default installation prefix is
-`/usr/local/xdmod`.  These instructions assume you are installing Open
-XDMoD in `/opt/xdmod`.
+The source package can be downloaded from
+[GitHub](https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}).
+Make sure to download `xdmod-{{ page.sw_version }}.tar.gz`, not the
+GitHub-generated "Source code" files.
 
-    # tar zxvf xdmod-{{ page.sw_version }}-el8.tar.gz
+These instructions assume you are installing Open XDMoD in `/opt/xdmod-{{
+page.sw_version }}`. Change the installation prefix as desired. The default
+installation prefix is `/usr/local/xdmod`.
+
+    # tar zxvf xdmod-{{ page.sw_version }}.tar.gz
     # cd xdmod-{{ page.sw_version }}
-    # ./install --prefix=/opt/xdmod
+    # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 Create Open XDMoD User And Group
 --------------------------------
@@ -21,12 +25,12 @@ For improved security, create an Open XDMoD user and group that will have
 access to sensitive data:
 
     # groupadd -r xdmod
-    # useradd -r -M -c "Open XDMoD" -g xdmod -d /opt/xdmod/lib -s /sbin/nologin xdmod
+    # useradd -r -M -c "Open XDMoD" -g xdmod -d /opt/xdmod-{{ page.sw_version }}/lib -s /sbin/nologin xdmod
 
 Secure the file containing database passwords:
 
-    # chmod 440 /opt/xdmod/etc/portal_settings.ini
-    # chown apache:xdmod /opt/xdmod/etc/portal_settings.ini
+    # chmod 440 /opt/xdmod-{{ page.sw_version }}/etc/portal_settings.ini
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/etc/portal_settings.ini
 
 **NOTE**: The `portal_settings.ini` file must be readable by Apache and any
 user that will run the Open XDMoD commands.  Replace the Apache username
@@ -41,26 +45,26 @@ out of your system and log back in for this change to take effect.
 
 Update log directory and file ownership and permissions:
 
-    # chmod 770 /opt/xdmod/logs
-    # chown apache:xdmod /opt/xdmod/logs
-    # touch /opt/xdmod/logs/exceptions.log
-    # chmod 660 /opt/xdmod/logs/exceptions.log
-    # chown apache:xdmod /opt/xdmod/logs/exceptions.log
-    # touch /opt/xdmod/logs/query.log
-    # chmod 660 /opt/xdmod/logs/query.log
-    # chown apache:xdmod /opt/xdmod/logs/query.log
+    # chmod 770 /opt/xdmod-{{ page.sw_version }}/logs
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/logs
+    # touch /opt/xdmod-{{ page.sw_version }}/logs/exceptions.log
+    # chmod 660 /opt/xdmod-{{ page.sw_version }}/logs/exceptions.log
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/logs/exceptions.log
+    # touch /opt/xdmod-{{ page.sw_version }}/logs/query.log
+    # chmod 660 /opt/xdmod-{{ page.sw_version }}/logs/query.log
+    # chown apache:xdmod /opt/xdmod-{{ page.sw_version }}/logs/query.log
 
 The `exceptions.log` and `query.log` may be written to by both Apache and Open
 XDMoD commands.
 
 Update the bin directory permissions so that only users with the `xdmod` group can run Open XDMoD commands:
 
-    # chmod 750 /opt/xdmod/bin/*
+    # chmod 750 /opt/xdmod-{{ page.sw_version }}/bin/*
 
 Run Configuration Script
 ------------------------
 
-    # /opt/xdmod/bin/xdmod-setup
+    # /opt/xdmod-{{ page.sw_version }}/bin/xdmod-setup
 
 Complete each setup section with the required information.
 
@@ -69,11 +73,11 @@ See the [Configuration Guide](configuration.html) for more details.
 Copy Configuration Files
 ------------------------
 
-    # cp /opt/xdmod/share/templates/apache.conf /etc/apache2/conf.d/xdmod.conf
+    # cp /opt/xdmod-{{ page.sw_version }}/share/templates/apache.conf /etc/apache2/conf.d/xdmod.conf
 
-    # cp /opt/xdmod/etc/cron.d/xdmod /etc/cron.d/xdmod
+    # cp /opt/xdmod-{{ page.sw_version }}/etc/cron.d/xdmod /etc/cron.d/xdmod
 
-    # cp /opt/xdmod/etc/logrotate.d/xdmod /etc/logrotate.d/xdmod
+    # cp /opt/xdmod-{{ page.sw_version }}/etc/logrotate.d/xdmod /etc/logrotate.d/xdmod
 
 The directories where these files are needed may differ depending on
 your operating system.
@@ -98,13 +102,13 @@ PBS stores its accounting logs in a directory where the name of each
 file corresponds to the end date of the jobs it contains.  A directory
 such as this can be specified using the `-d` option:
 
-    $ /opt/xdmod/bin/xdmod-shredder -v -r *resource* -f pbs \
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-shredder -v -r *resource* -f pbs \
           -d /var/spool/pbs/server_priv/accounting
 
 SGE stores its accounting logs in a single file so the `-i` (input)
 option should be used:
 
-    $ /opt/xdmod/bin/xdmod-shredder -v -r *resource* -f sge \
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-shredder -v -r *resource* -f sge \
           -i /var/lib/gridengine/default/common/accounting
 
 Slurm stores its accounting logs in a database that can be queried using
@@ -112,7 +116,7 @@ the `sacct` command.  Since the accounting data is not directly
 accessible in files Open XDMoD provides a helper script that writes the
 data to a file and then shreds that file:
 
-    $ /opt/xdmod/bin/xdmod-slurm-helper -v -r *resource*
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-slurm-helper -v -r *resource*
 
 The resource name here must match the one supplied to the setup script.
 
@@ -124,7 +128,7 @@ using `ssh` with a public key to run the command on another machine).
 Ingest Data
 -----------
 
-    $ /opt/xdmod/bin/xdmod-ingestor -v
+    $ /opt/xdmod-{{ page.sw_version }}/bin/xdmod-ingestor -v
 
 See the [Ingestor Guide](ingestor.html) for more details.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -5,39 +5,60 @@ title: Upgrade Guide
 General Upgrade Notes
 ---------------------
 
-- Open XDMoD only supports upgrading to a new version from the version that
-  directly precedes it unless otherwise noted below.  If you need to upgrade
-  from an older version you must upgrade through all the intermediate versions
-  or perform a clean installation.
-- Make a backup of your Open XDMoD configuration files before running
-  the upgrade script.  The upgrade script may overwrite your current
-  configuration files.
-- If the upgrade includes database schema changes (see notes at the
-  bottom of this page), you should backup all your data.
+- Open XDMoD version numbers are of the form X.Y.Z, where X.Y is the major
+  version number and Z is the minor version number.
+    - Software changes for minor versions include security updates and bug
+      fixes.
+    - Software changes for major versions usually have new features added,
+      database structure changes, and non-backwards compatible changes.
+    - Major version numbers usually (but not always) increment by 0.5, e.g.,
+      9.0, 9.5, 10.0, 10.5, etc.
+- Unless otherwise noted below, Open XDMoD only supports upgrades to:
+    - Minor versions of the same major version (e.g., from 9.5.0 to 9.5.1,
+      from 10.0.0 to 10.0.3, etc.),
+    - The next major version (e.g., from 9.5.0 to 10.0.0, from 10.0.2 to
+      11.0.0, etc.), or
+    - Minor versions of the next major version (e.g., from 9.5.0 to 10.0.1,
+      from 10.5.1 to 11.0.1, etc.).
+- If you need to jump more than one major version, you must incrementally
+  upgrade to each of the intermediate major versions (or a minor version
+  thereof), e.g., if you want to upgrade from 9.5.1 to 11.0.2, then you must
+  upgrade from 9.5.1 to 10.0.\*, then from 10.0.\* to 10.5.\*, then from
+  10.5.\* to 11.0.2.
+- Make backups of your Open XDMoD configuration files and databases before
+  running the upgrade script. The upgrade script may overwrite your current
+  configuration files and data.
 - Do not change the version in `portal_settings.ini` before running the
-  upgrade script.  The version number will be changed by the upgrade
+  upgrade script. The version number will be changed by the upgrade
   script.
-- If you have installed any additional Open XDMoD packages (e.g.
-  `xdmod-appkernels`, `xdmod-supremm`, or `xdmod-ondemand`), upgrade those to
-  the latest version before running `xdmod-upgrade`.
+- Make sure to follow the instructions below in the proper order, and note that
+  there may be version-specific upgrade notes. If you have installed any of the
+  optional modules for Open XDMoD, they may have their own version-specific
+  upgrade notes as well, see:
+    - [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
+    - [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
+    - [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
 
 RPM Upgrade Process
 -------------------
 
-### Download Latest Open XDMoD RPM package
+### Download Open XDMoD RPM package
 
-Download available at [GitHub][github-latest-release].
+Download available at [GitHub][github-release].
 
 ### Install the RPM
 
-    # yum install xdmod-{{ page.sw_version }}-1.0.el7.noarch.rpm
+    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
 
-Likewise, install the latest `xdmod-appkernels`, `xdmod-supremm`, and/or
-`xdmod-ondemand` RPM files if you have those modules installed.
+If you have installed any of the optional modules for Open XDMoD, download and
+install their RPMs, too:
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-rpm.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
 
 After upgrading the package you may need to manually merge any files
 that you have manually changed before the upgrade.  You do not need to
-merge `portal_settings.ini`.  This file will be updated by the upgrade
+merge `portal_settings.ini`. This file will be updated by the upgrade
 script.  If you have manually edited this file, you should create a
 backup and merge any changes after running the upgrade script.
 
@@ -58,9 +79,11 @@ This example assumes that your previous version of Open XDMoD is installed at
 `/opt/xdmod-{{ page.sw_version }}`.  It is recommended to install the new version of Open XDMoD
 in a different directory than your existing version.
 
-### Download Latest Open XDMoD Source Package
+### Download Open XDMoD Source Package
 
-Download available at [GitHub][github-latest-release].
+Download available at [GitHub][github-release]. Make sure to download
+`xdmod-{{ page.sw_version }}.tar.gz`, not the GitHub-generated "Source code"
+files.
 
 ### Extract and Install Source Package
 
@@ -68,8 +91,11 @@ Download available at [GitHub][github-latest-release].
     # cd xdmod-{{ page.sw_version }}
     # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
-Likewise, install the latest `xdmod-appkernels` or `xdmod-supremm`
-tarballs if you have those installed.
+If you have installed any of the optional modules for Open XDMoD, download,
+extract, and install their source packages, too:
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-source.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
 
 ### Copy Current Config Files
 
@@ -97,7 +123,12 @@ the recommended values listed in the [Configuration Guide][mysql-config].
 
     # /opt/xdmod-{{ page.sw_version }}/bin/xdmod-upgrade
 
-10.5.0 Upgrade Notes
+### Update Apache Configuration
+
+Make sure to update `/etc/httpd/conf.d/xdmod.conf` to change
+`/opt/xdmod-{{ page.prev_sw_version }}` to `/opt/xdmod-{{ page.sw_version }}`.
+
+Additional 10.5.0 Upgrade Notes
 -------------------
 
 Open XDMoD 10.5.0 is a major release that includes new features along with many
@@ -130,5 +161,5 @@ The `xdmod-upgrade` script will add settings to `portal_settings.ini` to support
 
 The `xdmod-upgrade` script will create the new `moddb.user_tokens` table to support API tokens for the new [Data Analytics Framework](data-analytics-framework.md).
 
-[github-latest-release]: https://github.com/ubccr/xdmod/releases/latest
-[mysql-config]: configuration.md#mysql-configuration
+[github-release]: https://github.com/ubccr/xdmod/releases/tag/v{{ page.rpm_version }}
+[mysql-config]: configuration.html#mariadb-configuration

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -42,25 +42,39 @@ General Upgrade Notes
 RPM Upgrade Process
 -------------------
 
-### Download Open XDMoD RPM package
+### Install RPM package(s)
 
-Download available at [GitHub][github-release].
+Note that if you have installed any of the optional modules for Open XDMoD, you
+should also include their new RPM file(s) on the same `dnf install` command
+line below that you use to install the new Open XDMoD RPM file. The upgrade
+guides for each of the optional modules are linked below; these each contain a
+link to the GitHub page for the module release, which has the link to their
+RPM file.
 
-### Install the RPM
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
 
-    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm
+If your web server can reach GitHub via HTTPS, you can install the RPM
+package(s) directly:
 
-If you have installed any of the optional modules for Open XDMoD, download and
-install their RPMs, too:
-- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-rpm.html)
-- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
-- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
+    # dnf install https://github.com/ubccr/xdmod/releases/download/v{{ page.rpm_version }}/xdmod-{{ page.rpm_version }}.el8.noarch.rpm [optional module RPMs]
 
-After upgrading the package you may need to manually merge any files
-that you have manually changed before the upgrade.  You do not need to
-merge `portal_settings.ini`. This file will be updated by the upgrade
-script.  If you have manually edited this file, you should create a
-backup and merge any changes after running the upgrade script.
+Otherwise, you can download the RPM file from the [GitHub page for the
+release][github-release] and install it (along with any of the optional modules
+you have installed as explained above):
+
+    # dnf install xdmod-{{ page.rpm_version }}.el8.noarch.rpm [optional module RPMs]
+
+After installing the RPM(s), you may need to manually merge changes to any
+files that you had previously manually changed in your Open XDMoD installation.
+Any such files will have extensions of `.rpmnew` or `.rpmsave` and can be
+located with the following command. The exception to this is
+`portal_settings.ini`; this file will be updated by the `xdmod-upgrade` command
+later; any manual changes you want to merge to this file should be merged after
+running the `xdmod-upgrade` command in a later step below.
+
+    # find /etc/xdmod /usr/bin /usr/lib64/xdmod /usr/share/xdmod -regextype sed -regex '.*\.rpm\(new\|save\)$'
 
 ### Verify Server Configuration Settings
 
@@ -92,10 +106,14 @@ files.
     # ./install --prefix=/opt/xdmod-{{ page.sw_version }}
 
 If you have installed any of the optional modules for Open XDMoD, download,
-extract, and install their source packages, too:
-- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-install-source.html)
-- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-install.html)
-- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/install.html)
+extract, and install their source packages, too. The upgrade guides for
+each of the optional modules are linked below; these each contain a link to
+the GitHub page for the module release, which has the link to their source
+package.
+
+- [Application Kernels](https://appkernels.xdmod.org/{{ page.version }}/ak-upgrade.html)
+- [Job Performance (SUPReMM)](https://supremm.xdmod.org/{{ page.version }}/supremm-upgrade.html)
+- [OnDemand](https://ondemand.xdmod.org/{{ page.version }}/upgrade.html)
 
 ### Copy Current Config Files
 


### PR DESCRIPTION
Backport of https://github.com/ubccr/xdmod/pull/2014 and https://github.com/ubccr/xdmod/pull/2017 for the `xdmod10.5` branch.