### PR TITLE
Remove Data Analytics Framework token authentication via GET/POST params.

### DIFF
--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -25,7 +25,7 @@ class Tokens
     const DELIMITER = '.';
 
     /**
-     * Perform token authentication given an the value of an Authorization header.
+     * Perform token authentication given the value of an Authorization header.
      *
      * @param string $authorizationHeader
      * @param string $endpoint | null $endpoint the endpoint being requested, used only for logging.

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -28,7 +28,7 @@ class Tokens
      * Perform token authentication given the value of an Authorization header.
      *
      * @param string $authorizationHeader
-     * @param string $endpoint | null $endpoint the endpoint being requested, used only for logging.
+     * @param string | null $endpoint the endpoint being requested, used only for logging.
      *
      * @return XDUser the authenticated user.
      *

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -67,6 +67,7 @@ class Tokens
             JOIN moddb.Users u ON u.id = ut.user_id
         WHERE u.id = :user_id and u.account_is_active = 1
 SQL;
+
         $row = $db->query($query, array(':user_id' => $userId));
 
         if (count($row) === 0) {

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -25,20 +25,17 @@ class Tokens
     const DELIMITER = '.';
 
     /**
-     * Perform token authentication for the provided $userId & $token combo. If the authentication is successful, an
-     * XDUser object will be returned for the provided $userId. If not, an exception will be thrown.
+     * Perform token authentication given an the value of an Authorization header.
      *
-     * @param int|string $userId   The id used to look up the the users hashed token.
-     * @param string     $password The value to be checked against the retrieved hashed token.
+     * @param string $authorizationHeader
+     * @param string $endpoint | null $endpoint the endpoint being requested, used only for logging.
      *
-     * @return XDUser for the provided $userId, if the authentication is successful else an exception will be thrown.
+     * @return XDUser the authenticated user.
      *
      * @throws Exception                 if unable to retrieve a database connection.
-     * @throws UnauthorizedHttpException if no token can be found for the provided $userId,
-     *                                   if the stored token for $userId has expired, or
-     *                                   if the provided $token doesn't match the stored hash.
+     * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
      */
-    public static function authenticate($authorizationHeader, $request = null)
+    public static function authenticate($authorizationHeader, $endpoint = null)
     {
         if (0 !== strpos($authorizationHeader, Tokens::HEADER_KEY . ' ')) {
             throw new UnauthorizedHttpException(

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -127,8 +127,10 @@ SQL;
      * This function is a stop-gap that is meant to be used to protect controller endpoints until they can be moved to
      * the new REST stack.
      *
-     * @return XDUser|null if the authentication is successful then an XDUser instance for the authenticated user will
-     * be returned, if the authentication is not successful then null will be returned.
+     * @return XDUser the authenticated user.
+     *
+     * @throws Exception                 if unable to retrieve a database connection.
+     * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
      */
     public static function authenticateToken()
     {

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -101,11 +101,7 @@ SQL;
             'User '
             . $dbUserId
             . ' requested '
-            . (
-                !is_null($request)
-                ? $request->getPathInfo()
-                : $_SERVER['SCRIPT_NAME']
-            )
+            . (!is_null($endpoint) ? $endpoint : $_SERVER['SCRIPT_NAME'])
             . ' with API token using '
             . $_SERVER['HTTP_USER_AGENT']
         );

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -50,11 +50,12 @@ class Tokens
         if (false === $delimPosition) {
             throw new UnauthorizedHttpException(
                 Tokens::HEADER_KEY,
-                'Invalid token format.'
+                'Invalid API token.'
             );
         }
         $userId = substr($rawToken, 0, $delimPosition);
         $token = substr($rawToken, $delimPosition + 1);
+
         $db = \CCR\DB::factory('database');
         $query = <<<SQL
         SELECT
@@ -65,7 +66,6 @@ class Tokens
             JOIN moddb.Users u ON u.id = ut.user_id
         WHERE u.id = :user_id and u.account_is_active = 1
 SQL;
-
         $row = $db->query($query, array(':user_id' => $userId));
 
         if (count($row) === 0) {
@@ -84,7 +84,7 @@ SQL;
         }
 
         // finally check that the provided token matches its stored hash.
-        if (!password_verify($password, $expectedToken)) {
+        if (!password_verify($token, $expectedToken)) {
             throw new UnauthorizedHttpException(Tokens::HEADER_KEY, 'Invalid API token.');
         }
 

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -752,9 +752,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
      *
      * @param Request $request
      * @return \XDUser
-     * @throws UnauthorizedHttpException if the provided token is empty, if there is not a provided token,
-     *                                   or if the user's token from the db does not validate against the
-     *                                   provided token.
+     * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
      */
     protected function authenticateToken($request)
     {

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -766,7 +766,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
             );
         }
         $authorizationHeader = $request->headers->get('Authorization');
-        return Tokens::authenticate($authorizationHeader, $request);
+        return Tokens::authenticate($authorizationHeader, $request->getPathInfo());
     }
 
     /**

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -762,7 +762,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
         if (!$request->headers->has('Authorization')) {
             throw new UnauthorizedHttpException(
                 Tokens::HEADER_KEY,
-                'No Token Provided.'
+                Tokens::MISSING_TOKEN_MESSAGE
             );
         }
         $authorizationHeader = $request->headers->get('Authorization');

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -766,7 +766,7 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
             );
         }
         $authorizationHeader = $request->headers->get('Authorization');
-        return Tokens::authenticate($authorizationHeader);
+        return Tokens::authenticate($authorizationHeader, $request);
     }
 
     /**

--- a/docs/data-analytics-framework.md
+++ b/docs/data-analytics-framework.md
@@ -2,7 +2,7 @@
 title: Data Analytics Framework
 ---
 
-The XDMoD Data Analytics Framework provides REST API access to the XDMoD data warehouse. Users can access the API programmatically using the [xdmod-data](https://github.com/ubccr/xdmod-data) package. To use the API, users must generate API Tokens for themselves through the portal interface.
+The XDMoD Data Analytics Framework provides REST API access to the XDMoD data warehouse. Users can access the API programmatically using the [xdmod-data](https://github.com/ubccr/xdmod-data) package. To use the API, users must generate API tokens for themselves through the portal interface.
 
 ## Configuration
 
@@ -19,7 +19,7 @@ expiration_interval = "6 months"
 
 ## API Token Generation
 
-Users should follow [these steps](https://github.com/ubccr/xdmod-data#api-token-access) to generate an API Token.
+Users should follow [these steps](https://github.com/ubccr/xdmod-data#api-token-access) to generate an API token.
 
 ## API Token Revocation
 

--- a/docs/xdmod-rest-schema.json
+++ b/docs/xdmod-rest-schema.json
@@ -568,7 +568,7 @@ layout: null
                     "totalCount": 0,
                     "results": [],
                     "data": [],
-                    "message": "No Token Provided.",
+                    "message": "No API token provided.",
                     "code": 0
                 }
             },
@@ -592,7 +592,7 @@ layout: null
                     "totalCount": 0,
                     "results": [],
                     "data": [],
-                    "message": "The API Token has expired.",
+                    "message": "API token has expired.",
                     "code": 0
                 }
             }

--- a/docs/xdmod-rest-schema.json
+++ b/docs/xdmod-rest-schema.json
@@ -572,18 +572,6 @@ layout: null
                     "code": 0
                 }
             },
-            "malformed-token": {
-                "value": {
-                    "success": false,
-                    "count": 0,
-                    "total": 0,
-                    "totalCount": 0,
-                    "results": [],
-                    "data": [],
-                    "message": "Invalid token format.",
-                    "code": 0
-                }
-            },
             "invalid-token": {
                 "value": {
                     "success": false,
@@ -3061,9 +3049,6 @@ layout: null
                                 "examples": {
                                     "empty-token": {
                                         "$ref": "#/components/examples/empty-token"
-                                    },
-                                    "malformed-token": {
-                                        "$ref": "#/components/examples/malformed-token"
                                     },
                                     "invalid-token": {
                                         "$ref": "#/components/examples/invalid-token"

--- a/html/controllers/metric_explorer/get_dimension.php
+++ b/html/controllers/metric_explorer/get_dimension.php
@@ -2,13 +2,15 @@
 @require_once('common.php');
 
 use DataWarehouse\Access\MetricExplorer;
+use Models\Services\Tokens;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 // Attempt authentication by API token.
-$user = \Models\Services\Tokens::authenticateToken();
-
-// If token authentication failed then fall back to the standard session-based
-// authentication method.
-if ($user === null) {
+try {
+    $user = Tokens::authenticateToken();
+} catch (UnauthorizedHttpException $e) {
+    // If token authentication failed then fall back to the standard
+    // session-based authentication method.
     $user = \xd_security\detectUser(array(\XDUser::PUBLIC_USER));
 }
 

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -2,14 +2,17 @@
 
 use Models\Services\Acls;
 use Models\Services\Realms;
+use Models\Services\Tokens;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 @require_once('common.php');
 
-// To enable API Token
-$user = \Models\Services\Tokens::authenticateToken();
-
-// If token authentication failed then fallback to the standard session based authentication method.
-if ($user === null) {
+// Attempt authentication by API token.
+try {
+    $user = Tokens::authenticateToken();
+} catch (UnauthorizedHttpException $e) {
+    // If token authentication failed then fall back to the standard
+    // session-based authentication method.
     $user = \xd_security\getLoggedInUser();
 }
 

--- a/html/controllers/user_interface/get_charts.php
+++ b/html/controllers/user_interface/get_charts.php
@@ -1,15 +1,17 @@
 <?php
 
 use DataWarehouse\Access\Usage;
+use Models\Services\Tokens;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 $logger = new \CCR\RequestLogger();
 
 // Attempt authentication by API token.
-$user = \Models\Services\Tokens::authenticateToken();
-
-// If token authentication failed then fall back to the standard session-based
-// authentication method.
-if ($user === null) {
+try {
+    $user = Tokens::authenticateToken();
+} catch (UnauthorizedHttpException $e) {
+    // If token authentication failed then fall back to the standard
+    // session-based authentication method.
     $user = \xd_security\detectUser(array(\XDUser::PUBLIC_USER));
 }
 

--- a/tests/integration/lib/TokenAuthTest.php
+++ b/tests/integration/lib/TokenAuthTest.php
@@ -192,55 +192,28 @@ abstract class TokenAuthTest extends BaseTest
             ];
         }
 
-        // Do one request with the token in both the header and the query
-        // parameters (because the Apache server eats the 'Authorization'
-        // header on EL7) and one request with the token only in the query
-        // parameters, to make sure the result is the same.
-        $actualBodies = [];
-        foreach (['token_in_header', 'token_not_in_header'] as $mode) {
-            // Construct a test helper for making the request.
-            $helper = new XdmodTestHelper();
+        // Construct a test helper for making the request.
+        $helper = new XdmodTestHelper();
 
-            // Add the token to the header.
-            if ('token_in_header' === $mode) {
-                $helper->addheader(
-                    'Authorization',
-                    Tokens::HEADER_KEY . ' ' . $token
-                );
-            }
-
-            // Add the token to the query parameters.
-            parent::assertRequiredKeys(['params'], $input, '$input');
-            if (is_null($input['params'])) {
-                $input['params'] = [];
-            }
-            $input['params'][Tokens::HEADER_KEY] = $token;
-
-            // Make the request and validate the response.
-            $actualBodies[$mode] = parent::requestAndValidateJson(
-                $helper,
-                $input,
-                $output
-            );
-        }
-        $this->assertSame(
-            json_encode($actualBodies['token_in_header']),
-            json_encode($actualBodies['token_not_in_header']),
-            json_encode(
-                $actualBodies['token_in_header'],
-                JSON_PRETTY_PRINT
-            )
-            . "\n"
-            . json_encode(
-                $actualBodies['token_not_in_header'],
-                JSON_PRETTY_PRINT
-            )
+        // Add the token to the header.
+        $helper->addheader(
+            'Authorization',
+            Tokens::HEADER_KEY . ' ' . $token
         );
+
+        // Make the request and validate the response.
+        $actualBody = parent::requestAndValidateJson(
+            $helper,
+            $input,
+            $output
+        );
+
         // If the token is expired, unexpire it.
         if ('expired_token' === $tokenType) {
             self::unexpireToken($role);
         }
-        return $actualBodies['token_in_header'];
+
+        return $actualBody;
     }
 
     /**

--- a/tests/integration/lib/TokenAuthTest.php
+++ b/tests/integration/lib/TokenAuthTest.php
@@ -161,11 +161,11 @@ abstract class TokenAuthTest extends BaseTest
             // separate key in the output test artifact for each token type.
             } elseif ('token_required' === $input['authentication_type']) {
                 $messages = [
-                    'empty_token' => 'No Token Provided.',
-                    'malformed_token' => 'Invalid API token.',
-                    'invalid_token' => 'Invalid API token.',
-                    'expired_token' => 'The API Token has expired.',
-                    'revoked_token' => 'Invalid API token.'
+                    'empty_token' => Tokens::MISSING_TOKEN_MESSAGE,
+                    'malformed_token' => Tokens::INVALID_TOKEN_MESSAGE,
+                    'invalid_token' => Tokens::INVALID_TOKEN_MESSAGE,
+                    'expired_token' => Tokens::EXPIRED_TOKEN_MESSAGE,
+                    'revoked_token' => Tokens::INVALID_TOKEN_MESSAGE
                 ];
                 $output = [
                     'status_code' => 401,

--- a/tests/integration/lib/TokenAuthTest.php
+++ b/tests/integration/lib/TokenAuthTest.php
@@ -162,7 +162,7 @@ abstract class TokenAuthTest extends BaseTest
             } elseif ('token_required' === $input['authentication_type']) {
                 $messages = [
                     'empty_token' => 'No Token Provided.',
-                    'malformed_token' => 'Invalid token format.',
+                    'malformed_token' => 'Invalid API token.',
                     'invalid_token' => 'Invalid API token.',
                     'expired_token' => 'The API Token has expired.',
                     'revoked_token' => 'Invalid API token.'

--- a/user_manual_builder/About.rst
+++ b/user_manual_builder/About.rst
@@ -48,7 +48,7 @@ follow.
       Role Delegation Menu
 
 Also in the **My Profile** window is a tab that allows you to create an
-**API Token** to use with the
+**API token** to use with the
 `Data Analytics Framework <https://pypi.org/project/xdmod-data>`_
 (:numref:`api_token_menu`).
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR removes the ability to authenticate to the Data Analytics Framework REST API via API token in GET or POST parameters and makes it so the token must be provided via `Authorization` header. The GET/POST param functionality was in place for CentOS 7 to work around the `Authorization` header being eaten by Apache, and it is no longer needed.

These changes mean the current method of counting Data Analytics Framework requests for our reporting KPIs will no longer work (they involved reading the logs with `ident = 'rest.logger.db' or ident = 'controller.log'` and searching for the `Bearer` parameter). To correct this, this PR adds logging with a new `ident = 'daf'`.

This PR also updates the error messages and documentation to use consistent lowercasing of "token" and to move the duplicate error message strings into variables.

This PR also refactors some duplicated code into functions.

There is also a PR for https://github.com/ubccr/xdmod-xsede/pull/570.

## Motivation and Context
Code cleanup and better practice not to have the API token in the request parameters.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR updates the token auth integration tests.

In a Docker container with the changes from this PR, I also made requests via the version of `xdmod-data` from https://github.com/ubccr/xdmod-data/pull/68 and confirmed the logs appeared as expected, e.g.,:

```
+-------+---------------------+-------+----------+-----------------------------------------------------------------------------------------------------------+
| id    | logtime             | ident | priority | message                                                                                                   |
+-------+---------------------+-------+----------+-----------------------------------------------------------------------------------------------------------+
| 14122 | 2025-04-09 19:00:20 | daf   |        6 | {"message":"User 3 requested /controllers/metric_explorer.php with API token using xdmod-data Python v1.1.0.dev09"} |
| 14123 | 2025-04-09 19:00:21 | daf   |        6 | {"message":"User 3 requested /controllers/user_interface.php with API token using xdmod-data Python v1.1.0.dev09"}  |
| 14125 | 2025-04-09 19:00:21 | daf   |        6 | {"message":"User 3 requested /v1/warehouse/export/realms with API token using xdmod-data Python v1.1.0.dev09"}      |
| 14127 | 2025-04-09 19:00:22 | daf   |        6 | {"message":"User 3 requested /v1/warehouse/raw-data with API token using xdmod-data Python v1.1.0.dev09"}           |
+-------+---------------------+-------+----------+-----------------------------------------------------------------------------------------------------------+
```

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request