### PR TITLE
Increase robustnification.

### DIFF
--- a/tests/playwright/lib/metricExplorer.page.ts
+++ b/tests/playwright/lib/metricExplorer.page.ts
@@ -90,6 +90,7 @@ class MetricExplorer extends BasePage{
         await expect(this.containerLocator).toBeVisible();
         await expect(this.catalogContainerLocator).toBeVisible();
         await expect(this.collapseButtonLocator).toBeVisible();
+        await this.clickSelector(this.logo);
     }
 
     /**

--- a/tests/playwright/tests/metricExplorer/metricExplorer.spec.ts
+++ b/tests/playwright/tests/metricExplorer/metricExplorer.spec.ts
@@ -85,6 +85,7 @@ test.describe('Metric Explorer', async () => {
             const xdmod = new XDMoD(page, baseUrl);
             await loginPage.login(roles['cd'].username, roles['cd'].password, (roles['cd'].givenname + " " + roles['cd'].surname));
             await xdmod.selectTab('metric_explorer');
+            await me.waitForLoaded();
             await test.step('Add data via metric catalog', async () => {
                 await me.createNewChart(chartName, 'Timeseries', 'Line');
                 await page.click(me.selectors.toolbar.configureTime.frameButton);
@@ -103,6 +104,7 @@ test.describe('Metric Explorer', async () => {
             const xdmod = new XDMoD(page, baseUrl);
             await loginPage.login(roles['cd'].username, roles['cd'].password, (roles['cd'].givenname + " " + roles['cd'].surname));
             await xdmod.selectTab('metric_explorer');
+            await me.waitForLoaded();
             await test.step('Add Filters in Toolbar', async () => {
                 await me.loadExistingChartByName(chartName);
                 await page.locator(me.chart.titleByText(chartName)).waitFor({state:'visible'});


### PR DESCRIPTION
Saw an intermittent failure in the Metric Explorer tests - looked to be caused by the test running while the data catalog was still moving. This update ensures the data catalog animation should have ended. Also click on the top left, which moves the mouse pointer away from any location that has hover overs (this also was seen in a error case where the hover over was in the way). 