### PR TITLE
PHP 8.2 Migration Prep: add dyn properties

### DIFF
--- a/classes/CCR/DB/OracleDB.php
+++ b/classes/CCR/DB/OracleDB.php
@@ -20,6 +20,8 @@ use Exception;
 
 class OracleDB extends PDODB
 {
+    protected $_dsn;
+
     /* ------------------------------------------------------------------------------------------
      * Set up the machinery. Oracle requires at minimum a database name (local naming,
      * this resolves to an entry in tnsnames.org) or a name, host, and optionally a port

--- a/classes/DB/PDODBSynchronizingIngestor.php
+++ b/classes/DB/PDODBSynchronizingIngestor.php
@@ -12,6 +12,8 @@ use Psr\Log\LoggerInterface;
 class PDODBSynchronizingIngestor implements Ingestor
 {
 
+    protected $insertColumns;
+
     /**
      * Destination database.
      *

--- a/classes/DataWarehouse/Data/RawDataset.php
+++ b/classes/DataWarehouse/Data/RawDataset.php
@@ -4,6 +4,8 @@ namespace DataWarehouse\Data;
 
 class RawDataset
 {
+    protected $userType;
+
     private $query;
     private $query_results;
 

--- a/classes/DataWarehouse/Data/SimpleData.php
+++ b/classes/DataWarehouse/Data/SimpleData.php
@@ -14,6 +14,7 @@ namespace DataWarehouse\Data;
  */
 class SimpleData extends \Common\Identity
 {
+    protected $values;
     // ----------- instance variables ------------- //
 
     // SimpleData type may be one of 'dim', 'met', or 'time'

--- a/classes/DataWarehouse/Query/Cloud/JobTimeseries.php
+++ b/classes/DataWarehouse/Query/Cloud/JobTimeseries.php
@@ -17,6 +17,9 @@ use CCR\DB;
 
 class JobTimeseries
 {
+
+    protected $db;
+
     public function __construct() {
         $this->db = DB::factory('datawarehouse');
     }

--- a/classes/DataWarehouse/Query/TimeseriesQuery.php
+++ b/classes/DataWarehouse/Query/TimeseriesQuery.php
@@ -65,6 +65,9 @@ use Psr\Log\LoggerInterface;
 
 class TimeseriesQuery extends Query implements iQuery
 {
+
+    protected $sortInfo;
+
     public function getQueryType()
     {
         return 'timeseries';

--- a/classes/DataWarehouse/Visualization/AggregateChart.php
+++ b/classes/DataWarehouse/Visualization/AggregateChart.php
@@ -15,6 +15,11 @@ use DataWarehouse\RoleRestrictionsStringBuilder;
 */
 class AggregateChart
 {
+    protected $_legend_location;
+    protected $_hasLegend;
+    protected $_limit;
+    protected $show_filters;
+
     protected $_swapXY;
     protected $_chart;
     protected $_width;

--- a/classes/DataWarehouse/Visualization/TimeseriesChart.php
+++ b/classes/DataWarehouse/Visualization/TimeseriesChart.php
@@ -24,6 +24,9 @@ use DataWarehouse\Data\TimeseriesDataset;
 */
 class TimeseriesChart extends AggregateChart
 {
+    protected $show_filters;
+    protected $_hasLegend;
+
     // ---------------------------------------------------------
     // __construct()
     //

--- a/classes/ETL/EtlOverseerOptions.php
+++ b/classes/ETL/EtlOverseerOptions.php
@@ -17,6 +17,8 @@ use Psr\Log\LoggerInterface;
 
 class EtlOverseerOptions extends \CCR\Loggable
 {
+    protected $resourceCodeToIdMapSql;
+
     // Start of the ETL period
     private $startDate = null;
 

--- a/classes/ETL/Ingestor/CloudInstanceTypeStateIngestor.php
+++ b/classes/ETL/Ingestor/CloudInstanceTypeStateIngestor.php
@@ -24,8 +24,14 @@ use Psr\Log\LoggerInterface;
 
 class CloudInstanceTypeStateIngestor extends pdoIngestor implements iAction
 {
+    protected $_end_time;
 
-    private $_instance_type_state;
+    /**
+     * @var null
+     */
+    protected $_instance_state;
+
+    protected $_instance_type_state;
 
     /**
      * @see ETL\Ingestor\pdoIngestor::__construct()

--- a/classes/ETL/Ingestor/CloudResourceSpecsStateTransformIngestor.php
+++ b/classes/ETL/Ingestor/CloudResourceSpecsStateTransformIngestor.php
@@ -25,6 +25,7 @@ use Psr\Log\LoggerInterface;
 
 class CloudResourceSpecsStateTransformIngestor extends pdoIngestor implements iAction
 {
+    protected $_end_time;
 
     private $_instance_state;
 

--- a/classes/ETL/Maintenance/ManageAggregateTables.php
+++ b/classes/ETL/Maintenance/ManageAggregateTables.php
@@ -24,6 +24,9 @@ use ETL\DbModel\AggregationTable;
 
 class ManageAggregateTables extends ManageTables
 {
+
+    protected $etlDestinationTable;
+
     /* ------------------------------------------------------------------------------------------
      * Override aRdbmsDestinationAction::createDestinationTableObjects() because there are
      * multiple definition files referenced by this action and we will be generating a

--- a/classes/OpenXdmod/Setup/SubMenuQuitSetup.php
+++ b/classes/OpenXdmod/Setup/SubMenuQuitSetup.php
@@ -11,6 +11,8 @@ namespace OpenXdmod\Setup;
 class SubMenuQuitSetup extends SetupItem
 {
 
+    protected $parent;
+
     public function __construct($console, SubMenuSetupItem $parent)
     {
         parent::__construct($console);

--- a/classes/Reports/ClassicReport.php
+++ b/classes/Reports/ClassicReport.php
@@ -4,6 +4,8 @@ namespace Reports;
 
 class ClassicReport
 {
+    protected $settings;
+
     private $styles = array();
     private $fonts = array();
     private $phpWord = null;

--- a/classes/User/Elements/Module.php
+++ b/classes/User/Elements/Module.php
@@ -12,6 +12,10 @@ namespace User\Elements;
 class Module extends \Common\Identity
 {
 
+    protected $_position;
+
+    protected $_permitted_modules;
+
     /**
      * Is this a default module?
      *

--- a/classes/User/Elements/QueryDescripter.php
+++ b/classes/User/Elements/QueryDescripter.php
@@ -8,6 +8,8 @@ use \DataWarehouse\Query\TimeseriesQuery;
 class QueryDescripter
 {
 
+    protected $groupByInstance;
+
     /**
      * @var \Realm\iRealm The Realm that we are querying.
      */

--- a/classes/UserStorage.php
+++ b/classes/UserStorage.php
@@ -2,6 +2,9 @@
 
 class UserStorage
 {
+    protected $_user;
+    protected $_container;
+
     const MAX_RECORDS = 2000;
 
     public function __construct($user, $container)

--- a/tests/component/lib/BaseTest.php
+++ b/tests/component/lib/BaseTest.php
@@ -7,6 +7,8 @@ use Models\Services\Realms;
 
 abstract class BaseTest extends \PHPUnit\Framework\TestCase
 {
+    protected $testFiles;
+
     private static $TEST_ARTIFACT_OUTPUT_PATH;
 
     protected static $XDMOD_REALMS;

--- a/tests/integration/lib/Controllers/MetricExplorerTest.php
+++ b/tests/integration/lib/Controllers/MetricExplorerTest.php
@@ -7,6 +7,8 @@ use IntegrationTests\TestHarness\XdmodTestHelper;
 
 class MetricExplorerTest extends TokenAuthTest
 {
+    private $helper;
+
     protected function setup(): void
     {
         $this->helper = new XdmodTestHelper();

--- a/tests/integration/lib/Rest/JobViewerTest.php
+++ b/tests/integration/lib/Rest/JobViewerTest.php
@@ -7,6 +7,8 @@ use IntegrationTests\TestHarness\XdmodTestHelper;
 
 class JobViewerTest extends BaseTest
 {
+    private $xdmodhelper;
+
     const ENDPOINT = 'rest/v0.1/warehouse/';
 
     public function setup(): void

--- a/tests/integration/lib/TestHarness/XdmodTestHelper.php
+++ b/tests/integration/lib/TestHarness/XdmodTestHelper.php
@@ -4,6 +4,8 @@ namespace IntegrationTests\TestHarness;
 
 class XdmodTestHelper
 {
+    private $responseHeaders;
+
     private $config;
     private $siteurl;
     private $headers;

--- a/tests/unit/lib/DataWarehouse/Export/CsvFileWriterTest.php
+++ b/tests/unit/lib/DataWarehouse/Export/CsvFileWriterTest.php
@@ -13,6 +13,8 @@ use IntegrationTests\TestHarness\TestFiles;
  */
 class CsvFileWriterTest extends TestCase
 {
+    private $testFiles;
+
     /**
      * Test artifacts path.
      * @var string

--- a/tests/unit/lib/DataWarehouse/Export/JsonFileWriterTest.php
+++ b/tests/unit/lib/DataWarehouse/Export/JsonFileWriterTest.php
@@ -13,6 +13,9 @@ use IntegrationTests\TestHarness\TestFiles;
  */
 class JsonFileWriterTest extends TestCase
 {
+
+    private $testFiles;
+
     /**
      * Test artifacts path.
      * @var string

--- a/tests/unit/lib/DataWarehouse/Export/NullFileWriterTest.php
+++ b/tests/unit/lib/DataWarehouse/Export/NullFileWriterTest.php
@@ -13,6 +13,9 @@ use IntegrationTests\TestHarness\TestFiles;
  */
 class NullFileWriterTest extends TestCase
 {
+
+    private $testFiles;
+
     /**
      * Test artifacts path.
      * @var string

--- a/tests/unit/lib/DataWarehouse/ExportBuilderTest.php
+++ b/tests/unit/lib/DataWarehouse/ExportBuilderTest.php
@@ -4,6 +4,8 @@ namespace UnitTests\DataWarehouse;
 
 class ExportBuilderTest extends \PHPUnit\Framework\TestCase
 {
+    private $_dummydata;
+
     public function __construct(?string $name = null, array $data = [], $dataName = '')
     {
         $this->_dummydata = array(array(

--- a/tests/unit/lib/DataWarehouse/Visualization/ColorGeneratorTest.php
+++ b/tests/unit/lib/DataWarehouse/Visualization/ColorGeneratorTest.php
@@ -4,6 +4,9 @@ namespace UnitTests\DataWarehouse\Visualization;
 
 class ColorGeneratorTest extends \PHPUnit\Framework\TestCase
 {
+    private $expected;
+    private $inputdata;
+
     public function setup(): void
     {
         // Cut and pasted from the colors1.json file.


### PR DESCRIPTION
## Description
These changes were derived from the composer library `rector/rector` which helps identify php code that matches specific rules / sets of rules. In this case the rule used was the "Complete Dynamic Properties" https://getrector.com/rule-detail/complete-dynamic-properties-rector . 

*NOTE: If you dry-run that rule on a freshly checked out XDMoD repo it will include some white space modifications. I have not included those changes in this PR*

## Motivation and Context
As of PHP 8.2 dynamically creating properties for an object has been deprecated ( https://php.watch/versions/8.2/dynamic-properties-deprecated ). As the changes to support this are compatible with PHP 7.4 this PR can be merged prior to the main 7.4 -> 8.2 upgrade.

## Tests performed
All automated tests have been run locally.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
