### PR TITLE
Library support needed for Allocations realm performance improvements

### DIFF
--- a/classes/DB/EtlJournalHelper.php
+++ b/classes/DB/EtlJournalHelper.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace DB;
+
+/*
+ * Helper class for managing the logs of the last_modified times
+ * for the ETL process.
+ */
+class EtlJournalHelper
+{
+
+    public function __construct($schema, $table) {
+
+        $this->schema = $schema;
+        $this->table = $table;
+
+        $this->dwdb = \CCR\DB::factory('datawarehouse', false);
+
+        $this->lastModified = null;
+        $this->mostRecent = null;
+    }
+
+    /*
+     * Return the timestamp of the latest record that
+     * was sucessfully processed. Or null if there is no
+     * recorded log entry.
+     *
+     * This function also stores the timestamp of the latest
+     * record that exists in the source table.
+     */
+    public function getLastModified() {
+
+        $mostRecent = $this->dwdb->query(
+            'SELECT UNIX_TIMESTAMP(last_modified) + 1 AS most_recent FROM `' . $this->schema . '`.`' . $this->table . '` ORDER BY last_modified DESC LIMIT 1'
+        );
+
+        if (count($mostRecent) > 0) {
+            $this->mostRecent = $mostRecent[0]['most_recent'];
+        }
+
+        $lastRunInfo = $this->dwdb->query(
+            'SELECT FROM_UNIXTIME(max_index) AS last_modified FROM modw_etl.log WHERE etlProfileName = ? ORDER BY max_index DESC LIMIT 1',
+            array($this->schema . '.' . $this->table)
+        );
+
+        $this->dwdb->disconnect();
+
+        if (count($lastRunInfo) > 0) {
+            $this->lastModified = $lastRunInfo[0]['last_modified'];
+        }
+
+        return $this->lastModified;
+    }
+
+    /*
+     * Add a log entry with the timestamps information that was queried
+     * by the previous call to getLastModified
+     */
+    public function markAsDone($process_start_time, $process_end_time) {
+
+        $markAsDone = $this->dwdb->prepare(
+            'INSERT INTO modw_etl.log (etlProfileName, min_index, max_index, start_ts, end_ts) VALUES (?, UNIX_TIMESTAMP(?), ?, UNIX_TIMESTAMP(?), UNIX_TIMESTAMP(?))'
+        );
+
+        $markAsDone->execute(
+            array(
+                $this->schema . '.' . $this->table,
+                $this->lastModified,
+                $this->mostRecent,
+                $process_start_time,
+                $process_end_time
+            )
+        );
+
+        $this->dwdb->disconnect();
+    }
+}

--- a/classes/ETL/EtlOverseerOptions.php
+++ b/classes/ETL/EtlOverseerOptions.php
@@ -409,20 +409,32 @@ class EtlOverseerOptions extends \CCR\Loggable
      * database. If date is NULL, use the current date to ensure that the date is always set.
      *
      * @param $date A date representation or null to use the current date.
+     * @param $parseDateString If true then try to parse the date string into a mysql-compatible
+     *                         local time string. If false then use the string unmodified. The
+     *                         parseDateString option is ignore if a date of NULL is used.
      *
      * @return This object to support method chaining.
      * ------------------------------------------------------------------------------------------
      */
 
-    public function setLastModifiedStartDate($date)
+    public function setLastModifiedStartDate($date, $parseDateString = true)
     {
         if ( null === $date ) {
             $this->lastModifiedStartDate = null;
-        } elseif ( false === ( $ts = strtotime($date)) ) {
-            $msg = get_class($this) . ": Could not parse last modified start date '$date'";
-            throw new Exception($msg);
+            return $this;
+        }
+
+        if ($parseDateString) {
+            $ts = strtotime($date);
+
+            if ($ts === false) {
+                $msg = get_class($this) . ": Could not parse last modified start date '$date'";
+                throw new Exception($msg);
+            } else {
+                $this->lastModifiedStartDate = date("Y-m-d H:i:s", $ts);
+            }
         } else {
-            $this->lastModifiedStartDate = date("Y-m-d H:i:s", $ts);
+            $this->lastModifiedStartDate = $date;
         }
 
         return $this;


### PR DESCRIPTION
## Description

The allocations realm has some etl pipeline updates that ensure that the realm data is present and correct. The new pipeline switches to using the EtlJournalHelper to track which rows need to be ingested / updated.

This pull request moves the EtlJournalHelper to the core XDMoD and updates the helper class and the EtlOverseer class to add support for last_modified column values in Postgres databases.

The EtlJournalHelper has been around in the supremm realm for quite a while. Its being moved in to the core because multiple modules will be using its functionality.