### PR TITLE
Fix CI website validation.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/xdmod-jekyll-theme"]
-	path = docs/xdmod-jekyll-theme
-	url = https://github.com/ubccr/xdmod-jekyll-theme

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -42,7 +42,7 @@ defaults:
     values:
       layout: "page"
       version: "11.5"
-      prev_sw_version: "11.0.2"
+      prev_sw_version: "11.0.3"
       sw_version: "11.5.0"
       rpm_version: "11.5.0-1"
       style: "effervescence"
@@ -50,8 +50,9 @@ defaults:
 
 # Build settings
 markdown: kramdown
-theme_subdir: "/xdmod-jekyll-theme"
-gems:
+remote_theme: ubccr/xdmod-jekyll-theme@v0.2.0
+plugins:
   - jekyll-redirect-from
+  - jekyll-remote-theme
 whitelist:
   - jekyll-redirect-from

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,1 +1,0 @@
-../xdmod-jekyll-theme/_layouts/page.html

--- a/docs/xdmod-rest-schema.json
+++ b/docs/xdmod-rest-schema.json
@@ -16,7 +16,7 @@ layout: null
             "url": "https://www.gnu.org/licenses/lgpl-3.0.txt"
         },
         "x-logo": {
-            "url": "https://open.xdmod.org/xdmod-jekyll-theme/assets/images/xdmod_logo.png",
+            "url": "https://open.xdmod.org/assets/images/xdmod_logo.png",
             "backgroundColor": "#FFFFFF",
             "altText": ""
         },


### PR DESCRIPTION
This PR fixes the CI test `Build-Validate-Website-Documentation` by merging in the `xdmod-jekyll-theme` changes from https://github.com/ubccr/xdmod/pull/2207