### PR TITLE
Remove disk_gb column from sql_data.d json file

### DIFF
--- a/configuration/etl/etl_data.d/cloud_common/instance_type.json
+++ b/configuration/etl/etl_data.d/cloud_common/instance_type.json
@@ -1,4 +1,4 @@
 [
-    ["resource_id", "instance_type_id", "instance_type", "display", "description", "num_cores", "memory_mb", "disk_gb", "start_time", "end_time"],
-    [-1,            1,                  "Unknown",       "Unknown", null,            0,           0,           0,         0,            null]
+    ["resource_id", "instance_type_id", "instance_type", "display", "description", "num_cores", "memory_mb", "start_time", "end_time"],
+    [-1,            1,                  "Unknown",       "Unknown", null,          0,           0,           0,            null]
 ]


### PR DESCRIPTION
The data in this json file is ingested into `modw_cloud.instance_type` which no longer has a `disk_gb` column. With this file still having the `disk_gb` column the following warning is shown.

```
[warning] xdmod.jobs-cloud-common.CloudInstanceTypeUnknownInitializer (ETL\Ingestor\StructuredFileIngestor): The following 1 source record fields were not mapped to any tables: (disk_gb)
```
When the column is removed from the json file the warning does not happen.

## Tests performed
Tested in docker

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
