### PR TITLE
Add some indexes and update table defn for Reports

### DIFF
--- a/configuration/etl/etl.d/xdmod-migration-11_0_2-11_5_0.json
+++ b/configuration/etl/etl.d/xdmod-migration-11_0_2-11_5_0.json
@@ -42,6 +42,16 @@
     },
     "migration-11_0_2-11_5_0": [
         {
+            "name": "update-reports",
+            "description": "Update report tables to remove duplicate rows",
+            "namespace": "ETL\\Maintenance",
+            "class": "ExecuteSql",
+            "options_class": "MaintenanceOptions",
+            "sql_file_list": [
+                "migrations/11.0.0-11.5.0/moddb/reports.sql"
+            ]
+        },
+        {
             "name": "update-moddb-tables",
             "description": "Update managed tables in moddb",
             "namespace": "ETL\\Maintenance",

--- a/configuration/etl/etl_sql.d/migrations/11.0.0-11.5.0/moddb/reports.sql
+++ b/configuration/etl/etl_sql.d/migrations/11.0.0-11.5.0/moddb/reports.sql
@@ -1,5 +1,6 @@
+-- Drop any rows that have duplicate report_ids
 START TRANSACTION//
-CREATE TEMPORARY TABLE `UniqueReports` (
+CREATE TEMPORARY TABLE `tmp_uniquereports` (
   `report_id` varchar(100) DEFAULT NULL,
   `user_id` int(11) NOT NULL,
   `name` varchar(1000) DEFAULT 'TAS Report',
@@ -14,10 +15,21 @@ CREATE TEMPORARY TABLE `UniqueReports` (
   `charts_per_page` int(1) DEFAULT NULL,
   `active_role` varchar(30) DEFAULT NULL,
   `last_modified` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
-  UNIQUE INDEX idx_report (report_id),
-  UNIQUE INDEX idx_user (user_id, name)
+  UNIQUE INDEX idx_report (report_id)
 )//
-INSERT IGNORE INTO `UniqueReports` SELECT * FROM Reports//
-DELETE FROM Reports//
-INSERT INTO Reports SELECT * FROM UniqueReports//
+INSERT IGNORE INTO `tmp_uniquereports` SELECT * FROM `moddb`.`Reports`//
+DELETE FROM `moddb`.`Reports`//
+INSERT INTO `moddb`.`Reports` SELECT * FROM `tmp_uniquereports`//
+COMMIT//
+
+-- Then rename any reports that have duplicate names
+START TRANSACTION//
+CREATE TEMPORARY TABLE `tmp_duplicatenames`
+SELECT rr.user_id,
+       rr.report_id,
+       rr.name,
+       ROW_NUMBER() OVER (PARTITION BY rr.user_id, rr.name ORDER BY rr.report_id) as duplicate_index
+FROM `moddb`.`Reports` rr//
+UPDATE `moddb`.`Reports` r, `tmp_duplicatenames` dup SET r.name = CONCAT(r.name, ' [duplicate # ', dup.duplicate_index, ']') WHERE dup.duplicate_index > 1 AND dup.report_id = r.report_id//
+
 COMMIT//

--- a/configuration/etl/etl_sql.d/migrations/11.0.0-11.5.0/moddb/reports.sql
+++ b/configuration/etl/etl_sql.d/migrations/11.0.0-11.5.0/moddb/reports.sql
@@ -1,0 +1,23 @@
+START TRANSACTION//
+CREATE TEMPORARY TABLE `UniqueReports` (
+  `report_id` varchar(100) DEFAULT NULL,
+  `user_id` int(11) NOT NULL,
+  `name` varchar(1000) DEFAULT 'TAS Report',
+  `derived_from` varchar(1000) DEFAULT NULL,
+  `title` varchar(1000) DEFAULT 'TAS Report',
+  `header` varchar(1000) DEFAULT NULL,
+  `footer` varchar(1000) DEFAULT NULL,
+  `format` enum('Pdf','Pptx','Doc','Xls','Html') NOT NULL DEFAULT 'Pdf',
+  `schedule` enum('Once','Daily','Weekly','Monthly','Quarterly','Semi-annually','Annually') NOT NULL DEFAULT 'Once',
+  `delivery` enum('Download','E-mail') NOT NULL DEFAULT 'E-mail',
+  `selected` tinyint(1) NOT NULL DEFAULT 0,
+  `charts_per_page` int(1) DEFAULT NULL,
+  `active_role` varchar(30) DEFAULT NULL,
+  `last_modified` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  UNIQUE INDEX idx_report (report_id),
+  UNIQUE INDEX idx_user (user_id, name)
+)//
+INSERT IGNORE INTO `UniqueReports` SELECT * FROM Reports//
+DELETE FROM Reports//
+INSERT INTO Reports SELECT * FROM UniqueReports//
+COMMIT//

--- a/configuration/etl/etl_tables.d/xdb/chart-pool.json
+++ b/configuration/etl/etl_tables.d/xdb/chart-pool.json
@@ -6,12 +6,12 @@
             {
                 "name": "user_id",
                 "type": "int(11)",
-                "nullable": true
+                "nullable": false
             },
             {
                 "name": "chart_id",
                 "type": "text",
-                "nullable": true
+                "nullable": false
             },
             {
                 "name": "insertion_rank",
@@ -58,6 +58,12 @@
                 ],
                 "type": "BTREE",
                 "is_unique": true
+            },
+            {
+                "name": "idx_user",
+                "columns": [
+                    "user_id"
+                ]
             }
         ],
         "triggers": []

--- a/configuration/etl/etl_tables.d/xdb/report-charts.json
+++ b/configuration/etl/etl_tables.d/xdb/report-charts.json
@@ -6,7 +6,7 @@
             {
                 "name": "report_id",
                 "type": "varchar(100)",
-                "nullable": true
+                "nullable": false
             },
             {
                 "name": "user_id",
@@ -66,7 +66,17 @@
                 "nullable": true
             }
         ],
-        "indexes": [],
+        "indexes": [
+            {
+                "name": "idx_chartlookup",
+                "columns": [
+                    "user_id",
+                    "report_id"
+                ],
+                "type": "BTREE",
+                "is_unique": false
+            }
+	],
         "triggers": []
     }
 }

--- a/configuration/etl/etl_tables.d/xdb/reports.json
+++ b/configuration/etl/etl_tables.d/xdb/reports.json
@@ -6,7 +6,7 @@
             {
                 "name": "report_id",
                 "type": "varchar(100)",
-                "nullable": true
+                "nullable": false
             },
             {
                 "name": "user_id",
@@ -82,7 +82,33 @@
                 "extra": "ON UPDATE CURRENT_TIMESTAMP"
             }
         ],
-        "indexes": [],
+        "indexes": [
+            {
+                "name": "PRIMARY",
+                "columns": [
+                    "report_id"
+                ],
+                "type": "BTREE",
+                "is_unique": true
+            },
+            {
+                "name": "idx_uniquename",
+                "columns": [
+                    "user_id",
+                    "name"
+                ],
+                "type": "BTREE",
+                "is_unique": true
+            },
+            {
+                "name": "idx_reportlookup",
+                "columns": [
+                    "user_id"
+                ],
+                "type": "BTREE",
+                "is_unique": false
+            }
+        ],
         "triggers": []
     }
 }


### PR DESCRIPTION
## Description

This adds some indexes and constraints to a couple of the Reports tables.

Also added a migration to remove duplicate rows and fixup duplicate report names. I saw both dupliacte report_ids and duplicate report names in the report tables on the ACCESS dev and prod instances. Looking at the report timestamps these are from around 2013. Looks like the code to check for duplicates was added around this time.
The migration script was tested on both a copy of the dev and copy of the prod tables.

The migration does two steps - renames reports that have duplicate names to append `[duplicate # n]` to the nth duplicate. Then it removes rows that have duplicate report_ids. This seems the best approach to minimize potential data loss  - if two rows have the same report_id then they are not distingushable in the current code (any select statements just look at the first row returned and update statements update all rows with the matching report_id.

There is a tiny chance that there is an XDMoD instance with duplicate report names and also a report name that is the same as the transformed duplicate name. If this happens then no data will be lost, but the upgrade will fail when it gets to the etl "ALTER TABLE" step. If it does then we can help the user out manually!
