### PR TITLE
Add memory to cloud instance type ingestor sorting to prevent unique key errors

### DIFF
--- a/classes/ETL/Ingestor/CloudInstanceTypeStateIngestor.php
+++ b/classes/ETL/Ingestor/CloudInstanceTypeStateIngestor.php
@@ -143,7 +143,7 @@ class CloudInstanceTypeStateIngestor extends pdoIngestor implements iAction
         // is lost. To work around this we add a dummy row filled with zeroes.
         $colCount = count($this->etlSourceQuery->records);
         $unionValues = array_fill(0, $colCount, 0);
-        $sql .= "\nUNION ALL\nSELECT " . implode(',', $unionValues) . "\nORDER BY 1 DESC, 3 ASC, 9 ASC, 8 ASC, 2 DESC";
+        $sql .= "\nUNION ALL\nSELECT " . implode(',', $unionValues) . "\nORDER BY 1 DESC, 3 ASC, 9 ASC, 8 ASC, 7 ASC, 2 DESC";
 
         return $sql;
     }


### PR DESCRIPTION
Adding the `memory_mb` field to list of columns to sort by when the `CloudInstanceTypeIngestor` runs. This is the same issue as #2056 just with a different column.

## Tests performed
Tested in docker and on dev system

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
