### PR TITLE
Fix syntax errors in markdown files.

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -1,3 +1,7 @@
+---
+title: Cloud Metrics
+---
+
 ## Prerequisites
 - A full working installation of XDMoD. [XDMoD install instructions](install.html)
 

--- a/docs/etl/data-endpoint-oracle.md
+++ b/docs/etl/data-endpoint-oracle.md
@@ -1,4 +1,6 @@
-# Oracle Data Endpoint
+---
+site: Oracle Data Endpoint
+---
 
 The Oracle data endpoint requires that Oracle client libraries are installed and the oci8 extension
 is installed into PHP. The supported method for connecting to Oracle is via the Oracle Instant

--- a/docs/etl/data-verification.md
+++ b/docs/etl/data-verification.md
@@ -1,5 +1,6 @@
-
-# Verification of Data After Changes to ETL
+---
+site: Verification of Data After Changes to ETL
+---
 
 ## Description
 

--- a/docs/etl/json-references.md
+++ b/docs/etl/json-references.md
@@ -1,4 +1,6 @@
-# XDMoD ETL Support For RFC-6901 JSON References
+---
+title: XDMoD ETL Support For RFC-6901 JSON References
+---
 
 Reference handlers in JSON files will allow us to reference and include entities defined in external
 files into the current file, supporting re-use. This work is largely based on the JSON schema with

--- a/docs/gateways-realm.md
+++ b/docs/gateways-realm.md
@@ -1,3 +1,7 @@
+---
+title: Gateways realm
+---
+
 # Enabling the Gateways realm
 
 The gateways realm displays jobs information due to science gateways. It does this by incorporating jobs data in a new XDMoD database, `modw_gateways`, created for capturing gateways data. This realm is not enabled by default in the current release. These instructions show you how to enable and populate the gateways realm in your Open XDMoD installation.
@@ -28,7 +32,7 @@ Verify:
 Successful execution results in creation of the modw_gateways database schema with empty enduser, gateway, gatewayfact_by_day_joblist, and job_metadata tables.
 
 ### b. Select and ingest jobs data for the modw_gateways database
-XDMoD needs a mechanism to identify HPC jobs that were run via a gateway. The default mechanism is to use the last name associated with the user account that ran the jobs. Instructions for configuring the names are in the (User/PI Names guide)[user-names.md]. The steps to use this mechanism are:
+XDMoD needs a mechanism to identify HPC jobs that were run via a gateway. The default mechanism is to use the last name associated with the user account that ran the jobs. Instructions for configuring the names are in the [User/PI Names guide](user-names.md). The steps to use this mechanism are:
 1) Choose a suitable identifier to be used for a gateway (such as 'Gateway Proxy User')
 1) Update the last name entries in `names.csv` for each gateway proxy user account.
 1) Import the updated `names.csv`

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,4 +1,6 @@
-# Integrations
+---
+title: Integrations
+---
 
 Open XDMoD can be integrated with other applications such as [Open OnDemand](https://openondemand.org/)
 

--- a/docs/module-assets.md
+++ b/docs/module-assets.md
@@ -1,4 +1,6 @@
-# Open XDMoD Module Assets
+---
+title: Open XDMoD Module Assets
+---
 
 An Open XDMoD module may contain JavaScript and CSS assets that will be
 included in the portal or internal (admin) dashboard.

--- a/docs/openidc.md
+++ b/docs/openidc.md
@@ -1,4 +1,6 @@
-# OpenID Connect Setup
+---
+title: OpenID Connect Setup
+---
 
 This documentation will only cover the additional steps required to configure XDMoD to use OpenID Connect as an SSO identity
 provider. All the file paths included below assume that an RPM installation has been performed. If you have a source install

--- a/docs/shredder.md
+++ b/docs/shredder.md
@@ -6,7 +6,7 @@ This guide will attempt to outline the use of the Open XDMoD shredder
 command line utility.  The shredder is responsible for loading data from
 resource manager log files into the Open XDMoD databases.  If you are
 running Slurm, you should first read the
-[Slurm Notes](resource-manager-slurm.html).
+[Slurm Notes](resource-manager-slurm.md).
 
 General Usage
 -------------
@@ -67,11 +67,11 @@ For [TORQUE and OpenPBS][pbs] use `pbs`, for [Sun Grid Engine][sge] use
     $ xdmod-shredder -f slurm ...
     $ xdmod-shredder -f lsf ...
 
-[pbs]:   resource-manager-pbs.md
-[sge]:   resource-manager-sge.md
-[uge]:   resource-manager-uge.md
+[pbs]: resource-manager-pbs.md
+[sge]: resource-manager-sge.md
+[uge]: resource-manager-uge.md
 [slurm]: resource-manager-slurm.md
-[lsf]:   resource-manager-lsf.md
+[lsf]: resource-manager-lsf.md
 
 **Cloud:**
 
@@ -83,8 +83,8 @@ The convention for shredding cloud files is identical to job data:
 
 **Storage:**
 
-The shredder accepts one format for storage data.  See the [Storage
-Metrics](storage.md) documentation for an example.  The convention for
+The shredder accepts one format for storage data.  See the [Storage Metrics](storage.md)
+ documentation for an example.  The convention for
 shredding storage files is identical to job data:
 
     $ xdmod-shredder -f storage ...
@@ -98,7 +98,7 @@ note that this is **not** currently supported for cloud and storage files:
     $ xdmod-shredder -i file ...
 
 An entire directory of files may be shredded.  For all job formats other than
-`pbs` (see [PBS Notes](resource-manager-pbs.html) for details) this will shred
+`pbs` (see [PBS Notes](resource-manager-pbs.md) for details) this will shred
 every file in the directory.  Cloud and storage files must end in `.json`.
 
     $ xdmod-shredder -d directory ...


### PR DESCRIPTION
## Description

We had a bug report (and suggested code change) from @einonm about broken links in the documentation files. 
We use Jekyll with the github-pages Jekyll plugins which includes the Jekyll Relative Links plugin which converts
markdown links into html links with the correct path. It turns out that the relative links plugin will (silently)
fail to translate the links if there are line breaks in the markdown or extra spaces in the references (see the changes
in shredder.md). In my testing I also found that the jekyll version on github pages would fail to process files if they were missing the title directive.

This pull request fixes the incorrect syntax and adds title sections for all pages.
 
I note that we want to have the links with the ".md" suffix so that the pages work both when viewed in github.com as well as the rendered version working in the open.xdmod.org site.