### PR TITLE
Updates to make XDMoD compatible with MariaDB 10.5, 10.11, 11.4, 11.8, and 12.3

### DIFF
--- a/classes/CCR/DB/MySQLHelper.php
+++ b/classes/CCR/DB/MySQLHelper.php
@@ -587,7 +587,7 @@ class MySQLHelper
     {
         $args = array_map('escapeshellarg', $args);
 
-        $command = 'mysql ' . implode(' ', $args);
+        $command = static::clientCommandName() . ' ' . implode(' ', $args);
 
         if ($input !== null) {
             $command .= ' <' . escapeshellarg($input);
@@ -596,22 +596,64 @@ class MySQLHelper
         $output    = array();
         $returnVar = 0;
         $tmpHome = xd_utilities\createTemporaryDirectory('mysql-helper-');
+        $stderrFile = tempnam(sys_get_temp_dir(), 'mysql-helper-stderr-');
 
+        // Capture stderr separately rather than folding it into stdout.
+        // Callers such as databaseExists() parse stdout as query results, and
+        // the client writes advisory notices to stderr -- for example the
+        // "Deprecated program name" warning MariaDB 11.0+ emits, and the
+        // "--ssl-verify-server-cert is disabled" notice on passwordless
+        // logins.  Either would otherwise be read as a result row.
         exec(
-            sprintf('%s %s 2>&1', 'HOME=' . escapeshellarg($tmpHome), $command),
+            sprintf(
+                '%s %s 2>%s',
+                'HOME=' . escapeshellarg($tmpHome),
+                $command,
+                escapeshellarg($stderrFile)
+            ),
             $output,
             $returnVar
         );
 
+        $stderr = (string)@file_get_contents($stderrFile);
+        @unlink($stderrFile);
         rmdir($tmpHome);
 
         if ($returnVar != 0) {
             $msg = "Command returned non-zero value '$returnVar': "
                 . implode("\n", $output);
+            if (trim($stderr) !== '') {
+                $msg .= "\n" . trim($stderr);
+            }
             throw new Exception($msg);
         }
 
         return $output;
+    }
+
+    /**
+     * Name of the MariaDB/MySQL command line client to execute.
+     *
+     * MariaDB 11.0 deprecated the "mysql" name in favour of "mariadb" and
+     * prints a notice to stderr whenever the old name is used.  Prefer the
+     * new name where it is available so the notice is never emitted, and so
+     * that the code keeps working once the compatibility symlinks are
+     * removed altogether.
+     *
+     * @return string The client executable name.
+     */
+    private static function clientCommandName()
+    {
+        static $name = null;
+
+        if ($name === null) {
+            $output    = array();
+            $returnVar = 0;
+            exec('command -v mariadb 2>/dev/null', $output, $returnVar);
+            $name = ($returnVar === 0 && count($output) > 0) ? 'mariadb' : 'mysql';
+        }
+
+        return $name;
     }
 
     /**

--- a/classes/ETL/DbModel/Column.php
+++ b/classes/ETL/DbModel/Column.php
@@ -114,6 +114,12 @@ class Column extends NamedEntity implements iEntity
                 } else {
                     $value = strtolower($value);
                 }
+                // Fold the utf8mb3 character set family back to the legacy "utf8" spelling
+                // so that servers reporting either name compare as equal. See
+                // Entity::normalizeCharsetName().
+                if ( 'charset' == $property || 'collation' == $property ) {
+                    $value = $this->normalizeCharsetName($value);
+                }
                 break;
 
             default:

--- a/classes/ETL/DbModel/Entity.php
+++ b/classes/ETL/DbModel/Entity.php
@@ -234,6 +234,45 @@ class Entity extends Loggable
     }  // filterAndVerifyValue()
 
     /* ------------------------------------------------------------------------------------------
+     * MariaDB 10.6 renamed the canonical form of the 3 byte UTF-8 character set from
+     * "utf8" to "utf8mb3" and reports the new name via information_schema. The character
+     * set itself did not change, so a table declared as "utf8" but discovered as
+     * "utf8mb3" is not actually different and Should not generate an ALTER TABLE.
+     *
+     * Normalize to the legacy "utf8" spelling rather than to "utf8mb3" because "utf8" is
+     * accepted as a character set name by every supported server (10.3 through 12.x)
+     * while "utf8mb3" is unknown to MariaDB 10.5 and earlier. Generated DDL therefore
+     * remains valid across the whole supported range.
+     *
+     * Only the utf8mb3 family is folded. utf8mb4 is a different character set
+     * and is returned untouched.
+     *
+     * @param ?string $name A character set or collation name
+     *
+     * @return ?string The normalized name
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function normalizeCharsetName(?string $name) : ?string
+    {
+        if ( null === $name ) {
+            return $name;
+        }
+
+        if ( 0 === strcasecmp($name, 'utf8mb3') ) {
+            return 'utf8';
+        }
+
+        // e.g. utf8mb3_unicode_ci -> utf8_unicode_ci, utf8mb3_uca1400_ai_ci -> utf8_uca1400_ai_ci
+
+        if ( 0 === stripos($name, 'utf8mb3_') ) {
+            return 'utf8' . substr($name, strlen('utf8mb3'));
+        }
+
+        return $name;
+    }  // normalizeCharsetName()
+
+    /* ------------------------------------------------------------------------------------------
      * @return The character used to quote system identifiers
      * ------------------------------------------------------------------------------------------
      */

--- a/classes/ETL/DbModel/Entity.php
+++ b/classes/ETL/DbModel/Entity.php
@@ -233,26 +233,23 @@ class Entity extends Loggable
         return $value;
     }  // filterAndVerifyValue()
 
-    /* ------------------------------------------------------------------------------------------
+    /**
      * MariaDB 10.6 renamed the canonical form of the 3 byte UTF-8 character set from
      * "utf8" to "utf8mb3" and reports the new name via information_schema. The character
      * set itself did not change, so a table declared as "utf8" but discovered as
-     * "utf8mb3" is not actually different and Should not generate an ALTER TABLE.
+     * "utf8mb3" is not actually different and should not generate an ALTER TABLE.
      *
      * Normalize to the legacy "utf8" spelling rather than to "utf8mb3" because "utf8" is
      * accepted as a character set name by every supported server (10.3 through 12.x)
      * while "utf8mb3" is unknown to MariaDB 10.5 and earlier. Generated DDL therefore
      * remains valid across the whole supported range.
      *
-     * Only the utf8mb3 family is folded. utf8mb4 is a different character set
-     * and is returned untouched.
+     * Only the utf8mb3 family is folded. utf8mb4 is a different character set and is
+     * returned untouched.
      *
      * @param ?string $name A character set or collation name
-     *
      * @return ?string The normalized name
-     * ------------------------------------------------------------------------------------------
      */
-
     protected function normalizeCharsetName(?string $name) : ?string
     {
         if ( null === $name ) {
@@ -270,7 +267,7 @@ class Entity extends Loggable
         }
 
         return $name;
-    }  // normalizeCharsetName()
+    }
 
     /* ------------------------------------------------------------------------------------------
      * @return The character used to quote system identifiers

--- a/classes/ETL/DbModel/Table.php
+++ b/classes/ETL/DbModel/Table.php
@@ -136,6 +136,12 @@ class Table extends SchemaEntity implements iEntity, iDiscoverableEntity, iAlter
                 if ( 'comment' != $property ) {
                     $value = strtolower($value);
                 }
+                // Fold the utf8mb3 character set family back to the legacy "utf8" spelling
+                // so that servers reporting either name compare as equal. See
+                // Entity::normalizeCharsetName().
+                if ( 'charset' == $property || 'collation' == $property ) {
+                    $value = $this->normalizeCharsetName($value);
+                }
                 break;
 
             default:

--- a/configuration/etl/etl_sql.d/migrations/11.0.0-11.5.0/moddb/reports.sql
+++ b/configuration/etl/etl_sql.d/migrations/11.0.0-11.5.0/moddb/reports.sql
@@ -16,7 +16,12 @@ CREATE TEMPORARY TABLE `tmp_uniquereports` (
   `active_role` varchar(30) DEFAULT NULL,
   `last_modified` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   UNIQUE INDEX idx_report (report_id)
-)//
+)
+-- Explicitly set the charset rather than inheriting the database default. From
+-- MariaDB 11.5 on, the default is utf8mb4_uca1400_ai_ci, which is accent insensitive, 
+-- so the UNIQUE INDEX above would collapse report_ids that differ only by accent and
+-- INSERT IGNORE would silently discard those rows before they are written back.
+CHARACTER SET utf8 COLLATE utf8_unicode_ci//
 INSERT IGNORE INTO `tmp_uniquereports` SELECT * FROM `moddb`.`Reports`//
 DELETE FROM `moddb`.`Reports`//
 INSERT INTO `moddb`.`Reports` SELECT * FROM `tmp_uniquereports`//


### PR DESCRIPTION
## Description
We would like XDMoD to be compatible with newer versions of MariaDB. These changes make it so XDMoD is able to run with version of MariaDB up to 12.3. The changes are.

- Choose which command line command to use to run sql statements. The `mysql` command line command is removed in 11.0 in favor of `mariadb`. Check which command exists and use the appropriate one.
-   MariaDB 10.6 renamed the 3-byte UTF-8 character set from utf8 to utf8mb3 in information_schema. The character set itself did not change, but etlv2 manages the tables and  compares the discovered name against the declared one as a plain string, so on 10.6 and newer it thinks every managed table is wrong and emiits an ALTER TABLE ... CONVERT TO CHARACTER SET for each one on every run and repeating indefinitely since converting to utf8 can never make the comparison converge. These ALTERs are no-ops that change no data, but each takes an exclusive metadata lock and they permanently mask real schema changes in the ETL logs. This normalizes utf8mb3/utf8mb3_* to the legacy utf8/utf8_* spelling when charset and collation values are set, so both sides of the comparison agree. Normalizing toward utf8 rather than utf8mb3 is deliberate: utf8 is accepted as a  character set name by every supported server, while utf8mb3 is unknown to MariaDB 10.5 and earlier, so generated DDL stays valid across the whole 10.3–12.3 range.
- The 11.5.0 moddb.Reports migration action created its deduplication temp table without an explicit character set, inheriting the database default, which after MariaDB 11.5 is the accent-insensitive utf8mb4_uca1400_ai_ci. That made the table's UNIQUE INDEX collapse report IDs differing only by accent, so INSERT IGNORE would silently discard those rows before the reduced set was written back over moddb.Reports. The temp table now pins utf8/utf8_unicode_ci to match moddb.Reports.

## Motivation and Context
We'd like to be able to use newer versions of MariaDB

## Tests performed
Tested with MariaDB 10.3, 10.5, 10.11, 11.4, 11.8, and 12.3 in separate docker containers.

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [ ] The milestone is set correctly on the pull request
- [ ] The appropriate labels have been added to the pull request
