### PR TITLE
[TRIVIAL] Fix documentation links pointing to .md files

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -126,7 +126,7 @@ The first column should be the username of the PI as seen in your resources even
 as seen in your resources event log files. The third column is the name of the resource in XDMoD.
 
 If you want the first and last name of the PI to be shown instead of their username when viewing this data you should add the PI username and
-first and last name to the `names.csv` file and ingested. Details on doing this can be found in the [`User/PI Names`](user-names.md) documentation.
+first and last name to the `names.csv` file and ingested. Details on doing this can be found in the [`User/PI Names`](user-names.html) documentation.
 
 ## Hierarchy
 
@@ -196,4 +196,4 @@ Cloud resources are added by using the xdmod-setup command.
 `php /usr/share/xdmod/tools/etl/etl_overseer.php -p ingest-resources`
 
 ### Ingesting cloud event data
-Cloud data is shredded and ingested using the [`xdmod-shredder`](shredder.md) and [`xdmod-ingestor`](ingestor.md) commands. Please see their respective guides for further information.
+Cloud data is shredded and ingested using the [`xdmod-shredder`](shredder.html) and [`xdmod-ingestor`](ingestor.html) commands. Please see their respective guides for further information.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Prerequisites
 Before running the interactive `xdmod-setup` script, ensure the following:
 
 - The base XDMoD software and any desired XDMoD submodules have been installed
-  following the [Installation Guide](install.md).
+  following the [Installation Guide](install.html).
 - The MariaDB server is configured per the instructions below and is
   running.
 

--- a/docs/gateways-realm.md
+++ b/docs/gateways-realm.md
@@ -28,7 +28,7 @@ Verify:
 Successful execution results in creation of the modw_gateways database schema with empty enduser, gateway, gatewayfact_by_day_joblist, and job_metadata tables.
 
 ### b. Select and ingest jobs data for the modw_gateways database
-XDMoD needs a mechanism to identify HPC jobs that were run via a gateway. The default mechanism is to use the last name associated with the user account that ran the jobs. Instructions for configuring the names are in the (User/PI Names guide)[user-names.md]. The steps to use this mechanism are:
+XDMoD needs a mechanism to identify HPC jobs that were run via a gateway. The default mechanism is to use the last name associated with the user account that ran the jobs. Instructions for configuring the names are in the (User/PI Names guide)[user-names.html]. The steps to use this mechanism are:
 1) Choose a suitable identifier to be used for a gateway (such as 'Gateway Proxy User')
 1) Update the last name entries in `names.csv` for each gateway proxy user account.
 1) Import the updated `names.csv`

--- a/docs/gpu-metrics.md
+++ b/docs/gpu-metrics.md
@@ -85,7 +85,7 @@ Univa Grid Engine is the only Grid Engine based product that is confirmed to
 report GPU count data.  If your Grid Engine based product reports GPU data in
 the same format then it will be interpreted in the same was as described here.
 
-Please report any issues to the email address on our [support page](support.md).
+Please report any issues to the email address on our [support page](support.html).
 
 The GPU count source for UGE is the `category` field in the accounting log
 files.  If a value is specified for `gpu` then that is used as the total number

--- a/docs/resource-specifications.md
+++ b/docs/resource-specifications.md
@@ -6,8 +6,8 @@ title: Resource Specifications Realm
 - A full working installation of XDMoD. [XDMoD install instructions](install.html)
 
 ## What is the Resource Specifications realm?
-The Resource Specifications realm in Open XDMoD provides a way to track the changes in computing capacity over time, such as the number of CPUs and GPUs as well as CPU Hours, GPU Hours and other metrics. The source for this data is the `resource_specs.json` configuration file (see the [Configuration Guide](configuration.md)). The data
-for this file are ingested into the XDMoD database when `xdmod-ingestor` is run. The only extra command needed is to aggregate the data using the `xdmod-ingestor` command. Please see the [`xdmod-ingestor` guide](ingestor.md) for further information.
+The Resource Specifications realm in Open XDMoD provides a way to track the changes in computing capacity over time, such as the number of CPUs and GPUs as well as CPU Hours, GPU Hours and other metrics. The source for this data is the `resource_specs.json` configuration file (see the [Configuration Guide](configuration.html)). The data
+for this file are ingested into the XDMoD database when `xdmod-ingestor` is run. The only extra command needed is to aggregate the data using the `xdmod-ingestor` command. Please see the [`xdmod-ingestor` guide](ingestor.html) for further information.
 
 ## Available metrics
 - Average Number of CPU Cores: Allocated (Core Count)

--- a/docs/shredder.md
+++ b/docs/shredder.md
@@ -67,11 +67,11 @@ For [TORQUE and OpenPBS][pbs] use `pbs`, for [Sun Grid Engine][sge] use
     $ xdmod-shredder -f slurm ...
     $ xdmod-shredder -f lsf ...
 
-[pbs]:   resource-manager-pbs.md
-[sge]:   resource-manager-sge.md
-[uge]:   resource-manager-uge.md
-[slurm]: resource-manager-slurm.md
-[lsf]:   resource-manager-lsf.md
+[pbs]:   resource-manager-pbs.html
+[sge]:   resource-manager-sge.html
+[uge]:   resource-manager-uge.html
+[slurm]: resource-manager-slurm.html
+[lsf]:   resource-manager-lsf.html
 
 **Cloud:**
 
@@ -84,7 +84,7 @@ The convention for shredding cloud files is identical to job data:
 **Storage:**
 
 The shredder accepts one format for storage data.  See the [Storage
-Metrics](storage.md) documentation for an example.  The convention for
+Metrics](storage.html) documentation for an example.  The convention for
 shredding storage files is identical to job data:
 
     $ xdmod-shredder -f storage ...

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -78,8 +78,8 @@ must then be used in the JSON storage input files described above.
 
 ## Data Ingestion
 
-Storage data is shredded and ingested using the [`xdmod-shredder`](shredder.md)
-and [`xdmod-ingestor`](ingestor.md) commands. Please see their respective
+Storage data is shredded and ingested using the [`xdmod-shredder`](shredder.html)
+and [`xdmod-ingestor`](ingestor.html) commands. Please see their respective
 guides for further information.
 
 All of the following commands must be executed in the order specified below to


### PR DESCRIPTION
Some documentation links are pointing to the source .md files, resulting in 404 errors - fix this by changing the extension to .html to match other documentation links.

