### PR TITLE
Using assertEquals() with delta argument has been depreciated in PHPUnit 9. Use assertEqualsWithDelta() instead

### DIFF
--- a/tests/integration/lib/Controllers/UsageExplorerTest.php
+++ b/tests/integration/lib/Controllers/UsageExplorerTest.php
@@ -402,7 +402,7 @@ EOF
         $this->assertCount(1, $dataseries[0]['y']);
         $this->assertArrayHasKey('y', $dataseries[0]);
 
-        $this->assertEquals($expected, $dataseries[0]['y'][0], '', 1.0e-6);
+        $this->assertEqualsWithDelta($expected, $dataseries[0]['y'][0], 1.0e-6);
     }
 
     /**

--- a/tests/integration/lib/Rest/DashboardControllerProviderTest.php
+++ b/tests/integration/lib/Rest/DashboardControllerProviderTest.php
@@ -134,7 +134,7 @@ class DashboardControllerProviderTest extends BaseUserAdminTest
                         $expectedValue = (float)$value[0];
                         $actualValue = (float)$actualData[$fieldName][0];
 
-                        $this->assertEquals($expectedValue, $actualValue, "Failed equivalency for: $fieldName", 1.0e-8);
+                        $this->assertEqualsWithDelta($expectedValue, $actualValue, 1.0e-8, "Failed equivalency for: $fieldName");
                     } else {
                         $this->assertEquals($value, $actualData[$fieldName]);
                     }

--- a/tests/regression/lib/Controllers/MetricExplorerChartsTest.php
+++ b/tests/regression/lib/Controllers/MetricExplorerChartsTest.php
@@ -189,7 +189,7 @@ class MetricExplorerChartsTest extends \PHPUnit\Framework\TestCase
 
         foreach ($series as $s) {
             $this->assertEquals($sdata['name'], $s->name);
-            $this->assertEquals($sdata['y'], $s->y[0], '', 1.0E-6);
+            $this->assertEqualsWithDelta($sdata['y'], $s->y[0], 1.0E-6);
             $sdata = next($expected['series_data']);
         }
 


### PR DESCRIPTION
## Description
In PHPUnit 9, `assertEquals()` no longer takes the fourth argument, which is the delta argument. Instead `assertEqualsWithDelta()` can be used.

## Motivation and Context
Correcting tests

## Tests performed
Tested in docker and test pass

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
