### PR TITLE
Plotly JS charts now consider timezones

### DIFF
--- a/html/gui/js/PlotlyChartWrapper.js
+++ b/html/gui/js/PlotlyChartWrapper.js
@@ -88,20 +88,20 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
 
         // Format timezone -- Plotly does not support timezones
         // Therefore, we need to utilize moment JS.
-        let axis = baseChartOptions.layout.swapXY ? 'y' : 'x';
-        baseChartOptions.data.forEach((series) => {
-            if (series.type !== 'pie') {
-                series[axis].forEach((elem, index, seriesArr) => {
+        const axis = (baseChartOptions.layout.swapXY ? 'y' : 'x') + 'axis';
+        if (baseChartOptions.layout[axis].timeseries) {
+            const axisName = axis.slice(0,1);
+            baseChartOptions.data.forEach((series) => {
+                series[axisName].forEach((elem, index, seriesArr) => {
                     seriesArr[index] = moment.tz(elem, CCR.xdmod.timezone).format();
                 });
-            }
-        });
+            });
 
-        // Format timezone for the tickvals also
-        axis = axis + 'axis';
-        baseChartOptions.layout[axis].tickvals.forEach((tick, index, tickvals) => {
-            tickvals[index] = moment.tz(tick, CCR.xdmod.timezone).format();
-        });
+            // Format timezone for the tickvals also
+            baseChartOptions.layout[axis].tickvals.forEach((tick, index, tickvals) => {
+                tickvals[index] = moment.tz(tick, CCR.xdmod.timezone).format();
+            });
+        }
     }
 
     const chart = Plotly.newPlot(baseChartOptions.renderTo, baseChartOptions.data, baseChartOptions.layout, configs);

--- a/html/gui/js/PlotlyChartWrapper.js
+++ b/html/gui/js/PlotlyChartWrapper.js
@@ -88,9 +88,9 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
 
         // Format timezone -- Plotly does not support timezones
         // Therefore, we need to utilize moment JS.
-        const axis = (baseChartOptions.layout.swapXY ? 'y' : 'x') + 'axis';
+        const axis = (baseChartOptions.layout.swapXY ? 'yaxis' : 'xaxis';
         if (baseChartOptions.layout[axis].timeseries) {
-            const axisName = axis.slice(0,1);
+            const axisName = axis.slice(0, 1);
             baseChartOptions.data.forEach((series) => {
                 series[axisName].forEach((elem, index, seriesArr) => {
                     seriesArr[index] = moment.tz(elem, CCR.xdmod.timezone).format();

--- a/html/gui/js/PlotlyChartWrapper.js
+++ b/html/gui/js/PlotlyChartWrapper.js
@@ -85,6 +85,23 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
             }
             return Math.sign(trace1.traceorder - trace2.traceorder);
         });
+
+        // Format timezone -- Plotly does not support timezones
+        // Therefore, we need to utilize moment JS.
+        let axis = baseChartOptions.layout.swapXY ? 'y' : 'x';
+        baseChartOptions.data.forEach((series) => {
+            if (series.type !== 'pie') {
+                series[axis].forEach((elem, index, seriesArr) => {
+                    seriesArr[index] = moment.tz(elem, CCR.xdmod.timezone).format();
+                });
+            }
+        });
+
+        // Format timezone for the tickvals also
+        axis = axis + 'axis';
+        baseChartOptions.layout[axis].tickvals.forEach((tick, index, tickvals) => {
+            tickvals[index] = moment.tz(tick, CCR.xdmod.timezone).format();
+        });
     }
 
     const chart = Plotly.newPlot(baseChartOptions.renderTo, baseChartOptions.data, baseChartOptions.layout, configs);

--- a/html/gui/js/PlotlyChartWrapper.js
+++ b/html/gui/js/PlotlyChartWrapper.js
@@ -88,7 +88,7 @@ XDMoD.utils.createChart = function (chartOptions, extraHandlers) {
 
         // Format timezone -- Plotly does not support timezones
         // Therefore, we need to utilize moment JS.
-        const axis = (baseChartOptions.layout.swapXY ? 'yaxis' : 'xaxis';
+        const axis = baseChartOptions.layout.swapXY ? 'yaxis' : 'xaxis';
         if (baseChartOptions.layout[axis].timeseries) {
             const axisName = axis.slice(0, 1);
             baseChartOptions.data.forEach((series) => {


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
Should have been in original conversion (PR #1822). This update makes all XDMoD charts timezone aware. Plotly JS does not support timezones. Therefore, moment js was utilized to convert the dates to the web server's timezone.

This bug was found by @ryanrath and Shava. The the following [chart](https://xdmod-dev.ccr.xdmod.org:9004/#main_tab_panel:metric_explorer?config=eyJmZWF0dXJlZCI6ZmFsc2UsInRyZW5kX2xpbmUiOmZhbHNlLCJ4X2F4aXMiOnt9LCJ5X2F4aXMiOnt9LCJsZWdlbmQiOnt9LCJkZWZhdWx0RGF0YXNldENvbmZpZyI6e30sInN3YXBfeHkiOmZhbHNlLCJzaGFyZV95X2F4aXMiOmZhbHNlLCJoaWRlX3Rvb2x0aXAiOmZhbHNlLCJzaG93X3JlbWFpbmRlciI6ZmFsc2UsInRpbWVzZXJpZXMiOnRydWUsInRpdGxlIjoidW50aXRsZWQgcXVlcnkgMSIsImxlZ2VuZF90eXBlIjoiYm90dG9tX2NlbnRlciIsImZvbnRfc2l6ZSI6Mywic2hvd19maWx0ZXJzIjp0cnVlLCJzaG93X3dhcm5pbmdzIjp0cnVlLCJkYXRhX3NlcmllcyI6eyJkYXRhIjpbeyJncm91cF9ieSI6ImNiX2Z1bmRlciIsImNvbG9yIjoiYXV0byIsImxvZ19zY2FsZSI6ZmFsc2UsInN0ZF9lcnIiOmZhbHNlLCJ2YWx1ZV9sYWJlbHMiOmZhbHNlLCJkaXNwbGF5X3R5cGUiOiJjb2x1bW4iLCJjb21iaW5lX3R5cGUiOiJzdGFjayIsInNvcnRfdHlwZSI6InZhbHVlX2Rlc2MiLCJpZ25vcmVfZ2xvYmFsIjpmYWxzZSwibG9uZ19sZWdlbmQiOnRydWUsInhfYXhpcyI6ZmFsc2UsImhhc19zdGRfZXJyIjpmYWxzZSwidHJlbmRfbGluZSI6ZmFsc2UsImxpbmVfdHlwZSI6IlNvbGlkIiwibGluZV93aWR0aCI6Miwic2hhZG93IjpmYWxzZSwiZmlsdGVycyI6eyJkYXRhIjpbXSwidG90YWwiOjB9LCJ6X2luZGV4IjowLCJ2aXNpYmlsaXR5IjpudWxsLCJlbmFibGVkIjp0cnVlLCJtZXRyaWMiOiJjYl9zcGVuZCIsInJlYWxtIjoiQ2xvdWRCYW5rU3BlbmQiLCJjYXRlZ29yeSI6IkNsb3VkQmFuayBTcGVuZCIsImlkIjotNTE0MTU2OTE4MjMzNTM1fV0sInRvdGFsIjoxfSwiYWdncmVnYXRpb25fdW5pdCI6IkF1dG8iLCJnbG9iYWxfZmlsdGVycyI6eyJkYXRhIjpbXSwidG90YWwiOjB9LCJ0aW1lZnJhbWVfbGFiZWwiOiIxIHllYXIiLCJzdGFydF9kYXRlIjoiMjAyNC0wNC0xMCIsImVuZF9kYXRlIjoiMjAyNS0wNC0xMCIsInN0YXJ0IjowLCJsaW1pdCI6MTB9), exposes the bug for 'America/Los_Angeles' vs 'America/New_York' timezones.

_Note:_ Job Viewer charts were already timezone aware because they are created through a separate mechanism than all other XDMoD charts.
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Wrong date range shown on the plot depending on the data time range and client's timezone.
<!--- If it fixes an open issue, please link to the issue here. -->

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
Tested the chart linked across various timezones. (See [here](https://developer.chrome.com/docs/devtools/sensors#geolocation) for more details on changing timezone)
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
