### PR TITLE
Robustness improvements for playwright

### DIFF
--- a/tests/playwright/lib/internal_dashboard.page.ts
+++ b/tests/playwright/lib/internal_dashboard.page.ts
@@ -14,17 +14,16 @@ class InternalDashboard extends BasePage implements LoginInterface {
 
     async login(username: string, password: string, display: string) {
         await this.verifyLocation('/internal_dashboard', 'XDMoD Internal Dashboard');
-        await this.usernameLocator.isVisible();
-        await this.passwordLocator.isVisible();
-        await this.submitLocator.isVisible();
 
         await this.usernameLocator.fill(username);
         await this.passwordLocator.fill(password);
         await this.submitLocator.click();
-        await this.submitLocator.isHidden();
+        await expect(this.submitLocator).toBeHidden();
 
-        await this.logoutLinkLocator.isVisible();
         await expect(this.loggedInDisplayLocator).toContainText(display);
+
+        const userManagementTab = this.page.locator(selectors.header.tabs.user_management());
+        await expect(userManagementTab).toBeVisible({ timeout: 10_000 });
     }
 
     async logout() {

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,10 +1,10 @@
 import {PlaywrightTestConfig, devices} from '@playwright/test';
-// Comment to trigger CI man do I hate trello boards...
+
 const config: PlaywrightTestConfig = {
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
     timeout: 60000,
-    workers: 5,
+    workers: 1,
     use: {
         trace: 'on-first-retry',
         video: 'on-first-retry',


### PR DESCRIPTION
Removed some calls to `isVisible()` function which returns a boolean
which was being ignored by the code.

Add extra wait so the internal dashboard is loaded before proceeding.

Run tests in serial mode to mitigate race conditions in the XDMoD database.
