### PR TITLE
Add resource_metadata.json to build.json.

### DIFF
--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -79,6 +79,7 @@
             "configuration/resource_specs.json",
             "configuration/resource_types.json",
             "configuration/resource_allocation_types.json",
+            "configuration/resource_metadata.json",
             "configuration/resources.json",
             "configuration/roles.json",
             "configuration/roles.d",


### PR DESCRIPTION
This adds the new `resource_metadata.json` from #2066 to `build.json` so it will be added to the configuration directory when XDMoD is installed/upgraded.