### PR TITLE
Remove xdmod-jekyll-theme submodule (xdmod10.0).

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/xdmod-jekyll-theme"]
-	path = docs/xdmod-jekyll-theme
-	url = https://github.com/ubccr/xdmod-jekyll-theme

--- a/docs/xdmod-rest-schema.json
+++ b/docs/xdmod-rest-schema.json
@@ -13,7 +13,7 @@
             "url": "https://www.gnu.org/licenses/lgpl-3.0.txt"
         },
         "x-logo": {
-            "url": "https://open.xdmod.org/xdmod-jekyll-theme/assets/images/xdmod_logo.png",
+            "url": "https://open.xdmod.org/assets/images/xdmod_logo.png",
             "backgroundColor": "#FFFFFF",
             "altText": ""
         },


### PR DESCRIPTION
Updates per https://github.com/ubccr/xdmod/pull/2207 for `xdmod10.0` branch.