### PR TITLE
Add ability to deprecate names of raw data fields.

### DIFF
--- a/classes/DataWarehouse/Data/RawStatisticsConfiguration.php
+++ b/classes/DataWarehouse/Data/RawStatisticsConfiguration.php
@@ -229,6 +229,12 @@ class RawStatisticsConfiguration
                 'anonymize' => ($export === 'anonymize'),
                 'documentation' => $field['documentation']
             ];
+            if (isset($field['deprecated'])) {
+                if (!is_bool($field['deprecated'])) {
+                    throw new Exception('"deprecated" must be a boolean.');
+                }
+                $f['deprecated'] = $field['deprecated'];
+            }
             if (isset($field['deprecatedNames'])) {
                 if (!is_array($field['deprecatedNames']) ||
                     count($field['deprecatedNames']) !== count(array_filter($field['deprecatedNames'], 'is_string'))

--- a/classes/DataWarehouse/Data/RawStatisticsConfiguration.php
+++ b/classes/DataWarehouse/Data/RawStatisticsConfiguration.php
@@ -222,13 +222,22 @@ class RawStatisticsConfiguration
                 $display .= ' (Deidentified)';
             }
 
-            $fields[] = [
+            $f = [
                 'name' => $field['name'],
                 'alias' => isset($field['alias']) ? $field['alias'] : $field['name'],
                 'display' => $display,
                 'anonymize' => ($export === 'anonymize'),
                 'documentation' => $field['documentation']
             ];
+            if (isset($field['deprecatedNames'])) {
+                if (!is_array($field['deprecatedNames']) ||
+                    count($field['deprecatedNames']) !== count(array_filter($field['deprecatedNames'], 'is_string'))
+                ) {
+                    throw new Exception('"deprecatedNames" must be an array of strings.');
+                }
+                $f['deprecatedNames'] = $field['deprecatedNames'];
+            }
+            $fields[] = $f;
         }
 
         return $fields;

--- a/configuration/rawstatistics.d/20_jobs.json
+++ b/configuration/rawstatistics.d/20_jobs.json
@@ -193,7 +193,8 @@
                 "column": "name",
                 "group": "Administration",
                 "documentation": "The organization of the person who ran the task",
-                "batchExport": true
+                "batchExport": true,
+                "deprecatedNames": ["Organization"]
             },
             {
                 "name": "Principal Investigator",

--- a/etl/js/lib/etl_profile.js
+++ b/etl/js/lib/etl_profile.js
@@ -924,6 +924,14 @@ ETLProfile.prototype.integrateWithXDMoD = function () {
                     fieldDef.withError = col.withError;
                 }
 
+                if (col.deprecated) {
+                    fieldDef.deprecated = col.deprecated;
+                }
+
+                if (col.deprecatedNames) {
+                    fieldDef.deprecatedNames = col.deprecatedNames;
+                }
+
                 rawStatsInteg.addField(fieldDef);
             }
         }


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
Currently, if a raw data field is renamed or removed, it can break Python scripts and notebooks that use its name.

This PR adds the ability to mark a raw data field as deprecated so that the `xdmod-data` API can post a `FutureWarning` if a user tries to use it (functionality added to `xdmod-data` in https://github.com/ubccr/xdmod-data/pull/91) rather than an exception being thrown.

#2026 renames the raw data field `Organization` to `User Institution`, so this PR marks `Organization` as a deprecated name of it. Below is a screenshot of what the `FutureWarning` will look like if someone tries to use it:

<img width="500" src="https://github.com/user-attachments/assets/514f0248-022a-405c-a0c1-a5fb3ce6bceb" />

---

So, to use the new functionality to deprecate a name of a field, add a `deprecatedNames` property whose value is an array containing the name.

There are also cases where a field is not being renamed but is instead being removed. [Upcoming xdmod-xsede PR] has examples of these. In this case, simply add a `"deprecated": true` property to the field and update the field's description to explain what the user should do. https://github.com/ubccr/xdmod-data/pull/91 adds functionality to `xdmod-data` to grab the description, remove any leading string `DEPRECATED: `, and include it in the `FutureWarning`. Below is an example screenshot of this.

<img width="500" src="https://github.com/user-attachments/assets/9424db26-64a4-4d93-adfd-1d89e124cdde" />

---

The new `deprecated` and `deprecatedNames` properties are not used anywhere else in the portal, so this does not change any other existing functionality.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
