### PR TITLE
Add backticks to filter lists temp table

### DIFF
--- a/bin/xdmod-build-filter-lists
+++ b/bin/xdmod-build-filter-lists
@@ -89,8 +89,7 @@ build($realms, $logger, $appendToList);
 
 function build($realms, $logger, $appendToList){
     try {
-        $filterListBuilder = new FilterListBuilder();
-        $filterListBuilder->setLogger($logger);
+        $filterListBuilder = new FilterListBuilder($logger);        
         if (count($realms) > 0){
             foreach($realms as $realm){
                 if(!empty($realm)){

--- a/bin/xdmod-build-filter-lists
+++ b/bin/xdmod-build-filter-lists
@@ -89,7 +89,7 @@ build($realms, $logger, $appendToList);
 
 function build($realms, $logger, $appendToList){
     try {
-        $filterListBuilder = new FilterListBuilder($logger);        
+        $filterListBuilder = new FilterListBuilder($logger);
         if (count($realms) > 0){
             foreach($realms as $realm){
                 if(!empty($realm)){

--- a/bin/xdmod-build-filter-lists
+++ b/bin/xdmod-build-filter-lists
@@ -89,7 +89,8 @@ build($realms, $logger, $appendToList);
 
 function build($realms, $logger, $appendToList){
     try {
-        $filterListBuilder = new FilterListBuilder($logger);
+        $filterListBuilder = new FilterListBuilder();
+        $filterListBuilder->setLogger($logger);
         if (count($realms) > 0){
             foreach($realms as $realm){
                 if(!empty($realm)){

--- a/classes/DB/FilterListBuilder.php
+++ b/classes/DB/FilterListBuilder.php
@@ -60,7 +60,7 @@ class FilterListBuilder extends Loggable
 
     public function __construct() {
         parent::__construct();
-        $this->filterTemporaryTable = sprintf("modw_aggregates.`%s`", uniqid('filter_tmp_', true));
+        $this->filterTemporaryTable = sprintf("`modw_aggregates`.`%s`", uniqid('filter_tmp_', true));
     }
 
     /**

--- a/classes/DB/FilterListBuilder.php
+++ b/classes/DB/FilterListBuilder.php
@@ -60,7 +60,7 @@ class FilterListBuilder extends Loggable
 
     public function __construct() {
         parent::__construct();
-        $this->filterTemporaryTable = uniqid('modw_aggregates.filter_tmp_', true);
+        $this->filterTemporaryTable = sprintf("modw_aggregates.`%s`", uniqid('filter_tmp_', true));
     }
 
     /**
@@ -144,7 +144,7 @@ class FilterListBuilder extends Loggable
             $lastModified = $journalHelper->getLastModified();
             $this->setLastModifiedStartDate($lastModified);
             $tempTableSql = "CREATE TEMPORARY TABLE $this->filterTemporaryTable AS SELECT * FROM $schema.$tableName where last_modified >= '$this->lastModifiedStartDate'";
-            $this->logger->debug("Creating temporary table: $tempTableSql");
+            $this->logger->debug("Creating temporary table: $tempTableSql with sql: $tempTableSql");
             $db->execute($tempTableSql);
         }
 

--- a/classes/DB/FilterListBuilder.php
+++ b/classes/DB/FilterListBuilder.php
@@ -9,6 +9,7 @@ use Realm\iGroupBy;
 use Realm\iRealm;
 use DataWarehouse\Query\iQuery;
 use DataWarehouse\Query\TimeAggregationUnit;
+use Psr\Log\LoggerInterface;
 
 /**
  * Builds lists of filters for every realm's dimensions.
@@ -58,8 +59,8 @@ class FilterListBuilder extends Loggable
      */
     private $filterTemporaryTable = '';
 
-    public function __construct() {
-        parent::__construct();
+    public function __construct(?LoggerInterface $logger = null) {
+        parent::__construct($logger);
         $this->filterTemporaryTable = sprintf("`modw_aggregates`.`%s`", uniqid('filter_tmp_', true));
     }
 
@@ -144,7 +145,7 @@ class FilterListBuilder extends Loggable
             $lastModified = $journalHelper->getLastModified();
             $this->setLastModifiedStartDate($lastModified);
             $tempTableSql = "CREATE TEMPORARY TABLE $this->filterTemporaryTable AS SELECT * FROM $schema.$tableName where last_modified >= '$this->lastModifiedStartDate'";
-            $this->logger->debug("Creating temporary table: $tempTableSql with sql: $tempTableSql");
+            $this->logger->debug("Creating temporary table: $tempTableSql");
             $db->execute($tempTableSql);
         }
 


### PR DESCRIPTION
This PR adds backticks to the temporary table name. The temporary table used when appending to the filters lists uses `uniqid` to help create a unique table name but `uniqid` sometimes returns a number with a decimal in it which is not valid for a table name without backticks. 

Also, use `$filterListBuilder->setLogger($logger)` to set the logger for the filter lists in `xdmod-build-filter-lists` as setting the logger in the constructor does not work.

## Tests performed
Tested in docker and xdmod-dev

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
