### PR TITLE
Simplify metric explorer getFormat

### DIFF
--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -22,10 +22,7 @@ class MetricExplorer extends Common
 {
     public function get_data($user)
     {
-        $requestedFormat = 'csv';
-        if (isset($this->request['format'])) {
-            $requestedFormat = strtolower($this->request['format']);
-        }
+        $requestedFormat = $this->request['format'] ?? null;
 
         $format = \DataWarehouse\ExportBuilder::validateFormat(
             $requestedFormat,

--- a/classes/DataWarehouse/Access/MetricExplorer.php
+++ b/classes/DataWarehouse/Access/MetricExplorer.php
@@ -22,13 +22,13 @@ class MetricExplorer extends Common
 {
     public function get_data($user)
     {
-        if(isset($this->request['config'])) {
-            $config = json_decode($this->request['config'], true);
-            $this->request = array_merge($config, $this->request);
+        $requestedFormat = 'csv';
+        if (isset($this->request['format'])) {
+            $requestedFormat = strtolower($this->request['format']);
         }
 
-        $format = \DataWarehouse\ExportBuilder::getFormat(
-            $this->request,
+        $format = \DataWarehouse\ExportBuilder::validateFormat(
+            $requestedFormat,
             'png',
             array(
                 'svg',

--- a/classes/DataWarehouse/ExportBuilder.php
+++ b/classes/DataWarehouse/ExportBuilder.php
@@ -620,4 +620,28 @@ class ExportBuilder
 
         return $name;
     }
+
+    /** Validates that the format requested by the user is located in the set of formats that are supported and either
+     * all formats are allowed ( signified by there being no $allowedFormats ) or the requested format was found in the
+     * set of allowed formats. If valid the requested format is returned. If no requested format is provided then the
+     * default value will be returned.
+     *
+     * @param ?string $requestedFormat
+     * @param string $default
+     * @param array $allowedFormats
+     * @return string
+     */
+    public static function validateFormat(?string $requestedFormat, string $default = 'jsonstore', array $allowedFormats = []): string
+    {
+        if (!isset($requestedFormat)) {
+            return $default;
+        }
+        $requestedFormat = strtolower($requestedFormat);
+        $formatSupported = isset(self::$supported_formats[$requestedFormat]);
+        $noFormatSubset = count($allowedFormats) === 0;
+        $requestedFormatInSubset = in_array($requestedFormat, $allowedFormats);
+
+
+        return $formatSupported && ($noFormatSubset || $requestedFormatInSubset) ? $requestedFormat : $default;
+    }
 }

--- a/classes/DataWarehouse/ExportBuilder.php
+++ b/classes/DataWarehouse/ExportBuilder.php
@@ -226,42 +226,7 @@ class ExportBuilder
             header("$k: $v");
         }
     }
-
-    /**
-     * Get the output format from a request.
-     *
-     * @param array $request The HTTP request data.
-     * @param string $default The default output format
-     *     (defaults to "jsonstore").
-     * @param array $format_subset The allowed subset of formats.  If
-     *     the format specified by the request is not in this array,
-     *     the default format will be used.
-     */
-    public static function getFormat(
-        array $request,
-        $default = 'jsonstore',
-        array $formats_subset = array()
-    ) {
-        $format = $default;
-
-        if (isset($request['format'])) {
-            $f = strtolower($request['format']);
-
-            if (
-                isset(static::$supported_formats[$f])
-                && (
-                    count($formats_subset) == 0
-                    ||
-                    (count($formats_subset) > 0 && array_search($f, $formats_subset) !== false)
-                )
-            ) {
-                $format = $f;
-            }
-        }
-
-        return $format;
-    }
-
+    
     /**
      * Export data.
      *

--- a/classes/DataWarehouse/ExportBuilder.php
+++ b/classes/DataWarehouse/ExportBuilder.php
@@ -226,7 +226,7 @@ class ExportBuilder
             header("$k: $v");
         }
     }
-    
+
     /**
      * Export data.
      *
@@ -591,12 +591,12 @@ class ExportBuilder
      * set of allowed formats. If valid the requested format is returned. If no requested format is provided then the
      * default value will be returned.
      *
-     * @param ?string $requestedFormat
+     * @param string $requestedFormat
      * @param string $default
      * @param array $allowedFormats
      * @return string
      */
-    public static function validateFormat(?string $requestedFormat, string $default = 'jsonstore', array $allowedFormats = []): string
+    public static function validateFormat(string $requestedFormat, string $default, array $allowedFormats): string
     {
         if (!isset($requestedFormat)) {
             return $default;

--- a/html/controllers/metric_explorer/get_rawdata.php
+++ b/html/controllers/metric_explorer/get_rawdata.php
@@ -14,10 +14,8 @@ $returnData = array();
 
 $start = microtime(true);
 try {
-    $requestedFormat = null;
-    if (isset($request['format'])) {
-        $requestedFormat = strtolower($request['format']);
-    }
+
+    $requestedFormat = $_REQUEST['format'] ?? null;
 
     $format = \DataWarehouse\ExportBuilder::validateFormat($requestedFormat, 'jsonstore', ['jsonstore']);
 

--- a/html/controllers/metric_explorer/get_rawdata.php
+++ b/html/controllers/metric_explorer/get_rawdata.php
@@ -14,18 +14,12 @@ $returnData = array();
 
 $start = microtime(true);
 try {
-    if (isset($_REQUEST['config'])) {
-        $config = json_decode($_REQUEST['config'], true);
-        $_REQUEST = array_merge($config, $_REQUEST);
+    $requestedFormat = null;
+    if (isset($request['format'])) {
+        $requestedFormat = strtolower($request['format']);
     }
 
-    $format = \DataWarehouse\ExportBuilder::getFormat(
-        $_REQUEST,
-        'jsonstore',
-        array(
-            'jsonstore'
-        )
-    );
+    $format = \DataWarehouse\ExportBuilder::validateFormat($requestedFormat, 'jsonstore', ['jsonstore']);
 
     $user = \xd_security\detectUser(
         array(XDUser::INTERNAL_USER, XDUser::PUBLIC_USER)


### PR DESCRIPTION
## Description
Refactored `getFormat` to the much simpler new function `validateFormat` and removed `getFormat`. 

## Motivation and Context
These changes are to address the points raised in: https://github.com/ubccr/xdmod-xsede/issues/1154

## Tests performed
All automated tests.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The pull request description is suitable for a Changelog entry
- [X] The milestone is set correctly on the pull request
- [X] The appropriate labels have been added to the pull request
