### PR TITLE
Restore Data Analytics Framework token authentication via GET/POST params.

### DIFF
--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -4,6 +4,7 @@ namespace Models\Services;
 
 use CCR\Log;
 use Exception;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use XDUser;
@@ -15,11 +16,6 @@ use XDUser;
 class Tokens
 {
     /**
-     * This is the key that will be used when adding an API Token to a request's headers.
-     */
-    const HEADER_KEY = 'Bearer';
-
-    /**
      * This is the delimiter that's used when returning a newly created API token to the user.
      */
     const DELIMITER = '.';
@@ -29,31 +25,83 @@ class Tokens
     const EXPIRED_TOKEN_MESSAGE = 'API token has expired.';
 
     /**
-     * Perform token authentication given the value of an Authorization header.
+     * Attempt to authenticate a user via an API token included in a given request.
      *
-     * @param string $authorizationHeader
-     * @param string | null $endpoint the endpoint being requested, used only for logging.
+     * @param Request $request
      *
-     * @return XDUser the authenticated user.
+     * @return XDUser the succesfully authenticated user.
      *
      * @throws Exception                 if unable to retrieve a database connection.
      * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
      */
-    public static function authenticate($authorizationHeader, $endpoint = null)
+    public static function authenticate($request)
     {
-        if (0 !== strpos($authorizationHeader, Tokens::HEADER_KEY . ' ')) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                Tokens::MISSING_TOKEN_MESSAGE
-            );
+        $token = null;
+        // Try to extract the token from the header.
+        if ($request->headers->has('Authorization')) {
+            $token = self::getTokenFromHeader($request->headers->get('Authorization'));
         }
-        $rawToken = substr($authorizationHeader, strlen(Tokens::HEADER_KEY) + 1);
+        // If the token is not in the header, then fall back to extracting from
+        // the GET/POST params.
+        if (empty($token)) {
+            $token = $request->get('Bearer');
+        }
+        // If we still haven't found a token, then authentication fails.
+        if (empty($token)) {
+            self::throwUnauthorized(self::MISSING_TOKEN_MESSAGE);
+        }
+        return self::authenticateToken($token, $request->getPathInfo());
+    }
+
+    /**
+     * This function is a stop-gap that is meant to be used to protect controller endpoints until they can be moved to
+     * the new REST stack.
+     *
+     * @return XDUser the successfully authenticated user.
+     *
+     * @throws Exception                 if unable to retrieve a database connection.
+     * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
+     */
+    public static function authenticateController()
+    {
+        $token = null;
+        // Try to extract the token from the header.
+        $headers = getallheaders();
+        if (!empty($headers['Authorization'])) {
+            $token = self::getTokenFromHeader($headers['Authorization']);
+        }
+        // If the token is not in the header, then fall back to extracting from
+        // the GET/POST params.
+        if (empty($token)) {
+            if (isset($_GET['Bearer']) && is_string($_GET['Bearer'])) {
+                $token = $_GET['Bearer'];
+            } elseif (isset($_POST['Bearer']) && is_string($_POST['Bearer'])) {
+                $token = $_POST['Bearer'];
+            }
+        }
+        // If we still haven't found a token, then authentication fails.
+        if (empty($token)) {
+            self::throwUnauthorized(self::MISSING_TOKEN_MESSAGE);
+        }
+        return self::authenticateToken($token);
+    }
+
+    /**
+     * Perform authentication given a token.
+     *
+     * @param string $rawToken
+     * @param string | null $endpoint the endpoint being requested, used only for logging.
+     *
+     * @return XDUser the successfully authenticated user.
+     *
+     * @throws Exception                 if unable to retrieve a database connection.
+     * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
+     */
+    private static function authenticateToken($rawToken, $endpoint = null)
+    {
         $delimPosition = strpos($rawToken, Tokens::DELIMITER);
         if (false === $delimPosition) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                Tokens::INVALID_TOKEN_MESSAGE
-            );
+            self::throwUnauthorized(self::INVALID_TOKEN_MESSAGE);
         }
         $userId = substr($rawToken, 0, $delimPosition);
         $token = substr($rawToken, $delimPosition + 1);
@@ -72,10 +120,7 @@ SQL;
         $row = $db->query($query, array(':user_id' => $userId));
 
         if (count($row) === 0) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                Tokens::INVALID_TOKEN_MESSAGE
-            );
+            self::throwUnauthorized(self::INVALID_TOKEN_MESSAGE);
         }
 
         $expectedToken = $row[0]['token'];
@@ -86,18 +131,12 @@ SQL;
         $now = new \DateTime();
         $expires = new \DateTime($expiresOn);
         if ($expires < $now) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                Tokens::EXPIRED_TOKEN_MESSAGE
-            );
+            self::throwUnauthorized(self::EXPIRED_TOKEN_MESSAGE);
         }
 
         // finally check that the provided token matches its stored hash.
         if (!password_verify($token, $expectedToken)) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                Tokens::INVALID_TOKEN_MESSAGE
-            );
+            self::throwUnauthorized(self::INVALID_TOKEN_MESSAGE);
         }
 
         // Log the request so we can count it in our reporting of usage of the
@@ -119,28 +158,33 @@ SQL;
             . $_SERVER['HTTP_USER_AGENT']
         );
 
-        // and if we've made it this far we can safely return the requested Users data.
+        // and if we've made it this far we can safely return the requested user's data.
         return XDUser::getUserByID($dbUserId);
     }
 
     /**
-     * This function is a stop-gap that is meant to be used to protect controller endpoints until they can be moved to
-     * the new REST stack.
+     * Extract the bearer token from an authorization header string.
      *
-     * @return XDUser the authenticated user.
-     *
-     * @throws Exception                 if unable to retrieve a database connection.
-     * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
+     * @param string $header
+     * @return string | null the token if the header has the 'Bearer' key, null otherwise.
      */
-    public static function authenticateToken()
+    public static function getTokenFromHeader($header)
     {
-        $headers = getallheaders();
-        if (empty($headers['Authorization'])) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                Tokens::MISSING_TOKEN_MESSAGE
-            );
+        if (0 !== strpos($authorizationHeader, 'Bearer ')) {
+            return null;
         }
-        return Tokens::authenticate($headers['Authorization']);
+        return substr($authorizationHeader, strlen('Bearer') + 1);
+    }
+
+    /**
+     * Throw a 401 Unauthorized exception with the given message and indicating
+     * that a Bearer token should be used for authentication.
+     *
+     * @param string $message
+     * @throws UnauthorizedHttpException
+     */
+    public static function throwUnauthorized($message)
+    {
+        throw new UnauthorizedHttpException('Bearer', $message);
     }
 }

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -3,9 +3,6 @@
 namespace Models\Services;
 
 use CCR\Log;
-use Exception;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use XDUser;
 
@@ -27,11 +24,11 @@ class Tokens
     /**
      * Attempt to authenticate a user via an API token included in a given request.
      *
-     * @param Request $request
+     * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return XDUser the succesfully authenticated user.
      *
-     * @throws Exception                 if unable to retrieve a database connection.
+     * @throws \Exception                if unable to retrieve a database connection.
      * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
      */
     public static function authenticate($request)
@@ -59,7 +56,7 @@ class Tokens
      *
      * @return XDUser the successfully authenticated user.
      *
-     * @throws Exception                 if unable to retrieve a database connection.
+     * @throws \Exception                if unable to retrieve a database connection.
      * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
      */
     public static function authenticateController()
@@ -94,7 +91,7 @@ class Tokens
      *
      * @return XDUser the successfully authenticated user.
      *
-     * @throws Exception                 if unable to retrieve a database connection.
+     * @throws \Exception                if unable to retrieve a database connection.
      * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
      */
     private static function authenticateToken($rawToken, $endpoint = null)

--- a/classes/Models/Services/Tokens.php
+++ b/classes/Models/Services/Tokens.php
@@ -170,10 +170,10 @@ SQL;
      */
     public static function getTokenFromHeader($header)
     {
-        if (0 !== strpos($authorizationHeader, 'Bearer ')) {
+        if (0 !== strpos($header, 'Bearer ')) {
             return null;
         }
-        return substr($authorizationHeader, strlen('Bearer') + 1);
+        return substr($header, strlen('Bearer') + 1);
     }
 
     /**

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -747,26 +747,6 @@ abstract class BaseControllerProvider implements ControllerProviderInterface
     }
 
     /**
-     * Attempt to authorize the the provided `$request` via an included API Token.
-     *
-     * @param Request $request
-     * @return \XDUser
-     * @throws UnauthorizedHttpException if the token is missing, malformed, invalid, or expired.
-     */
-    protected function authenticateToken($request)
-    {
-        $authorizationHeader = null;
-        if (!$request->headers->has('Authorization')) {
-            throw new UnauthorizedHttpException(
-                Tokens::HEADER_KEY,
-                Tokens::MISSING_TOKEN_MESSAGE
-            );
-        }
-        $authorizationHeader = $request->headers->get('Authorization');
-        return Tokens::authenticate($authorizationHeader, $request->getPathInfo());
-    }
-
-    /**
      * Attempts to convert the provided $value into an instance of DateTime by using the provided $format. If $value is
      * unable to be converted into a valid DateTime or if warnings are generated during the process it will be filtered
      * and null returned.

--- a/classes/Rest/Controllers/BaseControllerProvider.php
+++ b/classes/Rest/Controllers/BaseControllerProvider.php
@@ -3,7 +3,6 @@
 namespace Rest\Controllers;
 
 use DateTime;
-use Models\Services\Tokens;
 use Rest\Utilities\Authentication;
 use Silex\Application;
 use Silex\ControllerCollection;

--- a/classes/Rest/Controllers/WarehouseControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseControllerProvider.php
@@ -12,6 +12,7 @@ use Exception;
 use Models\Services\Acls;
 use Models\Services\Parameters;
 use Models\Services\Realms;
+use Models\Services\Tokens;
 use PDO;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -2133,7 +2134,7 @@ class WarehouseControllerProvider extends BaseControllerProvider
      */
     public function getRawData(Request $request, Application $app)
     {
-        $user = parent::authenticateToken($request);
+        $user = Tokens::authenticate($request);
         $params = $this->validateRawDataParams($request, $user);
         $realmManager = new RealmManager();
         $queryClass = $realmManager->getRawDataQueryClass($params['realm']);

--- a/classes/Rest/Controllers/WarehouseExportControllerProvider.php
+++ b/classes/Rest/Controllers/WarehouseExportControllerProvider.php
@@ -10,6 +10,7 @@ use DataWarehouse\Export\QueryHandler;
 use DataWarehouse\Export\RealmManager;
 use DateTime;
 use Exception;
+use Models\Services\Tokens;
 use Psr\Log\LoggerInterface;
 use Silex\Application;
 use Silex\ControllerCollection;
@@ -96,7 +97,7 @@ class WarehouseExportControllerProvider extends BaseControllerProvider
         // We need to wrap the token authentication because we want the token authentication to be optional, proceeding
         // to the normal session authentication if a token is not provided.
         try {
-            $user = $this->authenticateToken($request);
+            $user = Tokens::authenticate($request);
         } catch (Exception $e) {
             // NOOP
         }

--- a/html/controllers/metric_explorer/get_dimension.php
+++ b/html/controllers/metric_explorer/get_dimension.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 // Attempt authentication by API token.
 try {
-    $user = Tokens::authenticateToken();
+    $user = Tokens::authenticateController();
 } catch (UnauthorizedHttpException $e) {
     // If token authentication failed then fall back to the standard
     // session-based authentication method.

--- a/html/controllers/metric_explorer/get_dw_descripter.php
+++ b/html/controllers/metric_explorer/get_dw_descripter.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 // Attempt authentication by API token.
 try {
-    $user = Tokens::authenticateToken();
+    $user = Tokens::authenticateController();
 } catch (UnauthorizedHttpException $e) {
     // If token authentication failed then fall back to the standard
     // session-based authentication method.

--- a/html/controllers/user_interface/get_charts.php
+++ b/html/controllers/user_interface/get_charts.php
@@ -8,7 +8,7 @@ $logger = new \CCR\RequestLogger();
 
 // Attempt authentication by API token.
 try {
-    $user = Tokens::authenticateToken();
+    $user = Tokens::authenticateController();
 } catch (UnauthorizedHttpException $e) {
     // If token authentication failed then fall back to the standard
     // session-based authentication method.

--- a/tests/integration/lib/TokenAuthTest.php
+++ b/tests/integration/lib/TokenAuthTest.php
@@ -62,10 +62,7 @@ abstract class TokenAuthTest extends BaseTest
         $role
     ) {
         $token = self::getToken('valid_token', $role);
-        $testHelper->addheader(
-            'Authorization',
-            Tokens::HEADER_KEY . ' ' . $token
-        );
+        $testHelper->addheader('Authorization', "Bearer $token");
         return BaseTest::makeHttpRequest($testHelper, $input);
     }
 
@@ -188,7 +185,7 @@ abstract class TokenAuthTest extends BaseTest
             && 'valid_token' !== $tokenType
         ) {
             $output['headers'] = [
-                'WWW-Authenticate' => Tokens::HEADER_KEY
+                'WWW-Authenticate' => 'Bearer'
             ];
         }
 
@@ -203,10 +200,7 @@ abstract class TokenAuthTest extends BaseTest
 
             // Add the token to the header.
             if ('token_in_header' === $mode) {
-                $helper->addheader(
-                    'Authorization',
-                    Tokens::HEADER_KEY . ' ' . $token
-                );
+                $helper->addheader('Authorization', "Bearer $token");
             }
 
             // Add the token to the query parameters.
@@ -214,7 +208,7 @@ abstract class TokenAuthTest extends BaseTest
             if (is_null($input['params'])) {
                 $input['params'] = [];
             }
-            $input['params'][Tokens::HEADER_KEY] = $token;
+            $input['params']['Bearer'] = $token;
 
             // Make the request and validate the response.
             $actualBodies[$mode] = parent::requestAndValidateJson(

--- a/tests/integration/lib/TokenAuthTest.php
+++ b/tests/integration/lib/TokenAuthTest.php
@@ -189,52 +189,29 @@ abstract class TokenAuthTest extends BaseTest
             ];
         }
 
-        // Do one request with the token in both the header and the query
-        // parameters (because the Apache server eats the 'Authorization'
-        // header) and one request with the token only in the query
-        // parameters, to make sure the result is the same.
-        $actualBodies = [];
-        foreach (['token_in_header', 'token_not_in_header'] as $mode) {
-            // Construct a test helper for making the request.
-            $helper = new XdmodTestHelper();
+        // Construct a test helper for making the request.
+        $helper = new XdmodTestHelper();
 
-            // Add the token to the header.
-            if ('token_in_header' === $mode) {
-                $helper->addheader('Authorization', "Bearer $token");
-            }
-
-            // Add the token to the query parameters.
-            parent::assertRequiredKeys(['params'], $input, '$input');
-            if (is_null($input['params'])) {
-                $input['params'] = [];
-            }
-            $input['params']['Bearer'] = $token;
-
-            // Make the request and validate the response.
-            $actualBodies[$mode] = parent::requestAndValidateJson(
-                $helper,
-                $input,
-                $output
-            );
+        // Add the token to the query parameters.
+        parent::assertRequiredKeys(['params'], $input, '$input');
+        if (is_null($input['params'])) {
+            $input['params'] = [];
         }
-        $this->assertSame(
-            json_encode($actualBodies['token_in_header']),
-            json_encode($actualBodies['token_not_in_header']),
-            json_encode(
-                $actualBodies['token_in_header'],
-                JSON_PRETTY_PRINT
-            )
-            . "\n"
-            . json_encode(
-                $actualBodies['token_not_in_header'],
-                JSON_PRETTY_PRINT
-            )
+        $input['params']['Bearer'] = $token;
+
+        // Make the request and validate the response.
+        $actualBody = parent::requestAndValidateJson(
+            $helper,
+            $input,
+            $output
         );
+
         // If the token is expired, unexpire it.
         if ('expired_token' === $tokenType) {
             self::unexpireToken($role);
         }
-        return $actualBodies['token_in_header'];
+
+        return $actualBody;
     }
 
     /**

--- a/tests/integration/lib/TokenAuthTest.php
+++ b/tests/integration/lib/TokenAuthTest.php
@@ -192,28 +192,55 @@ abstract class TokenAuthTest extends BaseTest
             ];
         }
 
-        // Construct a test helper for making the request.
-        $helper = new XdmodTestHelper();
+        // Do one request with the token in both the header and the query
+        // parameters (because the Apache server eats the 'Authorization'
+        // header) and one request with the token only in the query
+        // parameters, to make sure the result is the same.
+        $actualBodies = [];
+        foreach (['token_in_header', 'token_not_in_header'] as $mode) {
+            // Construct a test helper for making the request.
+            $helper = new XdmodTestHelper();
 
-        // Add the token to the header.
-        $helper->addheader(
-            'Authorization',
-            Tokens::HEADER_KEY . ' ' . $token
+            // Add the token to the header.
+            if ('token_in_header' === $mode) {
+                $helper->addheader(
+                    'Authorization',
+                    Tokens::HEADER_KEY . ' ' . $token
+                );
+            }
+
+            // Add the token to the query parameters.
+            parent::assertRequiredKeys(['params'], $input, '$input');
+            if (is_null($input['params'])) {
+                $input['params'] = [];
+            }
+            $input['params'][Tokens::HEADER_KEY] = $token;
+
+            // Make the request and validate the response.
+            $actualBodies[$mode] = parent::requestAndValidateJson(
+                $helper,
+                $input,
+                $output
+            );
+        }
+        $this->assertSame(
+            json_encode($actualBodies['token_in_header']),
+            json_encode($actualBodies['token_not_in_header']),
+            json_encode(
+                $actualBodies['token_in_header'],
+                JSON_PRETTY_PRINT
+            )
+            . "\n"
+            . json_encode(
+                $actualBodies['token_not_in_header'],
+                JSON_PRETTY_PRINT
+            )
         );
-
-        // Make the request and validate the response.
-        $actualBody = parent::requestAndValidateJson(
-            $helper,
-            $input,
-            $output
-        );
-
         // If the token is expired, unexpire it.
         if ('expired_token' === $tokenType) {
             self::unexpireToken($role);
         }
-
-        return $actualBody;
+        return $actualBodies['token_in_header'];
     }
 
     /**


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->
## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR restores the ability to authenticate to the Data Analytics Framework REST API via API token in a `Bearer` parameter of GET or POST requests instead of an `Authorization` header. This functionality had been removed in #2028, but after that PR was merged, it was discovered that the eating of the `Authorization` header described in that PR also happens in Rocky 8, and a proper fix requires an update to the Apache configuration. Because updating the Apache configuration requires the admin to make manual changes, this is deemed a substantial enough change to warrant deferring it to a major release. So, for now, we are rolling back to allowing the `Bearer` parameter to be used when making GET/POST requests.

This PR also refactors the code a bit to make it easier to read and maintain. Specifically:
* Remove the constant `HEADER_KEY` because the string `'Bearer'` is unlikely to change, and it is more readable not to have to look up the value of the constant.
* Move the `authenticateToken` method from `BaseControllerProvider` into the `Tokens` class, renamed as `authenticate` — this relegates all the handling of the token authentication to the `Tokens` service to encapsulate it all in one place.
* Rename the `authenticateToken` method in the `Tokens` class to `authenticateController` since it is meant to be a temporary function until the controller endpoints are refactored into the new REST stack in a future version of XDMoD.
* Rename the `authenticate` method in the `Tokens` class to `authenticateToken` and make it private since now there are no external classes that need to use it.
* Move common exception throwing in the `Tokens` class into a function to simplify the repeated code.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In addition to making sure the CI tests passed, I also ran various tests on my port on `xdmod-dev` with the changes from this PR, running `curl` with and without a token in a `Bearer` parameter for the various endpoints that use token authentication.

This PR changes the integration test for the API tokens to put the token in the query parameters instead of the header. A future PR that fixes the Apache configuration should also update this to test both the case where the token is in the header and the case where the token is instead in the query parameters.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
