### PR TITLE
Change batch aggregation to select only time periods that are being aggregated

### DIFF
--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1513,23 +1513,23 @@ class pdoAggregator extends aAggregator
      * Rewrite the aggregation WHERE clause from a single clause that queries the min/max
      * range with a clause for each time period being aggregated and connect them using
      * the OR keyword.
-     * 
+     *
      * For example, if the original WHERE clause is:
-     * 
+     *
      *   task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id AND task.is_deleted = 0
-     * 
+     *
      * and we are aggregating 2 periods with period_start_day_id/period_end_day_id values of
      * 20200101/20200131 and 20200201/20200229, this method will rewrite the WHERE clause to:
-     * 
+     *
      *  (task.start_day_id <= :period_end_day_id_0 AND task.end_day_id >= :period_start_day_id_0 AND task.is_deleted = 0)
      *  OR (task.start_day_id <= :period_end_day_id_1 AND task.end_day_id >= :period_start_day_id_1 AND task.is_deleted = 0)
      *
      * Returns array($whereSql, $periodParams) where $periodParams holds the
      * per-period bind values keyed by :p_start_<i> / :p_end_<i>.
-     * 
+     *
      * @param $whereClause string the original WHERE clause with bind variables for a single period
      * @param $aggregationPeriodSlice array the list of periods being aggregated in this batch
-     * 
+     *
      * @return array of rewritten WHERE clause and the bind parameters to use for that clause
      */
     private function rewriteWhereForPeriodSlice($whereClause, array $aggregationPeriodSlice)

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1462,7 +1462,9 @@ class pdoAggregator extends aAggregator
         $origTableName = $this->sourceEndpoint->getSchema(true) . "." . $this->sourceEndpoint->quoteSystemIdentifier($this->etlStageQuery->joins[0]->name);
         $tmpTableAlias = $this->sourceEndpoint->quoteSystemIdentifier($this->etlStageQuery->joins[0]->alias);
 
-        $this->logger->debug("[batch aggregation] Create temporary table $qualifiedTmpTableName for " . count($aggregationPeriodSlice) . " period(s)");
+        $firstSlice = current($aggregationPeriodSlice);
+        $lastSlice = end($aggregationPeriodSlice);
+        $this->logger->debug("[batch aggregation] Create temporary table $qualifiedTmpTableName with min period = " . $firstSlice['period_start_day_id'] . " and max period = " . $lastSlice['period_end_day_id'] . " for " . count($aggregationPeriodSlice) . " period(s)");
 
         $sql = "DROP TEMPORARY TABLE IF EXISTS $qualifiedTmpTableName";
 

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1041,21 +1041,18 @@ class pdoAggregator extends aAggregator
 
                     $availableParams = array_combine($availableParamKeys, $availableParamValues);
 
-                    // Build a CROSS JOIN against an inline list of the periods in this slice and
-                    // rewrite the WHERE clause so the per-period overlap is checked against each
-                    // listed period rather than a single min/max range. Without this, a slice
-                    // containing non-contiguous periods would pull every row in the day_id range
-                    // spanning the gap into the temporary table.
-                    list($periodListJoin, $rewrittenWhere, $periodParams) =
-                        self::buildPerPeriodTempTableSql($whereClause, $aggregationPeriodSlice);
+                    // Rewrite the per-period overlap in the WHERE clause as an OR'd group,
+                    // one branch per period in the slice. Without this, a slice containing
+                    // non-contiguous periods would pull every row in the day_id range spanning
+                    // the gap into the temporary table.
+                    list($whereClause, $periodParams) = $this->rewriteWhereForPeriodSlice($whereClause, $aggregationPeriodSlice);
                     unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
                     $availableParams = array_merge($availableParams, $periodParams);
 
                     $sql =
                         "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                        . "SELECT DISTINCT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
-                        . $periodListJoin
-                        . " WHERE " . $rewrittenWhere;
+                        . "SELECT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
+                        . "WHERE " . $whereClause;
 
                     preg_match_all($bindParamRegex, $sql, $matches);
                     $bindParams = $matches[0];
@@ -1489,16 +1486,15 @@ class pdoAggregator extends aAggregator
                 "Undefined macros found in WHERE clause"
             );
 
-            list($periodListJoin, $rewrittenWhere, $periodParams) =
-                self::buildPerPeriodTempTableSql($whereClause, $aggregationPeriodSlice);
+            list($whereClause, $periodParams) =
+                $this->rewriteWhereForPeriodSlice($whereClause, $aggregationPeriodSlice);
             unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
             $availableParams = array_merge($availableParams, $periodParams);
 
             $sql =
                 "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                . "SELECT DISTINCT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
-                . $periodListJoin
-                . " WHERE " . $rewrittenWhere;
+                . "SELECT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
+                . "WHERE " . $whereClause;
 
             $matches = array();
             preg_match_all('/(:[a-zA-Z0-9_-]+)/', $sql, $matches);
@@ -1518,38 +1514,36 @@ class pdoAggregator extends aAggregator
     }
 
     /**
-     * Build the inline period-list CROSS JOIN and the per-period rewrite of
-     * a WHERE clause that uses :period_start_day_id / :period_end_day_id.
+     * Rewrite a WHERE clause that uses :period_start_day_id / :period_end_day_id
+     * so the per-period overlap is checked against each period in the slice
+     * (OR'd together) rather than a single min/max range.
      *
-     * Returns array($periodListJoin, $rewrittenWhere, $periodParams) where:
-     *   - $periodListJoin is "CROSS JOIN ( SELECT ... UNION ALL ... ) `xdmod_period_list`"
-     *   - $rewrittenWhere has :period_start_day_id / :period_end_day_id replaced
-     *     with references to the joined columns
-     *   - $periodParams holds the per-period bind values
-     *     (:p_start_<i>, :p_end_<i>)
+     * Returns array($whereSql, $periodParams) where $periodParams holds the
+     * per-period bind values keyed by :p_start_<i> / :p_end_<i>.
      */
-    private static function buildPerPeriodTempTableSql($whereClause, array $aggregationPeriodSlice)
+    private function rewriteWhereForPeriodSlice($whereClause, array $aggregationPeriodSlice)
     {
-        $unionParts = array();
         $params = array();
         foreach (array_values($aggregationPeriodSlice) as $i => $period) {
-            $unionParts[] = (0 === $i)
-                ? "SELECT :p_start_$i AS p_start, :p_end_$i AS p_end"
-                : "SELECT :p_start_$i, :p_end_$i";
             $params[":p_start_$i"] = $period['period_start_day_id'];
             $params[":p_end_$i"]   = $period['period_end_day_id'];
         }
 
-        $periodListJoin =
-            "CROSS JOIN (" . implode(" UNION ALL ", $unionParts) . ") `xdmod_period_list`";
-
-        $rewrittenWhere = preg_replace(
-            array('/:period_end_day_id\b/', '/:period_start_day_id\b/'),
-            array('`xdmod_period_list`.p_end', '`xdmod_period_list`.p_start'),
+        $sliceSize = count($aggregationPeriodSlice);
+        $whereSql = preg_replace_callback(
+            '/(\w+)\.start_day_id\s*<=\s*:period_end_day_id\s+AND\s+\1\.end_day_id\s*>=\s*:period_start_day_id/i',
+            function ($m) use ($sliceSize) {
+                $alias = $m[1];
+                $branches = array();
+                for ($i = 0; $i < $sliceSize; $i++) {
+                    $branches[] = "($alias.start_day_id <= :p_end_$i AND $alias.end_day_id >= :p_start_$i)";
+                }
+                return "(" . implode(" OR ", $branches) . ")";
+            },
             $whereClause
         );
 
-        return array($periodListJoin, $rewrittenWhere, $params);
+        return array($whereSql, $params);
     }
 
     /**

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1490,14 +1490,14 @@ class pdoAggregator extends aAggregator
             unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
             $availableParams = array_merge($availableParams, $periodParams);
 
+            $matches = array();
+            preg_match_all('/(:[a-zA-Z0-9_-]+)/', $whereClause, $matches);
+            $bindParams = $matches[0];
+            $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
+
             $sql =
                 "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
                 . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
-
-            $matches = array();
-            preg_match_all('/(:[a-zA-Z0-9_-]+)/', $sql, $matches);
-            $bindParams = $matches[0];
-            $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
 
             $this->logger->debug(
                 sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1041,22 +1041,17 @@ class pdoAggregator extends aAggregator
 
                     $availableParams = array_combine($availableParamKeys, $availableParamValues);
 
-                    // Rewrite the per-period overlap in the WHERE clause as an OR'd group,
-                    // one branch per period in the slice. Without this, a slice containing
-                    // non-contiguous periods would pull every row in the day_id range spanning
-                    // the gap into the temporary table.
                     list($whereClause, $periodParams) = $this->rewriteWhereForPeriodSlice($whereClause, $aggregationPeriodSlice);
                     unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
                     $availableParams = array_merge($availableParams, $periodParams);
 
-                    $sql =
-                        "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                        . "SELECT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
-                        . "WHERE " . $whereClause;
-
-                    preg_match_all($bindParamRegex, $sql, $matches);
+                    preg_match_all($bindParamRegex, $whereClause, $matches);
                     $bindParams = $matches[0];
                     $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
+
+                    $sql =
+                        "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
+                        . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
 
                     $this->logger->debug(
                         sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)
@@ -1491,6 +1486,7 @@ class pdoAggregator extends aAggregator
             $availableParams = array_merge($availableParams, $periodParams);
 
             $matches = array();
+            $bindParams = array();
             preg_match_all('/(:[a-zA-Z0-9_-]+)/', $whereClause, $matches);
             $bindParams = $matches[0];
             $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1041,22 +1041,17 @@ class pdoAggregator extends aAggregator
 
                     $availableParams = array_combine($availableParamKeys, $availableParamValues);
 
-                    // Rewrite the per-period overlap in the WHERE clause as an OR'd group,
-                    // one branch per period in the slice. Without this, a slice containing
-                    // non-contiguous periods would pull every row in the day_id range spanning
-                    // the gap into the temporary table.
                     list($whereClause, $periodParams) = $this->rewriteWhereForPeriodSlice($whereClause, $aggregationPeriodSlice);
                     unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
                     $availableParams = array_merge($availableParams, $periodParams);
 
-                    $sql =
-                        "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                        . "SELECT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
-                        . "WHERE " . $whereClause;
-
                     preg_match_all($bindParamRegex, $sql, $matches);
                     $bindParams = $matches[0];
                     $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
+
+                    $sql =
+                        "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
+                        . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
 
                     $this->logger->debug(
                         sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)
@@ -1486,20 +1481,18 @@ class pdoAggregator extends aAggregator
                 "Undefined macros found in WHERE clause"
             );
 
-            list($whereClause, $periodParams) =
-                $this->rewriteWhereForPeriodSlice($whereClause, $aggregationPeriodSlice);
+            list($whereClause, $periodParams) = $this->rewriteWhereForPeriodSlice($whereClause, $aggregationPeriodSlice);
             unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
             $availableParams = array_merge($availableParams, $periodParams);
-
-            $sql =
-                "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                . "SELECT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
-                . "WHERE " . $whereClause;
 
             $matches = array();
             preg_match_all('/(:[a-zA-Z0-9_-]+)/', $sql, $matches);
             $bindParams = $matches[0];
             $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
+
+            $sql =
+                "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
+                . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
 
             $this->logger->debug(
                 sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1517,25 +1517,49 @@ class pdoAggregator extends aAggregator
      */
     private function rewriteWhereForPeriodSlice($whereClause, array $aggregationPeriodSlice)
     {
-        $params = array();
+        // Period bind variables that may appear in a WHERE clause and the
+        // period-row key each one resolves to. Add to this list if a new
+        // :period_* bind variable is introduced. Order matters only as
+        // documentation — the regex uses a non-word-character lookahead so
+        // :period_start does not eat into :period_start_day_id.
+        $bindMap = array(
+            ':period_start_day_id' => 'period_start_day_id',
+            ':period_end_day_id'   => 'period_end_day_id',
+            ':period_start'        => 'period_start',
+            ':period_end'          => 'period_end',
+        );
+
+        // Only rewrite bind vars that actually appear in the WHERE — avoids
+        // emitting useless params and avoids tripping on unrelated columns
+        // that happen to share a key name with $bindMap.
+        $bindMap = array_filter(
+            $bindMap,
+            function ($col, $bindVar) use ($whereClause) {
+                return preg_match('/' . preg_quote($bindVar, '/') . '(?![a-zA-Z0-9_])/', $whereClause) === 1;
+            },
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        $branches = array();
+        $params   = array();
         foreach (array_values($aggregationPeriodSlice) as $i => $period) {
-            $params[":p_start_$i"] = $period['period_start_day_id'];
-            $params[":p_end_$i"]   = $period['period_end_day_id'];
+            $branch = $whereClause;
+            foreach ($bindMap as $bindVar => $col) {
+                if (!array_key_exists($col, $period)) {
+                    continue;
+                }
+                $perPeriod = $bindVar . "_$i";
+                $branch = preg_replace(
+                    '/' . preg_quote($bindVar, '/') . '(?![a-zA-Z0-9_])/',
+                    $perPeriod,
+                    $branch
+                );
+                $params[$perPeriod] = $period[$col];
+            }
+            $branches[] = "($branch)";
         }
 
-        $sliceSize = count($aggregationPeriodSlice);
-        $whereSql = preg_replace_callback(
-            '/(\w+)\.start_day_id\s*<=\s*:period_end_day_id\s+AND\s+\1\.end_day_id\s*>=\s*:period_start_day_id/i',
-            function ($m) use ($sliceSize) {
-                $alias = $m[1];
-                $branches = array();
-                for ($i = 0; $i < $sliceSize; $i++) {
-                    $branches[] = "($alias.start_day_id <= :p_end_$i AND $alias.end_day_id >= :p_start_$i)";
-                }
-                return "(" . implode(" OR ", $branches) . ")";
-            },
-            $whereClause
-        );
+        $whereSql = "(" . implode(" OR ", $branches) . ")";
 
         return array($whereSql, $params);
     }

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1041,17 +1041,22 @@ class pdoAggregator extends aAggregator
 
                     $availableParams = array_combine($availableParamKeys, $availableParamValues);
 
+                    // Rewrite the per-period overlap in the WHERE clause as an OR'd group,
+                    // one branch per period in the slice. Without this, a slice containing
+                    // non-contiguous periods would pull every row in the day_id range spanning
+                    // the gap into the temporary table.
                     list($whereClause, $periodParams) = $this->rewriteWhereForPeriodSlice($whereClause, $aggregationPeriodSlice);
                     unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
                     $availableParams = array_merge($availableParams, $periodParams);
 
+                    $sql =
+                        "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
+                        . "SELECT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
+                        . "WHERE " . $whereClause;
+
                     preg_match_all($bindParamRegex, $sql, $matches);
                     $bindParams = $matches[0];
                     $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
-
-                    $sql =
-                        "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                        . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
 
                     $this->logger->debug(
                         sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)
@@ -1485,14 +1490,14 @@ class pdoAggregator extends aAggregator
             unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
             $availableParams = array_merge($availableParams, $periodParams);
 
+            $sql =
+                "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
+                . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
+
             $matches = array();
             preg_match_all('/(:[a-zA-Z0-9_-]+)/', $sql, $matches);
             $bindParams = $matches[0];
             $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
-
-            $sql =
-                "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
 
             $this->logger->debug(
                 sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1041,14 +1041,26 @@ class pdoAggregator extends aAggregator
 
                     $availableParams = array_combine($availableParamKeys, $availableParamValues);
 
-                    $bindParams = array();
-                    preg_match_all($bindParamRegex, $whereClause, $matches);
-                    $bindParams = $matches[0];
-                    $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
+                    // Build a CROSS JOIN against an inline list of the periods in this slice and
+                    // rewrite the WHERE clause so the per-period overlap is checked against each
+                    // listed period rather than a single min/max range. Without this, a slice
+                    // containing non-contiguous periods would pull every row in the day_id range
+                    // spanning the gap into the temporary table.
+                    list($periodListJoin, $rewrittenWhere, $periodParams) =
+                        self::buildPerPeriodTempTableSql($whereClause, $aggregationPeriodSlice);
+                    unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
+                    $availableParams = array_merge($availableParams, $periodParams);
 
                     $sql =
                         "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                        . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
+                        . "SELECT DISTINCT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
+                        . $periodListJoin
+                        . " WHERE " . $rewrittenWhere;
+
+                    preg_match_all($bindParamRegex, $sql, $matches);
+                    $bindParams = $matches[0];
+                    $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
+
                     $this->logger->debug(
                         sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)
                     );
@@ -1061,7 +1073,7 @@ class pdoAggregator extends aAggregator
                 }
 
                 if ($this->etlStageQuery) {
-                    $this->createStageBatchTempTable($minDayId, $maxDayId, $availableParams);
+                    $this->createStageBatchTempTable($aggregationPeriodSlice, $availableParams);
                 }
 
                 $this->logger->info("[batch aggregation] Setup for batch $minPeriodId - $maxPeriodId (day_id $minDayId - $maxDayId): "
@@ -1445,20 +1457,20 @@ class pdoAggregator extends aAggregator
     /**
      * Create and populate the temporary table used in batch mode aggregation
      * as defined by the "stage_query" parameter setting in the ETL action
-     * definition. This table will contain all of the rows between the specified
-     * start and end periods.
+     * definition. This table will contain only the rows that overlap one of
+     * the periods in the supplied slice (rather than every row in the day_id
+     * range spanning that slice).
      *
-     * @param $minDayId string the start of the batch aggregation slide
-     * @param $maxDayId string the end of the batch aggregation slide
+     * @param $aggregationPeriodSlice array the periods in the current batch
      * @param $availableParams array the PDO parameters to substitute in the select statement
      */
-    protected function createStageBatchTempTable($minDayId, $maxDayId, $availableParams)
+    protected function createStageBatchTempTable(array $aggregationPeriodSlice, array $availableParams)
     {
         $qualifiedTmpTableName = $this->sourceEndpoint->getSchema(true) . "." . $this->sourceEndpoint->quoteSystemIdentifier(self::BATCH_STAGE_TABLE_NAME);
         $origTableName = $this->sourceEndpoint->getSchema(true) . "." . $this->sourceEndpoint->quoteSystemIdentifier($this->etlStageQuery->joins[0]->name);
         $tmpTableAlias = $this->sourceEndpoint->quoteSystemIdentifier($this->etlStageQuery->joins[0]->alias);
 
-        $this->logger->debug("[batch aggregation] Create temporary table $qualifiedTmpTableName with min period = $minDayId, max period = $maxDayId");
+        $this->logger->debug("[batch aggregation] Create temporary table $qualifiedTmpTableName for " . count($aggregationPeriodSlice) . " period(s)");
 
         $sql = "DROP TEMPORARY TABLE IF EXISTS $qualifiedTmpTableName";
 
@@ -1477,15 +1489,21 @@ class pdoAggregator extends aAggregator
                 "Undefined macros found in WHERE clause"
             );
 
-            $matches = array();
-            $bindParams = array();
-            preg_match_all('/(:[a-zA-Z0-9_-]+)/', $whereClause, $matches);
-            $bindParams = $matches[0];
-            $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
+            list($periodListJoin, $rewrittenWhere, $periodParams) =
+                self::buildPerPeriodTempTableSql($whereClause, $aggregationPeriodSlice);
+            unset($availableParams[':period_start_day_id'], $availableParams[':period_end_day_id']);
+            $availableParams = array_merge($availableParams, $periodParams);
 
             $sql =
                 "CREATE TEMPORARY TABLE $qualifiedTmpTableName AS "
-                . "SELECT * FROM $origTableName $tmpTableAlias WHERE " . $whereClause;
+                . "SELECT DISTINCT $tmpTableAlias.* FROM $origTableName $tmpTableAlias "
+                . $periodListJoin
+                . " WHERE " . $rewrittenWhere;
+
+            $matches = array();
+            preg_match_all('/(:[a-zA-Z0-9_-]+)/', $sql, $matches);
+            $bindParams = $matches[0];
+            $usedParams = array_intersect_key($availableParams, array_fill_keys($bindParams, 0));
 
             $this->logger->debug(
                 sprintf("[batch aggregation] Batch temp table %s: %s", $this->sourceEndpoint, $sql)
@@ -1497,6 +1515,41 @@ class pdoAggregator extends aAggregator
                 array('exception' => $e, 'sql' => $sql)
             );
         }
+    }
+
+    /**
+     * Build the inline period-list CROSS JOIN and the per-period rewrite of
+     * a WHERE clause that uses :period_start_day_id / :period_end_day_id.
+     *
+     * Returns array($periodListJoin, $rewrittenWhere, $periodParams) where:
+     *   - $periodListJoin is "CROSS JOIN ( SELECT ... UNION ALL ... ) `xdmod_period_list`"
+     *   - $rewrittenWhere has :period_start_day_id / :period_end_day_id replaced
+     *     with references to the joined columns
+     *   - $periodParams holds the per-period bind values
+     *     (:p_start_<i>, :p_end_<i>)
+     */
+    private static function buildPerPeriodTempTableSql($whereClause, array $aggregationPeriodSlice)
+    {
+        $unionParts = array();
+        $params = array();
+        foreach (array_values($aggregationPeriodSlice) as $i => $period) {
+            $unionParts[] = (0 === $i)
+                ? "SELECT :p_start_$i AS p_start, :p_end_$i AS p_end"
+                : "SELECT :p_start_$i, :p_end_$i";
+            $params[":p_start_$i"] = $period['period_start_day_id'];
+            $params[":p_end_$i"]   = $period['period_end_day_id'];
+        }
+
+        $periodListJoin =
+            "CROSS JOIN (" . implode(" UNION ALL ", $unionParts) . ") `xdmod_period_list`";
+
+        $rewrittenWhere = preg_replace(
+            array('/:period_end_day_id\b/', '/:period_start_day_id\b/'),
+            array('`xdmod_period_list`.p_end', '`xdmod_period_list`.p_start'),
+            $whereClause
+        );
+
+        return array($periodListJoin, $rewrittenWhere, $params);
     }
 
     /**

--- a/classes/ETL/Aggregator/pdoAggregator.php
+++ b/classes/ETL/Aggregator/pdoAggregator.php
@@ -1510,12 +1510,27 @@ class pdoAggregator extends aAggregator
     }
 
     /**
-     * Rewrite a WHERE clause that uses :period_start_day_id / :period_end_day_id
-     * so the per-period overlap is checked against each period in the slice
-     * (OR'd together) rather than a single min/max range.
+     * Rewrite the aggregation WHERE clause from a single clause that queries the min/max
+     * range with a clause for each time period being aggregated and connect them using
+     * the OR keyword.
+     * 
+     * For example, if the original WHERE clause is:
+     * 
+     *   task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id AND task.is_deleted = 0
+     * 
+     * and we are aggregating 2 periods with period_start_day_id/period_end_day_id values of
+     * 20200101/20200131 and 20200201/20200229, this method will rewrite the WHERE clause to:
+     * 
+     *  (task.start_day_id <= :period_end_day_id_0 AND task.end_day_id >= :period_start_day_id_0 AND task.is_deleted = 0)
+     *  OR (task.start_day_id <= :period_end_day_id_1 AND task.end_day_id >= :period_start_day_id_1 AND task.is_deleted = 0)
      *
      * Returns array($whereSql, $periodParams) where $periodParams holds the
      * per-period bind values keyed by :p_start_<i> / :p_end_<i>.
+     * 
+     * @param $whereClause string the original WHERE clause with bind variables for a single period
+     * @param $aggregationPeriodSlice array the list of periods being aggregated in this batch
+     * 
+     * @return array of rewritten WHERE clause and the bind parameters to use for that clause
      */
     private function rewriteWhereForPeriodSlice($whereClause, array $aggregationPeriodSlice)
     {

--- a/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
+++ b/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
@@ -57,10 +57,10 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
 
         $slice = array();
         for ($i = 0; $i < 9; $i++) {
-            $d = 6210 + $i;
+            $d = 202600007 + $i;
             $slice[] = self::period($d, $d);
         }
-        $slice[] = self::period(4748, 4748);
+        $slice[] = self::period(202200007, 202200007);
 
         list($whereSql, $params) = self::rewrite($where, $slice);
 
@@ -97,8 +97,8 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
         $this->assertDoesNotMatchRegularExpression('/:period_end_day_id(?![_0-9])/', $whereSql);
 
         // Outlier 2022 day is bound to its own slot, not absorbed into a range.
-        $this->assertSame(4748, $params[':period_start_day_id_9']);
-        $this->assertSame(4748, $params[':period_end_day_id_9']);
+        $this->assertSame(202200007, $params[':period_start_day_id_9']);
+        $this->assertSame(202200007, $params[':period_end_day_id_9']);
     }
 
     /**
@@ -114,7 +114,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             . " AND task.is_deleted = 0"
             . " AND task.resource_id IN (1,2,3)";
 
-        $slice = array(self::period(1000, 1000), self::period(1001, 1001));
+        $slice = array(self::period(202600007, 202600007), self::period(202600008, 202600008));
 
         list($whereSql) = self::rewrite($where, $slice);
 
@@ -137,13 +137,13 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     {
         $where = "task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id";
 
-        $slice = array(self::period(7000, 7000));
+        $slice = array(self::period(202600007, 202600007));
 
         list($whereSql, $params) = self::rewrite($where, $slice);
 
         $this->assertSame(0, substr_count($whereSql, ' OR '));
-        $this->assertSame(7000, $params[':period_start_day_id_0']);
-        $this->assertSame(7000, $params[':period_end_day_id_0']);
+        $this->assertSame(202600007, $params[':period_start_day_id_0']);
+        $this->assertSame(202600007, $params[':period_end_day_id_0']);
     }
 
     /**
@@ -154,14 +154,14 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     {
         $where = "task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id";
 
-        $slice = array(self::period(6210, 6240), self::period(4748, 4778));
+        $slice = array(self::period(202600001, 202600031), self::period(202600060, 202600090));
 
         list(, $params) = self::rewrite($where, $slice);
 
-        $this->assertSame(6210, $params[':period_start_day_id_0']);
-        $this->assertSame(6240, $params[':period_end_day_id_0']);
-        $this->assertSame(4748, $params[':period_start_day_id_1']);
-        $this->assertSame(4778, $params[':period_end_day_id_1']);
+        $this->assertSame(202600001, $params[':period_start_day_id_0']);
+        $this->assertSame(202600031, $params[':period_end_day_id_0']);
+        $this->assertSame(202600060, $params[':period_start_day_id_1']);
+        $this->assertSame(202600090, $params[':period_end_day_id_1']);
     }
 
     /**
@@ -172,7 +172,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     {
         $where = "gw.start_day_id <= :period_end_day_id AND gw.end_day_id >= :period_start_day_id AND gw.is_deleted = 0";
 
-        $slice = array(self::period(100, 100), self::period(200, 200));
+        $slice = array(self::period(202600007, 202600007), self::period(202600008, 202600008));
 
         list($whereSql) = self::rewrite($where, $slice);
 
@@ -192,15 +192,15 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     {
         $where = "log_day_id BETWEEN :period_start_day_id AND :period_end_day_id";
 
-        $slice = array(self::period(100, 100), self::period(500, 500), self::period(900, 900));
+        $slice = array(self::period(202600007, 202600007), self::period(202600008, 202600008), self::period(202600011, 202600011));
 
         list($whereSql, $params) = self::rewrite($where, $slice);
 
         $this->assertSame(3, substr_count($whereSql, 'log_day_id BETWEEN :period_start_day_id_'));
         $this->assertSame(2, substr_count($whereSql, ' OR '));
-        $this->assertSame(100, $params[':period_start_day_id_0']);
-        $this->assertSame(500, $params[':period_start_day_id_1']);
-        $this->assertSame(900, $params[':period_start_day_id_2']);
+        $this->assertSame(202600007, $params[':period_start_day_id_0']);
+        $this->assertSame(202600008, $params[':period_start_day_id_1']);
+        $this->assertSame(202600011, $params[':period_start_day_id_2']);
     }
 
     /**
@@ -251,16 +251,16 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             . " AND log_time BETWEEN :period_start AND :period_end";
 
         $slice = array(
-            self::period(100, 100, '2026-01-01 00:00:00', '2026-01-01 23:59:59'),
+            self::period(202600007, 202600007, '2026-01-07 00:00:00', '2026-01-07 23:59:59'),
         );
 
         list($whereSql, $params) = self::rewrite($where, $slice);
 
         $this->assertStringContainsString('log_day_id BETWEEN :period_start_day_id_0 AND :period_end_day_id_0', $whereSql);
         $this->assertStringContainsString('log_time BETWEEN :period_start_0 AND :period_end_0', $whereSql);
-        $this->assertSame(100, $params[':period_start_day_id_0']);
-        $this->assertSame(100, $params[':period_end_day_id_0']);
-        $this->assertSame('2026-01-01 00:00:00', $params[':period_start_0']);
-        $this->assertSame('2026-01-01 23:59:59', $params[':period_end_0']);
+        $this->assertSame(202600007, $params[':period_start_day_id_0']);
+        $this->assertSame(202600007, $params[':period_end_day_id_0']);
+        $this->assertSame('2026-01-07 00:00:00', $params[':period_start_0']);
+        $this->assertSame('2026-01-07 23:59:59', $params[':period_end_0']);
     }
 }

--- a/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
+++ b/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
@@ -15,9 +15,7 @@ use ReflectionClass;
 class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Invoke the private instance helper via reflection. The helper does not
-     * touch $this, so we construct the aggregator without invoking its
-     * (non-trivial) constructor and bind the call to the bare instance.
+     * Invoke the private instance helper via reflection.
      */
     private static function rewrite($whereClause, array $slice)
     {
@@ -84,8 +82,8 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             substr_count($whereSql, ' OR '),
             'one OR between consecutive period branches'
         );
-        // Each branch keeps the original predicate shape (just with renamed
-        // bind variables).
+
+        // Each branch keeps the original predicate shape.
         $this->assertSame(
             count($slice),
             substr_count($whereSql, 'task.start_day_id <= :period_end_day_id_'),
@@ -102,9 +100,8 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Non-period predicates get duplicated into every OR branch (semantically
-     * identical by distributive law). Aliases and other predicates must be
-     * preserved verbatim inside each branch.
+     * Non-period predicates get duplicated into every OR branch . Aliases 
+     * and other predicates must be preserved verbatim inside each branch.
      */
     public function testWhereClauseRewritePreservesAliasAndOtherPredicates()
     {
@@ -183,10 +180,8 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Single-column BETWEEN form on day_id (used by ood/pagefact_by_*.json:
-     * `log_day_id BETWEEN :period_start_day_id AND :period_end_day_id`). The
-     * rewrite must produce one BETWEEN per period rather than a single
-     * min/max BETWEEN spanning the slice.
+     * Single-column BETWEEN form on day_id. The rewrite must produce one BETWEEN 
+     * per period rather than a single min/max BETWEEN spanning the slice.
      */
     public function testSingleColumnBetweenOnDayIdIsExpandedPerPeriod()
     {
@@ -204,8 +199,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Timestamp BETWEEN form (used by accounts/accountfact_by_*.json:
-     * `af.account_creation_time BETWEEN :period_start AND :period_end`).
+     * Timestamp BETWEEN form using :period_start and :period_end.
      * These bind variables resolve to the period_start / period_end timestamp
      * columns in the dirty-period row, not the day_id columns.
      */
@@ -233,8 +227,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('2026-01-02 00:00:00', $params[':period_start_1']);
         $this->assertSame('2026-01-02 23:59:59', $params[':period_end_1']);
 
-        // The unsuffixed bind vars must not still appear (regression check
-        // for :period_start matching inside :period_start_day_id, etc.).
+        // The unsuffixed bind vars must not still appear.
         $this->assertDoesNotMatchRegularExpression('/:period_start(?![_0-9])/', $whereSql);
         $this->assertDoesNotMatchRegularExpression('/:period_end(?![_0-9])/', $whereSql);
     }

--- a/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
+++ b/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
@@ -100,7 +100,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Non-period predicates get duplicated into every OR branch . Aliases 
+     * Non-period predicates get duplicated into every OR branch. Aliases
      * and other predicates must be preserved verbatim inside each branch.
      */
     public function testWhereClauseRewritePreservesAliasAndOtherPredicates()
@@ -180,7 +180,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Single-column BETWEEN form on day_id. The rewrite must produce one BETWEEN 
+     * Single-column BETWEEN form on day_id. The rewrite must produce one BETWEEN
      * per period rather than a single min/max BETWEEN spanning the slice.
      */
     public function testSingleColumnBetweenOnDayIdIsExpandedPerPeriod()

--- a/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
+++ b/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Unit tests for the per-period batch temp-table WHERE rewrite used by
+ * pdoAggregator. The rewrite is what scopes the SELECT into `agg_tmp`
+ * (and `agg_tmp_stage`) to only the rows that overlap the periods in the
+ * current batch slice rather than the full day_id range that spans the
+ * slice.
+ */
+
+namespace UnitTests\ETL\Aggregator;
+
+use ETL\Aggregator\pdoAggregator;
+use ReflectionClass;
+
+class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Invoke the private instance helper via reflection. The helper does not
+     * touch $this, so we construct the aggregator without invoking its
+     * (non-trivial) constructor and bind the call to the bare instance.
+     */
+    private static function rewrite($whereClause, array $slice)
+    {
+        $rc = new ReflectionClass(pdoAggregator::class);
+        $instance = $rc->newInstanceWithoutConstructor();
+        $m = $rc->getMethod('rewriteWhereForPeriodSlice');
+        $m->setAccessible(true);
+        return $m->invoke($instance, $whereClause, $slice);
+    }
+
+    /**
+     * A non-contiguous slice (nine days in 2026 plus one day from 2022) 
+     * should produce one OR branch per period, with the per-period bind 
+     * values matching the slice — not the slice's min/max range.
+     */
+    public function testNonContiguousSliceProducesOneOrBranchPerPeriod()
+    {
+        $where =
+            "task.start_day_id <= :period_end_day_id"
+            . " AND task.end_day_id >= :period_start_day_id"
+            . " AND task.is_deleted = 0";
+
+        // Build a 10-period slice: nine consecutive days in 2026 plus an
+        // outlier in 2022. day_id values are arbitrary placeholders.
+        $slice = array();
+        for ($i = 0; $i < 9; $i++) {
+            $d = 6210 + $i;
+            $slice[] = array('period_start_day_id' => $d, 'period_end_day_id' => $d);
+        }
+        $slice[] = array('period_start_day_id' => 4748, 'period_end_day_id' => 4748);
+
+        list($whereSql, $params) = self::rewrite($where, $slice);
+
+        // Every period in the slice contributes exactly one bind value pair.
+        $this->assertCount(20, $params, 'one :p_start_<i> + :p_end_<i> per period');
+        foreach ($slice as $i => $period) {
+            $this->assertSame(
+                $period['period_start_day_id'],
+                $params[":p_start_$i"],
+                "p_start_$i bound to slice period $i start"
+            );
+            $this->assertSame(
+                $period['period_end_day_id'],
+                $params[":p_end_$i"],
+                "p_end_$i bound to slice period $i end"
+            );
+        }
+
+        // One OR branch per period: count of "task.start_day_id <= :p_end_"
+        // occurrences must equal the slice length.
+        $this->assertSame(
+            count($slice),
+            substr_count($whereSql, 'task.start_day_id <= :p_end_'),
+            'one OR branch per period'
+        );
+        // n periods => n-1 " OR " separators inside the rewritten group.
+        $this->assertSame(
+            count($slice) - 1,
+            substr_count($whereSql, ' OR '),
+            'one OR between consecutive period branches'
+        );
+
+        // The original period bind variables are gone.
+        $this->assertStringNotContainsString(':period_start_day_id', $whereSql);
+        $this->assertStringNotContainsString(':period_end_day_id', $whereSql);
+
+        // The outlier 2022 day did not get absorbed into a 4-year range.
+        $this->assertSame(4748, $params[':p_start_9']);
+        $this->assertSame(4748, $params[':p_end_9']);
+    }
+
+    /**
+     * The rewritten WHERE must replace the period overlap predicate with the
+     * OR group while leaving all other predicates intact, and must preserve
+     * the original column alias inside each OR branch.
+     */
+    public function testWhereClauseRewritePreservesAliasAndOtherPredicates()
+    {
+        $where =
+            "task.start_day_id <= :period_end_day_id"
+            . " AND task.end_day_id >= :period_start_day_id"
+            . " AND task.is_deleted = 0"
+            . " AND task.resource_id IN (1,2,3)";
+
+        $slice = array(
+            array('period_start_day_id' => 1000, 'period_end_day_id' => 1000),
+            array('period_start_day_id' => 1001, 'period_end_day_id' => 1001),
+        );
+
+        list($whereSql) = self::rewrite($where, $slice);
+
+        $this->assertStringNotContainsString(
+            ':period_start_day_id',
+            $whereSql,
+            'period_start bind var fully removed from WHERE'
+        );
+        $this->assertStringNotContainsString(
+            ':period_end_day_id',
+            $whereSql,
+            'period_end bind var fully removed from WHERE'
+        );
+        $this->assertStringContainsString(
+            'task.start_day_id <= :p_end_0',
+            $whereSql,
+            'first OR branch references original alias and per-period end bind'
+        );
+        $this->assertStringContainsString(
+            'task.end_day_id >= :p_start_0',
+            $whereSql,
+            'first OR branch references original alias and per-period start bind'
+        );
+        $this->assertStringContainsString(
+            'task.start_day_id <= :p_end_1',
+            $whereSql,
+            'second OR branch present'
+        );
+        $this->assertStringContainsString(
+            'task.is_deleted = 0',
+            $whereSql,
+            'unrelated predicates preserved'
+        );
+        $this->assertStringContainsString(
+            'task.resource_id IN (1,2,3)',
+            $whereSql,
+            'unrelated predicates preserved'
+        );
+    }
+
+    /**
+     * A slice with one period (i.e. when batching effectively degenerates to
+     * a single period) must produce a single OR branch with no OR operator.
+     */
+    public function testSinglePeriodSliceProducesSingleBranch()
+    {
+        $where =
+            "task.start_day_id <= :period_end_day_id"
+            . " AND task.end_day_id >= :period_start_day_id";
+
+        $slice = array(
+            array('period_start_day_id' => 7000, 'period_end_day_id' => 7000),
+        );
+
+        list($whereSql, $params) = self::rewrite($where, $slice);
+
+        $this->assertSame(
+            0,
+            substr_count($whereSql, ' OR '),
+            'no OR operator when only one period in the slice'
+        );
+        $this->assertSame(
+            1,
+            substr_count($whereSql, 'task.start_day_id <= :p_end_'),
+            'exactly one OR branch'
+        );
+        $this->assertSame(array(':p_start_0' => 7000, ':p_end_0' => 7000), $params);
+    }
+
+    /**
+     * For monthly aggregation, periods cover a range of days
+     * (period_start_day_id != period_end_day_id). The rewrite must preserve
+     * those ranges per period rather than collapsing them.
+     */
+    public function testMonthlySliceKeepsEachPeriodRange()
+    {
+        $where = "task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id";
+
+        $slice = array(
+            array('period_start_day_id' => 6210, 'period_end_day_id' => 6240),  // a 31-day month
+            array('period_start_day_id' => 4748, 'period_end_day_id' => 4778),  // a non-contiguous month
+        );
+
+        list(, $params) = self::rewrite($where, $slice);
+
+        $this->assertSame(6210, $params[':p_start_0']);
+        $this->assertSame(6240, $params[':p_end_0']);
+        $this->assertSame(4748, $params[':p_start_1']);
+        $this->assertSame(4778, $params[':p_end_1']);
+    }
+
+    /**
+     * Action defs use a variety of source-table aliases (task, sr, ra, crs,
+     * r). The captured alias must be re-used in every OR branch.
+     */
+    public function testRewritePreservesArbitraryAlias()
+    {
+        $where = "sr.start_day_id <= :period_end_day_id AND sr.end_day_id >= :period_start_day_id AND sr.instance_state_id = 1";
+
+        $slice = array(
+            array('period_start_day_id' => 100, 'period_end_day_id' => 100),
+            array('period_start_day_id' => 200, 'period_end_day_id' => 200),
+        );
+
+        list($whereSql) = self::rewrite($where, $slice);
+
+        $this->assertStringContainsString('sr.start_day_id <= :p_end_0', $whereSql);
+        $this->assertStringContainsString('sr.end_day_id >= :p_start_0', $whereSql);
+        $this->assertStringContainsString('sr.start_day_id <= :p_end_1', $whereSql);
+        $this->assertStringContainsString('sr.end_day_id >= :p_start_1', $whereSql);
+        $this->assertStringContainsString('sr.instance_state_id = 1', $whereSql);
+    }
+}

--- a/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
+++ b/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
@@ -29,9 +29,24 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * A non-contiguous slice (nine days in 2026 plus one day from 2022) 
-     * should produce one OR branch per period, with the per-period bind 
-     * values matching the slice, not the slice's min/max range.
+     * Build a slice element carrying the standard period columns. Tests can
+     * pass any subset of overrides.
+     */
+    private static function period($startDayId, $endDayId, $start = null, $end = null)
+    {
+        return array(
+            'period_start_day_id' => $startDayId,
+            'period_end_day_id'   => $endDayId,
+            'period_start'        => $start,
+            'period_end'          => $end,
+        );
+    }
+
+    /**
+     * A non-contiguous slice (mirrors the real-world bug: nine days in 2026
+     * plus one day from 2022) should produce one OR branch per period, with
+     * the per-period bind values matching the slice — not the slice's
+     * min/max range.
      */
     public function testNonContiguousSliceProducesOneOrBranchPerPeriod()
     {
@@ -40,59 +55,56 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             . " AND task.end_day_id >= :period_start_day_id"
             . " AND task.is_deleted = 0";
 
-        // Build a 10-period slice: nine consecutive days in 2026 plus an
-        // outlier in 2022. day_id values are arbitrary placeholders.
         $slice = array();
         for ($i = 0; $i < 9; $i++) {
-            $d = 202600003 + $i;
-            $slice[] = array('period_start_day_id' => $d, 'period_end_day_id' => $d);
+            $d = 6210 + $i;
+            $slice[] = self::period($d, $d);
         }
-        $slice[] = array('period_start_day_id' => 202200152, 'period_end_day_id' => 202200152);
+        $slice[] = self::period(4748, 4748);
 
         list($whereSql, $params) = self::rewrite($where, $slice);
 
-        // Every period in the slice contributes exactly one bind value pair.
-        $this->assertCount(20, $params, 'one :p_start_<i> + :p_end_<i> per period');
+        // Each period contributes one renamed pair for each :period_*_day_id
+        // bind var that appears in the WHERE — here, two pairs per period.
+        $this->assertCount(2 * count($slice), $params);
         foreach ($slice as $i => $period) {
             $this->assertSame(
                 $period['period_start_day_id'],
-                $params[":p_start_$i"],
-                "p_start_$i bound to slice period $i start"
+                $params[":period_start_day_id_$i"]
             );
             $this->assertSame(
                 $period['period_end_day_id'],
-                $params[":p_end_$i"],
-                "p_end_$i bound to slice period $i end"
+                $params[":period_end_day_id_$i"]
             );
         }
 
-        // One OR branch per period: count of "task.start_day_id <= :p_end_"
-        // occurrences must equal the slice length.
-        $this->assertSame(
-            count($slice),
-            substr_count($whereSql, 'task.start_day_id <= :p_end_'),
-            'one OR branch per period'
-        );
-        // n periods => n-1 " OR " separators inside the rewritten group.
+        // One OR branch per period.
         $this->assertSame(
             count($slice) - 1,
             substr_count($whereSql, ' OR '),
             'one OR between consecutive period branches'
         );
+        // Each branch keeps the original predicate shape (just with renamed
+        // bind variables).
+        $this->assertSame(
+            count($slice),
+            substr_count($whereSql, 'task.start_day_id <= :period_end_day_id_'),
+            'one branch per period preserves the original overlap shape'
+        );
 
-        // The original period bind variables are gone.
-        $this->assertStringNotContainsString(':period_start_day_id', $whereSql);
-        $this->assertStringNotContainsString(':period_end_day_id', $whereSql);
+        // Original (un-suffixed) period bind vars are gone.
+        $this->assertDoesNotMatchRegularExpression('/:period_start_day_id(?![_0-9])/', $whereSql);
+        $this->assertDoesNotMatchRegularExpression('/:period_end_day_id(?![_0-9])/', $whereSql);
 
-        // The outlier 2022 day did not get absorbed into a 4-year range.
-        $this->assertSame(202200152, $params[':p_start_9']);
-        $this->assertSame(202200152, $params[':p_end_9']);
+        // Outlier 2022 day is bound to its own slot, not absorbed into a range.
+        $this->assertSame(4748, $params[':period_start_day_id_9']);
+        $this->assertSame(4748, $params[':period_end_day_id_9']);
     }
 
     /**
-     * The rewritten WHERE must replace the period overlap predicate with the
-     * OR group while leaving all other predicates intact, and must preserve
-     * the original column alias inside each OR branch.
+     * Non-period predicates get duplicated into every OR branch (semantically
+     * identical by distributive law). Aliases and other predicates must be
+     * preserved verbatim inside each branch.
      */
     public function testWhereClauseRewritePreservesAliasAndOtherPredicates()
     {
@@ -102,120 +114,153 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             . " AND task.is_deleted = 0"
             . " AND task.resource_id IN (1,2,3)";
 
-        $slice = array(
-            array('period_start_day_id' => 202600003, 'period_end_day_id' => 202600003),
-            array('period_start_day_id' => 202600004, 'period_end_day_id' => 202600004),
-        );
+        $slice = array(self::period(1000, 1000), self::period(1001, 1001));
 
         list($whereSql) = self::rewrite($where, $slice);
 
-        $this->assertStringNotContainsString(
-            ':period_start_day_id',
-            $whereSql,
-            'period_start bind var fully removed from WHERE'
-        );
-        $this->assertStringNotContainsString(
-            ':period_end_day_id',
-            $whereSql,
-            'period_end bind var fully removed from WHERE'
-        );
-        $this->assertStringContainsString(
-            'task.start_day_id <= :p_end_0',
-            $whereSql,
-            'first OR branch references original alias and per-period end bind'
-        );
-        $this->assertStringContainsString(
-            'task.end_day_id >= :p_start_0',
-            $whereSql,
-            'first OR branch references original alias and per-period start bind'
-        );
-        $this->assertStringContainsString(
-            'task.start_day_id <= :p_end_1',
-            $whereSql,
-            'second OR branch present'
-        );
-        $this->assertStringContainsString(
-            'task.is_deleted = 0',
-            $whereSql,
-            'unrelated predicates preserved'
-        );
-        $this->assertStringContainsString(
-            'task.resource_id IN (1,2,3)',
-            $whereSql,
-            'unrelated predicates preserved'
-        );
+        $this->assertDoesNotMatchRegularExpression('/:period_start_day_id(?![_0-9])/', $whereSql);
+        $this->assertDoesNotMatchRegularExpression('/:period_end_day_id(?![_0-9])/', $whereSql);
+
+        $this->assertStringContainsString('task.start_day_id <= :period_end_day_id_0', $whereSql);
+        $this->assertStringContainsString('task.end_day_id >= :period_start_day_id_0', $whereSql);
+        $this->assertStringContainsString('task.start_day_id <= :period_end_day_id_1', $whereSql);
+
+        // Non-period predicates duplicated once per OR branch.
+        $this->assertSame(2, substr_count($whereSql, 'task.is_deleted = 0'));
+        $this->assertSame(2, substr_count($whereSql, 'task.resource_id IN (1,2,3)'));
     }
 
     /**
-     * A slice with one period (i.e. when batching effectively degenerates to
-     * a single period) must produce a single OR branch with no OR operator.
+     * Single-period slice degenerates to one branch with no OR operator.
      */
     public function testSinglePeriodSliceProducesSingleBranch()
     {
-        $where =
-            "task.start_day_id <= :period_end_day_id"
-            . " AND task.end_day_id >= :period_start_day_id";
+        $where = "task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id";
 
-        $slice = array(
-            array('period_start_day_id' => 202600003, 'period_end_day_id' => 202600003),
-        );
+        $slice = array(self::period(7000, 7000));
 
         list($whereSql, $params) = self::rewrite($where, $slice);
 
-        $this->assertSame(
-            0,
-            substr_count($whereSql, ' OR '),
-            'no OR operator when only one period in the slice'
-        );
-        $this->assertSame(
-            1,
-            substr_count($whereSql, 'task.start_day_id <= :p_end_'),
-            'exactly one OR branch'
-        );
-        $this->assertSame(array(':p_start_0' => 202600003, ':p_end_0' => 202600003), $params);
+        $this->assertSame(0, substr_count($whereSql, ' OR '));
+        $this->assertSame(7000, $params[':period_start_day_id_0']);
+        $this->assertSame(7000, $params[':period_end_day_id_0']);
     }
 
     /**
-     * For monthly aggregation, periods cover a range of days
-     * (period_start_day_id != period_end_day_id). The rewrite must preserve
-     * those ranges per period rather than collapsing them.
+     * Monthly aggregation uses periods that span a range of days. The rewrite
+     * must preserve each period's range rather than collapsing them.
      */
     public function testMonthlySliceKeepsEachPeriodRange()
     {
         $where = "task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id";
 
-        $slice = array(
-            array('period_start_day_id' => 202600001, 'period_end_day_id' => 202600031),  // a 31-day month
-            array('period_start_day_id' => 202600060, 'period_end_day_id' => 202600090),  // a non-contiguous month
-        );
+        $slice = array(self::period(6210, 6240), self::period(4748, 4778));
 
         list(, $params) = self::rewrite($where, $slice);
 
-        $this->assertSame(202600001, $params[':p_start_0']);
-        $this->assertSame(202600031, $params[':p_end_0']);
-        $this->assertSame(202600060, $params[':p_start_1']);
-        $this->assertSame(202600090, $params[':p_end_1']);
+        $this->assertSame(6210, $params[':period_start_day_id_0']);
+        $this->assertSame(6240, $params[':period_end_day_id_0']);
+        $this->assertSame(4748, $params[':period_start_day_id_1']);
+        $this->assertSame(4778, $params[':period_end_day_id_1']);
     }
 
     /**
      * Action defs use a variety of source-table aliases (task, sr, ra, crs,
-     * r). The captured alias must be re-used in every OR branch.
+     * gw, r). The rewrite must work with any alias.
      */
     public function testRewritePreservesArbitraryAlias()
     {
-        $where = "sr.start_day_id <= :period_end_day_id AND sr.end_day_id >= :period_start_day_id AND sr.instance_state_id = 1";
+        $where = "gw.start_day_id <= :period_end_day_id AND gw.end_day_id >= :period_start_day_id AND gw.is_deleted = 0";
 
-        $slice = array(
-            array('period_start_day_id' => 202600003, 'period_end_day_id' => 202600003),
-            array('period_start_day_id' => 202600004, 'period_end_day_id' => 202600004),
-        );
+        $slice = array(self::period(100, 100), self::period(200, 200));
 
         list($whereSql) = self::rewrite($where, $slice);
 
-        $this->assertStringContainsString('sr.start_day_id <= :p_end_0', $whereSql);
-        $this->assertStringContainsString('sr.end_day_id >= :p_start_0', $whereSql);
-        $this->assertStringContainsString('sr.start_day_id <= :p_end_1', $whereSql);
-        $this->assertStringContainsString('sr.end_day_id >= :p_start_1', $whereSql);
-        $this->assertStringContainsString('sr.instance_state_id = 1', $whereSql);
+        $this->assertStringContainsString('gw.start_day_id <= :period_end_day_id_0', $whereSql);
+        $this->assertStringContainsString('gw.end_day_id >= :period_start_day_id_0', $whereSql);
+        $this->assertStringContainsString('gw.start_day_id <= :period_end_day_id_1', $whereSql);
+        $this->assertSame(2, substr_count($whereSql, 'gw.is_deleted = 0'));
+    }
+
+    /**
+     * Single-column BETWEEN form on day_id (used by ood/pagefact_by_*.json:
+     * `log_day_id BETWEEN :period_start_day_id AND :period_end_day_id`). The
+     * rewrite must produce one BETWEEN per period rather than a single
+     * min/max BETWEEN spanning the slice.
+     */
+    public function testSingleColumnBetweenOnDayIdIsExpandedPerPeriod()
+    {
+        $where = "log_day_id BETWEEN :period_start_day_id AND :period_end_day_id";
+
+        $slice = array(self::period(100, 100), self::period(500, 500), self::period(900, 900));
+
+        list($whereSql, $params) = self::rewrite($where, $slice);
+
+        $this->assertSame(3, substr_count($whereSql, 'log_day_id BETWEEN :period_start_day_id_'));
+        $this->assertSame(2, substr_count($whereSql, ' OR '));
+        $this->assertSame(100, $params[':period_start_day_id_0']);
+        $this->assertSame(500, $params[':period_start_day_id_1']);
+        $this->assertSame(900, $params[':period_start_day_id_2']);
+    }
+
+    /**
+     * Timestamp BETWEEN form (used by accounts/accountfact_by_*.json:
+     * `af.account_creation_time BETWEEN :period_start AND :period_end`).
+     * These bind variables resolve to the period_start / period_end timestamp
+     * columns in the dirty-period row, not the day_id columns.
+     */
+    public function testTimestampBetweenIsExpandedPerPeriod()
+    {
+        $where = "af.account_creation_time BETWEEN :period_start AND :period_end";
+
+        $slice = array(
+            self::period(0, 0, '2026-01-01 00:00:00', '2026-01-01 23:59:59'),
+            self::period(0, 0, '2026-01-02 00:00:00', '2026-01-02 23:59:59'),
+        );
+
+        list($whereSql, $params) = self::rewrite($where, $slice);
+
+        $this->assertStringContainsString(
+            'af.account_creation_time BETWEEN :period_start_0 AND :period_end_0',
+            $whereSql
+        );
+        $this->assertStringContainsString(
+            'af.account_creation_time BETWEEN :period_start_1 AND :period_end_1',
+            $whereSql
+        );
+        $this->assertSame('2026-01-01 00:00:00', $params[':period_start_0']);
+        $this->assertSame('2026-01-01 23:59:59', $params[':period_end_0']);
+        $this->assertSame('2026-01-02 00:00:00', $params[':period_start_1']);
+        $this->assertSame('2026-01-02 23:59:59', $params[':period_end_1']);
+
+        // The unsuffixed bind vars must not still appear (regression check
+        // for :period_start matching inside :period_start_day_id, etc.).
+        $this->assertDoesNotMatchRegularExpression('/:period_start(?![_0-9])/', $whereSql);
+        $this->assertDoesNotMatchRegularExpression('/:period_end(?![_0-9])/', $whereSql);
+    }
+
+    /**
+     * `:period_start` must not eat into `:period_start_day_id`. A WHERE that
+     * mixes both kinds of bind variable in the same clause must rewrite each
+     * one independently.
+     */
+    public function testMixedDayIdAndTimestampBindVarsAreDisambiguated()
+    {
+        $where =
+            "log_day_id BETWEEN :period_start_day_id AND :period_end_day_id"
+            . " AND log_time BETWEEN :period_start AND :period_end";
+
+        $slice = array(
+            self::period(100, 100, '2026-01-01 00:00:00', '2026-01-01 23:59:59'),
+        );
+
+        list($whereSql, $params) = self::rewrite($where, $slice);
+
+        $this->assertStringContainsString('log_day_id BETWEEN :period_start_day_id_0 AND :period_end_day_id_0', $whereSql);
+        $this->assertStringContainsString('log_time BETWEEN :period_start_0 AND :period_end_0', $whereSql);
+        $this->assertSame(100, $params[':period_start_day_id_0']);
+        $this->assertSame(100, $params[':period_end_day_id_0']);
+        $this->assertSame('2026-01-01 00:00:00', $params[':period_start_0']);
+        $this->assertSame('2026-01-01 23:59:59', $params[':period_end_0']);
     }
 }

--- a/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
+++ b/tests/unit/lib/ETL/Aggregator/PdoAggregatorBatchTempTableTest.php
@@ -31,7 +31,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
     /**
      * A non-contiguous slice (nine days in 2026 plus one day from 2022) 
      * should produce one OR branch per period, with the per-period bind 
-     * values matching the slice — not the slice's min/max range.
+     * values matching the slice, not the slice's min/max range.
      */
     public function testNonContiguousSliceProducesOneOrBranchPerPeriod()
     {
@@ -44,10 +44,10 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
         // outlier in 2022. day_id values are arbitrary placeholders.
         $slice = array();
         for ($i = 0; $i < 9; $i++) {
-            $d = 6210 + $i;
+            $d = 202600003 + $i;
             $slice[] = array('period_start_day_id' => $d, 'period_end_day_id' => $d);
         }
-        $slice[] = array('period_start_day_id' => 4748, 'period_end_day_id' => 4748);
+        $slice[] = array('period_start_day_id' => 202200152, 'period_end_day_id' => 202200152);
 
         list($whereSql, $params) = self::rewrite($where, $slice);
 
@@ -85,8 +85,8 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
         $this->assertStringNotContainsString(':period_end_day_id', $whereSql);
 
         // The outlier 2022 day did not get absorbed into a 4-year range.
-        $this->assertSame(4748, $params[':p_start_9']);
-        $this->assertSame(4748, $params[':p_end_9']);
+        $this->assertSame(202200152, $params[':p_start_9']);
+        $this->assertSame(202200152, $params[':p_end_9']);
     }
 
     /**
@@ -103,8 +103,8 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             . " AND task.resource_id IN (1,2,3)";
 
         $slice = array(
-            array('period_start_day_id' => 1000, 'period_end_day_id' => 1000),
-            array('period_start_day_id' => 1001, 'period_end_day_id' => 1001),
+            array('period_start_day_id' => 202600003, 'period_end_day_id' => 202600003),
+            array('period_start_day_id' => 202600004, 'period_end_day_id' => 202600004),
         );
 
         list($whereSql) = self::rewrite($where, $slice);
@@ -157,7 +157,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             . " AND task.end_day_id >= :period_start_day_id";
 
         $slice = array(
-            array('period_start_day_id' => 7000, 'period_end_day_id' => 7000),
+            array('period_start_day_id' => 202600003, 'period_end_day_id' => 202600003),
         );
 
         list($whereSql, $params) = self::rewrite($where, $slice);
@@ -172,7 +172,7 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
             substr_count($whereSql, 'task.start_day_id <= :p_end_'),
             'exactly one OR branch'
         );
-        $this->assertSame(array(':p_start_0' => 7000, ':p_end_0' => 7000), $params);
+        $this->assertSame(array(':p_start_0' => 202600003, ':p_end_0' => 202600003), $params);
     }
 
     /**
@@ -185,16 +185,16 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
         $where = "task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id";
 
         $slice = array(
-            array('period_start_day_id' => 6210, 'period_end_day_id' => 6240),  // a 31-day month
-            array('period_start_day_id' => 4748, 'period_end_day_id' => 4778),  // a non-contiguous month
+            array('period_start_day_id' => 202600001, 'period_end_day_id' => 202600031),  // a 31-day month
+            array('period_start_day_id' => 202600060, 'period_end_day_id' => 202600090),  // a non-contiguous month
         );
 
         list(, $params) = self::rewrite($where, $slice);
 
-        $this->assertSame(6210, $params[':p_start_0']);
-        $this->assertSame(6240, $params[':p_end_0']);
-        $this->assertSame(4748, $params[':p_start_1']);
-        $this->assertSame(4778, $params[':p_end_1']);
+        $this->assertSame(202600001, $params[':p_start_0']);
+        $this->assertSame(202600031, $params[':p_end_0']);
+        $this->assertSame(202600060, $params[':p_start_1']);
+        $this->assertSame(202600090, $params[':p_end_1']);
     }
 
     /**
@@ -206,8 +206,8 @@ class PdoAggregatorBatchTempTableTest extends \PHPUnit\Framework\TestCase
         $where = "sr.start_day_id <= :period_end_day_id AND sr.end_day_id >= :period_start_day_id AND sr.instance_state_id = 1";
 
         $slice = array(
-            array('period_start_day_id' => 100, 'period_end_day_id' => 100),
-            array('period_start_day_id' => 200, 'period_end_day_id' => 200),
+            array('period_start_day_id' => 202600003, 'period_end_day_id' => 202600003),
+            array('period_start_day_id' => 202600004, 'period_end_day_id' => 202600004),
         );
 
         list($whereSql) = self::rewrite($where, $slice);


### PR DESCRIPTION
Currently, when aggregating in batches, the data loaded into the temporary table and aggregated is between the min and max time periods for the batch and it may be the case that not all time periods in that range need to be aggregated. This PR changes to only loading the time periods that are being aggregated into the batch. It takes the `WHERE` clause in the aggregation and rewrites it to be multiple clauses, one for each time period be aggregated. 

For example, if the original WHERE clause is:
```
task.start_day_id <= :period_end_day_id AND task.end_day_id >= :period_start_day_id AND task.is_deleted = 0
```
and we are aggregating 2 periods with period_start_day_id/period_end_day_id values of 20200101/20200131 and 20200201/20200229, the `WHERE` clause will be rewritten to:
```
(task.start_day_id <= :period_end_day_id_0 AND task.end_day_id >= :period_start_day_id_0 AND task.is_deleted = 0) 
OR 
(task.start_day_id <= :period_end_day_id_1 AND task.end_day_id >= :period_start_day_id_1 AND task.is_deleted = 0)
```
This speeds up the batch temp table creation and aggregation when there is a large gap in the time periods being aggregated in a batch.

## Tests performed
Tested in docker and on xdmod-dev. New unit tests are added too.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
