### PR TITLE
Add the ability to configure a warning dialog that appears when the JupyterLab button is clicked.

### DIFF
--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -146,9 +146,17 @@ XDMoD.GlobalToolbar.JupyterLab = {
     scale: 'small',
     iconCls: 'btn_jupyterlab',
     id: 'global-toolbar-jupyterlab',
-    tooltip: 'Launch JupyterLab.',
+    tooltip: 'Launch single-user JupyterLab server.',
     handler() {
-        window.open(CCR.xdmod.JupyterHubURL);
+        Ext.MessageBox.confirm(
+            'Launch single-user JupyterLab server',
+            'WARNING: You are about to launch a single-user JupyterLab server that has a limited lifespan and no persistent storage. Please remember to periodically download any files you want to save from the server. Do you wish to continue?',
+            function (btn) {
+                if (btn === 'yes') {
+                    window.open(CCR.xdmod.JupyterHubURL);
+                }
+            }
+        );
     }
 
 }; // XDMoD.GlobalToolbar.JupyterLab

--- a/html/gui/js/CCR.js
+++ b/html/gui/js/CCR.js
@@ -146,17 +146,21 @@ XDMoD.GlobalToolbar.JupyterLab = {
     scale: 'small',
     iconCls: 'btn_jupyterlab',
     id: 'global-toolbar-jupyterlab',
-    tooltip: 'Launch single-user JupyterLab server.',
+    tooltip: 'Launch your single-user JupyterLab server.',
     handler() {
-        Ext.MessageBox.confirm(
-            'Launch single-user JupyterLab server',
-            'WARNING: You are about to launch a single-user JupyterLab server that has a limited lifespan and no persistent storage. Please remember to periodically download any files you want to save from the server. Do you wish to continue?',
-            function (btn) {
-                if (btn === 'yes') {
-                    window.open(CCR.xdmod.JupyterHubURL);
+        if (typeof CCR.xdmod.JupyterHubLaunchWarning === 'string') {
+            Ext.MessageBox.confirm(
+                'Launch JupyterLab',
+                CCR.xdmod.JupyterHubLaunchWarning,
+                function (btn) {
+                    if (btn === 'yes') {
+                        window.open(CCR.xdmod.JupyterHubURL);
+                    }
                 }
-            }
-        );
+            );
+        } else {
+            window.open(CCR.xdmod.JupyterHubURL);
+        }
     }
 
 }; // XDMoD.GlobalToolbar.JupyterLab

--- a/html/index.php
+++ b/html/index.php
@@ -372,6 +372,11 @@ JS;
             $jupyterhubURL = xd_utilities\getConfiguration('jupyterhub', 'url');
             print "CCR.xdmod.isJupyterHubConfigured = true;\n";
             print "CCR.xdmod.JupyterHubURL = " . json_encode($jupyterhubURL) . ";\n";
+            try {
+                $launchWarning = xd_utilities\getConfiguration('jupyterhub', 'launch_warning');
+                print "CCR.xdmod.JupyterHubLaunchWarning = " . json_encode($launchWarning) . ";\n";
+            } catch(\Exception $e) {
+            }
         } catch(\Exception $e) {
             print "CCR.xdmod.isJupyterHubConfigured = false;\n";
         }

--- a/html/index.php
+++ b/html/index.php
@@ -372,13 +372,9 @@ JS;
             $jupyterhubURL = xd_utilities\getConfiguration('jupyterhub', 'url');
             print "CCR.xdmod.isJupyterHubConfigured = true;\n";
             print "CCR.xdmod.JupyterHubURL = " . json_encode($jupyterhubURL) . ";\n";
-            try {
-                $launchWarning = xd_utilities\getConfiguration('jupyterhub', 'launch_warning');
-                print "CCR.xdmod.JupyterHubLaunchWarning = " . json_encode($launchWarning) . ";\n";
-            } catch(\Exception $e) {
-            }
+            $launchWarning = xd_utilities\getConfiguration('jupyterhub', 'launch_warning');
+            print "CCR.xdmod.JupyterHubLaunchWarning = " . json_encode($launchWarning) . ";\n";
         } catch(\Exception $e) {
-            print "CCR.xdmod.isJupyterHubConfigured = false;\n";
         }
         ?>
 


### PR DESCRIPTION
## Description
This PR adds the ability to configure a warning dialog that appears when the JupyterLab button is clicked. The text of the button is a configurable option in `portal_settings.ini` — if the option is not present, no dialog is shown when the button is clicked. In this way, admins of Open XDMoD who have set up an XDMoD-hosted JupyterHub can also configure a custom message for users to confirm before they launch their single-user JupyterLab server.

This PR is intended to be merged before Open XDMoD 11.0.2 is released.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The immediate need for this PR (in conjunction with [upcoming ccr-private-xdmod PR]) is to communicate to users of ACCESS XDMoD that the single-user JupyterLab servers have limited lifespans and do not have persistent storage.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my port on `xdmod-dev` with the changes from this PR applied, I confirmed the JupyterLab button still worked. Then, I added a `launch_warning` to the `jupyterhub` section in `portal_settings.ini` and confirmed it appeared when clicking the button. Finally, I removed the `jupyterhub` section all together and confirmed the main page still loads without errors.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
