### PR TITLE
Add security patch files.

### DIFF
--- a/open_xdmod/modules/xdmod/build.json
+++ b/open_xdmod/modules/xdmod/build.json
@@ -14,6 +14,7 @@
             "/html/gui/js/modules/Module.template",
             "/logs",
             "/phpcs.xml",
+            "/security",
             "/setup",
             "/sonar-project.properties",
             "/tests",

--- a/security/patches/GHSA-29qm-7w4v-43fw-9_5_0-11_0_2.patch
+++ b/security/patches/GHSA-29qm-7w4v-43fw-9_5_0-11_0_2.patch
@@ -1,0 +1,30 @@
+# Workaround patch file for https://github.com/ubccr/xdmod/security/advisories/GHSA-29qm-7w4v-43fw
+# For patching Open XDMoD versions 9.5.0 through 11.0.2
+diff --git a/libraries/charting.php b/libraries/charting.php
+index 777c3e3b80..b022e5fc01 100644
+--- a/libraries/charting.php
++++ b/libraries/charting.php
+@@ -145,17 +145,17 @@ function getSvgViaChromiumHelper($html, $width, $height){
+  */
+ 
+ function convertSvg($svgData, $format, $width, $height, $docmeta){
+-    $author = isset($docmeta['author']) ? addcslashes($docmeta['author'], "()\n\\") : 'XDMoD';
+-    $subject = isset($docmeta['subject']) ? addcslashes($docmeta['subject'], "()\n\\") : 'XDMoD chart';
+-    $title = isset($docmeta['title']) ? addcslashes($docmeta['title'], "()\n\\") :'XDMoD PDF chart export';
+-    $creator = addcslashes('XDMoD ' . OPEN_XDMOD_VERSION, "()\n\\");
++    $author = isset($docmeta['author']) ? escapeshellarg($docmeta['author']) : "'XDMoD'";
++    $subject = isset($docmeta['subject']) ? escapeshellarg($docmeta['subject']) : "'XDMoD chart'";
++    $title = isset($docmeta['title']) ? escapeshellarg($docmeta['title']) : "'XDMoD PDF chart export'";
++    $creator = escapeshellarg('XDMoD ' . OPEN_XDMOD_VERSION);
+ 
+     switch($format){
+         case 'png':
+-            $exifArgs = "-Title='$title' -Author='$author' -Description='$subject' -Source='$creator'";
++            $exifArgs = "-Title=$title -Author=$author -Description=$subject -Source=$creator";
+             break;
+         case 'pdf':
+-            $exifArgs = "-Title='$title' -Author='$author' -Subject='$subject' -Creator='$creator'";
++            $exifArgs = "-Title=$title -Author=$author -Subject=$subject -Creator=$creator";
+             break;
+         default:
+             return $svgData;

--- a/security/patches/GHSA-3hfh-m242-8rmh-pre_11_0_3.patch
+++ b/security/patches/GHSA-3hfh-m242-8rmh-pre_11_0_3.patch
@@ -1,0 +1,113 @@
+# Workaround patch file for https://github.com/ubccr/xdmod/security/advisories/GHSA-3hfh-m242-8rmh
+# For patching Open XDMoD versions prior to 11.0.3
+diff --git a/html/controllers/sab_user.php b/html/controllers/sab_user.php
+index 5821a70760..8b6331b996 100644
+--- a/html/controllers/sab_user.php
++++ b/html/controllers/sab_user.php
+@@ -4,19 +4,15 @@
+  *
+  * operation: params -----
+  *     enum_tg_users: start, limit, [query], pi_only
+- *     assign_assumed_person: person_id
+- *     get_mapping: use_default
+  */
+
+ require_once __DIR__ . '/../../configuration/linker.php';
+
+ \xd_security\start_session();
+
+-$controller = new XDController(array(STATUS_LOGGED_IN));
++$controller = new XDController(array(STATUS_LOGGED_IN, STATUS_MANAGER_ROLE));
+
+ $controller->registerOperation('enum_tg_users');
+-$controller->registerOperation('assign_assumed_person');
+-$controller->registerOperation('get_mapping');
+
+ $session_variable
+     = (isset($_POST['dashboard_mode']))
+diff --git a/html/controllers/sab_user/assign_assumed_person.php b/html/controllers/sab_user/assign_assumed_person.php
+deleted file mode 100644
+index 3a63c7a88d..0000000000
+--- a/html/controllers/sab_user/assign_assumed_person.php
++++ /dev/null
+@@ -1,38 +0,0 @@
+-<?php
+-
+-// Operation: sab_user->assign_assumed_person
+-
+-$params = array('person_id' => RESTRICTION_ASSIGNMENT);
+-
+-$isValid = xd_security\secureCheck($params, 'POST');
+-
+-if (!$isValid) {
+-    $returnData = array(
+-        'success' =>  false,
+-        'status'  => 'invalid_id_specified',
+-        'message' => 'invalid_id_specified',
+-    );
+-    xd_controller\returnJSON($returnData);
+-};
+-
+-$xdw = new XDWarehouse();
+-
+-if ($xdw->resolveName($_POST['person_id']) == NO_MAPPING) {
+-    $returnData = array(
+-        'success' =>  false,
+-        'status'  => 'no_person_mapping',
+-        'message' => 'no_person_mapping',
+-    );
+-    xd_controller\returnJSON($returnData);
+-}
+-
+-$_SESSION['assumed_person_id'] = $_POST['person_id'];
+-
+-$returnData = array(
+-    'success' =>  true,
+-    'status'  => 'success',
+-    'message' => 'success',
+-);
+-
+-xd_controller\returnJSON($returnData);
+-
+diff --git a/html/controllers/sab_user/get_mapping.php b/html/controllers/sab_user/get_mapping.php
+deleted file mode 100644
+index 27b174f7fc..0000000000
+--- a/html/controllers/sab_user/get_mapping.php
++++ /dev/null
+@@ -1,36 +0,0 @@
+-<?php
+-
+-// Operation: sab_user->get_mapping
+-
+-$params = array(
+-    'use_default' => RESTRICTION_YES_NO
+-);
+-
+-$isValid = xd_security\secureCheck($params, 'POST');
+-
+-if (!$isValid) {
+-    $returnData = array(
+-        'success' =>  false,
+-        'status'  => 'invalid_params_specified',
+-        'message' => 'invalid_params_specified',
+-    );
+-    xd_controller\returnJSON($returnData);
+-};
+-
+-$logged_in_user = \xd_security\getLoggedInUser();
+-
+-$mapped_person_id = $logged_in_user->getPersonID($_POST['use_default'] == 'y');
+-
+-$xdw = new XDWarehouse();
+-$mapped_person_name = $xdw->resolveName($mapped_person_id);
+-
+-$returnData = array(
+-    'success'            =>  true,
+-    'status'             => 'success',
+-    'message'            => 'success',
+-    'mapped_person_id'   => $mapped_person_id,
+-    'mapped_person_name' => $mapped_person_name,
+-);
+-
+-xd_controller\returnJSON($returnData);
+-

--- a/security/patches/GHSA-3pv7-qvc3-h527-pre_11_0_3.patch
+++ b/security/patches/GHSA-3pv7-qvc3-h527-pre_11_0_3.patch
@@ -1,0 +1,15 @@
+# Workaround patch file for https://github.com/ubccr/xdmod/security/advisories/GHSA-3pv7-qvc3-h527
+# For patching Open XDMoD versions prior to 11.0.3
+diff --git a/html/password_reset.php b/html/password_reset.php
+index d87fae054c..1bbd8acd37 100644
+--- a/html/password_reset.php
++++ b/html/password_reset.php
+@@ -75,7 +75,7 @@
+
+ 		}//if (INVALID)
+
+-      $first_name = $validationCheck['user_first_name'];
++      $first_name = htmlspecialchars($validationCheck['user_first_name'], ENT_QUOTES, 'UTF-8');
+
+       $mode = ( isset($_GET['mode']) && ($_GET['mode'] == 'new') ) ? 'create' : 'reset';
+

--- a/security/patches/GHSA-r33r-6g3c-r992-9_0_0-10_0_2.patch
+++ b/security/patches/GHSA-r33r-6g3c-r992-9_0_0-10_0_2.patch
@@ -1,0 +1,70 @@
+# Workaround patch file for https://github.com/ubccr/xdmod/security/advisories/GHSA-r33r-6g3c-r992
+# For patching Open XDMoD versions 9.0.0 through 10.0.2
+diff --git a/classes/Realm/GroupBy.php b/classes/Realm/GroupBy.php
+index 68d17cc8ea..9bd0989746 100644
+--- a/classes/Realm/GroupBy.php
++++ b/classes/Realm/GroupBy.php
+@@ -746,10 +746,12 @@ public function generateQueryFiltersFromRequest(array $request)
+         // for each of the key columns and align the values with the approprite aggregate key based
+         // on the order specified in the attribute_to_aggregate_table_key_map.
+ 
++        $db = DB::factory('datawarehouse');
++
+         foreach ( $requestFilters as $filterValues ) {
+             $list = explode(self::FILTER_DELIMITER, $filterValues);
+             foreach ( $this->attributeToAggregateKeyMap as $aggregateKey ) {
+-                $aggregateFilters[$aggregateKey][] = array_shift($list);
++                $aggregateFilters[$aggregateKey][] = $db->quote(array_shift($list));
+             }
+         }
+ 
+@@ -759,10 +761,7 @@ public function generateQueryFiltersFromRequest(array $request)
+         // request. If no attribute filter query was specified simply use the list of values.
+ 
+         foreach ( $aggregateFilters as $aggregateKeyColumn => $filterValues ) {
+-            // The original code always enclosed values in quotes but this may not be desirable,
+-            // although it is unclear if we can differentiate between strings and numerics stored as
+-            // strings.
+-            $substitution = sprintf("'%s'", implode("','", $filterValues));
++            $substitution = implode(",", $filterValues);
+             if ( ! isset($this->attributeFilterMapSqlList[$aggregateKeyColumn]) ) {
+                 $fieldIdQuery = $substitution;
+             } else {
+@@ -802,10 +801,12 @@ public function generateQueryParameterLabelsFromRequest(array $request)
+         // for each of the key columns and align the values with the approprite aggregate key based
+         // on the order specified in the attribute_to_aggregate_table_key_map.
+ 
++        $db = DB::factory('datawarehouse');
++
+         foreach ( $requestFilters as $filterValues ) {
+             $list = explode(self::FILTER_DELIMITER, $filterValues);
+             foreach ( $this->attributeToAggregateKeyMap as $attributeKey => $aggregateKey ) {
+-                $attributeKeyFilters[$attributeKey][] = array_shift($list);
++                $attributeKeyFilters[$attributeKey][] = $db->quote(array_shift($list));
+             }
+         }
+ 
+@@ -814,7 +815,7 @@ public function generateQueryParameterLabelsFromRequest(array $request)
+ 
+         $whereConditions = array();
+         foreach ( $attributeKeyFilters as $attributeKey => $filterValues ) {
+-            $whereConditions[] = sprintf("%s IN ('%s')", $attributeKey, implode("','", $filterValues));
++            $whereConditions[] = sprintf("%s IN (%s)", $attributeKey, implode(",", $filterValues));
+         }
+ 
+         // If the attribute description query was not specified we will use the existing
+@@ -847,13 +848,9 @@ public function generateQueryParameterLabelsFromRequest(array $request)
+         } else {
+             // Construct the where conditions for each key column and replace the placeholder in the
+             // attribute description query.
+-            //
+-            // The original code always enclosed values in quotes but this may not be desirable,
+-            // although it is unclear if we can differentiate between strings and numerics stored as
+-            // strings.
+ 
+             foreach ( $attributeKeyFilters as $attributeKey => $filterValues ) {
+-                $filters = "'" . implode("','", $filterValues) . "'";
++                $filters = implode(",", $filterValues);
+             }
+ 
+             $query = str_replace(

--- a/security/patches/GHSA-r33r-6g3c-r992-pre_9_0_0.patch
+++ b/security/patches/GHSA-r33r-6g3c-r992-pre_9_0_0.patch
@@ -1,0 +1,61 @@
+# Workaround patch file for https://github.com/ubccr/xdmod/security/advisories/GHSA-r33r-6g3c-r992
+# For patching Open XDMoD versions prior to 9.0.0
+diff --git a/classes/DataWarehouse/Query/GroupBy.php b/classes/DataWarehouse/Query/GroupBy.php
+index 68277c6bf3..b3b72dfca7 100644
+--- a/classes/DataWarehouse/Query/GroupBy.php
++++ b/classes/DataWarehouse/Query/GroupBy.php
+@@ -182,19 +182,23 @@ public function pullQueryParameterDescriptions(&$request)
+     }
+     public function pullQueryParameters2(&$request, $filter_query, $id_column)
+     {
++        $db = \CCR\DB::factory('datawarehouse');
+         $parameters = array();
+         $filterItems = array();
+         if (isset($request[$this->getName().'_filter']) && $request[$this->getName().'_filter'] != '') {
+             $filterString = $request[$this->getName().'_filter'];
+-            $filterItems = array_merge($filterItems, explode(',', $filterString));
++            $items = explode(',', $filterString);
++            foreach ($items as $filterItem) {
++                $filterItems[] = $db->quote($filterItem);
++            }
+         }
+
+         if (isset($request[$this->getName()])) {
+-            $filterItems[] = $request[$this->getName()];
++            $filterItems[] = $db->quote($request[$this->getName()]);
+         }
+         $filterCount = count($filterItems);
+         if ($filterCount > 0) {
+-            $fieldIdQuery = str_replace('_filter_', "'".implode("','", $filterItems)."'", $filter_query);
++            $fieldIdQuery = str_replace('_filter_', implode(",", $filterItems), $filter_query);
+
+             $parameters[] = new \DataWarehouse\Query\Model\Parameter($id_column, 'in', "($fieldIdQuery)");
+         }
+@@ -203,20 +207,24 @@ public function pullQueryParameters2(&$request, $filter_query, $id_column)
+     }
+     public function pullQueryParameterDescriptions2(&$request, $filter_query)
+     {
++        $db = \CCR\DB::factory('datawarehouse');
+         $parameters = array();
+         $filterItems = array();
+         if (isset($request[$this->getName().'_filter']) && $request[$this->getName().'_filter'] != '') {
+             $filterString = $request[$this->getName().'_filter'];
+-            $filterItems = array_merge($filterItems, explode(',', $filterString));
++            $items = explode(',', $filterString);
++            foreach ($items as $filterItem) {
++                $filterItems[] = $db->quote($filterItem);
++            }
+         }
+
+         if (isset($request[$this->getName()])) {
+-            $filterItems[] = $request[$this->getName()];
++            $filterItems[] = $db->quote($request[$this->getName()]);
+         }
+         $filterCount = count($filterItems);
+
+         if ($filterCount > 0) {
+-            $fieldLabelQuery = str_replace('_filter_', "'".implode("','", $filterItems)."'", $filter_query);
++            $fieldLabelQuery = str_replace('_filter_', implode(',', $filterItems), $filter_query);
+             $fieldLabelResults = \DataWarehouse::connect()->query($fieldLabelQuery);
+
+             $label = $this->getLabel();

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -1,6 +1,24 @@
+# Open XDMoD workaround security patch files
+
 This directory contains workaround patch files that pertain to known security
-vulnerabilities in Open XDMoD. Each patch file should contain a link at the top
-to the relevant security advisory from
-https://github.com/ubccr/xdmod/security/advisories, which should explain how to
-apply the patch, and an indication of which versions of Open XDMoD to which the
-patch applies.
+vulnerabilities in Open XDMoD. Each patch file should contain a comment at the
+top that:
+    1. Links to the corresponding security advisory from
+       https://github.com/ubccr/xdmod/security/advisories, which should explain
+       how to apply the patch, and
+    1. An indication of which versions of Open XDMoD to which the patch
+       applies.
+
+## Adding a new patch file
+
+To add a new patch file, developers should do the following:
+    1. Open a Pull Request that adds the patch file to this directory.
+    1. Once the Pull Request is approved and merged to the `main` branch,
+       obtain the SHA of the merge commit.
+    1. Copy the URL of the raw content of the patch file from the merge commit
+       on GitHub, i.e.:
+        ```
+        https://raw.githubusercontent.com/ubccr/xdmod/<commit-sha>/security/patches/<patch-name>.patch
+        ```
+    1. Include that URL as a link in the corresponding GitHub security advisory
+       along with instructions how to apply the patch.

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -4,9 +4,8 @@ This directory contains workaround patch files that pertain to known security
 vulnerabilities in Open XDMoD. Each patch file should contain a comment at the
 top that:
 
-1. Links to the corresponding [GitHub security
-   advisory](https://github.com/ubccr/xdmod/security/advisories), which should
-   explain how to apply the patch, and
+1. Links to the corresponding GitHub security advisory, which should explain
+   how to apply the patch, and
 1. An indication of which versions of Open XDMoD to which the patch applies.
 
 ## Adding a new patch file
@@ -21,5 +20,6 @@ To add a new patch file, developers should do the following:
     ```
     https://raw.githubusercontent.com/ubccr/xdmod/<commit-sha>/security/patches/<patch-name>.patch
     ```
-1. Include that URL as a link in the corresponding GitHub security advisory
-   along with instructions how to apply the patch.
+1. Include that URL as a link in the corresponding [GitHub security
+   advisory](https://github.com/ubccr/xdmod/security/advisories) along with
+   instructions how to apply the patch.

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -12,6 +12,23 @@ top that includes:
 
 To add a new patch file, developers should do the following:
 
+1. Name the file using the format:
+    ```
+    <GitHub security advisory ID>-<Open XDMoD versions affected>.patch
+    ```
+    e.g.,
+    ```
+    GHSA-29qm-7w4v-43fw-9_5_0-11_0_2.patch
+    ```
+    or
+    ```
+    GHSA-3hfh-m242-8rmh-pre_11_0_3.patch
+    ```
+   Or if a CVE has already been assigned, it can replace the GitHub security
+   advisory ID, i.e.,:
+    ```
+    CVE-<CVE number>-<Open XDMoD versions affected>.patch
+    ```
 1. Open a Pull Request that adds the patch file to this directory.
 1. Once the Pull Request is approved and merged to the `main` branch, obtain
    the SHA of the merge commit.

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -1,4 +1,6 @@
 This directory contains workaround patch files that pertain to known security
 vulnerabilities in Open XDMoD. Each patch file should contain a link at the top
-to the relevant security advisory (which should explain how to apply the patch)
-and an indication of which versions of Open XDMoD to which the patch applies.
+to the relevant security advisory from
+https://github.com/ubccr/xdmod/security/advisories, which should explain how to
+apply the patch, and an indication of which versions of Open XDMoD to which the
+patch applies.

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -3,22 +3,23 @@
 This directory contains workaround patch files that pertain to known security
 vulnerabilities in Open XDMoD. Each patch file should contain a comment at the
 top that:
-    1. Links to the corresponding security advisory from
-       https://github.com/ubccr/xdmod/security/advisories, which should explain
-       how to apply the patch, and
-    1. An indication of which versions of Open XDMoD to which the patch
-       applies.
+
+1. Links to the corresponding security advisory from
+   https://github.com/ubccr/xdmod/security/advisories, which should explain how
+   to apply the patch, and
+1. An indication of which versions of Open XDMoD to which the patch applies.
 
 ## Adding a new patch file
 
 To add a new patch file, developers should do the following:
-    1. Open a Pull Request that adds the patch file to this directory.
-    1. Once the Pull Request is approved and merged to the `main` branch,
-       obtain the SHA of the merge commit.
-    1. Copy the URL of the raw content of the patch file from the merge commit
-       on GitHub, i.e.:
-        ```
-        https://raw.githubusercontent.com/ubccr/xdmod/<commit-sha>/security/patches/<patch-name>.patch
-        ```
-    1. Include that URL as a link in the corresponding GitHub security advisory
-       along with instructions how to apply the patch.
+
+1. Open a Pull Request that adds the patch file to this directory.
+1. Once the Pull Request is approved and merged to the `main` branch, obtain
+   the SHA of the merge commit.
+1. Copy the URL of the raw content of the patch file from the merge commit on
+   GitHub, i.e.:
+    ```
+    https://raw.githubusercontent.com/ubccr/xdmod/<commit-sha>/security/patches/<patch-name>.patch
+    ```
+1. Include that URL as a link in the corresponding GitHub security advisory
+   along with instructions how to apply the patch.

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -19,9 +19,6 @@ To add a new patch file, developers should do the following:
     e.g.,
     ```
     GHSA-29qm-7w4v-43fw-9_5_0-11_0_2.patch
-    ```
-    or
-    ```
     GHSA-3hfh-m242-8rmh-pre_11_0_3.patch
     ```
    Or if a CVE has already been assigned, it can replace the GitHub security

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -2,9 +2,9 @@
 
 This directory contains workaround patch files that pertain to known security
 vulnerabilities in Open XDMoD. Each patch file should contain a comment at the
-top that:
+top that includes:
 
-1. Links to the corresponding GitHub security advisory, which should explain
+1. A link to the corresponding GitHub security advisory, which should explain
    how to apply the patch, and
 1. An indication of which versions of Open XDMoD to which the patch applies.
 

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -4,9 +4,9 @@ This directory contains workaround patch files that pertain to known security
 vulnerabilities in Open XDMoD. Each patch file should contain a comment at the
 top that:
 
-1. Links to the corresponding security advisory from
-   https://github.com/ubccr/xdmod/security/advisories, which should explain how
-   to apply the patch, and
+1. Links to the corresponding [GitHub security
+   advisory](https://github.com/ubccr/xdmod/security/advisories), which should
+   explain how to apply the patch, and
 1. An indication of which versions of Open XDMoD to which the patch applies.
 
 ## Adding a new patch file

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -26,7 +26,7 @@ To add a new patch file, developers should do the following:
     ```
     CVE-<CVE number>-<Open XDMoD versions affected>.patch
     ```
-1. Open a Pull Request that adds the patch file to this directory.
+1. Submit a Pull Request that adds the patch file to this directory.
 1. Once the Pull Request is approved and merged to the `main` branch, obtain
    the SHA of the merge commit.
 1. Copy the URL of the raw content of the patch file from the merge commit on

--- a/security/patches/README.md
+++ b/security/patches/README.md
@@ -1,0 +1,4 @@
+This directory contains workaround patch files that pertain to known security
+vulnerabilities in Open XDMoD. Each patch file should contain a link at the top
+to the relevant security advisory (which should explain how to apply the patch)
+and an indication of which versions of Open XDMoD to which the patch applies.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Include screenshots for GUI changes if appropriate -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

This PR adds a directory `security/patches` for storing workaround patch files pertaining to known security vulnerabilities in Open XDMoD. It also adds [instructions](https://github.com/aaronweeden/xdmod/tree/add-security-patches/security/patches) for adding new patch files.

## Motivation and Context
This allows us to host patch files that can be linked to in the corresponding GitHub security advisories.

## Tests performed
Tested manually applying the patch files in Docker containers running the various relevant Open XDMoD versions.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
